### PR TITLE
add proper lobby/round time to ESC menu

### DIFF
--- a/code/modules/escape_menu/details.dm
+++ b/code/modules/escape_menu/details.dm
@@ -34,7 +34,7 @@ GLOBAL_DATUM(escape_menu_details, /atom/movable/screen/escape_menu/details)
 	var/new_maptext = {"
 		<span style='text-align: right; line-height: 0.7'>
 			Round ID: [GLOB.round_id || "Unset"]<br />
-			Round Time: [ROUND_TIME()]<br />
+			[SSticker.round_start_time ? "Round Time" : "Lobby Time"]: [STATION_TIME_PASSED() > MIDNIGHT_ROLLOVER ? "[round(STATION_TIME_PASSED() / MIDNIGHT_ROLLOVER)]:[gameTimestamp(wtime = STATION_TIME_PASSED())]" : gameTimestamp(wtime = STATION_TIME_PASSED())]<br />
 			Map: [SSmapping.current_map.map_name || "Loading..."]<br />
 			Time Dilation: [round(SStime_track.time_dilation_current,1)]%<br />
 		</span>


### PR DESCRIPTION
## About The Pull Request

В ESC меню правильно показывает lobby/round time

## Why It's Good For The Game

Понятно когда раунд начался. Теперь и в ESC меню

## Changelog

:cl:
fix: В ESC меню правильно показывает lobby/round time
/:cl:
