### PR TITLE
tweak: min 30 alive players for lone op

### DIFF
--- a/modular_bandastation/events/code/events.dm
+++ b/modular_bandastation/events/code/events.dm
@@ -1,3 +1,6 @@
 /datum/controller/subsystem/events
 	frequency_lower = 7 MINUTES
 	frequency_upper = 12 MINUTES
+
+/datum/round_event_control/operative
+	min_players = 30


### PR DESCRIPTION
## About The Pull Request

Изменяем требование по игрокам для `/datum/round_event_control/operative` до 30. 

## Why It's Good For The Game

Игроки не могут пропустить антага даже на лоупопе. По этому делаем это кодом.
