### PR TITLE
simplify `automatic_transfer_subsystem` by removing timer usage

### DIFF
--- a/modular_bandastation/automatic_crew_transfer/code/crew_tranfer_vote.dm
+++ b/modular_bandastation/automatic_crew_transfer/code/crew_tranfer_vote.dm
@@ -29,7 +29,6 @@
 			return "Game not started yet."
 
 /datum/vote/crew_transfer/finalize_vote(winning_option)
-	SSautomatic_transfer.plan_crew_transfer_vote()
 	switch(winning_option)
 		if(CHOICE_CONTINUE)
 			return


### PR DESCRIPTION
## About The Pull Request

simplify `automatic_transfer_subsystem` by removing timer usage

## Why It's Good For The Game

Автоматический крю трансфер будет работать более стабильно, и код проще, как для такой простой системы.

## Changelog
:cl:
code: Упрощен код `automatic_transfer_subsystem`
/:cl:
