### PR TITLE
Change MediaWiki api link and scale AutoWiki icons

### DIFF
--- a/code/modules/autowiki/pages/base.dm
+++ b/code/modules/autowiki/pages/base.dm
@@ -50,7 +50,11 @@
 	if(uploaded_icons["[name]"])
 		CRASH("We tried uploading an icon, but the name \"[name]\" was already taken!")
 
-	fcopy(icon, "data/autowiki_files/[name].png")
+	// BANDASTATION EDIT - START
+	var/icon/scaled_icon = icon
+	scaled_icon.Scale(64, 64)
+	fcopy(scaled_icon, "data/autowiki_files/[name].png") // icon -> scaled_icon
+	// BANDASTATION EDIT - END
 	uploaded_icons["[name]"] = TRUE
 
 /// Escape a parameter such that it can be correctly put inside a wiki output

--- a/tools/autowiki/autowiki.js
+++ b/tools/autowiki/autowiki.js
@@ -36,7 +36,7 @@ async function main() {
 	const bot = new MWBot()
 
 	await bot.loginGetEditToken({
-		apiUrl: "https://tgstation13.org/wiki/api.php",
+		apiUrl: "https://tg.ss220.club/api.php",
 		username: USERNAME,
 		password: PASSWORD,
 	})


### PR DESCRIPTION
Меняет ссылку на апи с оффовского вики на наше.
Автовики не будет работать пока @larentoun или хэдэдэ, не добавят в сикреты репы, логин и пароль аккаунта

Запустил автовики со своей репы, [работает](https://tg.ss220.club/index.php/%D0%A1%D0%BB%D1%83%D0%B6%D0%B5%D0%B1%D0%BD%D0%B0%D1%8F:%D0%92%D0%BA%D0%BB%D0%B0%D0%B4/AutoWiki220)