### PR TITLE
Cyberiad: Polish & improve west ghetto maints

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -237,6 +237,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/armory,
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
+"adv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "adz" = (
 /obj/machinery/door/airlock/psych,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -2192,12 +2199,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"aDA" = (
-/obj/structure/rack,
-/obj/item/extinguisher,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
-/area/station/maintenance/port)
 "aDC" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
@@ -2586,10 +2587,14 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/mechbay)
 "aHS" = (
-/obj/effect/spawner/random/trash/graffiti,
-/turf/open/floor/iron/dark/side{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/meter/layer4,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "aIa" = (
 /obj/structure/lattice,
@@ -4578,6 +4583,7 @@
 "bhg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/small/directional/west,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "bhl" = (
@@ -5554,12 +5560,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"btu" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/port)
 "btA" = (
 /obj/structure/table,
 /obj/item/hatchet,
@@ -7106,6 +7106,12 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"bOr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/mob/living/basic/cockroach,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/ghetto/port)
 "bOu" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -7461,7 +7467,7 @@
 "bSi" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/wrapping,
+/obj/effect/decal/cleanable/plastic,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "bSj" = (
@@ -7884,6 +7890,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
+"bYR" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/closet,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/ghetto/port)
 "bZl" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -8290,6 +8302,11 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/stairs/left,
 /area/station/security/holding_cell)
+"cdu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/ghetto/port)
 "cdy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -9141,7 +9158,7 @@
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/port/fore)
 "cou" = (
-/obj/structure/sign/warning/vacuum/directional/north,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
 "cow" = (
@@ -10748,8 +10765,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "cIM" = (
-/obj/effect/spawner/random/structure/crate,
+/obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port)
 "cIN" = (
@@ -10991,6 +11009,23 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"cLR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/railing/corner/end/flip{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "cLS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12293,13 +12328,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
-"daT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/sign/warning/vacuum/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/port)
 "daV" = (
 /obj/structure/railing{
 	dir = 1
@@ -12316,6 +12344,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"daY" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/ghetto/port)
 "daZ" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -13046,6 +13084,12 @@
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"dkN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/spawner/random/trash/graffiti,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/ghetto/port)
 "dkO" = (
 /obj/effect/spawner/random/structure/barricade,
 /turf/open/floor/plating,
@@ -13213,6 +13257,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/library/ghetto)
+"dmx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/ghetto/port)
 "dmA" = (
 /obj/structure/chair/sofa/bench/solo{
 	dir = 4
@@ -13760,6 +13810,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
+"dsU" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/ghetto/port)
 "dsW" = (
 /obj/machinery/light/directional/south,
 /obj/structure/sign/poster/official/random/directional/south,
@@ -14276,8 +14330,10 @@
 /turf/open/openspace,
 /area/station/science/xenobiology)
 "dzH" = (
-/obj/effect/spawner/random/structure/tank_holder,
 /obj/structure/sign/departments/cargo/directional/west,
+/obj/structure/table,
+/obj/effect/spawner/random/trash/garbage,
+/obj/item/clothing/glasses/welding,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
 "dzL" = (
@@ -14387,6 +14443,13 @@
 /obj/structure/broken_flooring/side/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
+"dBp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron,
+/area/station/maintenance/port)
 "dBq" = (
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Foyer"
@@ -14844,6 +14907,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"dHh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/ghetto/port)
 "dHi" = (
 /obj/structure/railing{
 	dir = 1
@@ -16881,6 +16950,12 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"ejd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "ejf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17371,6 +17446,10 @@
 	},
 /turf/open/floor/iron/telecomms,
 /area/station/tcommsat/server)
+"epL" = (
+/obj/structure/ore_box,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/ghetto/port)
 "epO" = (
 /obj/structure/girder,
 /obj/effect/mapping_helpers/broken_floor,
@@ -17418,6 +17497,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "eqE" = (
@@ -17960,6 +18040,15 @@
 /obj/machinery/light/small/red/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"eAh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/loading_area,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/door/poddoor/shutters{
+	id = "ghetto_cargo_maint"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "eAj" = (
 /obj/machinery/light/directional/north,
 /obj/structure/sign/nanotrasen{
@@ -18581,6 +18670,7 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "eJe" = (
@@ -18858,6 +18948,16 @@
 	},
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
+"eMR" = (
+/obj/structure/sign/poster/random/directional/north,
+/obj/structure/rack,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/ghetto/port)
 "eNf" = (
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/qm)
@@ -20612,6 +20712,12 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
+"fjQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/station/maintenance/ghetto/port)
 "fjV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -21019,10 +21125,6 @@
 "fpW" = (
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/port/fore)
-"fpY" = (
-/obj/effect/spawner/random/trash,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/port)
 "fqc" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /obj/effect/turf_decal/tile/yellow{
@@ -21507,13 +21609,10 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "fwj" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/station/maintenance/ghetto/port)
 "fwl" = (
 /obj/machinery/door/firedoor,
@@ -22177,6 +22276,23 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
+"fEG" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/station/maintenance/ghetto/port)
 "fEV" = (
 /obj/machinery/computer/security/wooden_tv,
 /obj/machinery/button/door/directional/east{
@@ -22418,6 +22534,11 @@
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/ghetto)
+"fGZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/ghetto/port)
 "fHf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24359,6 +24480,10 @@
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
+"gfO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/stairs,
+/area/station/maintenance/ghetto/port)
 "gfS" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/turf_decal/stripes/corner{
@@ -24575,6 +24700,13 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
+"giL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "giO" = (
 /obj/structure/table,
 /obj/item/gun/ballistic/revolver/russian,
@@ -25082,6 +25214,7 @@
 "gqs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/commons/storage/emergency)
 "gqD" = (
@@ -26480,6 +26613,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/ordnance)
+"gKL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/ghetto/port)
 "gKM" = (
 /obj/structure/closet/crate/preopen,
 /turf/open/floor/plating,
@@ -26681,10 +26823,7 @@
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
 "gNa" = (
-/obj/structure/ladder{
-	pixel_y = 6;
-	pixel_x = -2
-	},
+/obj/structure/ladder,
 /obj/effect/turf_decal/stripes/box,
 /obj/structure/sign/directions/security/directional/north{
 	pixel_y = 39
@@ -27160,16 +27299,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/fore)
-"gSf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/port)
 "gSo" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/machinery/light/directional/south,
@@ -29437,6 +29566,19 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/fore)
+"hxl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "hxB" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -29559,8 +29701,16 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "hyG" = (
-/obj/effect/spawner/random/trash/grille_or_waste,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/ghetto/port)
 "hyZ" = (
 /obj/structure/cable,
@@ -31078,10 +31228,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "hSN" = (
-/obj/machinery/light/small/directional/west,
 /obj/structure/railing,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "hSS" = (
 /obj/structure/cable,
@@ -31561,6 +31715,13 @@
 /obj/structure/sign/poster/official/fruit_bowl/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
+"hZq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/gas_mask/directional/south,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/station/maintenance/ghetto/port)
 "hZr" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -32600,6 +32761,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
+"ioz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/button/door/directional/north{
+	id = "ghetto_cargo_maint";
+	name = "Storage Shutters Control";
+	req_access = list("engineering")
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/ghetto/port)
 "ioA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34175,6 +34347,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/lobby)
+"iJL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/wrapping,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central)
 "iJM" = (
 /obj/machinery/atmospherics/components/binary/pump/layer2{
 	dir = 8;
@@ -34595,9 +34775,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "iOS" = (
-/obj/structure/table,
-/obj/item/storage/box/lights,
-/obj/item/storage/toolbox/emergency,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/commons/storage/emergency)
 "iOT" = (
@@ -36745,9 +36924,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "jtc" = (
-/obj/structure/table_frame,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/catwalk_floor/iron_dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
 "jtk" = (
 /obj/structure/rack,
@@ -36962,6 +37141,7 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "jwP" = (
@@ -38449,6 +38629,11 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
+"jPd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/port)
 "jPj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/wood,
@@ -39157,6 +39342,13 @@
 /obj/item/storage/toolbox/electrical,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
+"jYA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/medical/memeorgans,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "jYC" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix{
 	dir = 4
@@ -41478,6 +41670,11 @@
 /area/station/science/robotics/lab)
 "kCd" = (
 /obj/machinery/light_switch/directional/south,
+/obj/structure/table,
+/obj/item/storage/box/lights,
+/obj/item/storage/toolbox/emergency,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/commons/storage/emergency)
 "kCf" = (
@@ -41990,7 +42187,8 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "kGC" = (
-/obj/structure/closet/emcloset,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
 "kGE" = (
@@ -42455,11 +42653,6 @@
 	},
 /turf/open/space/openspace,
 /area/space)
-"kLZ" = (
-/obj/machinery/light/cold/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/port)
 "kMb" = (
 /obj/structure/railing{
 	dir = 1
@@ -42614,6 +42807,14 @@
 	},
 /turf/open/floor/iron/telecomms,
 /area/station/tcommsat/server)
+"kOs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance/two,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "kOv" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -43434,6 +43635,15 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/engine/cult,
 /area/station/service/chapel/office)
+"kYQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "kYU" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -44196,9 +44406,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/storage)
 "lkX" = (
-/obj/structure/ladder{
-	name = "chemistry lab access"
-	},
+/obj/structure/ladder,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/door/window/left/directional/north{
 	name = "Chemistry Lab Access Hatch";
@@ -44386,12 +44594,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
-"lnd" = (
-/obj/structure/table_frame,
-/obj/effect/spawner/random/entertainment/plushie_delux,
-/obj/structure/sign/poster/contraband/random/directional/north,
-/turf/open/floor/iron/dark/side,
-/area/station/maintenance/ghetto/port)
 "lne" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -45270,6 +45472,7 @@
 "lwX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port/greater)
 "lxv" = (
@@ -45387,6 +45590,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"lyM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/station/maintenance/ghetto/port)
 "lyW" = (
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
@@ -45567,6 +45776,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/large,
 /area/station/maintenance/ghetto/central)
+"lAP" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/ghetto/port)
 "lAQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48920,6 +49134,14 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"mtr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/loading_area,
+/obj/machinery/door/poddoor/shutters{
+	id = "ghetto_cargo_maint"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "mts" = (
 /obj/structure/railing{
 	dir = 8
@@ -49005,11 +49227,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/station/maintenance/starboard/aft)
-"muv" = (
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/maintenance/ghetto/port)
 "muG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -49526,6 +49743,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/magistrate)
+"mBs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/crate,
+/obj/effect/turf_decal/bot,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/item/storage/backpack/satchel/eng,
+/obj/item/wirecutters,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/ghetto/port)
 "mBw" = (
 /obj/structure/rack,
 /obj/machinery/light/small/directional/north,
@@ -49557,9 +49783,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "mCc" = (
-/obj/structure/table_frame,
-/obj/effect/spawner/random/mod/maint,
-/turf/open/floor/catwalk_floor/iron_dark,
+/obj/structure/ladder,
+/obj/effect/turf_decal/stripes/box,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
 "mCg" = (
 /obj/structure/chair/comfy/brown{
@@ -50587,7 +50814,6 @@
 /turf/open/floor/plating/reinforced,
 /area/station/cargo/storage)
 "mOq" = (
-/obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -51400,6 +51626,14 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
+"mYA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/spawner/random/trash/moisture_trap,
+/obj/effect/spawner/random/trash/mess,
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "mYC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -52221,11 +52455,6 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/science/xenobiology)
-"nkt" = (
-/obj/structure/table_frame,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/ghetto/port)
 "nku" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53347,6 +53576,10 @@
 /obj/structure/spirit_board,
 /turf/open/floor/cult,
 /area/station/maintenance/starboard/fore)
+"nyR" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central)
 "nzc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -53393,6 +53626,8 @@
 "nzI" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "nzQ" = (
@@ -53490,6 +53725,13 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
+"nBc" = (
+/obj/effect/turf_decal/siding/thinplating_new{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "nBf" = (
 /obj/structure/closet,
 /turf/open/floor/plating,
@@ -54556,12 +54798,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
-"nOx" = (
-/obj/effect/spawner/random/trash/graffiti,
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
-/area/station/maintenance/ghetto/port)
 "nOA" = (
 /obj/structure/table,
 /obj/machinery/cell_charger{
@@ -55127,6 +55363,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"nVX" = (
+/obj/effect/spawner/random/structure/tank_holder,
+/obj/structure/sign/warning/vacuum/directional/west,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "nWg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55274,8 +55516,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
 "nXW" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/plating,
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
 "nXX" = (
 /obj/structure/curtain/cloth/fancy/mechanical/start_closed{
@@ -55625,6 +55868,12 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chemistry/ghetto)
+"obV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/ghetto/port)
 "obY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/decal/cleanable/dirt,
@@ -56428,10 +56677,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
-"omh" = (
-/obj/structure/cable,
-/turf/closed/wall,
-/area/station/maintenance/ghetto/port)
 "omE" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -56539,6 +56784,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/electric_shock/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
 "onS" = (
@@ -57918,7 +58164,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/sign/poster/random/directional/north,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "oFu" = (
@@ -58151,6 +58397,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"oIP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/station/maintenance/ghetto/port)
 "oIV" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/food_or_drink/snack,
@@ -58752,11 +59005,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "oRn" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/box,
+/obj/structure/ladder,
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/station/commons/storage/emergency)
 "oRG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/pump/on/scrubbers/hidden/layer2{
@@ -60502,6 +60754,15 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
+"poO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "poT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -60692,11 +60953,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"prN" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/port/greater)
 "prX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -61488,6 +61744,11 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
+"pBC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/ghetto/port)
 "pBD" = (
 /obj/item/book/manual/wiki/plumbing{
 	pixel_x = 4;
@@ -63178,6 +63439,7 @@
 "pVL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "pVM" = (
@@ -63508,6 +63770,14 @@
 "pZN" = (
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/ghetto/fore/starboard)
+"pZW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "pZY" = (
 /turf/closed/wall/r_wall,
 /area/station/command/meeting_room/council)
@@ -63594,8 +63864,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "qaG" = (
-/obj/structure/sign/poster/contraband/random/directional/north,
-/turf/open/floor/iron/dark/side,
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
+	color = "#ff0000";
+	name = "Scrubbers multi deck pipe adapter";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
+	color = "#0000ff";
+	name = "Supply multi deck pipe adapter";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
 "qaT" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -64286,6 +64566,7 @@
 /area/station/hallway/secondary/entry)
 "qli" = (
 /obj/effect/spawner/random/trash/graffiti,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "qll" = (
@@ -64510,6 +64791,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port)
 "qoy" = (
@@ -65297,6 +65579,7 @@
 "qzJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "qzN" = (
@@ -66391,6 +66674,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/kitchen)
+"qNK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/shard,
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "qNL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66872,12 +67165,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"qUa" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/maintenance/ghetto/port)
 "qUk" = (
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 2";
@@ -67764,6 +68051,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"reE" = (
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
+	color = "#ff0000";
+	name = "Scrubbers multi deck pipe adapter";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
+	color = "#0000ff";
+	name = "Supply multi deck pipe adapter";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/commons/storage/emergency)
 "reG" = (
 /obj/structure/chair/pew/right{
 	dir = 8
@@ -68016,6 +68316,11 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"rhY" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "rik" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68585,6 +68890,7 @@
 "roX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/stool/directional/south,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port)
 "rpc" = (
@@ -69634,11 +69940,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
-"rEj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/port)
 "rEu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70144,6 +70445,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/storage)
+"rLQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "rLY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -72064,6 +72375,14 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
+"sjN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/wrench,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "sjT" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/prisoner,
@@ -72288,6 +72607,7 @@
 /area/station/maintenance/ghetto/port)
 "smK" = (
 /obj/effect/spawner/random/structure/tank_holder,
+/obj/structure/sign/warning/vacuum/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "smM" = (
@@ -72986,6 +73306,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"svT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/wallframe/airalarm,
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/station/maintenance/ghetto/port)
 "svV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -74352,6 +74685,13 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
+"sPr" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance,
+/obj/item/stock_parts/capacitor,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/ghetto/port)
 "sPu" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Bridge - South"
@@ -76778,10 +77118,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/hallway/secondary/service)
-"tvv" = (
-/obj/structure/table_frame,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/ghetto/port)
 "tvz" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -76970,6 +77306,10 @@
 /obj/item/storage/dice,
 /turf/open/floor/carpet,
 /area/station/service/library/ghetto)
+"tye" = (
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/ghetto/port)
 "tyl" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -77614,8 +77954,9 @@
 /turf/open/floor/pod,
 /area/station/maintenance/ghetto/storage)
 "tHc" = (
-/obj/effect/spawner/random/clothing/kittyears_or_rabbitears,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
 "tHe" = (
 /obj/machinery/door/firedoor,
@@ -78924,6 +79265,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "tXL" = (
@@ -79090,13 +79432,6 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
-"uaa" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/port)
 "uae" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -79119,6 +79454,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/trash)
+"uas" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central)
 "uau" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -79322,6 +79664,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
+"ucu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paper/crumpled/muddy{
+	default_raw_text = "Пожалуйста, не пугайтесь! Он просто потерялся."
+	},
+/obj/item/pen,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/ghetto/port)
 "ucL" = (
 /obj/structure/table/wood,
 /obj/machinery/light/directional/south,
@@ -80528,6 +80879,10 @@
 /obj/structure/mirror/broken/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"uvj" = (
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "uvq" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 6
@@ -81764,6 +82119,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"uMP" = (
+/obj/machinery/light/cold/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "uMQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -82904,7 +83263,8 @@
 /area/station/security/checkpoint/third)
 "vcU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/space_heater,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "vcW" = (
@@ -83141,8 +83501,17 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/command/storage/eva)
 "vgi" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/catwalk_floor/iron_dark,
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospherics Connector"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/port)
 "vgn" = (
 /obj/structure/table/optable{
@@ -83686,6 +84055,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
+"vmM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/ghetto/port)
 "vmY" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil,
@@ -84123,6 +84498,14 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/security/processing)
+"vrI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "vrL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -84381,10 +84764,14 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "vtM" = (
-/obj/structure/firelock_frame{
-	anchored = 1
+/obj/structure/sign/warning/no_smoking/directional/north,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/chair,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/cardboard_cutout,
+/turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
 "vtN" = (
 /obj/machinery/door/firedoor,
@@ -86328,6 +86715,13 @@
 /obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/blueshield)
+"vVH" = (
+/obj/structure/closet,
+/obj/item/stack/rods/ten,
+/obj/effect/spawner/random/maintenance,
+/obj/item/stock_parts/matter_bin,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/ghetto/port)
 "vVL" = (
 /mob/living/basic/pet/cat/feral,
 /obj/structure/sign/painting/library{
@@ -86775,17 +87169,19 @@
 	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hos)
-"wbf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/port)
 "wbi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"wbn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/thinplating_new/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "wbH" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/rack,
@@ -88360,6 +88756,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "wwq" = (
@@ -89157,6 +89554,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
+"wFj" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/showroomfloor,
+/area/station/maintenance/ghetto/port)
 "wFk" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -89812,8 +90225,13 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "wOL" = (
-/obj/effect/spawner/random/clothing/beret_or_rabbitears,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/small/directional/north,
+/obj/structure/rack,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/port)
 "wOT" = (
 /obj/structure/closet/toolcloset,
@@ -90443,6 +90861,12 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"wXo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/ghetto/port)
 "wXp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/railing/corner/end{
@@ -90641,10 +91065,14 @@
 /turf/open/floor/carpet/red,
 /area/station/maintenance/department/security/ghetto)
 "xaB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
-/area/station/maintenance/port)
+/area/station/commons/storage/emergency)
 "xaT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -91139,6 +91567,13 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
+"xgg" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/ghetto/port)
 "xgi" = (
 /obj/structure/disposaloutlet{
 	dir = 1
@@ -91796,6 +92231,16 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"xoP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "xoV" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -92530,6 +92975,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/ghetto)
+"xzq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/spawner/random/trash/hobo_squat,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/ghetto/port)
 "xzQ" = (
 /obj/item/taperecorder{
 	pixel_x = -6;
@@ -92592,6 +93043,7 @@
 "xAE" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/broken_flooring/side/directional/south,
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "xAG" = (
@@ -93798,7 +94250,8 @@
 /turf/open/floor/iron/kitchen,
 /area/station/maintenance/ghetto/kitchen)
 "xQu" = (
-/obj/effect/spawner/random/structure/grille,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "xQz" = (
@@ -93875,6 +94328,12 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "xRr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/landmark/blobstart,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
@@ -94902,7 +95361,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "yfC" = (
@@ -95066,6 +95525,24 @@
 /mob/living/basic/mouse/brown/tom,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/command/nuke_storage)
+"yhO" = (
+/obj/structure/table,
+/obj/item/stack/sheet/cardboard,
+/obj/item/stack/sheet/cardboard,
+/obj/item/stack/sheet/cardboard,
+/obj/item/reagent_containers/cup/glass/drinkingglass{
+	pixel_x = -14;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/cup/glass/bottle/beer{
+	desc = "Takes you to a whole new level of thinking.";
+	name = "Meta-Cider";
+	pixel_x = -7;
+	pixel_y = 9
+	},
+/obj/item/cigarette,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central)
 "yhS" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/machinery/duct,
@@ -110935,14 +111412,14 @@ dDJ
 rbi
 tXH
 eJd
-rEj
+eUy
 qox
 qox
 eqC
-rEj
-rEj
-rEj
-rEj
+eUy
+eUy
+eUy
+eUy
 dvQ
 oNQ
 agH
@@ -111215,8 +111692,8 @@ mQU
 tWQ
 tWQ
 ceC
-doz
-doz
+vbK
+vbK
 doz
 doz
 doz
@@ -111470,9 +111947,9 @@ tWQ
 tWQ
 tWQ
 tWQ
-doz
 ceC
-doz
+vbK
+vbK
 doz
 doz
 doz
@@ -111720,16 +112197,16 @@ ceC
 ceC
 doz
 doz
+ceC
 doz
 doz
 doz
 doz
 doz
-doz
-doz
+ceC
 vbK
 vbK
-doz
+ceC
 doz
 doz
 doz
@@ -111977,16 +112454,16 @@ ceC
 doz
 doz
 doz
-doz
-doz
+ceC
 doz
 doz
 doz
 doz
 ceC
+vbK
+vbK
 ceC
-ceC
-ceC
+doz
 doz
 doz
 doz
@@ -112234,16 +112711,16 @@ doz
 doz
 doz
 doz
-doz
-doz
-doz
+ceC
 doz
 doz
 doz
 ceC
+vbK
+vbK
 ceC
 doz
-ceC
+doz
 doz
 doz
 doz
@@ -112487,20 +112964,20 @@ tWQ
 mEO
 dvQ
 tWQ
-doz
-doz
-doz
-doz
-doz
-doz
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+vbK
+vbK
 ceC
 doz
 doz
 doz
-ceC
-doz
-doz
-ceC
 doz
 doz
 doz
@@ -112743,17 +113220,17 @@ rgO
 cdo
 rlW
 iYM
-tWQ
+xWL
 doz
 doz
 doz
 doz
-doz
+ceC
 vbK
 vbK
-doz
-doz
-doz
+vbK
+vbK
+ceC
 ceC
 had
 xWL
@@ -113000,17 +113477,17 @@ hbN
 tWQ
 bSi
 iYM
-tWQ
+xWL
 doz
 doz
 doz
 doz
-doz
+ceC
 vbK
 jEk
 vbK
 ceC
-ceC
+doz
 ceC
 had
 nYx
@@ -113257,18 +113734,18 @@ dhq
 rfG
 boT
 ufS
-tWQ
+xWL
 doz
 doz
 doz
 doz
-doz
+ceC
 had
 rUF
 had
 doz
 doz
-doz
+ceC
 had
 ttJ
 mkn
@@ -113514,23 +113991,23 @@ hjQ
 rfG
 mQU
 eUy
-tWQ
+xWL
 doz
 doz
 doz
 doz
-doz
+ceC
 had
 mQU
 had
 doz
 doz
-doz
+ceC
 had
 ttJ
 mYm
 rgO
-mQU
+uMP
 tWQ
 doz
 doz
@@ -113772,22 +114249,22 @@ tWQ
 roX
 eUy
 tWQ
-doz
-doz
-doz
-doz
-doz
-had
-mQU
+ceC
+ceC
+ceC
+ceC
 had
 had
+mKc
 had
 had
 had
 had
 had
-kLZ
-mQU
+had
+had
+rgO
+rgO
 tWQ
 doz
 doz
@@ -114029,13 +114506,13 @@ tWQ
 kzI
 eUy
 tWQ
-doz
-tWQ
+ceC
 tWQ
 tWQ
 tWQ
 had
-mKc
+nVX
+mQU
 had
 dId
 xwq
@@ -114043,7 +114520,7 @@ hSN
 onQ
 aJv
 fwj
-mQU
+rgO
 rQU
 jHW
 rQU
@@ -114291,12 +114768,12 @@ tWQ
 eUy
 eUy
 eUy
-daT
+eUy
 eUy
 rZB
-gSf
+hrT
 rUs
-izM
+cLR
 hrT
 izM
 clg
@@ -114543,7 +115020,7 @@ rZo
 tWQ
 tEa
 tWQ
-fpY
+eAc
 eUy
 dvQ
 tWQ
@@ -114552,7 +115029,7 @@ tWQ
 tWQ
 tWQ
 tWQ
-eUy
+giL
 rQU
 rQU
 rQU
@@ -114794,21 +115271,21 @@ wPl
 pfs
 xyk
 pfs
-wPl
+rhY
 pAQ
 kfN
 mIo
 eUy
 sca
-wbf
 eUy
+adv
 hPH
 tWQ
-doz
 ceC
 doz
 doz
 tWQ
+epL
 eUy
 rQU
 kTl
@@ -115056,17 +115533,17 @@ tWQ
 tWQ
 tWQ
 tWQ
+fkc
 tWQ
 tWQ
-uaa
-rCk
 tWQ
-doz
+tWQ
 ceC
 doz
 doz
-omh
-yfu
+tWQ
+eMR
+eUy
 rQU
 kTl
 rFH
@@ -115314,15 +115791,15 @@ doz
 ceC
 doz
 doz
-tWQ
-tWQ
-tWQ
-tWQ
-tWQ
+doz
+ceC
+doz
+doz
 ceC
 doz
 doz
 tWQ
+lAP
 eUy
 rQU
 wov
@@ -115568,17 +116045,17 @@ doz
 doz
 doz
 doz
-doz
 ceC
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-jEk
 ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+tWQ
 tWQ
 oFm
 rQU
@@ -115823,21 +116300,21 @@ doz
 ceC
 doz
 doz
+tWQ
+tWQ
+tWQ
+tWQ
+tWQ
 doz
+ceC
 doz
 doz
 ceC
 doz
-tWQ
-tWQ
-tWQ
-tWQ
-tWQ
-tWQ
-doz
 doz
 tWQ
-eUy
+tye
+poO
 wPl
 tvY
 qUy
@@ -116080,21 +116557,21 @@ doz
 ceC
 doz
 doz
+tWQ
+bYR
+fkc
+mYA
+tWQ
+tWQ
+tWQ
+tWQ
+tWQ
+tWQ
 doz
-doz
-doz
-ceC
 doz
 tWQ
-xRr
-nOx
-mQU
-xRr
-tWQ
-ceC
-ceC
-tWQ
-eUy
+tye
+rLQ
 qUy
 qUy
 qUy
@@ -116335,18 +116812,18 @@ doz
 doz
 doz
 ceC
-doz
-doz
-doz
-doz
-doz
-ceC
-vbK
-tWQ
+oVL
+oVL
+fkc
+xzq
+bOr
+dHh
+fkc
+fGZ
 qaG
-tvv
+tWQ
 mCc
-muv
+tWQ
 tWQ
 tWQ
 tWQ
@@ -116592,23 +117069,23 @@ doz
 doz
 doz
 ceC
-ceC
-oVL
-oVL
-oVL
-oVL
-ceC
-vbK
+doz
+doz
+fkc
+mBs
+vmM
+wXo
+dmx
+cdu
+obV
 tWQ
-mQU
-nkt
 jtc
-qUa
+tWQ
 vtM
-mQU
-uSW
-mQU
-eUy
+ucu
+gfO
+nBc
+yfu
 qUy
 qpz
 vpp
@@ -116851,21 +117328,21 @@ ceC
 ceC
 doz
 doz
-doz
-doz
-doz
-doz
-ceC
+fkc
 tWQ
-gzr
-mQU
+fkc
+fkc
+fkc
+dsU
+lyM
 hyG
+lyM
 hyG
-tWQ
-tWQ
-tWQ
-tWQ
-eUy
+gKL
+obV
+hxl
+wbn
+yfu
 qUy
 ylH
 hET
@@ -117109,20 +117586,20 @@ ceC
 doz
 doz
 doz
-doz
-doz
-doz
-vbK
 tWQ
-uSW
+ejd
+kOs
+mtr
+pBC
+oIP
+had
+had
+had
+had
 tWQ
 tWQ
 tWQ
-tWQ
-doz
-doz
-tWQ
-eUy
+yfu
 qUy
 ybm
 xFE
@@ -117366,20 +117843,20 @@ ceC
 doz
 doz
 doz
-doz
-doz
-doz
-vbK
 tWQ
-vtM
+jYA
+xoP
+eAh
+dkN
+hZq
+had
+pZW
+fEG
+had
+doz
 tWQ
-ceC
-ceC
-ceC
-ceC
-ceC
-tWQ
-eUy
+tye
+rLQ
 qUy
 qUy
 qUy
@@ -117623,20 +118100,20 @@ ceC
 doz
 doz
 doz
-doz
-vbK
+tWQ
+fkc
 tWQ
 tWQ
+ioz
+lyM
+daY
+qNK
+svT
+had
+doz
 tWQ
-uSW
 tWQ
-ceC
-doz
-doz
-doz
-doz
-tWQ
-eUy
+oFm
 mQU
 eHR
 mQU
@@ -117880,19 +118357,19 @@ ceC
 doz
 doz
 doz
-vbK
-ceC
+doz
+doz
 tWQ
 nXW
 tHc
-mQU
+fjQ
+had
+sjN
+wFj
+had
+doz
 tWQ
-ceC
-doz
-doz
-doz
-doz
-tWQ
+sPr
 eUy
 smK
 tWQ
@@ -118137,19 +118614,19 @@ ceC
 doz
 doz
 doz
-vbK
+doz
 doz
 tWQ
-lnd
+tWQ
 vgi
-gzr
 tWQ
-ceC
-ceC
-doz
-doz
+had
+had
+had
+had
 doz
 tWQ
+vVH
 eUy
 tWQ
 tWQ
@@ -118382,7 +118859,7 @@ doz
 doz
 iEV
 iEV
-prN
+mai
 iEV
 ceC
 vbK
@@ -118394,18 +118871,18 @@ ceC
 ceC
 ceC
 doz
-vbK
-ceC
+doz
+doz
 tWQ
 wOL
 aHS
 xRr
 tWQ
+doz
 ceC
 doz
 doz
-doz
-mOI
+tWQ
 tWQ
 kbA
 tWQ
@@ -118650,22 +119127,22 @@ vbK
 ceC
 vbK
 vbK
-doz
-doz
+vbK
+vbK
+vbK
+tWQ
+xgg
+kYQ
+vrI
+tWQ
 ceC
-tWQ
-tWQ
-tWQ
-tWQ
-tWQ
-job
 ceC
-mOI
-mOI
+ceC
+ceC
 mOI
 dzH
-jKW
-qUM
+uas
+mOI
 doz
 doz
 doz
@@ -118910,18 +119387,18 @@ ceC
 ceC
 ceC
 ceC
-vbK
-vbK
-vbK
-vbK
-vbK
-job
-jEk
-ksr
-dGY
-fbN
-dGY
-jKW
+tWQ
+tWQ
+tWQ
+tWQ
+tWQ
+doz
+ceC
+doz
+doz
+qUM
+yhO
+iJL
 qUM
 doz
 doz
@@ -119167,18 +119644,18 @@ vbK
 vbK
 vbK
 ceC
-doz
-doz
-doz
-doz
-doz
-job
 ceC
-mOI
-mOI
-mOI
+doz
+doz
+ceC
+doz
+doz
+ceC
+doz
+doz
+qUM
 cou
-jKW
+uas
 qUM
 doz
 doz
@@ -119424,13 +119901,13 @@ doz
 doz
 doz
 ceC
+ceC
 doz
 doz
+ceC
 doz
 doz
-doz
-job
-doz
+ceC
 doz
 doz
 mOI
@@ -119453,8 +119930,8 @@ mOI
 sRa
 ahA
 mOI
-fRL
-fRL
+nyR
+nyR
 mOI
 skR
 lKj
@@ -177519,7 +177996,7 @@ jal
 gxm
 jal
 rCs
-jal
+xPx
 oSt
 cfd
 dfL
@@ -177776,7 +178253,7 @@ jal
 fBN
 jal
 mkk
-jal
+xPx
 xPx
 bhR
 snj
@@ -180345,7 +180822,7 @@ xPx
 vRs
 xQZ
 lLN
-uWj
+dBp
 xPx
 caC
 caC
@@ -181111,8 +181588,8 @@ vRs
 pqF
 yhh
 rNf
-vRs
-vRs
+vle
+uvj
 gpb
 cfd
 cfd
@@ -181367,10 +181844,10 @@ ehc
 ehc
 kAN
 ehc
-xaB
-mio
-tXL
-tXL
+ehc
+jPd
+iay
+iay
 wwp
 pVL
 iay
@@ -181623,10 +182100,10 @@ tXc
 tXc
 tXc
 tXc
-vle
-xaB
-mmm
-aDA
+tXc
+tXc
+tXc
+uWj
 xPx
 xPx
 xPx
@@ -181879,11 +182356,11 @@ jXy
 tXc
 lfd
 mht
-tXc
+reE
 tXc
 oRn
-vRs
-xQu
+tXc
+uWj
 xPx
 qtg
 snN
@@ -182137,9 +182614,9 @@ tXc
 kJE
 kup
 iOS
+kJE
+kJE
 tXc
-btu
-vRs
 xQu
 xPx
 bPP
@@ -182396,7 +182873,7 @@ gqs
 kCd
 tXc
 xaB
-vRs
+tXc
 nzI
 xPx
 pGg
@@ -182426,9 +182903,9 @@ beH
 tYD
 tYD
 tYD
-kJd
-kJd
-kJd
+tYD
+tYD
+tYD
 oXc
 pFT
 dAJ
@@ -182653,8 +183130,8 @@ mMV
 jai
 tXc
 iAQ
-gpb
-mmm
+xQu
+uWj
 eax
 eNf
 eNf
@@ -183165,7 +183642,7 @@ tXc
 nIh
 vFH
 tXc
-vRs
+qMw
 iEh
 xPx
 xPx


### PR DESCRIPTION
1. Заменил бесполезную комнату в гетто Кибериады на более интересный вариант.
2. Изменил наполнение западных техов гетто.
3. Небольшие визуальные изменения и фиксы.

## Summary by Sourcery

Improve the west ghetto maintenance area layout and visuals.

Enhancements:
- Replace a redundant room in the Cyberiad ghetto with a more engaging design.
- Update the contents of the western tech rooms in the ghetto.
- Implement minor visual improvements.

## Summary by Sourcery

Improve the layout and visuals of the western maintenance area in the Cyberiad ghetto.

Enhancements:
- Replace a redundant room with a more engaging design.
- Update the contents of the western tech rooms.
- Implement minor visual improvements.