### PR TITLE
Изменения бара

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -564,6 +564,11 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"ahK" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "ahO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -4657,6 +4662,14 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/wood,
 /area/station/service/kitchen/abandoned)
+"bkf" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/station/engineering/break_room)
 "bkh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -7575,6 +7588,13 @@
 	},
 /turf/open/openspace,
 /area/station/science/xenobiology)
+"bWX" = (
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/white,
+/area/station/science/explab)
 "bXd" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -12222,6 +12242,7 @@
 /obj/machinery/chem_dispenser/drinks{
 	pixel_y = 8
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "dcn" = (
@@ -13717,6 +13738,7 @@
 /area/station/maintenance/ghetto/fore/starboard)
 "duY" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "duZ" = (
@@ -14734,6 +14756,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "dJx" = (
@@ -19506,6 +19529,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"eXh" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/hfr_room)
 "eXj" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
@@ -19985,6 +20013,7 @@
 /obj/machinery/recharger{
 	pixel_y = 2
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "fdV" = (
@@ -20662,6 +20691,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/wood,
 /area/station/command/meeting_room/council)
 "fmN" = (
@@ -24806,6 +24836,7 @@
 "gpZ" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light/directional/east,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "gqk" = (
@@ -28901,6 +28932,19 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/science/ordnance)
+"hvT" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "hvU" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -29110,6 +29154,7 @@
 "hyE" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/pdapainter/security,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "hyG" = (
@@ -33647,6 +33692,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"iIp" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "iIx" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
@@ -34829,6 +34881,7 @@
 /obj/effect/turf_decal/tile/purple/anticorner{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "iXT" = (
@@ -36626,6 +36679,8 @@
 /obj/structure/table/reinforced,
 /obj/item/gun/energy/laser/practice,
 /obj/machinery/recharger,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/item/gun/energy/laser/carbine/practice,
 /turf/open/floor/iron,
 /area/station/security/range)
 "jxN" = (
@@ -37932,6 +37987,10 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
+"jON" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/gravity_generator)
 "jPb" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
@@ -38662,7 +38721,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "jYC" = (
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/inverse{
+/obj/machinery/atmospherics/components/trinary/mixer/airmix{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -41025,6 +41084,7 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "kCY" = (
@@ -41069,6 +41129,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "kDn" = (
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/stairs/left,
 /area/station/security/brig)
 "kDq" = (
@@ -41966,6 +42027,13 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/fore/starboard)
+"kMh" = (
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/station/science/lab)
 "kMk" = (
 /obj/effect/turf_decal/tile/dark_green/fourcorners,
 /obj/effect/decal/cleanable/dirt,
@@ -42799,6 +42867,7 @@
 	},
 /obj/structure/table,
 /obj/machinery/light/directional/west,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/wood/tile,
 /area/station/service/lawoffice)
 "kXD" = (
@@ -42856,6 +42925,13 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"kYl" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/wood,
+/area/station/service/library/upper)
 "kYn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -43783,6 +43859,7 @@
 	},
 /mob/living/basic/pet/cat/runtime,
 /obj/item/toy/cattoy,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "lmG" = (
@@ -44148,6 +44225,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "lqn" = (
@@ -46253,6 +46331,7 @@
 /area/station/service/hydroponics)
 "lRk" = (
 /obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "lRl" = (
@@ -46610,6 +46689,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "lWi" = (
@@ -48175,6 +48255,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "mtm" = (
@@ -53872,9 +53953,6 @@
 /area/station/maintenance/ghetto/fore/starboard)
 "nSw" = (
 /obj/structure/table/reinforced,
-/obj/structure/sign/picture_frame/portrait/bar{
-	pixel_y = 28
-	},
 /obj/machinery/button/door/directional/west{
 	id = "viplounge_bolt";
 	name = "ViP Bolt Control";
@@ -53895,7 +53973,6 @@
 	pixel_x = -6;
 	pixel_y = 2
 	},
-/obj/machinery/light/directional/north,
 /obj/item/reagent_containers/cup/glass/shaker{
 	pixel_x = -6;
 	pixel_y = 6
@@ -53904,6 +53981,7 @@
 	pixel_x = 6;
 	pixel_y = 2
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "nSA" = (
@@ -54356,6 +54434,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "nYk" = (
@@ -55880,6 +55959,7 @@
 	pixel_y = 6
 	},
 /obj/item/gavelhammer,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/wood/tile,
 /area/station/service/lawoffice)
 "oso" = (
@@ -56125,6 +56205,13 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
+"ovm" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/security/lockers)
 "ovo" = (
 /obj/structure/toilet{
 	dir = 8
@@ -58126,6 +58213,13 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
+"oWz" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "oWA" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
@@ -60812,6 +60906,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "pGg" = (
@@ -63378,6 +63473,7 @@
 /obj/structure/chair/sofa/bench/left{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/station/security/processing)
 "qpb" = (
@@ -65693,6 +65789,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "qUM" = (
@@ -69350,6 +69447,7 @@
 /obj/machinery/disposal/bin,
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/purple/anticorner,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "rUF" = (
@@ -71959,6 +72057,7 @@
 /obj/item/gun/energy/laser/practice,
 /obj/machinery/recharger,
 /obj/machinery/firealarm/directional/east,
+/obj/item/gun/energy/laser/carbine/practice,
 /turf/open/floor/iron,
 /area/station/security/range)
 "sCc" = (
@@ -76311,6 +76410,7 @@
 /area/station/service/library/artgallery)
 "tJN" = (
 /obj/structure/rack,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "tJP" = (
@@ -76718,6 +76818,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "tOz" = (
@@ -79710,7 +79811,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/prison/ghetto)
 "uFl" = (
-/obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -79840,6 +79940,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
+"uHu" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron,
+/area/station/engineering/hallway)
 "uHz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -82351,6 +82458,7 @@
 	},
 /obj/machinery/light/directional/north,
 /obj/effect/landmark/start/security_officer,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/station/security/office)
 "voK" = (
@@ -86834,6 +86942,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
+"wxo" = (
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/engineering/hallway/west)
 "wxr" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/effect/turf_decal/bot,
@@ -87866,6 +87979,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
+"wJN" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/project)
 "wJQ" = (
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 8
@@ -91692,7 +91810,7 @@
 /area/station/maintenance/starboard/aft)
 "xKI" = (
 /obj/machinery/vending/boozeomat,
-/obj/machinery/status_display/evac/directional/north,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "xKS" = (
@@ -91858,6 +91976,7 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/engineering/atmos)
 "xMK" = (
@@ -93072,6 +93191,9 @@
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/drinks/beer{
 	pixel_y = 8
+	},
+/obj/structure/sign/picture_frame/portrait/bar{
+	pixel_y = 28
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
@@ -184935,7 +185057,7 @@ bvX
 fur
 lWI
 poj
-fur
+wxo
 nXQ
 awU
 lvd
@@ -186743,7 +186865,7 @@ iyg
 sCQ
 bIS
 awU
-eZH
+hvT
 vfD
 jGU
 dRl
@@ -186878,7 +187000,7 @@ nRr
 yfC
 lAJ
 cEj
-xqz
+iIp
 dww
 sbI
 sEo
@@ -187489,7 +187611,7 @@ xBM
 xBM
 vBz
 vBz
-opB
+uHu
 eel
 hZh
 qrA
@@ -191236,7 +191358,7 @@ eMs
 cqN
 aSA
 ufm
-kBS
+ovm
 kBS
 kBS
 kBS
@@ -192889,7 +193011,7 @@ lmL
 nVO
 vNG
 cpe
-kGp
+bkf
 kGp
 kGp
 kGp
@@ -195455,7 +195577,7 @@ hpN
 doz
 qCU
 qzA
-bWk
+jON
 eAk
 qCU
 pbo
@@ -195487,7 +195609,7 @@ bSj
 aow
 dJG
 dNx
-qub
+eXh
 akp
 job
 kJd
@@ -196496,7 +196618,7 @@ cnU
 dQJ
 eRa
 oQf
-dQP
+wJN
 aXv
 gXr
 koW
@@ -201071,7 +201193,7 @@ qze
 nPb
 pdc
 kds
-fVJ
+oWz
 fVJ
 uvq
 yeD
@@ -204657,7 +204779,7 @@ nEe
 fnB
 fWn
 iXT
-tBF
+kYl
 pXZ
 qIV
 iur
@@ -205465,7 +205587,7 @@ hZc
 aqm
 dNa
 axZ
-vun
+bWX
 jvh
 lXy
 cZo
@@ -207252,7 +207374,7 @@ aZf
 qIF
 qIF
 sVl
-qIF
+ahK
 qIF
 sSW
 vVN
@@ -209290,7 +209412,7 @@ frw
 qkC
 ord
 dzT
-mTH
+kMh
 drZ
 tbp
 fgd

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -3437,11 +3437,11 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/captain)
 "aTN" = (
-/obj/structure/table/glass,
 /obj/item/taperecorder{
 	pixel_x = -6;
 	pixel_y = 4
 	},
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/light{
 	icon_state = "light_on-7";
 	state = 7;
@@ -7920,6 +7920,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "cbm" = (
@@ -20754,10 +20755,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/south)
 "fnW" = (
-/obj/structure/table/glass,
 /obj/item/toy/cards/deck{
 	pixel_y = 4
 	},
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/light{
 	icon_state = "light_on-7";
 	state = 7;
@@ -21328,6 +21329,7 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "fwa" = (
@@ -27627,7 +27629,7 @@
 /turf/open/floor/wood,
 /area/station/security/courtroom)
 "hfy" = (
-/obj/structure/table/glass,
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/light{
 	icon_state = "light_on-7";
 	state = 7;
@@ -47541,8 +47543,8 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "miT" = (
-/obj/structure/table/glass,
 /obj/item/storage/dice,
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/light{
 	icon_state = "light_on-7";
 	state = 7;
@@ -68488,8 +68490,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "rHD" = (
-/obj/structure/table/glass,
 /obj/item/clothing/head/utility/hardhat/cakehat,
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/light{
 	icon_state = "light_on-7";
 	state = 7;


### PR DESCRIPTION
## Что этот PR делает
Добавлен доступ бармена к повару и наоборот, стеклянные столы заменены на укрепленные из-за Пун-Пун момент.

## Почему это хорошо для игры

Пун-Пун не будет ломать столы из-за бешенства, повар и бармен смогут заходить друг к другу.

## Изображения изменений

![StrongDMM-2024-12-22 20 29 13](https://github.com/user-attachments/assets/df593f46-f25d-4ebc-9a98-6eef51c84c64)
![StrongDMM-2024-12-22 20 28 28](https://github.com/user-attachments/assets/af879109-1a50-4a68-80a1-195e6df50fa9)

## Changelog

:cl:
add: Доступ повара в бар и бармена к повару, больше огнетушителей в отделы, practice laser carbine в тренировочную комнату СБ
tweak: Стеклянные столы на укрепленные стеклянные столы, миксер в атмосе на правильный
/:cl:
