### PR TITLE
Fix: interview webhooh wrong arg

### DIFF
--- a/modular_bandastation/whitelist220/code/whitelist220.dm
+++ b/modular_bandastation/whitelist220/code/whitelist220.dm
@@ -52,7 +52,7 @@
 
 /datum/interview_manager/enqueue(datum/interview/to_queue)
 	. = ..()
-	send_interview_webhook(src, "New interview enqueued:")
+	send_interview_webhook(to_queue, "New interview enqueued:")
 
 /datum/interview/deny(client/denied_by)
 	. = ..()


### PR DESCRIPTION
Вот би проверку типов, дааааа. А ведь это есть в опендриме