### PR TITLE
silicons whisper into radio, so fix double tts

### DIFF
--- a/modular_bandastation/tts/code/tts_component.dm
+++ b/modular_bandastation/tts/code/tts_component.dm
@@ -132,7 +132,7 @@
 		location = parent
 	if(effect == /datum/singleton/sound_effect/radio)
 		is_local = FALSE
-		if(listener == speaker && !issilicon(parent)) // don't hear both radio and whisper from yourself
+		if(listener == speaker) // don't hear both radio and whisper from yourself
 			return
 
 	effect = get_effect(effect)


### PR DESCRIPTION

## About The Pull Request
Силиконы шепчат в рацию, как обычные хуманы. Убираем костыль, который создал двойной ТТС для силиконов

## Changelog
:cl:
fix: Двойной ТТС у силиконов, говорящих в рацию, убран
/:cl:
