### PR TITLE
Cyberiad: Secures chutes

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -8949,6 +8949,9 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/door/window/right/directional/north{
+	name = "Window Door"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "clU" = (
@@ -33798,6 +33801,13 @@
 /obj/effect/turf_decal/tile/purple/anticorner{
 	dir = 8
 	},
+/obj/machinery/door/window/right/directional/north{
+	name = "Window Door"
+	},
+/obj/effect/turf_decal/delivery/red,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/lower)
 "iFy" = (
@@ -65712,6 +65722,13 @@
 /obj/machinery/disposal/delivery_chute{
 	dir = 4
 	},
+/obj/effect/turf_decal/delivery/red,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/door/window/right/directional/east{
+	name = "Morgue Disposal"
+	},
 /turf/open/floor/iron/freezer,
 /area/station/science/robotics/lab)
 "qFR" = (
@@ -80132,6 +80149,7 @@
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 8
 	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "uoO" = (


### PR DESCRIPTION
Оградил смыв стеклом, чтобы бедолаги не смывались куда не попадя.

## Summary by Sourcery

New Features:
- Prevent accidental flushing of creatures by adding glass to the chutes.