### PR TITLE
Destroy NRP vehicles

### DIFF
--- a/modular_bandastation/balance/_balance.dm
+++ b/modular_bandastation/balance/_balance.dm
@@ -1,0 +1,4 @@
+/datum/modpack/balance
+	name = "Изменение баланса"
+	desc = "Любые изменения баланса идут сюда"
+	author = "larentoun"

--- a/modular_bandastation/balance/_balance.dme
+++ b/modular_bandastation/balance/_balance.dme
@@ -1,0 +1,3 @@
+#include "_balance.dm"
+
+#include "code/balance_riding.dm"

--- a/modular_bandastation/balance/code/balance_riding.dm
+++ b/modular_bandastation/balance/code/balance_riding.dm
@@ -1,12 +1,14 @@
 #define TG_SPEED 1.5
+#define RP_SPEED CONFIG_GET(number/movedelay/run_delay)
 
 /datum/component/riding/Initialize(mob/living/riding_mob, force, buckle_mob_flags, potion_boost)
 	. = ..()
 	if(. == COMPONENT_INCOMPATIBLE)
 		return
 	if(vehicle_move_delay == 0)
-		vehicle_move_delay = round(max(CONFIG_GET(number/movedelay/run_delay) - TG_SPEED, 0) * TG_SPEED, 0.01)
+		vehicle_move_delay = round(max(RP_SPEED - TG_SPEED, 0) * TG_SPEED, 0.01)
 		return
-	vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) / TG_SPEED * vehicle_move_delay, 0.01)
+	vehicle_move_delay = round(RP_SPEED / TG_SPEED * vehicle_move_delay, 0.01)
 
 #undef TG_SPEED
+#undef RP_SPEED

--- a/modular_bandastation/balance/code/balance_riding.dm
+++ b/modular_bandastation/balance/code/balance_riding.dm
@@ -5,7 +5,7 @@
 	if(. == COMPONENT_INCOMPATIBLE)
 		return
 	if(vehicle_move_delay == 0)
-		vehicle_move_delay = max(CONFIG_GET(number/movedelay/run_delay) - TG_SPEED, 0) * TG_SPEED
+		vehicle_move_delay = round(max(CONFIG_GET(number/movedelay/run_delay) - TG_SPEED, 0) * TG_SPEED, 0.01)
 		return
 	vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) / TG_SPEED * vehicle_move_delay, 0.01)
 

--- a/modular_bandastation/balance/code/balance_riding.dm
+++ b/modular_bandastation/balance/code/balance_riding.dm
@@ -5,7 +5,7 @@
 	if(. == COMPONENT_INCOMPATIBLE)
 		return
 	if(vehicle_move_delay == 0)
-		vehicle_move_delay = max(CONFIG_GET(number/movedelay/run_delay) - TG_SPEED, 0)
+		vehicle_move_delay = max(CONFIG_GET(number/movedelay/run_delay) - TG_SPEED, 0) * TG_SPEED
 		return
 	vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) / TG_SPEED * vehicle_move_delay, 0.01)
 

--- a/modular_bandastation/balance/code/balance_riding.dm
+++ b/modular_bandastation/balance/code/balance_riding.dm
@@ -1,0 +1,12 @@
+#define TG_SPEED 1.5
+
+/datum/component/riding/Initialize(mob/living/riding_mob, force, buckle_mob_flags, potion_boost)
+	. = ..()
+	if(. == COMPONENT_INCOMPATIBLE)
+		return
+	if(vehicle_move_delay == 0)
+		vehicle_move_delay = max(CONFIG_GET(number/movedelay/run_delay) - TG_SPEED, 0)
+		return
+	vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) / TG_SPEED * vehicle_move_delay, 0.01)
+
+#undef TG_SPEED

--- a/modular_bandastation/modular_bandastation.dme
+++ b/modular_bandastation/modular_bandastation.dme
@@ -8,6 +8,7 @@
 #include "aesthetics/_aesthetics.dme"
 #include "ai_laws/_ai_laws.dme"
 #include "autohiss/_autohiss.dme"
+#include "balance/_balance.dme"
 #include "barsigns/_barsigns.dme"
 #include "communication/_communication.dme"
 //#include "crawl_speed/_crawl_speed.dme" // Fixing floored melee brawl, or first steps to remove RP speed


### PR DESCRIPTION

## About The Pull Request
Теперь все средства передвижения уважают значение конфига.
Средства передвижения, которую имеют мув делей, просто получают модификатор исходя из `МУВ_ДЕЛЕЙ_КОНФИГ / МУВ_ДЕЛЕЙ_ТГ`
Средства передвижения, которые не имеют мув делей, получают разницу `МУВ_ДЕЛЕЙ_КОНФИГ - МУВ_ДЕЛЕЙ_ТГ`

## Changelog
:cl:
balance: NRP vehicles no more
/:cl:
