### PR TITLE
color speaker names in local chat channel as their corresponding runechat name

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -149,7 +149,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	var/namepart
 	var/list/stored_name = list(null)
 	SEND_SIGNAL(speaker, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART, stored_name, visible_name)
-	namepart = stored_name[NAME_PART_INDEX] || "[speaker.GetVoice()]"
+	namepart = "<span style='color: [speaker.chat_color]'>[stored_name[NAME_PART_INDEX] || speaker.GetVoice()]</span>" // Bandastation Addition: span with color
 
 	//End name span.
 	var/endspanpart = "</span>"
@@ -230,7 +230,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	processed_input = attach_spans(processed_input, spans)
 
 	var/processed_say_mod = say_emphasis(say_mod)
-	
+
 	return "[processed_say_mod], \"[processed_input]\""
 
 /// Transforms the speech emphasis mods from [/atom/movable/proc/say_emphasis] into the appropriate HTML tags. Includes escaping.


### PR DESCRIPTION

## Что этот PR делает

Красит имя в локальном в чате, в зависимости от цвета присвоенного к рунчату моба

## Почему это хорошо для игры

Легче понимать кто говорит вчат

## Изображения изменений

![image](https://github.com/user-attachments/assets/4b69e53b-0af9-483c-809a-966c971743b4)

## Тестирование

запустил, проверил

## Changelog

:cl:
add: Красит имя в локальном в чате, в зависимости от цвета присвоенного к рунчату моба
/:cl:

