### PR TITLE
adds vote for crew transfer and automatic crew transfer subsystem

### DIFF
--- a/config/bandastation/bandastation_config.txt
+++ b/config/bandastation/bandastation_config.txt
@@ -18,3 +18,15 @@
 #MIN_THREAT_TO_ROUNDSTART_PERCENT 30
 #MAX_THREAT_TO_ROUNDSTART_PERCENT 60
 #MIN_THREAT_LEVEL 20
+
+
+## Automatic crew transfer
+
+## Time after the roundstart the automatic crew transfer will run. 1.5 hours by default
+#AUTOMATIC_CREW_TRANSFER_VOTE_DELAY 54000
+## Time the automatic crew transfer vote will automatically run after if previous one not passed. 30 minutes by default
+#AUTOMATIC_CREW_TRANSFER_VOTE_INTERVAL 18000
+## If players are able to create crew transfer vote
+#ALLOW_CREW_TRANSFER_VOTE
+## If automatic crew transfer is enabled
+#ENABLE_AUTOMATIC_CREW_TRANSFER

--- a/modular_bandastation/automatic_crew_transfer/_automatic_crew_transfer.dm
+++ b/modular_bandastation/automatic_crew_transfer/_automatic_crew_transfer.dm
@@ -1,4 +1,4 @@
 /datum/modpack/automatic_crew_transfer
 	name = "Automatic Crew Transfer"
-	desc = "Добавляет автотическое голосование за завершение раунда посредством вызова шаттла"
+	desc = "Добавляет автоматическое голосование за завершение раунда посредством вызова шаттла."
 	author = "gaxeer"

--- a/modular_bandastation/automatic_crew_transfer/_automatic_crew_transfer.dm
+++ b/modular_bandastation/automatic_crew_transfer/_automatic_crew_transfer.dm
@@ -1,0 +1,4 @@
+/datum/modpack/automatic_crew_transfer
+	name = "Automatic Crew Transfer"
+	desc = "Добавляет автотическое голосование за завершение раунда посредством вызова шаттла"
+	author = "gaxeer"

--- a/modular_bandastation/automatic_crew_transfer/_automatic_crew_transfer.dme
+++ b/modular_bandastation/automatic_crew_transfer/_automatic_crew_transfer.dme
@@ -1,0 +1,5 @@
+#include "_automatic_crew_transfer.dm"
+
+#include "code/crew_tranfer_vote.dm"
+#include "code/automatic_transfer_subsystem.dm"
+#include "code/automatic_transfer_configuration.dm"

--- a/modular_bandastation/automatic_crew_transfer/code/automatic_transfer_configuration.dm
+++ b/modular_bandastation/automatic_crew_transfer/code/automatic_transfer_configuration.dm
@@ -1,0 +1,13 @@
+/datum/config_entry/number/automatic_crew_transfer_vote_delay
+	default = 54000
+	min_val = 18000
+
+/datum/config_entry/number/automatic_crew_transfer_vote_interval
+	default = 18000
+	min_val = 9000
+
+/datum/config_entry/flag/allow_crew_transfer_vote
+	default = TRUE
+
+/datum/config_entry/flag/enable_automatic_crew_transfer
+	default = TRUE

--- a/modular_bandastation/automatic_crew_transfer/code/automatic_transfer_subsystem.dm
+++ b/modular_bandastation/automatic_crew_transfer/code/automatic_transfer_subsystem.dm
@@ -1,0 +1,33 @@
+SUBSYSTEM_DEF(automatic_transfer)
+	name = "Automatic Transfer"
+	flags = SS_NO_FIRE
+	runlevels = RUNLEVEL_SETUP | RUNLEVEL_GAME
+	/// Id of planned crew transfer timer
+	var/crew_transfer_timer_id
+
+/datum/controller/subsystem/automatic_transfer/Initialize()
+	if(CONFIG_GET(flag/enable_automatic_crew_transfer))
+		setup_automatic_crew_transfer()
+
+	return SS_INIT_SUCCESS
+
+/datum/controller/subsystem/automatic_transfer/proc/plan_crew_transfer_vote(delay = CONFIG_GET(number/automatic_crew_transfer_vote_interval))
+	if(!CONFIG_GET(flag/enable_automatic_crew_transfer))
+		return
+
+	if(!crew_transfer_timer_id)
+		crew_transfer_timer_id = addtimer(CALLBACK(src, PROC_REF(start_crew_transfer_vote)), delay)
+
+/datum/controller/subsystem/automatic_transfer/proc/setup_automatic_crew_transfer()
+	PRIVATE_PROC(TRUE)
+
+	if(SSticker.current_state < GAME_STATE_PLAYING)
+		RegisterSignal(SSticker, COMSIG_TICKER_ROUND_STARTING, PROC_REF(plan_crew_transfer_vote), CONFIG_GET(number/automatic_crew_transfer_vote_delay))
+	else if(SSticker.current_state == GAME_STATE_PLAYING)
+		plan_crew_transfer_vote(max(0,  CONFIG_GET(number/automatic_crew_transfer_vote_delay) - (world.time - SSticker.round_start_time)))
+
+/datum/controller/subsystem/automatic_transfer/proc/start_crew_transfer_vote()
+	PRIVATE_PROC(TRUE)
+
+	SSvote.initiate_vote(/datum/vote/crew_transfer, "Automatic Crew Transfer", forced = TRUE)
+	crew_transfer_timer_id = null

