### PR TITLE
fix: TTS now don't disabled when pause

### DIFF
--- a/modular_bandastation/tts/code/tts_subsystem.dm
+++ b/modular_bandastation/tts/code/tts_subsystem.dm
@@ -125,10 +125,6 @@ SUBSYSTEM_DEF(tts220)
 
 	return SS_INIT_SUCCESS
 
-/datum/controller/subsystem/tts220/pause()
-	. = ..()
-	is_enabled = FALSE
-
 /datum/controller/subsystem/tts220/fire()
 	if(last_network_fire + 1 SECONDS <= world.time)
 		fire_networking()


### PR DESCRIPTION
## About The Pull Request

Don't stop TTS subsystem forever when paused

## Why It's Good For The Game

TTS works as intended

## Changelog

:cl:
fix: исправлены отваливания ТТСа в некоторых случаях
/:cl:
