### PR TITLE
Fix autotransfer shuttle call 

### DIFF
--- a/modular_bandastation/automatic_crew_transfer/code/automatic_transfer_subsystem.dm
+++ b/modular_bandastation/automatic_crew_transfer/code/automatic_transfer_subsystem.dm
@@ -32,5 +32,8 @@ SUBSYSTEM_DEF(automatic_transfer)
 /datum/controller/subsystem/automatic_transfer/proc/start_crew_transfer_vote()
 	PRIVATE_PROC(TRUE)
 
+	if(!EMERGENCY_IDLE_OR_RECALLED)
+		return
+
 	SSvote.initiate_vote(/datum/vote/crew_transfer, "Automatic Crew Transfer", forced = TRUE)
 	COOLDOWN_START(src, automatic_crew_transfer_vote_cooldown, CONFIG_GET(number/automatic_crew_transfer_vote_interval))

--- a/modular_bandastation/automatic_crew_transfer/code/crew_tranfer_vote.dm
+++ b/modular_bandastation/automatic_crew_transfer/code/crew_tranfer_vote.dm
@@ -22,11 +22,14 @@
 
 	switch(SSticker.current_state)
 		if(GAME_STATE_PLAYING)
+			if(!EMERGENCY_IDLE_OR_RECALLED)
+				return "Шаттл не может быть вызван."
+
 			return VOTE_AVAILABLE
 		if(GAME_STATE_FINISHED)
-			return "Game already finished."
+			return "Раунд уже закончен."
 		else
-			return "Game not started yet."
+			return "Раунд еще не начался."
 
 /datum/vote/crew_transfer/finalize_vote(winning_option)
 	switch(winning_option)
@@ -40,6 +43,11 @@
 
 /datum/vote/crew_transfer/proc/initiate_tranfer()
 	PRIVATE_PROC(TRUE)
+
+	if(!EMERGENCY_IDLE_OR_RECALLED)
+		log_admin("Shuttle can't be called by automatic crew transfer vote because it's already in use or disabled.")
+		message_admins(span_adminnotice("Shuttle can't be called by automatic crew transfer vote because it's already in use or disabled."))
+		return
 
 	SSshuttle.admin_emergency_no_recall = TRUE
 	SSshuttle.emergency.mode = SHUTTLE_IDLE


### PR DESCRIPTION
## About The Pull Request

Добавляет проверку на состояние шаттла перед запуском голосования на вызов шаттла и так же проверки в само голосование

## Summary by Sourcery

Bug Fixes:
- Prevent the automatic crew transfer vote from calling the shuttle if it's already in use or disabled.