--- a/modular_bandastation/automatic_crew_transfer/code/crew_tranfer_vote.dm
+++ b/modular_bandastation/automatic_crew_transfer/code/crew_tranfer_vote.dm
@@ -1,0 +1,52 @@
+#define CHOICE_INITIATE_CREW_TRANSFER "Initiate Crew Transfer"
+#define CHOICE_CONTINUE "Continue Playing"
+
+/datum/vote/crew_transfer
+	name = "Crew Transfer"
+	default_choices = list(
+		CHOICE_INITIATE_CREW_TRANSFER,
+		CHOICE_CONTINUE,
+	)
+	default_message = "Голосование за вызов шаттла"
+
+/datum/vote/crew_transfer/toggle_votable()
+	CONFIG_SET(flag/allow_crew_transfer_vote, !CONFIG_GET(flag/allow_crew_transfer_vote))
+
+/datum/vote/crew_transfer/is_config_enabled()
+	return CONFIG_GET(flag/allow_crew_transfer_vote)
+
+/datum/vote/crew_transfer/can_be_initiated(forced)
+	. = ..()
+	if(. != VOTE_AVAILABLE)
+		return .
+
+	switch(SSticker.current_state)
+		if(GAME_STATE_PLAYING)
+			return VOTE_AVAILABLE
+		if(GAME_STATE_FINISHED)
+			return "Game already finished."
+		else
+			return "Game not started yet."
+
+/datum/vote/crew_transfer/finalize_vote(winning_option)
+	SSautomatic_transfer.plan_crew_transfer_vote()
+	if(winning_option == CHOICE_CONTINUE)
+		return
+
+	if(winning_option == CHOICE_INITIATE_CREW_TRANSFER)
+		initiate_tranfer()
+
+	CRASH("[type] wasn't passed a valid winning choice. (Got: [winning_option || "null"])")
+
+/datum/vote/crew_transfer/proc/initiate_tranfer()
+	PRIVATE_PROC(TRUE)
+
+	SSshuttle.admin_emergency_no_recall = TRUE
+	SSshuttle.emergency.mode = SHUTTLE_IDLE
+	SSshuttle.emergency.request(reason = " Автоматическое окончание смены")
+
+	log_admin("Shuttle called due to automatic crew transfer vote.")
+	message_admins(span_adminnotice("Shuttle called due to automatic crew transfer vote."))
+
+#undef CHOICE_INITIATE_CREW_TRANSFER
+#undef CHOICE_CONTINUE

--- a/modular_bandastation/modular_bandastation.dme
+++ b/modular_bandastation/modular_bandastation.dme
@@ -37,4 +37,5 @@
 #include "jukebox/_jukebox.dme"
 #include "objects/_objects.dme"
 #include "orderables/_orderables.dme"
+#include "automatic_crew_transfer/_automatic_crew_transfer.dme"
 #include "overrides/_overrides.dme"


### PR DESCRIPTION
## About The Pull Request

Добавляет голосование за автоматическое завершение смены - шаттл невозможно будет отозвать без админского вмешательства.
Так же добавляет сабсистему которая будет запускать это голосование автоматически по истечению определенного времени в раунде - 1.5 часа по умолчанию. Интервал запуска повторного голосования после неудачного голосования - 30 минут по умолчанию.

## Why It's Good For The Game

Игроки смогут гармонично завершать раунд.

## Changelog

:cl:
add: Голосование за автоматическое завершение смены
add: Система которая запускает автоматическое голосование по истечению определенного времени в раунде
/:cl: