### PR TITLE
Italics_fix

### DIFF
--- a/code/modules/surgery/amputation.dm
+++ b/code/modules/surgery/amputation.dm
@@ -43,22 +43,22 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы начинаете отрезать [target.parse_zone_with_bodypart(target_zone)] у [target]..."),
-		span_notice("[user] начинает отрезать [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
-		span_notice("[user] начинает отрезать [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
+		span_notice("Вы начинаете отрезать <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]..."),
+		span_notice("[user] начинает отрезать <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
+		span_notice("[user] начинает отрезать <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
 	)
-	display_pain(target, "Вы чувствуете жуткую боль в [parse_zone(target_zone)]!")
+	display_pain(target, "Вы чувствуете жуткую боль в <i>[parse_zone(target_zone)]</i>!")
 
 
 /datum/surgery_step/sever_limb/success(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	display_results(
 		user,
 		target,
-		span_notice("Вы отрезали [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-		span_notice("[user] отрезал [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
-		span_notice("[user] отрезал [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
+		span_notice("Вы отрезали <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+		span_notice("[user] отрезал <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
+		span_notice("[user] отрезал <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
 	)
-	display_pain(target, "Вы больше не чувствуете свою отрезанную [target.parse_zone_with_bodypart(target_zone)]!")
+	display_pain(target, "Вы больше не чувствуете свою отрезанную <i>[target.parse_zone_with_bodypart(target_zone)]</i>!")
 
 	if(HAS_MIND_TRAIT(user, TRAIT_MORBID) && ishuman(user))
 		var/mob/living/carbon/human/morbid_weirdo = user

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -6,7 +6,7 @@
 	max_damage = LIMB_MAX_HP_CORE
 	body_zone = BODY_ZONE_HEAD
 	body_part = HEAD
-	plaintext_zone = "<i>голова</i>"
+	plaintext_zone = "голова"
 	w_class = WEIGHT_CLASS_BULKY //Quite a hefty load
 	slowdown = 1 //Balancing measure
 	throw_range = 2 //No head bowling

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -6,7 +6,7 @@
 	max_damage = LIMB_MAX_HP_CORE
 	body_zone = BODY_ZONE_CHEST
 	body_part = CHEST
-	plaintext_zone = "<i>грудь</i>"
+	plaintext_zone = "грудь"
 	is_dimorphic = TRUE
 	px_x = 0
 	px_y = 0
@@ -191,7 +191,7 @@
 	icon_state = "default_human_l_arm"
 	body_zone = BODY_ZONE_L_ARM
 	body_part = ARM_LEFT
-	plaintext_zone = "<i>левая рука</i>"
+	plaintext_zone = "левая рука"
 	aux_zone = BODY_ZONE_PRECISE_L_HAND
 	held_index = 1
 	px_x = -6
@@ -288,7 +288,7 @@
 	body_zone = BODY_ZONE_R_ARM
 	body_part = ARM_RIGHT
 	icon_state = "default_human_r_arm"
-	plaintext_zone = "<i>правая рука</i>"
+	plaintext_zone = "правая рука"
 	aux_zone = BODY_ZONE_PRECISE_R_HAND
 	aux_layer = BODYPARTS_HIGH_LAYER
 	held_index = 2
@@ -411,7 +411,7 @@
 	icon_state = "default_human_l_leg"
 	body_zone = BODY_ZONE_L_LEG
 	body_part = LEG_LEFT
-	plaintext_zone = "<i>левая нога</i>"
+	plaintext_zone = "левая нога"
 	px_x = -2
 	px_y = 12
 	can_be_disabled = TRUE
@@ -501,7 +501,7 @@
 	icon_state = "default_human_r_leg"
 	body_zone = BODY_ZONE_R_LEG
 	body_part = LEG_RIGHT
-	plaintext_zone = "<i>правая нога</i>"
+	plaintext_zone = "правая нога"
 	px_x = 2
 	px_y = 12
 	bodypart_trait_source = RIGHT_LEG_TRAIT

--- a/code/modules/surgery/bone_mending.dm
+++ b/code/modules/surgery/bone_mending.dm
@@ -60,13 +60,13 @@
 		display_results(
 			user,
 			target,
-			span_notice("Вы приступаете к устранению перелома в [target.parse_zone_with_bodypart(user.zone_selected)] у [target]..."),
-			span_notice("[user] приступает к устранению перелома в [target.parse_zone_with_bodypart(user.zone_selected)] у [target] при помощи [tool.name]."),
-			span_notice("[user] приступает к устранению перелома в [target.parse_zone_with_bodypart(user.zone_selected)] у [target]."),
+			span_notice("Вы приступаете к устранению перелома в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target]..."),
+			span_notice("[user] приступает к устранению перелома в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target] при помощи [tool.name]."),
+			span_notice("[user] приступает к устранению перелома в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target]."),
 		)
-		display_pain(target, "Ваша [target.parse_zone_with_bodypart(user.zone_selected)] испытывает сильную боль!")
+		display_pain(target, "Ваша <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> испытывает сильную боль!")
 	else
-		user.visible_message(span_notice("[user] ищет у [target] в [target.parse_zone_with_bodypart(user.zone_selected)]."), span_notice("Вы ищете у [target] в [target.parse_zone_with_bodypart(user.zone_selected)]..."))
+		user.visible_message(span_notice("[user] ищет у [target] в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i>."), span_notice("Вы ищете у [target] в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i>..."))
 
 /datum/surgery_step/repair_bone_hairline/success(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	if(surgery.operated_wound)
@@ -76,9 +76,9 @@
 		display_results(
 			user,
 			target,
-			span_notice("Вы успешно устранили перелом в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-			span_notice("[user] успешно устранил перелом в [target.parse_zone_with_bodypart(target_zone)] у [target] при помощи [tool.name]!"),
-			span_notice("[user] успешно устранил перелом в [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
+			span_notice("Вы успешно устранили перелом в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+			span_notice("[user] успешно устранил перелом в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target] при помощи [tool.name]!"),
+			span_notice("[user] успешно устранил перелом в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
 		)
 		log_combat(user, target, "repaired a hairline fracture in", addition="COMBAT_MODE: [uppertext(user.combat_mode)]")
 		qdel(surgery.operated_wound)
@@ -109,13 +109,13 @@
 		display_results(
 			user,
 			target,
-			span_notice("Вы начинаете восстанавливать кость в [target.parse_zone_with_bodypart(user.zone_selected)] у [target]..."),
-			span_notice("[user] начинает восстанавливать кость в [target.parse_zone_with_bodypart(user.zone_selected)] у [target] при помощи [tool.name]."),
-			span_notice("[user] начинает восстанавливать кость в [target.parse_zone_with_bodypart(user.zone_selected)] у [target]."),
+			span_notice("Вы начинаете восстанавливать кость в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target]..."),
+			span_notice("[user] начинает восстанавливать кость в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target] при помощи [tool.name]."),
+			span_notice("[user] начинает восстанавливать кость в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target]."),
 		)
-		display_pain(target, "Острая боль в [target.parse_zone_with_bodypart(user.zone_selected)] просто невыносима!")
+		display_pain(target, "Острая боль в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> просто невыносима!")
 	else
-		user.visible_message(span_notice("[user] ищет у [target] в [target.parse_zone_with_bodypart(user.zone_selected)]."), span_notice("Вы ищете у [target] в [target.parse_zone_with_bodypart(user.zone_selected)]..."))
+		user.visible_message(span_notice("[user] ищет у [target] в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i>."), span_notice("Вы ищете у [target] в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i>..."))
 
 /datum/surgery_step/reset_compound_fracture/success(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	if(surgery.operated_wound)
@@ -125,9 +125,9 @@
 		display_results(
 			user,
 			target,
-			span_notice("Вы успешно восстановили кость в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-			span_notice("[user] успешно восстановил кость в [target.parse_zone_with_bodypart(target_zone)] у [target] при помощи [tool.name]!"),
-			span_notice("[user] успешно восстановил кость в [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
+			span_notice("Вы успешно восстановили кость в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+			span_notice("[user] успешно восстановил кость в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target] при помощи [tool.name]!"),
+			span_notice("[user] успешно восстановил кость в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
 		)
 		log_combat(user, target, "reset a compound fracture in", addition="COMBAT MODE: [uppertext(user.combat_mode)]")
 	else
@@ -159,13 +159,13 @@
 		display_results(
 			user,
 			target,
-			span_notice("Вы приступаете к устранению перелома в [target.parse_zone_with_bodypart(user.zone_selected)] у [target]..."),
-			span_notice("[user] приступает к устранению перелома в [target.parse_zone_with_bodypart(user.zone_selected)] у [target] при помощи [tool.name]."),
-			span_notice("[user] приступает к устранению перелома в [target.parse_zone_with_bodypart(user.zone_selected)] у [target]."),
+			span_notice("Вы приступаете к устранению перелома в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target]..."),
+			span_notice("[user] приступает к устранению перелома в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target] при помощи [tool.name]."),
+			span_notice("[user] приступает к устранению перелома в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target]."),
 		)
-		display_pain(target, "Острая боль в [target.parse_zone_with_bodypart(user.zone_selected)] просто невыносима!")
+		display_pain(target, "Острая боль в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> просто невыносима!")
 	else
-		user.visible_message(span_notice("[user] ищет у [target] в [target.parse_zone_with_bodypart(user.zone_selected)]."), span_notice("Вы ищете у [target] в [target.parse_zone_with_bodypart(user.zone_selected)]..."))
+		user.visible_message(span_notice("[user] ищет у [target] в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i>."), span_notice("Вы ищете у [target] в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i>..."))
 
 /datum/surgery_step/repair_bone_compound/success(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	if(surgery.operated_wound)
@@ -175,9 +175,9 @@
 		display_results(
 			user,
 			target,
-			span_notice("Вы успешно устранили перелом в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-			span_notice("[user] успешно устранил перелом в [target.parse_zone_with_bodypart(target_zone)] у [target] при помощи [tool]!"),
-			span_notice("[user] успешно устранил перелом в [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
+			span_notice("Вы успешно устранили перелом в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+			span_notice("[user] успешно устранил перелом в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target] при помощи [tool]!"),
+			span_notice("[user] успешно устранил перелом в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
 		)
 		log_combat(user, target, "repaired a compound fracture in", addition="COMBAT_MODE: [uppertext(user.combat_mode)]")
 		qdel(surgery.operated_wound)
@@ -218,9 +218,9 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы начинаете избавляться от мелких обломков черепа в [target.parse_zone_with_bodypart(target_zone)] у [target]..."),
-		span_notice("[user] начинает избавляться от мелких обломков черепа в [target.parse_zone_with_bodypart(target_zone)] у [target]..."),
-		span_notice("[user] начинает копошиться в [target.parse_zone_with_bodypart(target_zone)] у [target]..."),
+		span_notice("Вы начинаете избавляться от мелких обломков черепа в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]..."),
+		span_notice("[user] начинает избавляться от мелких обломков черепа в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]..."),
+		span_notice("[user] начинает копошиться в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]..."),
 	)
 
 	display_pain(target, "Ваш мозг словно пронзают мелкие осколки стекла!")

--- a/code/modules/surgery/burn_dressing.dm
+++ b/code/modules/surgery/burn_dressing.dm
@@ -72,20 +72,20 @@
 	if(surgery.operated_wound)
 		var/datum/wound/burn/flesh/burn_wound = surgery.operated_wound
 		if(burn_wound.infestation <= 0)
-			to_chat(user, span_notice("У [target] в [target.parse_zone_with_bodypart(user.zone_selected)] нет зараженной плоти, которую нужно удалить!"))
+			to_chat(user, span_notice("У [target] в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> нет зараженной плоти, которую нужно удалить!"))
 			surgery.status++
 			repeatable = FALSE
 			return
 		display_results(
 			user,
 			target,
-			span_notice("Вы начинаете удалять зараженную плоть из [target.parse_zone_with_bodypart(user.zone_selected)] у [target]..."),
-			span_notice("[user] начинает удалять зараженную плоть из [target.parse_zone_with_bodypart(user.zone_selected)] у [target] при помощи [tool.name]."),
-			span_notice("[user] начинает удалять зараженную плоть из [target.parse_zone_with_bodypart(user.zone_selected)] у [target]."),
+			span_notice("Вы начинаете удалять зараженную плоть из <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target]..."),
+			span_notice("[user] начинает удалять зараженную плоть из <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target] при помощи [tool.name]."),
+			span_notice("[user] начинает удалять зараженную плоть из <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target]."),
 		)
-		display_pain(target, "Инфекция в вашей [target.parse_zone_with_bodypart(user.zone_selected)] адски зудит! Такое ощущение, что тебя режут ножом!")
+		display_pain(target, "Инфекция в вашей <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> адски зудит! Такое ощущение, что тебя режут ножом!")
 	else
-		user.visible_message(span_notice("[user] ищет [target.parse_zone_with_bodypart(user.zone_selected)] у [target]."), span_notice("Вы ищете [target.parse_zone_with_bodypart(user.zone_selected)] у [target]..."))
+		user.visible_message(span_notice("[user] ищет <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target]."), span_notice("Вы ищете <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target]..."))
 
 /datum/surgery_step/debride/success(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	var/datum/wound/burn/flesh/burn_wound = surgery.operated_wound
@@ -94,9 +94,9 @@
 		display_results(
 			user,
 			target,
-			span_notice("Вы успешно удалили часть зараженной плоти из [target.parse_zone_with_bodypart(target_zone)] у [target][progress_text]."),
-			span_notice("[user] успешно удалил часть зараженной плоти из [target.parse_zone_with_bodypart(target_zone)] у [target] при помощи [tool.name]!"),
-			span_notice("[user] успешно удалил часть зараженной плоти из [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
+			span_notice("Вы успешно удалили часть зараженной плоти из <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target][progress_text]."),
+			span_notice("[user] успешно удалил часть зараженной плоти из <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target] при помощи [tool.name]!"),
+			span_notice("[user] успешно удалил часть зараженной плоти из <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
 		)
 		log_combat(user, target, "excised infected flesh in", addition="COMBAT MODE: [uppertext(user.combat_mode)]")
 		surgery.operated_bodypart.receive_damage(brute=3, wound_bonus=CANT_WOUND)
@@ -113,9 +113,9 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы срезаете часть здоровой плоти из [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-		span_notice("[user] срезает часть здоровой плоти из [target.parse_zone_with_bodypart(target_zone)] у [target] при помощи [tool.name]!"),
-		span_notice("[user] срезает часть здоровой плоти из [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
+		span_notice("Вы срезаете часть здоровой плоти из <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+		span_notice("[user] срезает часть здоровой плоти из <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target] при помощи [tool.name]!"),
+		span_notice("[user] срезает часть здоровой плоти из <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
 	)
 	surgery.operated_bodypart.receive_damage(brute=rand(4,8), sharpness=TRUE)
 
@@ -146,13 +146,13 @@
 		display_results(
 			user,
 			target,
-			span_notice("Вы начинаете обрабатывать ожоги на [target.parse_zone_with_bodypart(user.zone_selected)] у [target]..."),
-			span_notice("[user] начинает обрабатывать ожоги на [target.parse_zone_with_bodypart(user.zone_selected)] у [target] при помощи [tool.name]."),
-			span_notice("[user] начинает обрабатывать ожоги на [target.parse_zone_with_bodypart(user.zone_selected)] у [target]."),
+			span_notice("Вы начинаете обрабатывать ожоги на <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target]..."),
+			span_notice("[user] начинает обрабатывать ожоги на <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target] при помощи [tool.name]."),
+			span_notice("[user] начинает обрабатывать ожоги на <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target]."),
 		)
-		display_pain(target, "Ожоги в [target.parse_zone_with_bodypart(user.zone_selected)] адски зудят!")
+		display_pain(target, "Ожоги в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> адски зудят!")
 	else
-		user.visible_message(span_notice("[user] ищет у [target] [target.parse_zone_with_bodypart(user.zone_selected)]."), span_notice("Вы ищете [target.parse_zone_with_bodypart(user.zone_selected)] у [target] ..."))
+		user.visible_message(span_notice("[user] ищет у [target] <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i>."), span_notice("Вы ищете <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target] ..."))
 
 /datum/surgery_step/dress/success(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	var/datum/wound/burn/flesh/burn_wound = surgery.operated_wound
@@ -160,9 +160,9 @@
 		display_results(
 			user,
 			target,
-			span_notice("Вы успешно перевязываете [target.parse_zone_with_bodypart(target_zone)] у [target] при помощи [tool.name]."),
-			span_notice("[user] успешно перевязывает [target.parse_zone_with_bodypart(target_zone)] у [target] при помощи [tool.name]!"),
-			span_notice("[user] успешно перевязывает [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
+			span_notice("Вы успешно перевязываете <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target] при помощи [tool.name]."),
+			span_notice("[user] успешно перевязывает <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target] при помощи [tool.name]!"),
+			span_notice("[user] успешно перевязывает <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
 		)
 		log_combat(user, target, "dressed burns in", addition="COMBAT MODE: [uppertext(user.combat_mode)]")
 		burn_wound.sanitization += sanitization_added

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -32,33 +32,33 @@
 		display_results(
 			user,
 			target,
-			span_notice("Вы начинаете вставлять [tool.name] в [target_zone] у [target]..."),
-			span_notice("[user] начинает вставлять [tool.name] в [target_zone] у [target]."),
-			span_notice("[user] начинает вставлять [tool.w_class > WEIGHT_CLASS_SMALL ? tool : "что-то"] в [target_zone] у [target]."),
+			span_notice("Вы начинаете вставлять [tool.name] в <i>[target_zone]</i> у [target]..."),
+			span_notice("[user] начинает вставлять [tool.name] в <i>[target_zone]</i> у [target]."),
+			span_notice("[user] начинает вставлять [tool.w_class > WEIGHT_CLASS_SMALL ? tool : "что-то"] в <i>[target_zone]</i> у [target]."),
 		)
-		display_pain(target, "Вы чувствуете, как что-то вставляют в ваш [target_zone], это чертовски больно!")
+		display_pain(target, "Вы чувствуете, как что-то вставляют в ваш <i>[target_zone]</i>, это чертовски больно!")
 	else
 		display_results(
 			user,
 			target,
-			span_notice("Вы проверяете на наличие предметов в [target_zone] у [target]..."),
-			span_notice("[user] проверяет на наличие предметов в [target_zone] у [target]."),
-			span_notice("[user] ищет что-то в [target_zone] [target]."),
+			span_notice("Вы проверяете на наличие предметов в <i>[target_zone]</i> у [target]..."),
+			span_notice("[user] проверяет на наличие предметов в <i>[target_zone]</i> у [target]."),
+			span_notice("[user] ищет что-то в <i>[target_zone]</i> [target]."),
 		)
 
 /datum/surgery_step/handle_cavity/success(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery = FALSE)
 	var/obj/item/bodypart/chest/target_chest = target.get_bodypart(BODY_ZONE_CHEST)
 	if(tool)
 		if(item_for_cavity || tool.w_class > WEIGHT_CLASS_NORMAL || HAS_TRAIT(tool, TRAIT_NODROP) || isorgan(tool))
-			to_chat(user, span_warning("Кажется, вы не можете поместить [tool.name] в [target_zone] у [target]!"))
+			to_chat(user, span_warning("Кажется, вы не можете поместить [tool.name] в <i>[target_zone]</i> у [target]!"))
 			return FALSE
 		else
 			display_results(
 				user,
 				target,
-				span_notice("Вы помещаете [tool.name] в [target_zone] у [target]."),
-				span_notice("[user] помещает [tool.name] в [target_zone] у [target]!"),
-				span_notice("[user] помещает [tool.w_class > WEIGHT_CLASS_SMALL ? tool : "что-то"] в [target_zone] у [target]."),
+				span_notice("Вы помещаете [tool.name] в <i>[target_zone]</i> у [target]."),
+				span_notice("[user] помещает [tool.name] в <i>[target_zone]</i> у [target]!"),
+				span_notice("[user] помещает [tool.w_class > WEIGHT_CLASS_SMALL ? tool : "что-то"] в <i>[target_zone]</i> у [target]."),
 			)
 			user.transferItemToLoc(tool, target, TRUE)
 			target_chest.cavity_item = tool
@@ -68,14 +68,14 @@
 			display_results(
 				user,
 				target,
-				span_notice("Вы вытягиваете [item_for_cavity] из [target_zone] у [target]."),
-				span_notice("[user] вытягивает [item_for_cavity] из [target_zone] у [target]!"),
-				span_notice("[user] вытягивает [item_for_cavity.w_class > WEIGHT_CLASS_SMALL ? item_for_cavity : "что-то"] из [target_zone] у [target]."),
+				span_notice("Вы вытягиваете [item_for_cavity] из <i>[target_zone]</i> у [target]."),
+				span_notice("[user] вытягивает [item_for_cavity] из <i>[target_zone]</i> у [target]!"),
+				span_notice("[user] вытягивает [item_for_cavity.w_class > WEIGHT_CLASS_SMALL ? item_for_cavity : "что-то"] из <i>[target_zone]</i> у [target]."),
 			)
-			display_pain(target, "Что-то вытащили из вашего [target_zone]! это чертовски больно!")
+			display_pain(target, "Что-то вытащили из вашего <i>[target_zone]</i>! это чертовски больно!")
 			user.put_in_hands(item_for_cavity)
 			target_chest.cavity_item = null
 			return ..()
 		else
-			to_chat(user, span_warning("Вы не нашли ничего в [target_zone] у [target]."))
+			to_chat(user, span_warning("Вы не нашли ничего в <i>[target_zone]</i> у [target]."))
 			return FALSE

--- a/code/modules/surgery/dental_implant.dm
+++ b/code/modules/surgery/dental_implant.dm
@@ -15,11 +15,11 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы начинаете вставлять [tool.name] в [target.parse_zone_with_bodypart(target_zone)] у [target]..."),
-		span_notice("[user] начинает вставлять [tool.name] в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-		span_notice("[user] начинает вставлять что-то в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
+		span_notice("Вы начинаете вставлять [tool.name] в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]..."),
+		span_notice("[user] начинает вставлять [tool.name] в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+		span_notice("[user] начинает вставлять что-то в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
 	)
-	display_pain(target, "Что-то засовывают вам в [target.parse_zone_with_bodypart(target_zone)]!")
+	display_pain(target, "Что-то засовывают вам в <i>[target.parse_zone_with_bodypart(target_zone)]</i>!")
 
 /datum/surgery_step/insert_pill/success(mob/user, mob/living/carbon/target, target_zone, obj/item/reagent_containers/pill/tool, datum/surgery/surgery, default_display_results = FALSE)
 	if(!istype(tool))
@@ -36,9 +36,9 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы вставили [tool.name] в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-		span_notice("[user] вставил [tool.name] в [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
-		span_notice("[user] вставил что-то в [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
+		span_notice("Вы вставили [tool.name] в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+		span_notice("[user] вставил [tool.name] в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
+		span_notice("[user] вставил что-то в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
 	)
 	return ..()
 

--- a/code/modules/surgery/implant_removal.dm
+++ b/code/modules/surgery/implant_removal.dm
@@ -30,18 +30,18 @@
 		display_results(
 			user,
 			target,
-			span_notice("Вы начинаете извлекать [implant] из [target_zone] у [target]..."),
-			span_notice("[user] начинает извлекать [implant] из [target_zone] у [target]."),
-			span_notice("[user] начинает что-то извлекать из [target_zone] у [target]."),
+			span_notice("Вы начинаете извлекать [implant] из <i>[target_zone]</i> у [target]..."),
+			span_notice("[user] начинает извлекать [implant] из <i>[target_zone]</i> у [target]."),
+			span_notice("[user] начинает что-то извлекать из <i>[target_zone]</i> у [target]."),
 		)
-		display_pain(target, "Вы чуствуете острую боль в [target_zone]!")
+		display_pain(target, "Вы чуствуете острую боль в <i>[target_zone]</i>!")
 	else
 		display_results(
 			user,
 			target,
-			span_notice("Вы ищете имплант в [target_zone] у [target]..."),
-			span_notice("[user] ищет имплант в [target_zone] у [target]."),
-			span_notice("[user] ищет что-то в [target_zone] у [target]."),
+			span_notice("Вы ищете имплант в <i>[target_zone]</i> у [target]..."),
+			span_notice("[user] ищет имплант в <i>[target_zone]</i> у [target]."),
+			span_notice("[user] ищет что-то в <i>[target_zone]</i> у [target]."),
 		)
 
 /datum/surgery_step/extract_implant/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
@@ -49,9 +49,9 @@
 		display_results(
 			user,
 			target,
-			span_notice("Вы успешно извлекли [implant] из [target_zone] у [target]."),
-			span_notice("[user] успешно извлек [implant] из [target_zone] у [target]!"),
-			span_notice("[user] успешно извлек что-то из [target_zone] у [target]!"),
+			span_notice("Вы успешно извлекли [implant] из <i>[target_zone]</i> у [target]."),
+			span_notice("[user] успешно извлек [implant] из <i>[target_zone]</i> у [target]!"),
+			span_notice("[user] успешно извлек что-то из <i>[target_zone]</i> у [target]!"),
 		)
 		display_pain(target, "Вы чувствуете, как [implant.name] извлекли из вас!")
 		implant.removed(target)
@@ -80,7 +80,7 @@
 			qdel(implant)
 
 	else
-		to_chat(user, span_warning("Вы не можете найти ничего в [target_zone] у [target]!"))
+		to_chat(user, span_warning("Вы не можете найти ничего в <i>[target_zone]</i> у [target]!"))
 	return ..()
 
 /datum/surgery/implant_removal/mechanic

--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -24,20 +24,20 @@
 		to_chat(user, span_warning("Это не аугментат, дурак!"))
 		return SURGERY_STEP_FAIL
 	if(aug.body_zone != target_zone)
-		to_chat(user, span_warning("Для [target.parse_zone_with_bodypart(target_zone)] не подходит [tool.name]."))
+		to_chat(user, span_warning("Для <i>[target.parse_zone_with_bodypart(target_zone)]</i> не подходит [tool.name]."))
 		return SURGERY_STEP_FAIL
 	target_limb = surgery.operated_bodypart
 	if(target_limb)
 		display_results(
 			user,
 			target,
-			span_notice("Вы начинаете аугментировать [target.parse_zone_with_bodypart(user.zone_selected)] у [target]..."),
-			span_notice("[user] начинает аугментировать [target.parse_zone_with_bodypart(user.zone_selected)] у [target] с помощью [aug.name]."),
-			span_notice("[user] начинает аугментировать [target.parse_zone_with_bodypart(user.zone_selected)] у [target]."),
+			span_notice("Вы начинаете аугментировать <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target]..."),
+			span_notice("[user] начинает аугментировать <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target] с помощью [aug.name]."),
+			span_notice("[user] начинает аугментировать <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target]."),
 		)
-		display_pain(target, "Вы чувствуете ужасную боль в [target.parse_zone_with_bodypart(user.zone_selected)]!")
+		display_pain(target, "Вы чувствуете ужасную боль в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i>!")
 	else
-		user.visible_message(span_notice("[user] ищет у [target] в [target.parse_zone_with_bodypart(user.zone_selected)]."), span_notice("Вы ищете у [target] в [target.parse_zone_with_bodypart(user.zone_selected)]..."))
+		user.visible_message(span_notice("[user] ищет у [target] в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i>."), span_notice("Вы ищете у [target] в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i>..."))
 
 
 //ACTUAL SURGERIES
@@ -74,9 +74,9 @@
 				display_results(
 					user,
 					target,
-					span_warning("Вы не смогли заменить [target.parse_zone_with_bodypart(target_zone)] у [target]! Тело отвергает [tool.name]!"),
-					span_warning("[user] не смог заменить [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
-					span_warning("[user] не смог заменить [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
+					span_warning("Вы не смогли заменить <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]! Тело отвергает [tool.name]!"),
+					span_warning("[user] не смог заменить <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
+					span_warning("[user] не смог заменить <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
 				)
 				tool.forceMove(target.loc)
 				return
@@ -85,12 +85,12 @@
 		display_results(
 			user,
 			target,
-			span_notice("Вы успешно заменили [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-			span_notice("[user] успешно заменил [target.parse_zone_with_bodypart(target_zone)] у [target] на [tool.name]!"),
-			span_notice("[user] успешно заменил [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
+			span_notice("Вы успешно заменили <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+			span_notice("[user] успешно заменил <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target] на [tool.name]!"),
+			span_notice("[user] успешно заменил <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
 		)
-		display_pain(target, "Ваш [target.parse_zone_with_bodypart(target_zone)] наполняется синтетическими ощущениями!", mechanical_surgery = TRUE)
+		display_pain(target, "Ваш <i>[target.parse_zone_with_bodypart(target_zone)]</i> наполняется синтетическими ощущениями!", mechanical_surgery = TRUE)
 		log_combat(user, target, "augmented", addition="by giving him new [target.parse_zone_with_bodypart(target_zone)] COMBAT MODE: [uppertext(user.combat_mode)]")
 	else
-		to_chat(user, span_warning("У [target] нет органической [target.parse_zone_with_bodypart(target_zone)] здесь!"))
+		to_chat(user, span_warning("У [target] нет органической <i>[target.parse_zone_with_bodypart(target_zone)]</i> здесь!"))
 	return ..()

--- a/code/modules/surgery/lipoplasty.dm
+++ b/code/modules/surgery/lipoplasty.dm
@@ -36,9 +36,9 @@
 		target,
 		span_notice("Вы начинаете отрезать лишний жир у [target]..."),
 		span_notice("[user] начинает отрезать лишний жир у [target]"),
-		span_notice("[user] начинает отрезать у [target] [target_zone] при помощи [tool.name]."),
+		span_notice("[user] начинает отрезать у [target] <i>[target_zone]</i> при помощи [tool.name]."),
 	)
-	display_pain(target, "Вы чувствуете резкую боль в вашей [target_zone]!")
+	display_pain(target, "Вы чувствуете резкую боль в вашей <i>[target_zone]</i>!")
 
 /datum/surgery_step/cut_fat/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results)
 	display_results(
@@ -46,9 +46,9 @@
 		target,
 		span_notice("Вы отрезали лишний жир у [target]."),
 		span_notice("[user] отрезал лишний жир у [target]!"),
-		span_notice("[user] заканчивает разрез на [target] [target_zone]."),
+		span_notice("[user] заканчивает разрез на [target] <i>[target_zone]</i>."),
 	)
-	display_pain(target, "Жир в вашей  [target_zone] ослабевает, свисает и болит как черт знает что!")
+	display_pain(target, "Жир в вашей  <i>[target_zone]</i> ослабевает, свисает и болит как черт знает что!")
 	return TRUE
 
 //remove fat
@@ -68,7 +68,7 @@
 		target,
 		span_notice("Вы начинаете извлекать лишний жир у [target]..."),
 		span_notice("[user] начинает извлекать лишний жир у [target]!"),
-		span_notice("[user] начинает извлекать что-то у [target] в [target_zone]."),
+		span_notice("[user] начинает извлекать что-то у [target] в <i>[target_zone]</i>."),
 	)
 	display_pain(target, "Вы чувствуете странное безболезненное потягивание за лишний жир!")
 

--- a/code/modules/surgery/mechanic_steps.dm
+++ b/code/modules/surgery/mechanic_steps.dm
@@ -14,11 +14,11 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы начинаете откручивать корпус в [target.parse_zone_with_bodypart(target_zone)] у [target]..."),
-		span_notice("[user] начинает откручивать корпус в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-		span_notice("[user] начинает откручивать корпус в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
+		span_notice("Вы начинаете откручивать корпус в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]..."),
+		span_notice("[user] начинает откручивать корпус в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+		span_notice("[user] начинает откручивать корпус в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
 	)
-	display_pain(target, "Вы ощущаете, как [target.parse_zone_with_bodypart(target_zone)] немеет по мере откручивания сенсорной панели.", TRUE)
+	display_pain(target, "Вы ощущаете, как <i>[target.parse_zone_with_bodypart(target_zone)]</i> немеет по мере откручивания сенсорной панели.", TRUE)
 
 /datum/surgery_step/mechanic_open/tool_check(mob/user, obj/item/tool)
 	if(implement_type == /obj/item && !tool.get_sharpness())
@@ -44,11 +44,11 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы начинаете закручивать корпус в [target.parse_zone_with_bodypart(target_zone)] у [target]..."),
-		span_notice("[user] начинает закручивать корпус в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-		span_notice("[user] начинает закручивать корпус в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
+		span_notice("Вы начинаете закручивать корпус в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]..."),
+		span_notice("[user] начинает закручивать корпус в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+		span_notice("[user] начинает закручивать корпус в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
 	)
-	display_pain(target, "Вы ощущаете, как начинаете получать показания датчиков из [target.parse_zone_with_bodypart(target_zone)], после того, как панель закрутили обратно.", TRUE)
+	display_pain(target, "Вы ощущаете, как начинаете получать показания датчиков из <i>[target.parse_zone_with_bodypart(target_zone)]</i>, после того, как панель закрутили обратно.", TRUE)
 
 /datum/surgery_step/mechanic_close/tool_check(mob/user, obj/item/tool)
 	if(implement_type == /obj/item && !tool.get_sharpness())
@@ -72,11 +72,11 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы начинаете подготовку электроники в [target.parse_zone_with_bodypart(target_zone)] у [target]..."),
-		span_notice("[user] начинает подготовку электроники в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-		span_notice("[user] начинает подготовку электроники в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
+		span_notice("Вы начинаете подготовку электроники в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]..."),
+		span_notice("[user] начинает подготовку электроники в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+		span_notice("[user] начинает подготовку электроники в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
 	)
-	display_pain(target, "Вы чувствуете слабое жужжание в [target.parse_zone_with_bodypart(target_zone)], когда электроника перезагружается.", TRUE)
+	display_pain(target, "Вы чувствуете слабое жужжание в <i>[target.parse_zone_with_bodypart(target_zone)]</i>, когда электроника перезагружается.", TRUE)
 
 //unwrench
 /datum/surgery_step/mechanic_unwrench
@@ -91,11 +91,11 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы начинаете откручивать болты в [target.parse_zone_with_bodypart(target_zone)] у [target]..."),
-		span_notice("[user] начинает откручивать болты в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-		span_notice("[user] начинает откручивать болты в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
+		span_notice("Вы начинаете откручивать болты в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]..."),
+		span_notice("[user] начинает откручивать болты в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+		span_notice("[user] начинает откручивать болты в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
 	)
-	display_pain(target, "Вы чувствуете вибрацию в [target.parse_zone_with_bodypart(target_zone)], когда болты начинают ослабевать.", TRUE)
+	display_pain(target, "Вы чувствуете вибрацию в <i>[target.parse_zone_with_bodypart(target_zone)]</i>, когда болты начинают ослабевать.", TRUE)
 
 /datum/surgery_step/mechanic_unwrench/tool_check(mob/user, obj/item/tool)
 	if(tool.usesound)
@@ -116,11 +116,11 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы начинаете закручивать болты в [target.parse_zone_with_bodypart(target_zone)] у [target]..."),
-		span_notice("[user] начинает закручивать болты в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-		span_notice("[user] начинает закручивать болты в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
+		span_notice("Вы начинаете закручивать болты в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]..."),
+		span_notice("[user] начинает закручивать болты в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+		span_notice("[user] начинает закручивать болты в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
 	)
-	display_pain(target, "Вы чувствуете вибрацию в [target.parse_zone_with_bodypart(target_zone)], когда болты начинают затягиваться.", TRUE)
+	display_pain(target, "Вы чувствуете вибрацию в <i>[target.parse_zone_with_bodypart(target_zone)]</i>, когда болты начинают затягиваться.", TRUE)
 
 /datum/surgery_step/mechanic_wrench/tool_check(mob/user, obj/item/tool)
 	if(tool.usesound)
@@ -140,11 +140,11 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы начинаете открывать держатели люка в [target.parse_zone_with_bodypart(target_zone)] у [target]..."),
-		span_notice("[user] начинает открывать держатели люка в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-		span_notice("[user] начинает открывать держатели люка в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
+		span_notice("Вы начинаете открывать держатели люка в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]..."),
+		span_notice("[user] начинает открывать держатели люка в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+		span_notice("[user] начинает открывать держатели люка в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
 	)
-	display_pain(target, "Вы получаете последние показания датчиков из вашей [target.parse_zone_with_bodypart(target_zone)], когда открывается люк.", TRUE)
+	display_pain(target, "Вы получаете последние показания датчиков из вашей <i>[target.parse_zone_with_bodypart(target_zone)]</i>, когда открывается люк.", TRUE)
 
 /datum/surgery_step/open_hatch/tool_check(mob/user, obj/item/tool)
 	if(tool.usesound)

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -158,7 +158,7 @@
 		if(!isorgan(target_organ))
 			if (target_zone == BODY_ZONE_PRECISE_EYES)
 				target_zone = check_zone(target_zone)
-			to_chat(user, span_warning("Вы не можете вставить [target_organ] в [target] [target.parse_zone_with_bodypart(target_zone)]!"))
+			to_chat(user, span_warning("Вы не можете вставить [target_organ] в [target] <i>[target.parse_zone_with_bodypart(target_zone)]</i>!"))
 			return SURGERY_STEP_FAIL
 		tool = target_organ
 	if(isorgan(tool))
@@ -167,7 +167,7 @@
 		success_sound = 'sound/surgery/organ2.ogg'
 		target_organ = tool
 		if(target_zone != target_organ.zone || target.get_organ_slot(target_organ.slot))
-			to_chat(user, span_warning("Здесь нет места для [target_organ] в [target] [target.parse_zone_with_bodypart(target_zone)]!"))
+			to_chat(user, span_warning("Здесь нет места для [target_organ] в [target] <i>[target.parse_zone_with_bodypart(target_zone)]</i>!"))
 			return SURGERY_STEP_FAIL
 		var/obj/item/organ/meatslab = tool
 		if(!meatslab.useable)
@@ -182,11 +182,11 @@
 		display_results(
 			user,
 			target,
-			span_notice("Вы вставляете [tool.name] в [target.parse_zone_with_bodypart(target_zone)] у [target]..."),
-			span_notice("[user] вставляет [tool.name] в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-			span_notice("[user] вставляет что-то в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
+			span_notice("Вы вставляете [tool.name] в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]..."),
+			span_notice("[user] вставляет [tool.name] в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+			span_notice("[user] вставляет что-то в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
 		)
-		display_pain(target, "Вы чувствуете, как что-то вставили в вашу [target.parse_zone_with_bodypart(target_zone)]!")
+		display_pain(target, "Вы чувствуете, как что-то вставили в вашу <i>[target.parse_zone_with_bodypart(target_zone)]</i>!")
 
 
 	else if(implement_type in implements_extract)
@@ -199,7 +199,7 @@
 		if (target_zone == BODY_ZONE_PRECISE_EYES)
 			target_zone = check_zone(target_zone)
 		if(!length(organs))
-			to_chat(user, span_warning("В [target.parse_zone_with_bodypart(target_zone)] нет органов, которые можно удалить у [target]!"))
+			to_chat(user, span_warning("В <i>[target.parse_zone_with_bodypart(target_zone)]</i> нет органов, которые можно удалить у [target]!"))
 			return SURGERY_STEP_FAIL
 		else
 			for(var/obj/item/organ/organ in organs)
@@ -221,11 +221,11 @@
 				display_results(
 					user,
 					target,
-					span_notice("Вы начинаете извлекать [target_organ] из [target.parse_zone_with_bodypart(target_zone)] у [target]..."),
-					span_notice("[user] начинает извлекать [target_organ] из [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-					span_notice("[user] начинает извлекать что-то из [target.parse_zone_with_bodypart(target_zone)] у [target]."),
+					span_notice("Вы начинаете извлекать [target_organ] из <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]..."),
+					span_notice("[user] начинает извлекать [target_organ] из <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+					span_notice("[user] начинает извлекать что-то из <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
 				)
-				display_pain(target, "Вы чувствуете, как [target_organ.name] извлекли из вашей [target.parse_zone_with_bodypart(target_zone)]!")
+				display_pain(target, "Вы чувствуете, как [target_organ.name] извлекли из вашей <i>[target.parse_zone_with_bodypart(target_zone)]</i>!")
 			else
 				return SURGERY_STEP_FAIL
 
@@ -247,11 +247,11 @@
 			display_results(
 				user,
 				target,
-				span_notice("Вы установили [tool.name] в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-				span_notice("[user] установил [tool.name] в [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
-				span_notice("[user] установил что-то в [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
+				span_notice("Вы установили [tool.name] в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+				span_notice("[user] установил [tool.name] в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
+				span_notice("[user] установил что-то в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
 			)
-			display_pain(target, "Ваша [target.parse_zone_with_bodypart(target_zone)] болит, пока [tool.name] приживается к телу!")
+			display_pain(target, "Ваша <i>[target.parse_zone_with_bodypart(target_zone)]</i> болит, пока [tool.name] приживается к телу!")
 			target_organ.on_surgical_insertion(user, target, target_zone, tool)
 		else
 			target_organ.forceMove(target.loc)
@@ -261,11 +261,11 @@
 			display_results(
 				user,
 				target,
-				span_notice("Вы успешно извлекате [target_organ] из [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-				span_notice("[user] успешно извлек [target_organ] из [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
-				span_notice("[user] успешно извлек что-то из [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
+				span_notice("Вы успешно извлекате [target_organ] из <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+				span_notice("[user] успешно извлек [target_organ] из <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
+				span_notice("[user] успешно извлек что-то из <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
 			)
-			display_pain(target, "Ваш [target.parse_zone_with_bodypart(target_zone)] болит, вы больше не чувствуете [target_organ.name]!")
+			display_pain(target, "Ваш <i>[target.parse_zone_with_bodypart(target_zone)]</i> болит, вы больше не чувствуете [target_organ.name]!")
 			log_combat(user, target, "surgically removed [target_organ.name] from", addition="COMBAT MODE: [uppertext(user.combat_mode)]")
 			target_organ.Remove(target)
 			target_organ.forceMove(get_turf(target))
@@ -274,9 +274,9 @@
 			display_results(
 				user,
 				target,
-				span_warning("Вы не можете ничего извлечь из [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
-				span_notice("[user] похоже не может ничего извлечь из [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
-				span_notice("[user] похоже не может ничего извлечь из [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
+				span_warning("Вы не можете ничего извлечь из <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
+				span_notice("[user] похоже не может ничего извлечь из <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
+				span_notice("[user] похоже не может ничего извлечь из <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
 			)
 	if(HAS_MIND_TRAIT(user, TRAIT_MORBID) && ishuman(user))
 		var/mob/living/carbon/human/morbid_weirdo = user

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -16,11 +16,11 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы начинаете делать надрез в [target.parse_zone_with_bodypart(target_zone)] у [target]..."),
-		span_notice("[user] начинает делать надрез в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-		span_notice("[user] начинает делать надрез в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
+		span_notice("Вы начинаете делать надрез в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]..."),
+		span_notice("[user] начинает делать надрез в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+		span_notice("[user] начинает делать надрез в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
 	)
-	display_pain(target, "Вы чувствуете колющую боль в [target.parse_zone_with_bodypart(target_zone)].")
+	display_pain(target, "Вы чувствуете колющую боль в <i>[target.parse_zone_with_bodypart(target_zone)]</i>.")
 
 /datum/surgery_step/incise/tool_check(mob/user, obj/item/tool)
 	if(implement_type == /obj/item && !tool.get_sharpness())
@@ -35,9 +35,9 @@
 			display_results(
 				user,
 				target,
-				span_notice("Вокруг [target.parse_zone_with_bodypart(target_zone)] у [human_target] образуется лужа крови."),
-				span_notice("Вокруг [target.parse_zone_with_bodypart(target_zone)] у [human_target] образуется лужа крови."),
-				span_notice("Вокруг [target.parse_zone_with_bodypart(target_zone)] у [human_target] образуется лужа крови."),
+				span_notice("Вокруг <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [human_target] образуется лужа крови."),
+				span_notice("Вокруг <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [human_target] образуется лужа крови."),
+				span_notice("Вокруг <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [human_target] образуется лужа крови."),
 			)
 			var/obj/item/bodypart/target_bodypart = target.get_bodypart(target_zone)
 			if(target_bodypart)
@@ -48,11 +48,11 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы начинаете <i>осторожно</i> делать надрез в [target.parse_zone_with_bodypart(target_zone)] у [target]..."),
-		span_notice("[user] начинает <i>осторожно</i> делать надрез в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-		span_notice("[user] начинает <i>осторожно</i> делать надрез в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
+		span_notice("Вы начинаете <i>осторожно</i> делать надрез в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]..."),
+		span_notice("[user] начинает <i>осторожно</i> делать надрез в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+		span_notice("[user] начинает <i>осторожно</i> делать надрез в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
 	)
-	display_pain(target, "Вы чувствуете <i>осторожный</i> колющий удар в [target.parse_zone_with_bodypart(target_zone)].")
+	display_pain(target, "Вы чувствуете <i>осторожный</i> колющий удар в <i>[target.parse_zone_with_bodypart(target_zone)]</i>.")
 
 //clamp bleeders
 /datum/surgery_step/clamp_bleeders
@@ -69,11 +69,11 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы начинаете зажимать кровеносные сосуды в [target.parse_zone_with_bodypart(target_zone)] у [target]..."),
-		span_notice("[user] начинает зажимать кровеносные сосуды в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-		span_notice("[user] начинает зажимать кровеносные сосуды в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
+		span_notice("Вы начинаете зажимать кровеносные сосуды в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]..."),
+		span_notice("[user] начинает зажимать кровеносные сосуды в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+		span_notice("[user] начинает зажимать кровеносные сосуды в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
 	)
-	display_pain(target, "Вы чувствуете укол, послче чего кровотечение в вашей [target.parse_zone_with_bodypart(target_zone)] замедляется.")
+	display_pain(target, "Вы чувствуете укол, послче чего кровотечение в вашей <i>[target.parse_zone_with_bodypart(target_zone)]</i> замедляется.")
 
 /datum/surgery_step/clamp_bleeders/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results)
 	if(locate(/datum/surgery_step/saw) in surgery.steps)
@@ -101,11 +101,11 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы начинаете раздвигать кожу в [target.parse_zone_with_bodypart(target_zone)] у [target]..."),
-		span_notice("[user] начинаете раздвигать кожу в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-		span_notice("[user] начинаете раздвигать кожу в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
+		span_notice("Вы начинаете раздвигать кожу в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]..."),
+		span_notice("[user] начинаете раздвигать кожу в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+		span_notice("[user] начинаете раздвигать кожу в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
 	)
-	display_pain(target, "Вы чувствуете сильную жгучую боль, распространяющуюся по всей [target.parse_zone_with_bodypart(target_zone)], по мере того, как кожа возвращается в прежнее состояние!")
+	display_pain(target, "Вы чувствуете сильную жгучую боль, распространяющуюся по всей <i>[target.parse_zone_with_bodypart(target_zone)]</i>, по мере того, как кожа возвращается в прежнее состояние!")
 
 //close incision
 /datum/surgery_step/close
@@ -123,11 +123,11 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы начинаете обрабатывать разрез в [target.parse_zone_with_bodypart(target_zone)] у [target]..."),
-		span_notice("[user] начинает обрабатывать разрез в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-		span_notice("[user] начинает обрабатывать разрез в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
+		span_notice("Вы начинаете обрабатывать разрез в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]..."),
+		span_notice("[user] начинает обрабатывать разрез в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+		span_notice("[user] начинает обрабатывать разрез в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
 	)
-	display_pain(target, "Ваша [target.parse_zone_with_bodypart(target_zone)] прижигается!")
+	display_pain(target, "Ваша <i>[target.parse_zone_with_bodypart(target_zone)]</i> прижигается!")
 
 /datum/surgery_step/close/tool_check(mob/user, obj/item/tool)
 	if(implement_type == TOOL_WELDER || implement_type == /obj/item)
@@ -173,11 +173,11 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы начинаете распиливать кость в [target.parse_zone_with_bodypart(target_zone)] у [target]..."),
-		span_notice("[user] начинает распиливать кость в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-		span_notice("[user] начинает распиливать кость в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
+		span_notice("Вы начинаете распиливать кость в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]..."),
+		span_notice("[user] начинает распиливать кость в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+		span_notice("[user] начинает распиливать кость в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
 	)
-	display_pain(target, "Вы чувствуете ужасную боль внутри [target.parse_zone_with_bodypart(target_zone)]!")
+	display_pain(target, "Вы чувствуете ужасную боль внутри <i>[target.parse_zone_with_bodypart(target_zone)]</i>!")
 
 /datum/surgery_step/saw/tool_check(mob/user, obj/item/tool)
 	if(implement_type == /obj/item && !(tool.get_sharpness() && (tool.force >= 10)))
@@ -189,11 +189,11 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы вскрываете [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-		span_notice("[user] вскрывает [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
-		span_notice("[user] вскрывает [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
+		span_notice("Вы вскрываете <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+		span_notice("[user] вскрывает <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
+		span_notice("[user] вскрывает <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
 	)
-	display_pain(target, "Такое ощущение, что в [target.parse_zone_with_bodypart(target_zone)] что-то сломано!")
+	display_pain(target, "Такое ощущение, что в <i>[target.parse_zone_with_bodypart(target_zone)]</i> что-то сломано!")
 	return ..()
 
 //drill bone
@@ -211,18 +211,18 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы начинаете сверлить прямо в кости в [target.parse_zone_with_bodypart(target_zone)] у [target]..."),
-		span_notice("[user] начинает сверлить прямо в кости в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-		span_notice("[user] начинает сверлить прямо в кости в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
+		span_notice("Вы начинаете сверлить прямо в кости в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]..."),
+		span_notice("[user] начинает сверлить прямо в кости в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+		span_notice("[user] начинает сверлить прямо в кости в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
 	)
-	display_pain(target, "Вы чувствуете ужасную пронзительную боль в [target.parse_zone_with_bodypart(target_zone)]!")
+	display_pain(target, "Вы чувствуете ужасную пронзительную боль в <i>[target.parse_zone_with_bodypart(target_zone)]</i>!")
 
 /datum/surgery_step/drill/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	display_results(
 		user,
 		target,
-		span_notice("Вы просверлили [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-		span_notice("[user] просверливает [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
-		span_notice("[user] просверливает [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
+		span_notice("Вы просверлили <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+		span_notice("[user] просверливает <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
+		span_notice("[user] просверливает <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
 	)
 	return ..()

--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -42,11 +42,11 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы начинаете вставлять [tool.name] в разрезе на [target.parse_zone_with_bodypart(target_zone)] у [target] ..."),
-		span_notice("[user] начинает вставлять [tool.name] в разрезе на [target.parse_zone_with_bodypart(target_zone)] у [target]]."),
-		span_notice("[user] начинает вставлять [tool.name] в разрезе на [target.parse_zone_with_bodypart(target_zone)] у [target]]."),
+		span_notice("Вы начинаете вставлять [tool.name] в разрезе на <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target] ..."),
+		span_notice("[user] начинает вставлять [tool.name] в разрезе на <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]]."),
+		span_notice("[user] начинает вставлять [tool.name] в разрезе на <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]]."),
 	)
-	display_pain(target, "Вы чувствуете, как что-то вставили вам под кожу в [target.parse_zone_with_bodypart(target_zone)].")
+	display_pain(target, "Вы чувствуете, как что-то вставили вам под кожу в <i>[target.parse_zone_with_bodypart(target_zone)]</i>.")
 
 /datum/surgery_step/insert_plastic/success(mob/user, mob/living/target, target_zone, obj/item/stack/tool, datum/surgery/surgery, default_display_results)
 	. = ..()

--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -62,27 +62,27 @@
 					organ_rejection_dam = 30
 
 			if(!bodypart_to_attach.can_attach_limb(target))
-				target.balloon_alert(user, "это не подходит к [target.parse_zone_with_bodypart(target_zone)]!")
+				target.balloon_alert(user, "это не подходит к <i>[target.parse_zone_with_bodypart(target_zone)]</i>!")
 				return SURGERY_STEP_FAIL
 
 		if(target_zone == bodypart_to_attach.body_zone) //so we can't replace a leg with an arm, or a human arm with a monkey arm.
 			display_results(
 				user,
 				target,
-				span_notice("Вы начинаете заменять [target.parse_zone_with_bodypart(target_zone)] у [target] на [tool.name]..."),
-				span_notice("[user] начинает заменять [target.parse_zone_with_bodypart(target_zone)] у [target.parse_zone_with_bodypart(target_zone)] на [tool.name]."),
-				span_notice("[user] начинает заменять [target.parse_zone_with_bodypart(target_zone)] у [target]."),
+				span_notice("Вы начинаете заменять <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target] на [tool.name]..."),
+				span_notice("[user] начинает заменять <i>[target.parse_zone_with_bodypart(target_zone)]</i> у <i>[target.parse_zone_with_bodypart(target_zone)]</i> на [tool.name]."),
+				span_notice("[user] начинает заменять <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
 			)
 		else
-			to_chat(user, span_warning("[tool.name] не подходит для [target.parse_zone_with_bodypart(target_zone)]."))
+			to_chat(user, span_warning("[tool.name] не подходит для <i>[target.parse_zone_with_bodypart(target_zone)]</i>."))
 			return SURGERY_STEP_FAIL
 	else if(target_zone == BODY_ZONE_L_ARM || target_zone == BODY_ZONE_R_ARM)
 		display_results(
 			user,
 			target,
 			span_notice("Вы начинаете прикреплять [tool.name] к [target]..."),
-			span_notice("[user] начинает прикреплять [tool.name] к [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-			span_notice("[user] начинает прикреплять что-то к [target.parse_zone_with_bodypart(target_zone)] у [target]."),
+			span_notice("[user] начинает прикреплять [tool.name] к <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+			span_notice("[user] начинает прикреплять что-то к <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
 		)
 	else
 		to_chat(user, span_warning("[tool.name] должен быть установлен в руку."))
@@ -105,11 +105,11 @@
 		display_results(
 			user,
 			target,
-			span_notice("Вы успешно заменили [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-			span_notice("[user] успешно заменил [target.parse_zone_with_bodypart(target_zone)] у [target] на [tool.name]!"),
-			span_notice("[user] успешно заменил [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
+			span_notice("Вы успешно заменили <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+			span_notice("[user] успешно заменил <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target] на [tool.name]!"),
+			span_notice("[user] успешно заменил <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
 		)
-		display_pain(target, "Вы наполняетесь позитивными ощущениями, потому что вы снова чувствуете ваш [target.parse_zone_with_bodypart(target_zone)]!", TRUE)
+		display_pain(target, "Вы наполняетесь позитивными ощущениями, потому что вы снова чувствуете ваш <i>[target.parse_zone_with_bodypart(target_zone)]</i>!", TRUE)
 		return
 	else
 		var/obj/item/bodypart/bodypart_to_attach = target.newBodyPart(target_zone, FALSE, FALSE)
@@ -123,7 +123,7 @@
 			span_notice("[user] заканчивает прикреплять [tool.name]!"),
 			span_notice("[user] завершает операцию по прикреплению!"),
 		)
-		display_pain(target, "Вы испытываете странные ощущения от своего нового [target.parse_zone_with_bodypart(target_zone)].", TRUE)
+		display_pain(target, "Вы испытываете странные ощущения от своего нового <i>[target.parse_zone_with_bodypart(target_zone)]</i>.", TRUE)
 		if(istype(tool, /obj/item/chainsaw))
 			qdel(tool)
 			var/obj/item/chainsaw/mounted_chainsaw/new_arm = new(target)

--- a/code/modules/surgery/repair_puncture.dm
+++ b/code/modules/surgery/repair_puncture.dm
@@ -50,22 +50,22 @@
 /datum/surgery_step/repair_innards/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/datum/wound/pierce/bleed/pierce_wound = surgery.operated_wound
 	if(!pierce_wound)
-		user.visible_message(span_notice("[user] ищет у [target] в [target.parse_zone_with_bodypart(user.zone_selected)]."), span_notice("Вы ищете у [target] в [target.parse_zone_with_bodypart(user.zone_selected)]..."))
+		user.visible_message(span_notice("[user] ищет у [target] в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i>."), span_notice("Вы ищете у [target] в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i>..."))
 		return
 
 	if(pierce_wound.blood_flow <= 0)
-		to_chat(user, span_notice("У [target] в [target.parse_zone_with_bodypart(user.zone_selected)] нет сквозного ранения, которое нуждается в обработке!"))
+		to_chat(user, span_notice("У [target] в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> нет сквозного ранения, которое нуждается в обработке!"))
 		surgery.status++
 		return
 
 	display_results(
 		user,
 		target,
-		span_notice("Вы начинаете приводить в порядок поврежденные кровеносные сосуды в [target.parse_zone_with_bodypart(user.zone_selected)] у [target]..."),
-		span_notice("[user] начинает приводить в порядок поврежденные кровеносные сосуды в [target.parse_zone_with_bodypart(user.zone_selected)] у [target] при помощи [tool.name]."),
-		span_notice("[user] начинает приводить в порядок поврежденные кровеносные сосуды в [target.parse_zone_with_bodypart(user.zone_selected)] у [target]."),
+		span_notice("Вы начинаете приводить в порядок поврежденные кровеносные сосуды в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target]..."),
+		span_notice("[user] начинает приводить в порядок поврежденные кровеносные сосуды в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target] при помощи [tool.name]."),
+		span_notice("[user] начинает приводить в порядок поврежденные кровеносные сосуды в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target]."),
 	)
-	display_pain(target, "Вы чувствуете ужасную колющую боль в [target.parse_zone_with_bodypart(user.zone_selected)]!")
+	display_pain(target, "Вы чувствуете ужасную колющую боль в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i>!")
 
 /datum/surgery_step/repair_innards/success(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	var/datum/wound/pierce/bleed/pierce_wound = surgery.operated_wound
@@ -76,9 +76,9 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы успешно восстанавливаете некоторые кровеносные сосуды в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-		span_notice("[user] успешно восстанавливает некоторые кровеносные сосуды в [target.parse_zone_with_bodypart(target_zone)] у [target] при помощи [tool.name]!"),
-		span_notice("[user] успешно восстанавливает некоторые кровеносные сосуды в [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
+		span_notice("Вы успешно восстанавливаете некоторые кровеносные сосуды в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+		span_notice("[user] успешно восстанавливает некоторые кровеносные сосуды в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target] при помощи [tool.name]!"),
+		span_notice("[user] успешно восстанавливает некоторые кровеносные сосуды в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
 	)
 	log_combat(user, target, "excised infected flesh in", addition="COMBAT MODE: [uppertext(user.combat_mode)]")
 	surgery.operated_bodypart.receive_damage(brute=3, wound_bonus=CANT_WOUND)
@@ -90,9 +90,9 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы повреждаете некоторые кровеносные сосуды в [target.parse_zone_with_bodypart(target_zone)] у [target]."),
-		span_notice("[user] повреждает некоторые кровеносные сосуды в [target.parse_zone_with_bodypart(target_zone)] у [target] при помощи [tool.name]!"),
-		span_notice("[user] повреждает некоторые кровеносные сосуды в [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
+		span_notice("Вы повреждаете некоторые кровеносные сосуды в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]."),
+		span_notice("[user] повреждает некоторые кровеносные сосуды в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target] при помощи [tool.name]!"),
+		span_notice("[user] повреждает некоторые кровеносные сосуды в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
 	)
 	surgery.operated_bodypart.receive_damage(brute=rand(4,8), sharpness=SHARP_EDGED, wound_bonus = 10)
 
@@ -117,16 +117,16 @@
 /datum/surgery_step/seal_veins/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/datum/wound/pierce/bleed/pierce_wound = surgery.operated_wound
 	if(!pierce_wound)
-		user.visible_message(span_notice("[user] ищет у [target] в [target.parse_zone_with_bodypart(user.zone_selected)]."), span_notice("Вы ищете у [target] в [target.parse_zone_with_bodypart(user.zone_selected)]..."))
+		user.visible_message(span_notice("[user] ищет у [target] в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i>."), span_notice("Вы ищете у [target] в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i>..."))
 		return
 	display_results(
 		user,
 		target,
-		span_notice("Вы начинаете восстанавливать некоторые из поврежденных кровеносных сосудов в [target.parse_zone_with_bodypart(user.zone_selected)] у [target]..."),
-		span_notice("[user] начинает восстанавливать некоторые из поврежденных кровеносных сосудов в [target.parse_zone_with_bodypart(user.zone_selected)] у [target] при помощи [tool.name]."),
-		span_notice("[user] начинает восстанавливать некоторые из поврежденных кровеносных сосудов в [target.parse_zone_with_bodypart(user.zone_selected)] у [target]."),
+		span_notice("Вы начинаете восстанавливать некоторые из поврежденных кровеносных сосудов в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target]..."),
+		span_notice("[user] начинает восстанавливать некоторые из поврежденных кровеносных сосудов в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target] при помощи [tool.name]."),
+		span_notice("[user] начинает восстанавливать некоторые из поврежденных кровеносных сосудов в <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> у [target]."),
 	)
-	display_pain(target, "В [target.parse_zone_with_bodypart(user.zone_selected)] все горит!")
+	display_pain(target, "В <i>[target.parse_zone_with_bodypart(user.zone_selected)]</i> все горит!")
 
 /datum/surgery_step/seal_veins/success(mob/living/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	var/datum/wound/pierce/bleed/pierce_wound = surgery.operated_wound
@@ -137,9 +137,9 @@
 	display_results(
 		user,
 		target,
-		span_notice("Вы успешно восстановили некоторые из поврежденных кровеносных сосудов в [target.parse_zone_with_bodypart(target_zone)] у [target] при помощи [tool.name]."),
-		span_notice("[user] успешно восстановил некоторые из поврежденных кровеносных сосудов в [target.parse_zone_with_bodypart(target_zone)] у [target] при помощи [tool.name]!"),
-		span_notice("[user] успешно восстановил некоторые из поврежденных кровеносных сосудов в [target.parse_zone_with_bodypart(target_zone)] у [target]!"),
+		span_notice("Вы успешно восстановили некоторые из поврежденных кровеносных сосудов в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target] при помощи [tool.name]."),
+		span_notice("[user] успешно восстановил некоторые из поврежденных кровеносных сосудов в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target] при помощи [tool.name]!"),
+		span_notice("[user] успешно восстановил некоторые из поврежденных кровеносных сосудов в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"),
 	)
 	log_combat(user, target, "dressed burns in", addition="COMBAT MODE: [uppertext(user.combat_mode)]")
 	pierce_wound.adjust_blood_flow(-0.5)
@@ -147,7 +147,7 @@
 		surgery.status = REALIGN_INNARDS
 		to_chat(user, span_notice("<i>Кажется, что кровеносные сосуды все еще смещены...</i>"))
 	else
-		to_chat(user, span_green("Вы восстановили все внутренние повреждения в [target.parse_zone_with_bodypart(target_zone)] у [target]!"))
+		to_chat(user, span_green("Вы восстановили все внутренние повреждения в <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target]!"))
 	return ..()
 
 #undef REALIGN_INNARDS

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -51,7 +51,7 @@
 			if(get_location_accessible(target, target_zone) || (surgery.surgery_flags & SURGERY_IGNORE_CLOTHES))
 				initiate(user, target, target_zone, tool, surgery, try_to_fail)
 			else
-				to_chat(user, span_warning("Вам надо снять все, что может закрывать [target.parse_zone_with_bodypart(target_zone)] у [target], для того чтобы начать операцию!"))
+				to_chat(user, span_warning("Вам надо снять все, что может закрывать <i>[target.parse_zone_with_bodypart(target_zone)]</i> у [target], для того чтобы начать операцию!"))
 			return TRUE //returns TRUE so we don't stab the guy in the dick or wherever.
 
 	if(repeatable)


### PR DESCRIPTION
## About The Pull Request

Исправляет баг с курсивом, когда на мониторе операций криво писало части тела. Сейчас части тела, которые используются при операциях, должны также писаться курсивом, но в мониторе - нет.

## Changelog

Курсив теперь не в parts.dm, а в файлах хиругрических операций

:cl:
fix: поправил курсив в коде при операциях
/:cl:

