### PR TITLE
Cyberiad: Move firelocks on stairs between z-levels down

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -329,7 +329,7 @@
 /obj/structure/table/wood,
 /obj/item/folder/yellow,
 /obj/item/pen,
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/station/service/library)
 "afI" = (
 /obj/machinery/camera/directional/east{
@@ -2726,6 +2726,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/south)
 "aJS" = (
@@ -3754,6 +3757,9 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/prison)
 "aXn" = (
@@ -4165,9 +4171,6 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
 	},
@@ -4242,7 +4245,6 @@
 /area/station/medical/medbay)
 "bdp" = (
 /obj/structure/railing,
-/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "bdx" = (
@@ -5917,6 +5919,12 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "bAH" = (
@@ -7370,7 +7378,6 @@
 /area/station/maintenance/ghetto/central)
 "bSU" = (
 /obj/structure/railing/corner,
-/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/service/chapel/monastery)
 "bSX" = (
@@ -8897,9 +8904,6 @@
 "cma" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -12664,6 +12668,9 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "dhI" = (
@@ -15115,6 +15122,7 @@
 "dMc" = (
 /obj/structure/railing,
 /obj/structure/chair,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "dMl" = (
@@ -16090,7 +16098,7 @@
 /area/station/maintenance/ghetto/port)
 "eal" = (
 /obj/machinery/light/small/directional/east,
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -16752,9 +16760,6 @@
 	dir = 8
 	},
 /obj/effect/spawner/random/trash/garbage,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "eiu" = (
@@ -18414,6 +18419,12 @@
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/station/service/library)
 "eHu" = (
@@ -18916,6 +18927,7 @@
 /area/station/maintenance/ghetto/port/aft)
 "eOB" = (
 /obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
 "eOK" = (
@@ -19507,6 +19519,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood,
 /area/station/service/library/upper)
 "eWs" = (
@@ -19656,10 +19669,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/aft)
-"eYA" = (
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "eYB" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/purple{
@@ -20080,15 +20089,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
-"fep" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
 "fer" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -20603,7 +20603,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -22160,15 +22160,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/abandoned)
-"fFH" = (
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/ordnance/office)
 "fFP" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -23593,6 +23584,7 @@
 "fXV" = (
 /obj/structure/railing,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/port/aft)
 "fYg" = (
@@ -25671,6 +25663,18 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/security/ghetto/north)
+"gCa" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/prison)
 "gCn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -26150,6 +26154,9 @@
 	dir = 1
 	},
 /obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -27063,6 +27070,9 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/south)
 "gTc" = (
@@ -27202,9 +27212,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -28569,7 +28576,6 @@
 /obj/structure/cable,
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor/border_only,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4
 	},
@@ -29286,9 +29292,6 @@
 /area/station/cargo/drone_bay)
 "hxo" = (
 /obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -30191,6 +30194,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/structure/railing/corner/end/flip{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/corner{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -31385,9 +31391,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "hZK" = (
@@ -31923,9 +31926,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
 "iik" = (
@@ -32116,6 +32116,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "ikz" = (
@@ -34860,6 +34863,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"iTM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/ghetto)
 "iTN" = (
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 8
@@ -36364,6 +36379,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/small,
 /area/station/maintenance/department/security/brig)
 "jow" = (
@@ -37327,6 +37345,7 @@
 /obj/structure/railing,
 /obj/structure/chair,
 /obj/structure/cable,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "jDM" = (
@@ -38225,6 +38244,12 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"jOp" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/service/library/upper)
 "jOr" = (
 /obj/effect/spawner/random/entertainment/arcade{
 	dir = 8
@@ -38720,9 +38745,6 @@
 /turf/open/water,
 /area/station/maintenance/starboard/lesser)
 "jVa" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -39762,9 +39784,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port)
@@ -41004,9 +41023,6 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -41061,7 +41077,6 @@
 "kzt" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
-	pixel_x = -4;
 	pixel_y = 3
 	},
 /turf/open/floor/wood,
@@ -41934,6 +41949,7 @@
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "kIb" = (
@@ -42780,7 +42796,7 @@
 "kSG" = (
 /obj/structure/table/wood,
 /obj/item/book/random,
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/station/service/library)
 "kSS" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -42945,6 +42961,9 @@
 /obj/structure/table,
 /obj/machinery/recharger,
 /obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -43465,6 +43484,9 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "lbY" = (
@@ -43811,6 +43833,7 @@
 "lhC" = (
 /obj/structure/railing,
 /obj/structure/cable,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "lhE" = (
@@ -44826,9 +44849,6 @@
 	},
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /turf/open/openspace,
@@ -45925,6 +45945,8 @@
 /area/station/maintenance/fore)
 "lIz" = (
 /obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/siding/wideplating_new,
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "lIJ" = (
@@ -45992,6 +46014,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"lJM" = (
+/obj/structure/platform/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/service/library)
 "lJY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46792,9 +46820,6 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "lUp" = (
@@ -47914,7 +47939,6 @@
 /obj/structure/cable,
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "min" = (
@@ -48782,10 +48806,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "mvu" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted{
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "mvv" = (
 /obj/structure/closet/secure_closet/personal{
@@ -51124,6 +51151,7 @@
 "naS" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "naU" = (
@@ -51242,6 +51270,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
+"ncw" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/station/service/library)
 "ncF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
@@ -51314,6 +51346,12 @@
 /obj/machinery/digital_clock/directional/east,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"ndS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central)
 "ndV" = (
 /turf/closed/wall,
 /area/station/science/server)
@@ -51636,6 +51674,9 @@
 /obj/structure/railing/corner/end{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "njq" = (
@@ -51647,6 +51688,9 @@
 	},
 /obj/structure/railing/corner{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
@@ -52515,6 +52559,9 @@
 	dir = 8
 	},
 /obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -53661,13 +53708,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
-"nJP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "nKc" = (
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 1
@@ -57833,6 +57873,9 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "oMe" = (
@@ -58980,6 +59023,8 @@
 	dir = 1
 	},
 /obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/siding/wideplating_new,
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "pcX" = (
@@ -59796,6 +59841,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "pnT" = (
@@ -60523,6 +60571,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "pxn" = (
@@ -61044,6 +61095,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "pDf" = (
@@ -61099,7 +61153,8 @@
 "pDX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/wood,
-/turf/open/floor/wood,
+/obj/item/storage/dice,
+/turf/open/floor/carpet,
 /area/station/service/library)
 "pDZ" = (
 /obj/structure/sign/painting/library{
@@ -61785,6 +61840,7 @@
 "pLU" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
 "pLV" = (
@@ -62258,9 +62314,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "pSx" = (
@@ -63471,6 +63524,9 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "qjB" = (
@@ -63649,7 +63705,6 @@
 /area/station/maintenance/department/security/ghetto/south)
 "qmc" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
@@ -64683,9 +64738,8 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/upper)
 "qBo" = (
-/obj/structure/table/wood,
 /obj/machinery/light/directional/west,
-/obj/item/storage/dice,
+/obj/machinery/photocopier,
 /turf/open/floor/wood,
 /area/station/service/library)
 "qBu" = (
@@ -65851,6 +65905,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/railing/corner/end/flip{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/science/ordnance)
@@ -71336,6 +71393,9 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/prison)
 "smf" = (
@@ -71587,6 +71647,9 @@
 	},
 /obj/machinery/light/cold/directional/west,
 /obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/small,
 /area/station/maintenance/department/security/brig)
 "spq" = (
@@ -72002,6 +72065,7 @@
 /obj/structure/railing/corner/end{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wideplating_new/corner,
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "svg" = (
@@ -74541,7 +74605,6 @@
 /area/station/maintenance/port/aft)
 "tgS" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
@@ -75482,6 +75545,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "tra" = (
@@ -76815,6 +76881,9 @@
 "tIz" = (
 /obj/machinery/light/directional/south,
 /obj/structure/railing/corner/end/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/corner{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -78157,7 +78226,6 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/service/chapel/monastery)
 "tZG" = (
@@ -78441,6 +78509,9 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
 "ucY" = (
@@ -78699,9 +78770,6 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
@@ -78816,6 +78884,9 @@
 	},
 /obj/structure/railing/corner/end/flip{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
@@ -79070,9 +79141,6 @@
 	dir = 1
 	},
 /obj/effect/spawner/random/structure/closet_maintenance,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "ull" = (
@@ -79363,6 +79431,9 @@
 /obj/structure/railing/corner/end{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/wideplating_new/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "uqb" = (
@@ -79516,6 +79587,9 @@
 	},
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/maintenance/department/security/brig)
@@ -80132,6 +80206,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -80769,9 +80846,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "uLt" = (
@@ -81114,7 +81188,6 @@
 /obj/structure/cable,
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "uPa" = (
@@ -81677,6 +81750,7 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "uYf" = (
@@ -82170,9 +82244,6 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /turf/open/openspace,
 /area/station/science/xenobiology)
 "vfD" = (
@@ -86068,6 +86139,9 @@
 	},
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/spawner/random/trash/garbage,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/port/aft)
 "wcA" = (
@@ -86218,9 +86292,6 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
@@ -86297,6 +86368,12 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
+"wfQ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port/aft)
 "wfV" = (
 /turf/closed/wall,
 /area/station/service/library)
@@ -86382,7 +86459,6 @@
 /obj/structure/cable,
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "wgK" = (
@@ -87739,6 +87815,12 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"wyX" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/iron,
+/area/station/security/prison)
 "wzc" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_centre,
 /obj/machinery/atmospherics/pipe/multiz/pink/visible{
@@ -88092,6 +88174,7 @@
 /obj/structure/railing/corner/end{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "wCB" = (
@@ -88418,6 +88501,9 @@
 	dir = 4
 	},
 /obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -89015,6 +89101,7 @@
 /area/station/hallway/primary/aft)
 "wNQ" = (
 /obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "wOb" = (
@@ -89083,7 +89170,6 @@
 "wPe" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "wPf" = (
@@ -90447,9 +90533,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "xhv" = (
@@ -91543,7 +91626,7 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
 "xvF" = (
-/obj/structure/stairs/south,
+/obj/structure/stairs/wood,
 /turf/open/floor/wood,
 /area/station/service/library)
 "xvV" = (
@@ -92051,6 +92134,13 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix)
+"xEJ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/wood,
+/area/station/service/library)
 "xEL" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/bot_white,
@@ -93722,7 +93812,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "xZD" = (
-/obj/machinery/photocopier,
+/obj/structure/platform/corner,
 /turf/open/floor/wood,
 /area/station/service/library)
 "xZI" = (
@@ -114236,8 +114326,8 @@ wdM
 sEA
 tzH
 svc
-tYH
-tYH
+iTM
+iTM
 hIM
 lyd
 rgK
@@ -117151,7 +117241,7 @@ mxy
 rmU
 aec
 vBQ
-aec
+wfQ
 awa
 hEk
 rmU
@@ -121761,7 +121851,7 @@ ceC
 mOI
 dlM
 cAn
-dGY
+ndS
 hIr
 aNI
 ePB
@@ -139463,9 +139553,9 @@ lFn
 tin
 geq
 xZD
-wYe
+xEJ
 eHp
-wYe
+lJM
 qdJ
 kDD
 kDD
@@ -139720,7 +139810,7 @@ wfV
 wfV
 wfV
 wfV
-wYe
+ncw
 xvF
 wfV
 qdJ
@@ -141072,7 +141162,7 @@ ocm
 cMA
 uNF
 vnE
-qIR
+tCI
 mvu
 sha
 sha
@@ -178486,7 +178576,7 @@ jPC
 nmb
 xRv
 ksw
-fTu
+wyX
 nUk
 nUk
 nUk
@@ -178743,7 +178833,7 @@ dOf
 fRC
 gjv
 ksw
-fTu
+wyX
 nUk
 nUk
 nUk
@@ -179000,7 +179090,7 @@ jPC
 jPC
 fVs
 bQY
-fTu
+wyX
 nUk
 nUk
 nUk
@@ -179257,7 +179347,7 @@ jpV
 jPC
 jPC
 uBw
-fTu
+wyX
 nUk
 nUk
 nUk
@@ -179514,7 +179604,7 @@ aiD
 oaV
 kLL
 oqj
-fTu
+wyX
 nUk
 nUk
 nUk
@@ -179775,10 +179865,10 @@ xDs
 uBm
 uBm
 njq
-omU
-omU
+gCa
+gCa
 slO
-omU
+gCa
 aXl
 kLL
 nUk
@@ -203452,7 +203542,7 @@ iPQ
 rLi
 bLC
 gnf
-pXZ
+gnf
 dFK
 dFK
 dFK
@@ -205001,7 +205091,7 @@ dFK
 eWq
 fkD
 fkD
-jfe
+jOp
 jfe
 jfe
 uMw
@@ -205761,7 +205851,7 @@ iPQ
 iPQ
 nBv
 dii
-fep
+nBv
 pEB
 gnf
 aGO
@@ -206866,7 +206956,7 @@ xJd
 erN
 qMG
 wJW
-nJP
+foW
 cuq
 cuq
 vfv
@@ -210673,7 +210763,7 @@ fjY
 xth
 bTH
 xVe
-eYA
+rMZ
 aWs
 aWs
 xho
@@ -212995,8 +213085,8 @@ kJd
 tYD
 tYD
 cCP
-fFH
-fFH
+uwD
+uwD
 dYm
 neh
 sSX


### PR DESCRIPTION
Closes https://github.com/ss220club/Bandastation/issues/924
1. Исправил небольшие недочёты.
2. Переместил фаерлоки на лестницах между уровнями вниз, дабы не было телепорта за фаерлок когда чел поднимается наверх.