### PR TITLE
Improve Icebox detective's office

### DIFF
--- a/_maps/bandastation/automapper/automapper_config.toml
+++ b/_maps/bandastation/automapper/automapper_config.toml
@@ -17,10 +17,18 @@
 # coordinates = [133, 182, 1]
 # trait_name = "Station"
 
-# Зона кекипажа
+# CentCom Crew Quarters
 [templates.CentCom_kekypaj]
 map_files = ["CentCom.dmm"]
 directory = "_maps/bandastation/automapper/templates/centcom/"
 required_map = "builtin"
 coordinates = [12, 53, 1]
 trait_name = "CentCom"
+
+# IceBoxStation Detective's Office
+[templates.iceboxstation_detective_office]
+map_files = ["iceboxstation_detective_office.dmm"]
+directory = "_maps/bandastation/automapper/templates/iceboxstation/"
+required_map = "IceBoxStation.dmm"
+coordinates = [86, 161, 2]
+trait_name = "Station"

--- a/_maps/bandastation/automapper/templates/iceboxstation/iceboxstation_detective_office.dmm
+++ b/_maps/bandastation/automapper/templates/iceboxstation/iceboxstation_detective_office.dmm
@@ -1,0 +1,268 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/closed/wall/r_wall,
+/area/station/security/detectives_office)
+"c" = (
+/obj/structure/rack,
+/obj/item/storage/briefcase,
+/obj/item/camera/detective,
+/obj/item/taperecorder{
+	pixel_x = -5
+	},
+/obj/structure/cable,
+/obj/structure/detectiveboard/directional/west,
+/turf/open/floor/carpet,
+/area/station/security/detectives_office)
+"e" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/machinery/computer/records/medical,
+/turf/open/floor/iron/grimy,
+/area/station/security/detectives_office)
+"g" = (
+/obj/machinery/vending/wardrobe/det_wardrobe,
+/turf/open/floor/iron/grimy,
+/area/station/security/detectives_office)
+"j" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/table/wood,
+/obj/machinery/fax{
+	fax_name = "Detective's Office";
+	name = "Detective's Fax Machine"
+	},
+/turf/open/floor/carpet,
+/area/station/security/detectives_office)
+"l" = (
+/turf/template_noop,
+/area/template_noop)
+"m" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "detective_shutters";
+	name = "Privacy Shutters"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/detectives_office)
+"o" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/obj/effect/landmark/start/detective,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet,
+/area/station/security/detectives_office)
+"q" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/turf/open/floor/plating,
+/area/station/security/detectives_office)
+"r" = (
+/obj/structure/closet/secure_closet/detective,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/station/security/detectives_office)
+"t" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/hollow/reinforced/middle{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/security/detectives_office)
+"v" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Security - Detective's Office"
+	},
+/obj/machinery/computer/records/security,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/grimy,
+/area/station/security/detectives_office)
+"y" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/grimy,
+/area/station/security/detectives_office)
+"z" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/grimy,
+/area/station/security/detectives_office)
+"B" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin/carbon{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/cup/glass/bottle/whiskey{
+	pixel_x = 9;
+	pixel_y = 7
+	},
+/obj/item/hand_labeler{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/lighter{
+	pixel_x = 8;
+	pixel_y = -9
+	},
+/obj/machinery/button/door/directional/south{
+	id = "detective_shutters";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/carpet,
+/area/station/security/detectives_office)
+"D" = (
+/obj/machinery/light_switch/directional/south,
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/station/security/detectives_office)
+"E" = (
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/station/security/detectives_office)
+"F" = (
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/grimy,
+/area/station/security/detectives_office)
+"H" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/grimy,
+/area/station/security/detectives_office)
+"I" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/evidence{
+	pixel_y = -5;
+	pixel_x = -2
+	},
+/turf/open/floor/carpet,
+/area/station/security/detectives_office)
+"J" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron/grimy,
+/area/station/security/detectives_office)
+"P" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/grimy,
+/area/station/security/detectives_office)
+"U" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/security{
+	name = "Detective's Office"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/security/detective,
+/turf/open/floor/iron/grimy,
+/area/station/security/detectives_office)
+"V" = (
+/obj/machinery/photocopier,
+/turf/open/floor/carpet,
+/area/station/security/detectives_office)
+"X" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/station/security/detectives_office)
+"Y" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/grimy,
+/area/station/security/detectives_office)
+"Z" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/security/wooden_tv,
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/grimy,
+/area/station/security/detectives_office)
+
+(1,1,1) = {"
+l
+a
+t
+t
+t
+a
+l
+"}
+(2,1,1) = {"
+a
+a
+y
+r
+V
+a
+a
+"}
+(3,1,1) = {"
+a
+Z
+z
+E
+E
+c
+q
+"}
+(4,1,1) = {"
+a
+e
+Y
+X
+o
+D
+a
+"}
+(5,1,1) = {"
+a
+v
+z
+j
+I
+B
+a
+"}
+(6,1,1) = {"
+a
+g
+J
+H
+P
+F
+a
+"}
+(7,1,1) = {"
+a
+a
+m
+U
+m
+a
+a
+"}


### PR DESCRIPTION
## About The Pull Request
Добавляет принтер, расширяет офис на 1 тайл по вертикали, починил кнопки шаттеров, которые не работали у оффов (хдд), немного переставил машинерию согласно стандартам маппинга.

### До:

![image](https://github.com/user-attachments/assets/6bb72fc9-a71d-4108-91c2-6162cf8d1570)

### После:

![image](https://github.com/user-attachments/assets/d8f3ba88-fac3-4daa-8411-facdc55a5fe4)
