### PR TITLE
tweak: return head dismembering back

### DIFF
--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -98,7 +98,7 @@
 		show_eyeless = FALSE
 
 		/// Can this head be dismembered normally?
-		can_dismember = FALSE
+		can_dismember = TRUE // SS220 - EDIT. Was `can_dismember = FALSE`
 
 /obj/item/bodypart/head/Destroy()
 	QDEL_NULL(worn_ears_offset)


### PR DESCRIPTION
## About The Pull Request

Возвращаем отрубание головы обычными ударами острым оружием
closes #315

## Why It's Good For The Game

Отрубание головы это весело и выглядит очень эффектно. Было вырезано из-за того что мейнтейнер посчитал, что это слишком часто абузят. Я не считаю это проблемой.

## Changelog

:cl:
code: теперь снова можно отрубать голову острым оружием при обычном ударе
/:cl: