### PR TITLE
add space after LOOC prefix

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -152,7 +152,7 @@
 		chat_color_name_to_use = target.get_visible_name(add_id_name = FALSE) // use face name for nonverbal messages
 	// Bandastation Edit Start
 	else if (extra_classes.Find("looc"))
-		LAZYADD(prefixes, "<span style='font-size: 6px; color: #6699cc;'><b>\[LOOC\]</b></span>")
+		LAZYADD(prefixes, "<span style='font-size: 6px; color: #6699cc;'><b>\[LOOC\]</b></span> ")
 	// Bandastation Edit End
 
 	if(isnull(chat_color_name_to_use))


### PR DESCRIPTION
## About The Pull Request

Добавлен пробел после LOOC префикса в runechat

## Why It's Good For The Game

Более читабельный LOOC runechat

## Changelog


:cl:
add: Добавлен пробел после LOOC префикса в runechat
/:cl:

