### PR TITLE
Fix painted windows overlay

### DIFF
--- a/modular_bandastation/aesthetics/windows/code/full_tile_windows.dm
+++ b/modular_bandastation/aesthetics/windows/code/full_tile_windows.dm
@@ -11,7 +11,7 @@
 	if(!edge_overlay_file)
 		return
 
-	edge_overlay = mutable_appearance(edge_overlay_file, "[smoothing_junction]", layer + 0.1, appearance_flags = RESET_COLOR)
+	edge_overlay = mutable_appearance(edge_overlay_file, "[smoothing_junction]", layer + 0.1, appearance_flags = RESET_COLOR|KEEP_APART)
 	. += edge_overlay
 
 /obj/structure/window/fulltile


### PR DESCRIPTION
## Что этот PR делает
Добавил ещё один флаг для оверлея рамок у окон
Какого-то хера одного перестало хватать, и рамки начали краситься

## Почему это хорошо для игры
Краситься должны только окна

## Изображения изменений
![image](https://github.com/user-attachments/assets/84b4e01d-04bd-46e1-8514-f992148eb1a2)

## Тестирование
Выше скрин

## Changelog

:cl:
Это не работает
/:cl:
