### PR TITLE
remove \improper from text before capitalize

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -379,6 +379,8 @@
 
 //Returns a string with the first element of the string capitalized.
 /proc/capitalize(t)
+	t = replacetext_char(t, "\improper", "")
+	t = replacetext_char(t, "\proper", "")
 	. = t
 	if(t)
 		. = t[1]

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -379,8 +379,10 @@
 
 //Returns a string with the first element of the string capitalized.
 /proc/capitalize(t)
+	// BANDASTATION EDIT START - Declents
 	t = replacetext_char(t, "\improper", "")
 	t = replacetext_char(t, "\proper", "")
+	// BANDASTATION EDIT END
 	. = t
 	if(t)
 		. = t[1]


### PR DESCRIPTION

## About The Pull Request
Убираем баг при капиталайзе с \improper