### PR TITLE
Removes "+" from messages

### DIFF
--- a/modular_bandastation/tts/code/hear.dm
+++ b/modular_bandastation/tts/code/hear.dm
@@ -1,3 +1,9 @@
+/mob/show_message(msg, type, alt_msg, alt_type, avoid_highlighting)
+    if(!client)
+        return FALSE
+    msg = replacetext_char(msg, "+", null)
+    . = ..()
+
 /mob/living/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods, message_range)
     . = ..()
     if(!.)


### PR DESCRIPTION

## About The Pull Request
fixes https://github.com/ss220club/Bandastation/issues/106

## Changelog
:cl:
fix: Теперь плюсик не пишется в чат
/:cl:
