### PR TITLE
captain access for captain display case

### DIFF
--- a/modular_bandastation/objects/_objects.dme
+++ b/modular_bandastation/objects/_objects.dme
@@ -49,6 +49,7 @@
 #include "code/machinery/vending/vending.dm"
 
 #include "code/structures/chairs.dm"
+#include "code/structures/displaycase.dm"
 #include "code/structures/platform.dm"
 #include "code/structures/posters.dm"
 #include "code/structures/statues.dm"

--- a/modular_bandastation/objects/code/structures/displaycase.dm
+++ b/modular_bandastation/objects/code/structures/displaycase.dm
@@ -1,0 +1,2 @@
+/obj/structure/displaycase/captain
+	req_access = list(ACCESS_CAPTAIN)


### PR DESCRIPTION
## Что этот PR делает

Капитанский доступ для капитанского дисплейкейса

## Почему это хорошо для игры

Не надо ломать дисплейкейс когда хочешь взять антикварный лазер. 
Можно положить лазер обратно

## Тестирование

Да, даже протестировал на всякий

## Changelog

:cl:
tweak: Капитанский доступ для капитанского дисплейкейса
/:cl:

## Summary by Sourcery

Allow captains to access the captain's display case.

New Features:
- Captains can now access the captain's display case.

Tests:
- The change has been tested.