### PR TITLE
Cyberiad: Brig overhaul

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -65,6 +65,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
+"aaP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/fore)
 "aaX" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/hangover,
@@ -868,9 +875,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "alH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured_corner,
+/area/station/security/mechbay)
 "alI" = (
 /obj/structure/table/wood,
 /turf/open/floor/iron/dark,
@@ -1507,14 +1514,25 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "auj" = (
-/obj/structure/frame,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/cup/rag{
+	pixel_y = 6
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/cup/glass/bottle/vodka/badminka{
+	pixel_x = 6;
+	pixel_y = 8
+	},
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto)
+/turf/open/floor/iron/dark/small,
+/area/station/security/interrogation/ghetto)
 "aum" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1570,11 +1588,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "avi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/turf/open/floor/iron/dark/textured_half,
+/area/station/security/mechbay)
 "avm" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -2028,31 +2046,22 @@
 /turf/open/floor/grass,
 /area/station/commons/dorms)
 "aBb" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/effect/spawner/random/junk_shell,
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/junk_shell,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "aBc" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/syringe/contraband/bath_salts{
-	pixel_x = -2
+/obj/machinery/mech_bay_recharge_port{
+	dir = 2
 	},
-/obj/item/reagent_containers/syringe/calomel{
-	pixel_x = -2;
-	pixel_y = 4
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 6
 	},
-/obj/item/reagent_containers/syringe{
-	pixel_x = -2;
-	pixel_y = 8
-	},
-/obj/item/clothing/mask/muzzle{
-	pixel_y = -2
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/turf/open/floor/iron/dark/small,
+/area/station/security/mechbay)
 "aBh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -2588,20 +2597,13 @@
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "aHP" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/random/engineering/tool{
-	pixel_x = 1;
-	pixel_y = 3
+/obj/structure/frame,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
 	},
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/camera/autoname/directional/east{
-	c_tag = "Brig - Lower Floor - Mechbay"
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 10
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/mechbay)
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "aHS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -2851,15 +2853,6 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/grass,
 /area/station/maintenance/ghetto/garden)
-"aKz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto)
 "aKG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/fueltank,
@@ -3125,6 +3118,14 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"aOo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/west,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/fore)
 "aOt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -3211,6 +3212,7 @@
 "aPJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/carpet/red,
 /area/station/maintenance/department/security/ghetto)
 "aPK" = (
@@ -3964,12 +3966,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"aYb" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto)
 "aYf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -4813,9 +4809,15 @@
 /turf/closed/wall/r_wall,
 /area/station/security/holding_cell)
 "bjy" = (
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark/small,
-/area/station/security/mechbay)
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/item/paper_bin{
+	pixel_y = 7
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "bjB" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -5297,6 +5299,7 @@
 /obj/structure/chair/plastic{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto)
 "bqJ" = (
@@ -5597,9 +5600,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"btN" = (
-/turf/closed/wall/r_wall,
-/area/station/security/execution/education)
 "btQ" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
@@ -6334,8 +6334,8 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "bEb" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/girder,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "bEm" = (
@@ -6446,8 +6446,11 @@
 "bFz" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/mechbay)
 "bFB" = (
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
@@ -6579,8 +6582,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/door/airlock/security,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto)
+/area/station/security/interrogation/ghetto)
 "bHT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -6696,6 +6705,7 @@
 "bJb" = (
 /obj/effect/turf_decal/tile/red,
 /obj/item/kirbyplants/random/dead,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "bJg" = (
@@ -6871,6 +6881,7 @@
 /obj/machinery/door/airlock/security,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto)
 "bLz" = (
@@ -7384,18 +7395,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
 "bRt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/door/airlock/security,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/window/brigdoor/left/directional/east{
+	req_access = list("brig_entrance");
+	name = "Security Checkpoint Window"
+	},
 /turf/open/floor/iron/dark,
-/area/station/security/mechbay)
+/area/station/maintenance/department/security/ghetto)
 "bRC" = (
 /obj/item/radio/intercom/chapel/directional/east,
 /obj/machinery/camera/directional/east{
@@ -7544,6 +7550,12 @@
 /obj/structure/sign/warning/vacuum/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
+"bTD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/department/security/ghetto)
 "bTH" = (
 /turf/closed/wall,
 /area/station/maintenance/starboard/aft)
@@ -7718,6 +7730,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
+"bVX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto)
 "bWk" = (
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/gravity_generator)
@@ -8972,12 +8992,11 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
 "clJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/junk_shell,
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "clK" = (
@@ -9540,14 +9559,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
 "ctd" = (
-/obj/machinery/mech_bay_recharge_port{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 10
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/mechbay)
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "cte" = (
 /obj/structure/reflector/double,
 /obj/effect/decal/cleanable/dirt,
@@ -9687,15 +9704,20 @@
 /area/station/engineering/supermatter/room)
 "cvc" = (
 /obj/structure/table/reinforced,
-/obj/item/assembly/signaler{
-	pixel_x = 13;
-	pixel_y = 4
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
 	},
-/obj/item/electropack{
-	pixel_y = 4
+/obj/effect/spawner/random/engineering/tool{
+	pixel_x = 5;
+	pixel_y = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/obj/effect/spawner/random/engineering/tool{
+	pixel_x = 1;
+	pixel_y = 3
+	},
+/obj/item/circuitboard/computer/mech_bay_power_console,
+/turf/open/floor/iron/dark/small,
+/area/station/security/mechbay)
 "cvd" = (
 /obj/effect/spawner/random/structure/closet_private,
 /turf/open/floor/iron,
@@ -9893,7 +9915,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
 "cxB" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
@@ -11579,12 +11600,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "cSW" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/brigdoor/right/directional/north{
-	req_access = list("brig_entrance")
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/interrogation/ghetto)
 "cTa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11593,10 +11611,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
 "cTc" = (
-/obj/vehicle/sealed/mecha/ripley/paddy/preset,
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/iron/recharge_floor,
-/area/station/security/mechbay)
+/obj/structure/filingcabinet/chestdrawer,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "cTu" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/item/radio/intercom/directional/south,
@@ -11968,9 +11989,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
 "cXb" = (
-/obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "cXd" = (
 /obj/machinery/light/directional/north,
@@ -13556,11 +13579,14 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/central)
 "dpm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/small,
-/area/station/security/mechbay)
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/item/folder/red,
+/obj/item/pen/red/security,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "dpn" = (
 /obj/structure/chair/pew/right{
 	dir = 4
@@ -13745,12 +13771,8 @@
 /turf/open/floor/iron/airless,
 /area/station/science/ordnance/bomb)
 "dsh" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
-/obj/machinery/firealarm/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto)
 "dsm" = (
@@ -13862,6 +13884,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
+"dtJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/wood/parquet,
+/area/station/maintenance/department/security/ghetto)
 "dtM" = (
 /obj/machinery/modular_computer/preset/curator{
 	dir = 8
@@ -14839,11 +14867,10 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "dGn" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/maintenance/two,
-/obj/structure/rack,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/department/security/ghetto)
 "dGo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -15449,8 +15476,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/junk_shell,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "dNO" = (
@@ -15550,7 +15578,6 @@
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison)
 "dPr" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/medical{
 	dir = 4
 	},
@@ -15710,15 +15737,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "dRN" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto)
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/interrogation/ghetto)
 "dSb" = (
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/status_display/evac/directional/north,
@@ -16220,10 +16243,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "dYB" = (
-/obj/structure/sink/kitchen/directional/south,
-/obj/item/reagent_containers/cup/bucket,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/camera/directional/north{
+	c_tag = "Brig - Mechbay"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/station/security/mechbay)
 "dYI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -16568,7 +16594,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/mechbay)
 "edC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/wood,
@@ -17188,16 +17214,6 @@
 /obj/effect/spawner/random/structure/closet_empty,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
-"emm" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Brig - Lower Floor - Stairs"
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto)
 "emn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/structure/window/reinforced/plasma,
@@ -17335,21 +17351,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "enV" = (
-/obj/structure/table/reinforced,
-/obj/item/taperecorder{
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/obj/item/assembly/flash{
-	pixel_y = 10;
-	pixel_x = -10
-	},
-/obj/item/stack/sticky_tape{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/iron/recharge_floor,
+/area/station/security/mechbay)
 "enX" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Cooling Bypass"
@@ -17801,6 +17805,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
@@ -18349,13 +18354,14 @@
 /area/station/maintenance/ghetto/auxiliary)
 "eEf" = (
 /obj/structure/table/reinforced,
-/obj/item/book/bible{
-	pixel_x = 4;
-	pixel_y = 2
+/obj/item/stack/sheet/glass{
+	pixel_y = 6
 	},
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/security/mechbay)
 "eEx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/warning/docking/directional/south,
@@ -19165,30 +19171,14 @@
 /turf/open/floor/carpet/green,
 /area/station/commons/dorms/apartment1)
 "ePX" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/cup/bottle/mutagen{
-	pixel_x = -8;
-	pixel_y = -10
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 4
 	},
-/obj/item/reagent_containers/cup/bottle/frostoil{
-	pixel_x = -4;
-	pixel_y = 6
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
 	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -8;
-	pixel_y = -2
-	},
-/obj/item/razor{
-	pixel_x = 8
-	},
-/obj/machinery/light/small/directional/west{
-	name = "maintenance light";
-	nightshift_allowed = 0;
-	nightshift_enabled = 1
-	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/turf/open/floor/iron/dark/small,
+/area/station/security/mechbay)
 "eQb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -19324,6 +19314,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/carpet/red,
 /area/station/maintenance/department/security/ghetto)
 "eSd" = (
@@ -19575,6 +19566,7 @@
 /area/station/hallway/primary/central/aft)
 "eVv" = (
 /obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto)
 "eVx" = (
@@ -19620,14 +19612,20 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "eVV" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/structure/sign/poster/official/random/directional/north,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_y = 2;
+	pixel_x = -4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
+/obj/item/book/bible{
+	pixel_x = 4;
+	pixel_y = 2
+	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/small,
+/area/station/security/interrogation/ghetto)
 "eWa" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -19666,6 +19664,7 @@
 /area/station/maintenance/starboard/upper)
 "eWs" = (
 /obj/item/restraints/handcuffs/cable/pink,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/customs)
 "eWt" = (
@@ -19786,13 +19785,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"eXX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto/fore)
 "eYd" = (
 /obj/structure/railing{
 	dir = 8
@@ -20543,11 +20535,13 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/ghetto)
 "fhT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_y = 4
 	},
-/turf/open/floor/iron/dark/small,
-/area/station/security/mechbay)
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "fhX" = (
 /obj/docking_port/stationary/laborcamp_home,
 /turf/open/space/openspace,
@@ -21099,14 +21093,17 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "foB" = (
-/obj/structure/frame/computer,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/item/assembly/signaler{
+	pixel_x = 13;
+	pixel_y = 4
+	},
+/obj/item/electropack{
+	pixel_y = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto)
+/turf/open/floor/iron/dark/small,
+/area/station/security/interrogation/ghetto)
 "foN" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -21412,7 +21409,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/mechbay)
 "fsH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21868,7 +21865,7 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/mechbay)
 "fyN" = (
 /turf/open/floor/iron/airless,
 /area/station/science/ordnance/bomb)
@@ -22922,6 +22919,7 @@
 "fLr" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "fLB" = (
@@ -23623,6 +23621,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"fUf" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Brig - Lower Floor - Stairs"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "fUh" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
@@ -23923,30 +23932,14 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "fYt" = (
-/obj/structure/table/reinforced,
-/obj/item/bikehorn{
-	pixel_y = -4
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 8
 	},
-/obj/machinery/light/small/directional/east{
-	name = "maintenance light";
-	nightshift_allowed = 0;
-	nightshift_enabled = 1;
-	nightshift_light_power = 0.4
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
 	},
-/obj/item/bikehorn/rubberducky{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -8;
-	pixel_y = 10
-	},
-/obj/item/food/grown/banana{
-	pixel_x = -6;
-	pixel_y = -6
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/turf/open/floor/iron/dark/small,
+/area/station/security/mechbay)
 "fYw" = (
 /obj/machinery/chem_dispenser/drinks/beer{
 	pixel_y = 8
@@ -23985,8 +23978,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
 "fYS" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto)
 "fYU" = (
@@ -24187,13 +24180,13 @@
 /turf/open/floor/carpet/black,
 /area/station/commons/lounge)
 "gbo" = (
-/obj/machinery/light/cold/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /obj/structure/closet/crate/bin,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/mechbay)
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "gbq" = (
 /obj/structure/chair/comfy/teal{
 	dir = 4
@@ -24257,6 +24250,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/bar)
 "gck" = (
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/checkpoint/customs)
 "gcr" = (
@@ -24912,6 +24906,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/department/security/ghetto)
 "glP" = (
@@ -25202,12 +25197,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "gpF" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/event_spawn,
+/obj/structure/chair,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/small,
+/area/station/security/interrogation/ghetto)
 "gpM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25292,11 +25289,6 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"gqU" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/security/medical)
 "grl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -26181,9 +26173,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/junk_shell,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "gEZ" = (
@@ -26592,11 +26584,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/smooth,
 /area/station/commons/toilet/restrooms)
-"gKn" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto)
 "gKv" = (
 /obj/machinery/button/door/directional/west{
 	id = "Toilet1";
@@ -26775,6 +26762,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage/gas)
+"gLT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/airlock/security,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/security/interrogation/ghetto)
 "gMm" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/table,
@@ -26794,6 +26794,7 @@
 /area/station/maintenance/starboard/upper)
 "gMp" = (
 /obj/effect/spawner/random/decoration/generic,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/customs)
 "gMr" = (
@@ -26804,15 +26805,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "gMw" = (
+/obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/door/airlock/security,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/security/general,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/small,
+/area/station/security/interrogation/ghetto)
 "gMH" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -27306,6 +27305,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/department/security/ghetto)
 "gRK" = (
@@ -28394,11 +28394,15 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "hha" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/small,
-/area/station/security/mechbay)
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "hhp" = (
 /obj/structure/table,
 /obj/machinery/camera{
@@ -29112,11 +29116,14 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "hqu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark/side,
-/area/station/maintenance/department/security/ghetto)
+/obj/machinery/duct,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/security/interrogation/ghetto)
 "hqy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29922,7 +29929,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/mechbay)
 "hBy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30092,6 +30099,8 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
 /obj/machinery/door/firedoor,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "hDB" = (
@@ -30814,12 +30823,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "hLT" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/structure/showcase/machinery/tv{
+	name = "зомбоящик";
+	desc = "Слегка потрепанный телевизор. Различные агитационные ролики Nanotrasen воспроизводятся по кругу, сопровождаемые НЕ веселой мелодией."
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/small,
+/area/station/security/interrogation/ghetto)
 "hLW" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -30832,11 +30845,14 @@
 "hLX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/morgue{
-	name = "Dungeon"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/machinery/door/airlock/security,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/mechbay)
 "hMe" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -31060,10 +31076,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "hOU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto)
+/turf/open/floor/iron/dark/small,
+/area/station/security/interrogation/ghetto)
 "hOY" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -31294,9 +31313,8 @@
 /area/station/security/courtroom/holding)
 "hST" = (
 /obj/item/target/clown,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/security/ghetto)
 "hSW" = (
@@ -32200,9 +32218,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "igt" = (
@@ -33190,17 +33208,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "itz" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/handcuffs{
-	pixel_x = -4;
-	pixel_y = 2
+/obj/vehicle/sealed/mecha/ripley/paddy/preset{
+	dir = 4
 	},
-/obj/item/clothing/suit/jacket/straight_jacket{
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/iron/recharge_floor,
+/area/station/security/mechbay)
 "itB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -33878,21 +33891,15 @@
 /area/station/engineering/atmos/hfr_room)
 "iDm" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 12;
-	pixel_y = 2
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
 	},
-/obj/item/kitchen/fork{
-	pixel_x = -2;
-	pixel_y = 4
+/obj/item/poster/random_official,
+/obj/item/poster/random_official{
+	pixel_y = 10
 	},
-/obj/item/kitchen/spoon{
-	pixel_x = -10;
-	pixel_y = 4
-	},
-/obj/structure/sign/poster/official/random/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/turf/open/floor/iron/dark/small,
+/area/station/security/mechbay)
 "iDn" = (
 /obj/machinery/atmospherics/components/binary/valve/on{
 	dir = 4
@@ -33940,6 +33947,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
+"iEe" = (
+/obj/structure/table/reinforced,
+/obj/item/instrument/bikehorn{
+	pixel_y = 12
+	},
+/obj/item/clothing/glasses/nightmare_vision,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/small,
+/area/station/security/interrogation/ghetto)
 "iEh" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -34184,6 +34200,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"iHo" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "iHp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35110,8 +35132,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "iTc" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/item/kirbyplants/random/dead,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto)
 "iTk" = (
@@ -35577,8 +35599,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "iZe" = (
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/department/security/ghetto)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/station/security/interrogation/ghetto)
 "iZh" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/engine/hull/reinforced,
@@ -35696,6 +35720,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "jaK" = (
@@ -35860,8 +35885,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "jdj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/closed/wall/r_wall/rust,
-/area/station/maintenance/department/security/ghetto)
+/area/station/security/interrogation/ghetto)
 "jdk" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -35910,16 +35939,6 @@
 	light_color = "#a659ff"
 	},
 /area/station/service/bar)
-"jdN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto)
 "jdP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -36762,9 +36781,9 @@
 /area/station/maintenance/ghetto/fore/starboard)
 "jqo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/security/ghetto)
 "jqv" = (
 /obj/structure/table/wood,
@@ -36868,7 +36887,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/mechbay)
 "jsb" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -37008,10 +37027,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "jtN" = (
@@ -37154,22 +37173,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "jvV" = (
-/obj/structure/closet/secure_closet/security/med,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/north,
+/obj/structure/sink/kitchen/directional/south,
+/obj/item/reagent_containers/cup/bucket,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto)
-"jwc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/department/security/ghetto)
+/turf/open/floor/iron/dark/small,
+/area/station/security/interrogation/ghetto)
 "jwd" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -37937,20 +37945,13 @@
 /area/station/maintenance/ghetto/fore/starboard)
 "jGf" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/cup/glass/bottle/vodka/badminka{
-	pixel_x = 6;
-	pixel_y = 8
+/obj/item/stack/rods/two,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
 	},
-/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/iron/dark/small,
+/area/station/security/mechbay)
 "jGo" = (
 /obj/structure/frame/computer{
 	dir = 1
@@ -38704,6 +38705,7 @@
 "jPt" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto)
 "jPx" = (
@@ -38834,6 +38836,7 @@
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "jRf" = (
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/customs)
 "jRs" = (
@@ -40041,6 +40044,32 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/holding_cell)
+"kgJ" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/cup/bottle/mutagen{
+	pixel_x = -8;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/cup/bottle/frostoil{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -8;
+	pixel_y = -2
+	},
+/obj/item/razor{
+	pixel_x = 8
+	},
+/obj/machinery/light/small/directional/west{
+	name = "maintenance light";
+	nightshift_allowed = 0;
+	nightshift_enabled = 1
+	},
+/obj/item/radio/intercom/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/small,
+/area/station/security/interrogation/ghetto)
 "kgN" = (
 /obj/structure/table/glass,
 /obj/item/folder/white{
@@ -40177,7 +40206,7 @@
 	},
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/mechbay)
 "kiz" = (
 /obj/machinery/plumbing/receiver{
 	dir = 1
@@ -40235,15 +40264,17 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "kiX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 8
+	},
+/area/station/security/mechbay)
 "kjf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/security/ghetto)
 "kjg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40549,9 +40580,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/aft)
 "knm" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/item/kirbyplants/random/dead,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "knr" = (
@@ -40872,10 +40902,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/medical/break_room)
 "kqO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/random/engineering/tank,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/washing_machine,
 /turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto)
+/area/station/security/interrogation/ghetto)
 "kqR" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron/dark/smooth_large,
@@ -41050,10 +41081,16 @@
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "ksO" = (
-/obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/loading_area,
-/turf/open/floor/iron/dark/small,
-/area/station/security/mechbay)
+/obj/structure/frame/computer{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "ksQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41338,10 +41375,7 @@
 /turf/open/misc/beach/sand,
 /area/station/service/hydroponics)
 "kwc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto)
 "kwf" = (
@@ -42133,6 +42167,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "kFB" = (
@@ -42700,6 +42735,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "kLX" = (
@@ -43114,6 +43150,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
+"kRC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "kRH" = (
 /obj/structure/cable,
 /obj/structure/dresser,
@@ -44760,9 +44802,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "lnS" = (
-/obj/machinery/vending/wallmed/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/station/security/mechbay)
 "lnZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -44894,6 +44941,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
+"lpv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/mechbay)
 "lpy" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -44959,6 +45011,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/bathroom,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/department/security/ghetto)
 "lqb" = (
@@ -46261,9 +46314,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto)
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/small,
+/area/station/security/interrogation/ghetto)
 "lFT" = (
 /obj/structure/chair{
 	dir = 4
@@ -47048,7 +47102,6 @@
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/port)
 "lOS" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/glass,
 /obj/item/storage/medkit/regular{
 	pixel_x = 3;
@@ -47503,6 +47556,7 @@
 "lVj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/department/security/ghetto)
 "lVn" = (
@@ -47550,12 +47604,12 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/vomit,
 /obj/machinery/camera/directional/north{
 	c_tag = "Brig - Lower Floor - Cells"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "lVR" = (
@@ -47816,16 +47870,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"lYL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/door/airlock/security,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/station/security/mechbay)
 "lYO" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -48377,6 +48421,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "mgj" = (
@@ -48516,7 +48561,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/security/ghetto)
 "mio" = (
@@ -48638,8 +48682,6 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/fore)
 "mki" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /obj/structure/cable,
@@ -48802,6 +48844,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"mmt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/sign/departments/medbay/alt/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "mmC" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -49286,9 +49336,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/kitchen)
 "mug" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/departments/medbay/alt/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "mul" = (
@@ -50062,6 +50113,10 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar)
+"mEt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "mEy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50531,13 +50586,31 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "mJl" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/item/bikehorn{
+	pixel_y = -4
 	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto)
+/obj/machinery/light/small/directional/east{
+	name = "maintenance light";
+	nightshift_allowed = 0;
+	nightshift_enabled = 1;
+	nightshift_light_power = 0.4
+	},
+/obj/item/bikehorn/rubberducky{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -8;
+	pixel_y = 10
+	},
+/obj/item/food/grown/banana{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/small,
+/area/station/security/interrogation/ghetto)
 "mJo" = (
 /obj/structure/table,
 /obj/item/camera,
@@ -50943,9 +51016,6 @@
 "mOU" = (
 /obj/structure/table/wood,
 /obj/machinery/airalarm/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/item/paper{
 	pixel_x = 4;
 	pixel_y = 2
@@ -50956,7 +51026,7 @@
 	},
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/mechbay)
 "mPa" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -52688,6 +52758,7 @@
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
@@ -52985,6 +53056,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"npv" = (
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/station/security/mechbay)
 "npz" = (
 /obj/machinery/door/airlock,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -53604,13 +53680,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "nxJ" = (
-/obj/machinery/space_heater,
+/obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/maintenance/department/security/ghetto)
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/security/interrogation/ghetto)
 "nxS" = (
 /obj/structure/cable,
 /obj/machinery/light_switch/directional/east,
@@ -53725,15 +53799,6 @@
 /obj/effect/turf_decal/tile/purple/half,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
-"nAa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/security,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/security/general,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto)
 "nAb" = (
 /obj/structure/ladder,
 /obj/effect/turf_decal/stripes/box,
@@ -53952,6 +54017,13 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/engine,
 /area/station/science/lower)
+"nCc" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/station/maintenance/department/security/ghetto)
 "nCd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
@@ -54695,9 +54767,9 @@
 /area/station/science/xenobiology)
 "nMn" = (
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "nMz" = (
@@ -54948,8 +55020,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "nPm" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/sign/warning/no_smoking/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "nPq" = (
@@ -55122,6 +55198,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
+"nRx" = (
+/turf/closed/wall/r_wall,
+/area/station/security/interrogation/ghetto)
 "nRy" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -55208,6 +55287,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/department/security/ghetto)
 "nSN" = (
@@ -55469,6 +55549,28 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
+"nWe" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/syringe/contraband/bath_salts{
+	pixel_x = -2
+	},
+/obj/item/reagent_containers/syringe/calomel{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_x = -2;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/muzzle{
+	pixel_y = -2
+	},
+/obj/item/clothing/glasses/blindfold{
+	pixel_y = -12
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/small,
+/area/station/security/interrogation/ghetto)
 "nWg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56322,6 +56424,13 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
+"ofY" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "oga" = (
 /obj/machinery/telecomms/message_server/preset,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -56442,12 +56551,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "oib" = (
@@ -56468,6 +56573,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "oil" = (
@@ -56642,6 +56749,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"ojM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "okh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -56848,14 +56962,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/gravity_generator)
 "onn" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/chair/plastic{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/south,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto)
+/obj/machinery/firealarm/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/interrogation/ghetto)
 "onA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57025,10 +57135,9 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/ghetto)
 "oph" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "opj" = (
 /obj/effect/spawner/random/structure/table,
@@ -57048,15 +57157,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
-"opo" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto)
 "opq" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/table,
@@ -58807,6 +58907,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
+"oMb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/department/security/ghetto/fore)
 "oMe" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -61192,13 +61299,6 @@
 	},
 /turf/open/water/alternative/muddy/no_fishing,
 /area/station/service/kitchen/abandoned)
-"ptQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/station/maintenance/department/security/ghetto)
 "ptS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61332,7 +61432,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "pva" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/reagent_dispensers/plumbed,
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto/fore)
 "pvc" = (
@@ -61369,7 +61472,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "pvq" = (
 /turf/closed/wall/r_wall,
@@ -61612,6 +61717,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
+"pyg" = (
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto)
 "pyi" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron/dark/small,
@@ -61682,11 +61791,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "pzf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto)
+/turf/open/floor/iron/dark/small,
+/area/station/security/interrogation/ghetto)
 "pzh" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -62092,11 +62200,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "pDQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto)
+/turf/open/floor/iron/dark/small,
+/area/station/security/interrogation/ghetto)
 "pDR" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/purple/anticorner{
@@ -62228,6 +62335,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/light/small/directional/south,
+/obj/machinery/duct,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/security/ghetto/fore)
 "pFq" = (
@@ -62279,12 +62387,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "pGf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/turf/open/floor/iron/dark/textured_half,
+/area/station/security/mechbay)
 "pGg" = (
 /obj/machinery/modular_computer/preset/id,
 /obj/machinery/light/directional/north,
@@ -63038,6 +63145,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
+"pPa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/vending/wallmed/directional/west,
+/turf/open/floor/iron/dark/small,
+/area/station/security/interrogation/ghetto)
 "pPt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/maintenance,
@@ -63086,9 +63201,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "pQh" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/maintenance/two,
+/obj/structure/rack,
 /turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto)
+/area/station/security/interrogation/ghetto)
 "pQj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63744,15 +63862,9 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "pXw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/interrogation/ghetto)
 "pXB" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
@@ -63829,6 +63941,7 @@
 	},
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "pYX" = (
@@ -65266,8 +65379,10 @@
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
 "qtW" = (
-/turf/closed/wall,
-/area/station/security/mechbay)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto)
 "qub" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -65478,9 +65593,13 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/ghetto)
 "qxv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark/small,
-/area/station/security/mechbay)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "qxw" = (
 /obj/structure/sink/directional/south,
 /obj/effect/turf_decal/siding/wood{
@@ -65784,10 +65903,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "qAJ" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/department/security/ghetto)
 "qAN" = (
 /obj/machinery/door/firedoor,
@@ -66033,7 +66152,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/mechbay)
 "qEI" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
@@ -66558,12 +66677,14 @@
 /area/station/maintenance/ghetto/starboard)
 "qLk" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/power/port_gen/pacman,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/maintenance/department/security/ghetto)
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/closet/crate/trashcart/laundry,
+/obj/item/clothing/under/rank/civilian/clown/sexy,
+/obj/item/clothing/under/rank/civilian/clown,
+/obj/item/clothing/mask/gas/clown_hat,
+/obj/item/clothing/mask/gas/clown_hat,
+/turf/open/floor/plating,
+/area/station/security/interrogation/ghetto)
 "qLw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66659,9 +66780,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "qMI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/station/maintenance/department/security/ghetto)
 "qMM" = (
 /obj/machinery/door/firedoor,
@@ -67569,7 +67692,6 @@
 	},
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "qXr" = (
@@ -67712,6 +67834,7 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/checkpoint/customs)
 "qZA" = (
@@ -67895,9 +68018,10 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/command/storage/eva)
 "rbf" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
 /area/station/maintenance/department/security/ghetto)
 "rbi" = (
 /turf/open/floor/plating,
@@ -67978,14 +68102,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "rci" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/mechbay)
 "rco" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/item/radio/intercom/directional/west,
@@ -68509,6 +68632,7 @@
 "rjl" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/door/window/brigdoor/right/directional/north,
+/obj/effect/turf_decal/delivery/red,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "rjm" = (
@@ -69029,8 +69153,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "rps" = (
@@ -69852,14 +69974,6 @@
 /obj/item/reagent_containers/cup/glass/drinkingglass,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/upper)
-"rBS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/corner{
-	dir = 8
-	},
-/area/station/maintenance/department/security/ghetto)
 "rBW" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -69936,7 +70050,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/mechbay)
 "rCs" = (
 /obj/structure/toilet{
 	pixel_y = 8
@@ -70378,6 +70492,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/aft)
+"rJl" = (
+/obj/structure/reagent_dispensers/plumbed{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/customs)
 "rJr" = (
 /obj/structure/table/wood,
 /obj/item/book/codex_gigas,
@@ -71368,19 +71488,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "rWw" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/random/engineering/tool{
-	pixel_x = -11
+/obj/structure/closet/secure_closet/security/med,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
 	},
-/obj/effect/spawner/random/engineering/tool{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 9
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/mechbay)
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "rWy" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/cleanable/dirt,
@@ -72341,13 +72455,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "sih" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto)
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/interrogation/ghetto)
 "siq" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
@@ -72687,6 +72798,14 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/pink/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
+"smj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/security/interrogation/ghetto)
 "smn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -72767,13 +72886,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "smP" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/machinery/light/cold/directional/south,
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "smU" = (
@@ -73134,12 +73250,13 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/fore)
 "srM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/maintenance/two,
+/obj/structure/rack,
 /turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto)
+/area/station/security/interrogation/ghetto)
 "ssc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -73328,11 +73445,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
-"sus" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto)
 "sux" = (
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
@@ -73693,6 +73805,24 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"szr" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 12;
+	pixel_y = 2
+	},
+/obj/item/kitchen/fork{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/kitchen/spoon{
+	pixel_x = -10;
+	pixel_y = 4
+	},
+/obj/structure/sign/poster/official/random/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/small,
+/area/station/security/interrogation/ghetto)
 "szw" = (
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway South";
@@ -73757,6 +73887,16 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/station/service/library)
+"sAz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/security,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto)
 "sAC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73988,9 +74128,10 @@
 /turf/open/floor/engine,
 /area/station/science/lower)
 "sDv" = (
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/department/security/ghetto)
 "sDw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -74228,7 +74369,6 @@
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance)
 "sFZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/latex,
 /obj/item/clothing/mask/surgical,
@@ -74465,13 +74605,11 @@
 /turf/open/floor/stone,
 /area/station/maintenance/ghetto/bar)
 "sJd" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "sJo" = (
@@ -75661,10 +75799,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "tcx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/mechbay)
 "tcB" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -76080,6 +76218,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "tjb" = (
@@ -76170,6 +76310,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
+"tks" = (
+/turf/closed/wall/r_wall/rust,
+/area/station/security/interrogation/ghetto)
 "tkt" = (
 /obj/machinery/computer/order_console/mining,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -76821,12 +76964,14 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
 "tqw" = (
-/obj/structure/table/reinforced,
-/obj/item/instrument/bikehorn{
-	pixel_y = 12
+/obj/machinery/mech_bay_recharge_port{
+	dir = 2
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/security/mechbay)
 "tqy" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
@@ -77391,14 +77536,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"txx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto)
 "txz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
@@ -77524,6 +77661,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto)
 "tAr" = (
@@ -78583,11 +78722,6 @@
 /obj/effect/landmark/start/depsec/supply,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
-"tMX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto)
 "tNe" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 9
@@ -78854,9 +78988,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "tRu" = (
@@ -78880,8 +79013,8 @@
 /area/station/engineering/hallway)
 "tRI" = (
 /obj/machinery/light/small/directional/south,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/maint,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/maintenance/department/security/ghetto)
 "tRN" = (
@@ -78961,6 +79094,19 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
+"tTl" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/handcuffs{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/clothing/suit/jacket/straight_jacket{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/small,
+/area/station/security/interrogation/ghetto)
 "tTn" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/airalarm/directional/south,
@@ -79020,13 +79166,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "tUb" = (
-/obj/structure/chair/plastic{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/interrogation/ghetto)
 "tUe" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -79489,6 +79633,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto/fore)
 "tYC" = (
@@ -80378,11 +80523,22 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
+"ukr" = (
+/obj/item/banner/security,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/south{
+	name = "maintenance light";
+	nightshift_allowed = 0;
+	nightshift_enabled = 1
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/security/interrogation/ghetto)
 "uks" = (
 /obj/machinery/door/airlock/security,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
 /obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "ukA" = (
@@ -80749,6 +80905,10 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"uqT" = (
+/obj/machinery/duct,
+/turf/closed/wall,
+/area/station/security/checkpoint/customs)
 "uqU" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -81024,9 +81184,6 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "uvB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
@@ -81256,8 +81413,13 @@
 /turf/closed/wall,
 /area/station/maintenance/ghetto/abandoned_gambling_den)
 "uzd" = (
-/turf/open/floor/iron/dark/small,
-/area/station/security/mechbay)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "uzk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -81309,6 +81471,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/east,
+/obj/machinery/duct,
 /turf/open/floor/iron/corner{
 	dir = 8
 	},
@@ -82992,6 +83155,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/garbage,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/fore)
 "uXq" = (
@@ -83038,6 +83202,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "uYf" = (
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/department/security/ghetto)
 "uYh" = (
@@ -83267,6 +83432,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
+"vaU" = (
+/turf/closed/wall,
+/area/station/security/interrogation/ghetto)
 "vaX" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -84933,6 +85101,7 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/checkpoint/customs)
 "vub" = (
@@ -85196,14 +85365,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
-"vxZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto)
 "vye" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -85221,18 +85382,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
-"vyo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/structure/table_or_rack,
-/obj/effect/spawner/random/mod/maint,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark/corner{
-	dir = 1
-	},
-/area/station/maintenance/department/security/ghetto)
 "vyE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/chair_flipped{
@@ -85255,9 +85404,12 @@
 /turf/open/misc/grass,
 /area/station/security/prison/garden)
 "vyN" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/small,
+/area/station/security/interrogation/ghetto)
 "vyQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/cafeteria,
@@ -85653,6 +85805,14 @@
 /obj/effect/spawner/random/clothing/costume,
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/ghetto/fore/starboard)
+"vEz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "vEC" = (
 /obj/structure/table,
 /obj/item/scalpel,
@@ -85741,12 +85901,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/plating,
 /area/station/commons/storage/emergency)
-"vFO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto)
 "vFQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -86270,12 +86424,6 @@
 /obj/item/paint_palette,
 /turf/open/floor/carpet/blue,
 /area/station/service/library/ghetto)
-"vMk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/closed/wall/r_wall/rust,
-/area/station/maintenance/department/security/ghetto)
 "vMn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -86424,13 +86572,13 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/aft)
 "vPk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto)
+/turf/open/floor/iron/dark/small,
+/area/station/security/interrogation/ghetto)
 "vPo" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -88246,11 +88394,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
-"woa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto)
 "wob" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable,
@@ -88612,14 +88755,23 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/storage)
 "wsN" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/taperecorder{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/item/assembly/flash{
+	pixel_y = 10;
+	pixel_x = -10
+	},
+/obj/item/stack/sticky_tape{
+	pixel_x = -6;
+	pixel_y = 2
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto)
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron/dark/small,
+/area/station/security/interrogation/ghetto)
 "wsO" = (
 /obj/effect/turf_decal/siding/wideplating_new/corner{
 	dir = 1
@@ -89251,10 +89403,11 @@
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "wAW" = (
-/obj/machinery/light/small/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto)
+/area/station/security/interrogation/ghetto)
 "wAY" = (
 /obj/structure/closet/crate,
 /obj/item/reagent_containers/cup/bowl,
@@ -90461,6 +90614,7 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
 /obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto)
 "wQa" = (
@@ -90807,6 +90961,12 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/aft)
+"wUe" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "wUk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -90886,8 +91046,13 @@
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "wVY" = (
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/station/security/mechbay)
 "wWf" = (
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 8
@@ -90936,9 +91101,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "wWM" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/small,
-/area/station/security/mechbay)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "wWN" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/dark,
@@ -91519,7 +91685,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/security/ghetto)
 "xes" = (
 /obj/machinery/firealarm/directional/north,
@@ -91792,12 +91960,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "xgZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/event_spawn,
-/obj/structure/chair,
-/turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad/secure,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/mechbay)
 "xhf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -91942,6 +92109,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
@@ -92343,12 +92511,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "xon" = (
+/obj/effect/spawner/random/engineering/tank,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/maintenance/two,
-/obj/structure/rack,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark/corner,
 /area/station/maintenance/department/security/ghetto)
 "xoo" = (
 /turf/closed/wall/r_wall,
@@ -93563,12 +93728,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "xGb" = (
-/obj/machinery/computer/mech_bay_power_console,
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 6
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
 	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/mechbay)
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "xGc" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron/dark/smooth_large,
@@ -94239,7 +94405,8 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "xOO" = (
@@ -94372,7 +94539,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/abandoned)
 "xQg" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
@@ -94459,6 +94625,9 @@
 "xRg" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical/ghetto)
+"xRh" = (
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/interrogation/ghetto)
 "xRq" = (
 /obj/structure/railing{
 	dir = 9
@@ -95962,7 +96131,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/execution/education)
+/area/station/security/mechbay)
 "ylO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/effect/turf_decal/tile/blue{
@@ -120010,11 +120179,11 @@ doz
 yjB
 yjB
 wxj
-jxu
-jdj
-jxu
-jxu
-jxu
+nRx
+tks
+nRx
+nRx
+nRx
 qGg
 wYp
 doz
@@ -120266,12 +120435,12 @@ doz
 doz
 doz
 yjB
-wxj
-jxu
+mrw
+nRx
 srM
 wAW
 pQh
-jxu
+nRx
 nqa
 wYp
 doz
@@ -120518,17 +120687,17 @@ doz
 doz
 ceC
 doz
-doz
-doz
-doz
-doz
 yjB
-mrw
-jxu
+yjB
+yjB
+yjB
+yjB
+wxj
+tks
 kqO
 iZe
 qLk
-jxu
+tks
 qGg
 wYp
 doz
@@ -120774,18 +120943,18 @@ doz
 doz
 doz
 ceC
-doz
 yjB
 yjB
-yjB
-yjB
-yjB
-wxj
+aOo
+aaP
+aaP
+aaP
+aaP
 jdj
 hqu
-iZe
+smj
 nxJ
-jdj
+tks
 qGg
 wYp
 aLe
@@ -121032,17 +121201,17 @@ doz
 doz
 ceC
 yjB
-yjB
-hxb
-wxj
-wxj
-wxj
-wxj
-vMk
-rBS
+vpY
+aaP
+nRx
+nRx
+nRx
+nRx
+nRx
+nRx
 bHH
-vyo
-jdj
+nRx
+nRx
 qGg
 ipw
 dNb
@@ -121289,17 +121458,17 @@ doz
 doz
 doz
 yjB
-vpY
-wxj
-jxu
-jxu
-jxu
-jxu
-jxu
-jxu
+ehR
+aaP
+nRx
+szr
+pPa
+kgJ
+nWe
+tTl
 gMw
-jxu
-jxu
+ukr
+nRx
 lNK
 aLe
 aLe
@@ -121546,17 +121715,17 @@ doz
 doz
 doz
 yjB
-ehR
-wxj
-jxu
+tGh
+aaP
+nRx
 auj
 pzf
 sih
-nAa
 pXw
-lFS
+pXw
+gMw
 dRN
-jxu
+nRx
 qGg
 aLe
 doz
@@ -121804,16 +121973,16 @@ doz
 doz
 yjB
 tGh
-wxj
-jxu
+aaP
+nRx
 jvV
 hOU
 gpF
 vyN
 hLT
-jwc
+gMw
 onn
-jxu
+nRx
 qGg
 aLe
 doz
@@ -122062,15 +122231,15 @@ yjB
 yjB
 lOa
 uXp
-jxu
+nRx
 foB
 pDQ
-aYb
 cSW
-gVp
+cSW
+xRh
 lFS
 tUb
-jxu
+nRx
 vcX
 aLe
 ceC
@@ -122314,20 +122483,20 @@ yjB
 hrD
 qdy
 ccu
-wxj
-hxb
-eXX
-wxj
-wxj
-jxu
+aaP
+aOo
+aaP
+aaP
+aaP
+nRx
 eVV
 vPk
 mJl
-vyN
+iEe
 wsN
-jdN
-gKn
-jxu
+lFS
+ukr
+nRx
 qGg
 aLe
 ceC
@@ -122571,20 +122740,20 @@ yjB
 aoj
 qdy
 qdy
-wxj
+aaP
 qdy
 dLf
 xTx
 mog
-jxu
-bML
-bML
-bML
-bML
-bML
-gMw
-bML
-jxu
+nRx
+vaU
+vaU
+vaU
+vaU
+vaU
+gLT
+vaU
+nRx
 qGg
 aLe
 doz
@@ -122828,7 +122997,7 @@ yjB
 ugr
 mDW
 yjB
-wxj
+aaP
 jxu
 jxu
 jxu
@@ -123085,7 +123254,7 @@ ceC
 yjB
 aQY
 yjB
-wxj
+aaP
 jxu
 xaY
 oCN
@@ -123599,7 +123768,7 @@ ceC
 job
 job
 yjB
-wdq
+oMb
 jxu
 xaY
 oXf
@@ -123615,7 +123784,7 @@ bML
 jxu
 jxu
 jxu
-wYp
+jxu
 qGg
 aLe
 doz
@@ -123872,7 +124041,7 @@ bML
 xon
 kwc
 dGn
-wYp
+jxu
 qGg
 aLe
 doz
@@ -124113,23 +124282,23 @@ doz
 doz
 ceC
 gVh
-wdq
+oMb
 jxu
 iMQ
 vPJ
 wxL
 vPJ
-vPJ
+dtJ
 fkL
 bML
-aKz
-lFS
+xAe
+bVX
 aqn
 uks
-qMI
+pyg
 qMI
 sDv
-wYp
+jxu
 qGg
 aLe
 ceC
@@ -124370,7 +124539,7 @@ ceC
 ceC
 ceC
 gVh
-wdq
+oMb
 jxu
 fYw
 sBz
@@ -124380,13 +124549,13 @@ aPJ
 uYf
 bML
 oia
-txx
+bVX
 nPm
 bML
-rbf
+nCc
 rbf
 qAJ
-wYp
+jxu
 qGg
 aLe
 aLe
@@ -124627,7 +124796,7 @@ doz
 doz
 ceC
 gVh
-wdq
+oMb
 jxu
 nuS
 ejN
@@ -124637,13 +124806,13 @@ aPJ
 fdQ
 bML
 dsh
-jwc
+xeo
 dNM
 bML
 bML
 bML
 bML
-wYp
+jxu
 nqa
 dNb
 qGg
@@ -124884,7 +125053,7 @@ doz
 doz
 ceC
 gVh
-wdq
+oMb
 jxu
 vlM
 ejN
@@ -124895,12 +125064,12 @@ wUX
 bML
 xAe
 xjr
-vxZ
+aqn
 wPP
-woa
+kwc
 hST
 tRI
-wYp
+jxu
 qGg
 bqY
 bqY
@@ -125151,13 +125320,13 @@ eSb
 kvz
 bML
 lVK
-ptQ
+xeo
 jtL
 bML
 jsP
 jPt
 bqA
-wYp
+jxu
 vsI
 bqY
 kiG
@@ -125398,7 +125567,7 @@ doz
 ceC
 gVh
 gVh
-wdq
+oMb
 jxu
 cae
 stq
@@ -125414,7 +125583,7 @@ bML
 bML
 bML
 bML
-wYp
+jxu
 qGg
 gtv
 nPy
@@ -125655,7 +125824,7 @@ doz
 doz
 gVh
 pva
-wdq
+oMb
 jxu
 fkL
 eqJ
@@ -125664,14 +125833,14 @@ bML
 mgh
 anj
 bML
-tMX
-ptQ
-vxZ
+bEb
+xeo
+aqn
 bLm
 gVp
 gVp
 fYS
-wYp
+jxu
 qGg
 vKx
 gCL
@@ -125912,7 +126081,7 @@ doz
 doz
 gVh
 pva
-wdq
+oMb
 jxu
 bML
 bML
@@ -125920,15 +126089,15 @@ bML
 bML
 pYN
 ozi
-bML
+fUf
 aBb
-lFS
+xjr
 cXb
 bML
 jhd
 min
 xlt
-wYp
+jxu
 qGg
 bqY
 uiM
@@ -126176,11 +126345,11 @@ bML
 wIr
 fjV
 kFy
-emm
-bML
+mEt
+mEt
 uvB
-jwc
-eFA
+xeo
+mmt
 bGE
 bGE
 bGE
@@ -126433,12 +126602,12 @@ bML
 wIr
 gOT
 kFy
-opo
-hDz
+ojM
+ojM
 sJd
 igm
-eFA
-gqU
+vEz
+mdT
 lOS
 qHA
 hFb
@@ -126691,11 +126860,11 @@ jsi
 rRu
 rpm
 smP
-bML
-uvB
+wUe
+ofY
 kjf
-vFO
-gqU
+cXb
+mdT
 hux
 hZl
 qDl
@@ -126943,13 +127112,13 @@ lie
 nPS
 jxu
 jxu
-cbh
-qtW
-qtW
+jxu
+bML
+bML
 bRt
-lYL
 qtW
-sus
+qtW
+ofY
 nMn
 clJ
 cxB
@@ -127200,7 +127369,7 @@ dFR
 wdq
 drT
 wvT
-cbh
+jxu
 cTc
 ksO
 dpm
@@ -127209,7 +127378,7 @@ qtW
 tRp
 jqo
 pvi
-gqU
+mdT
 sFZ
 mki
 dPr
@@ -127457,14 +127626,14 @@ mwS
 wdq
 drT
 aWp
-cbh
+jxu
 ctd
 qxv
 hha
 fhT
-qtW
+bML
 gET
-gVp
+iHo
 eFA
 mdT
 lsU
@@ -127714,14 +127883,14 @@ lXh
 wdq
 drT
 nZC
-cbh
+jxu
 xGb
 uzd
+kRC
 wWM
-wWM
-qtW
+sAz
 xON
-gVp
+bTD
 mug
 vXt
 vXt
@@ -127971,12 +128140,12 @@ oiH
 wdq
 drT
 cCu
-cbh
-cbh
+jxu
+jxu
 rWw
 aHP
 gbo
-qtW
+bML
 oph
 nPY
 knm
@@ -128229,11 +128398,11 @@ wdq
 drT
 drT
 drT
-cbh
-cbh
-cbh
-cbh
-cbh
+jxu
+jxu
+jxu
+jxu
+jxu
 jxu
 jxu
 jxu
@@ -132336,9 +132505,9 @@ doz
 doz
 doz
 doz
-ceC
-ceC
-ceC
+doz
+doz
+doz
 ceC
 ceC
 ceC
@@ -132593,11 +132762,11 @@ doz
 doz
 doz
 doz
+doz
+doz
+doz
 oVL
 ceC
-doz
-doz
-doz
 doz
 doz
 doz
@@ -132850,10 +133019,10 @@ doz
 doz
 doz
 doz
+doz
+doz
+doz
 oVL
-doz
-doz
-doz
 doz
 doz
 doz
@@ -133107,10 +133276,10 @@ doz
 doz
 doz
 doz
+doz
+doz
+doz
 oVL
-doz
-doz
-doz
 doz
 doz
 doz
@@ -133364,10 +133533,10 @@ doz
 doz
 doz
 doz
+doz
+doz
+doz
 oVL
-doz
-doz
-doz
 doz
 doz
 doz
@@ -133621,10 +133790,10 @@ doz
 doz
 doz
 doz
+doz
+doz
+doz
 oVL
-doz
-doz
-doz
 doz
 doz
 doz
@@ -133878,10 +134047,10 @@ doz
 doz
 doz
 doz
+doz
+doz
+doz
 oVL
-doz
-doz
-doz
 doz
 doz
 doz
@@ -134135,10 +134304,10 @@ doz
 doz
 doz
 doz
+doz
+doz
+doz
 oVL
-doz
-doz
-doz
 doz
 doz
 doz
@@ -134392,10 +134561,10 @@ doz
 doz
 doz
 doz
+doz
+doz
+doz
 oVL
-doz
-doz
-doz
 doz
 doz
 doz
@@ -134649,10 +134818,10 @@ doz
 doz
 doz
 doz
+doz
+doz
+doz
 oVL
-doz
-doz
-doz
 doz
 doz
 doz
@@ -134906,11 +135075,11 @@ doz
 doz
 doz
 doz
+doz
+doz
+doz
 oVL
 ceC
-doz
-doz
-doz
 doz
 doz
 doz
@@ -135163,9 +135332,9 @@ doz
 doz
 doz
 doz
-ceC
-ceC
-ceC
+doz
+doz
+doz
 ceC
 ceC
 ceC
@@ -195807,7 +195976,7 @@ aQU
 aQU
 aQU
 nMz
-nMz
+uqT
 nMz
 nMz
 nMz
@@ -196320,10 +196489,10 @@ dFP
 kJd
 dFP
 kJd
-tVE
-drc
-drc
-drc
+aQU
+rJl
+rJl
+rJl
 tVE
 tVE
 wba
@@ -198125,16 +198294,16 @@ qlc
 qlc
 tVE
 tYD
-btN
+cbh
 iDm
 avi
 ePX
 aBc
 itz
-btN
-btN
+cbh
+cbh
 fyE
-btN
+cbh
 mZY
 fgy
 fgy
@@ -198382,13 +198551,13 @@ kJd
 tYD
 kJd
 tYD
-btN
+cbh
 jGf
 kiX
-wVY
-wVY
+npv
+npv
 lnS
-btN
+cbh
 hBv
 ylI
 fsG
@@ -198639,7 +198808,7 @@ dFP
 dFP
 kJd
 kJd
-btN
+cbh
 dYB
 tcx
 xgZ
@@ -198896,15 +199065,15 @@ tYD
 tYD
 kJd
 tYD
-btN
+cbh
 cvc
 alH
+npv
+npv
 wVY
-wVY
-wVY
-btN
+cbh
 edB
-jrV
+lpv
 kiy
 mZY
 fgy
@@ -199153,13 +199322,13 @@ tYD
 tYD
 dFP
 kJd
-btN
+cbh
 eEf
 pGf
 fYt
 tqw
 enV
-btN
+cbh
 qEE
 rci
 mOU
@@ -199410,16 +199579,16 @@ tYD
 tYD
 kJd
 tYD
-btN
-btN
-btN
-btN
-btN
-btN
-btN
-btN
-btN
-btN
+cbh
+cbh
+cbh
+cbh
+cbh
+cbh
+cbh
+cbh
+cbh
+cbh
 mZY
 kbm
 hEs

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -2060,6 +2060,7 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 6
 	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark/small,
 /area/station/security/mechbay)
 "aBh" = (
@@ -6334,7 +6335,7 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "bEb" = (
-/obj/structure/girder,
+/obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
@@ -9563,6 +9564,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "cte" = (
@@ -16245,6 +16247,8 @@
 "dYB" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/delivery,
+/obj/structure/sign/poster/official/random/directional/north,
+/obj/machinery/light/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "Brig - Mechbay"
 	},
@@ -23622,14 +23626,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "fUf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/camera/directional/west{
 	c_tag = "Brig - Lower Floor - Stairs"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "fUh" = (
@@ -33367,6 +33371,14 @@
 /obj/item/wrench,
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
+"ivB" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/ghetto)
 "ivD" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/brown{
@@ -47605,7 +47617,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/decal/cleanable/vomit,
 /obj/machinery/camera/directional/north{
 	c_tag = "Brig - Lower Floor - Cells"
 	},
@@ -55692,6 +55703,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
+"nXH" = (
+/turf/closed/wall/rust,
+/area/station/security/interrogation/ghetto)
 "nXM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -57954,9 +57968,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "ozi" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
@@ -63936,9 +63947,6 @@
 "pYN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/duct,
@@ -68019,6 +68027,7 @@
 /area/station/ai_monitored/command/storage/eva)
 "rbf" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -70494,7 +70503,7 @@
 /area/station/medical/surgery/aft)
 "rJl" = (
 /obj/structure/reagent_dispensers/plumbed{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/station/security/checkpoint/customs)
@@ -72889,7 +72898,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "smU" = (
@@ -73895,7 +73903,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "sAC" = (
 /obj/structure/disposalpipe/segment{
@@ -76970,6 +76978,7 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 10
 	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark/small,
 /area/station/security/mechbay)
 "tqy" = (
@@ -89406,6 +89415,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/security/interrogation/ghetto)
 "wAY" = (
@@ -90962,9 +90972,11 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/aft)
 "wUe" = (
-/obj/effect/turf_decal/tile/red,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "wUk" = (
@@ -121203,9 +121215,9 @@ ceC
 yjB
 vpY
 aaP
-nRx
-nRx
-nRx
+tks
+tks
+tks
 nRx
 nRx
 nRx
@@ -121460,7 +121472,7 @@ doz
 yjB
 ehR
 aaP
-nRx
+tks
 szr
 pPa
 kgJ
@@ -121468,7 +121480,7 @@ nWe
 tTl
 gMw
 ukr
-nRx
+tks
 lNK
 aLe
 aLe
@@ -121717,7 +121729,7 @@ doz
 yjB
 tGh
 aaP
-nRx
+tks
 auj
 pzf
 sih
@@ -121725,7 +121737,7 @@ pXw
 pXw
 gMw
 dRN
-nRx
+tks
 qGg
 aLe
 doz
@@ -122496,7 +122508,7 @@ iEe
 wsN
 lFS
 ukr
-nRx
+tks
 qGg
 aLe
 ceC
@@ -122746,9 +122758,9 @@ dLf
 xTx
 mog
 nRx
-vaU
-vaU
-vaU
+nXH
+nXH
+nXH
 vaU
 vaU
 gLT
@@ -125062,7 +125074,7 @@ oKK
 aPJ
 wUX
 bML
-xAe
+ivB
 xjr
 aqn
 wPP

--- a/modular_bandastation/mapping/code/areas/station.dm
+++ b/modular_bandastation/mapping/code/areas/station.dm
@@ -25,59 +25,45 @@
 // Department's Lower Floor
 /area/station/service/library/ghetto
 	name = "Library Lower Floor"
-	icon_state = "library"
 
 /area/station/medical/chemistry/ghetto
 	name = "Chemistry Lower Floor"
-	icon_state = "chem"
 
 /area/station/engineering/atmos/mix/ghetto
 	name = "Atmospherics Mixing Room Lower Floor"
-	icon_state = "atmos_mix"
 
 /area/station/security/prison/ghetto
 	name = "Prison Wing Lower Floor"
-	icon_state = "sec_prison"
+
+/area/station/security/interrogation/ghetto
+	name = "In-Depth Interrogation Room Lower Floor"
 
 /area/station/cargo/storage/ghetto
 	name = "Cargo Bay Lower Floor"
-	icon_state = "cargo_bay"
 
 /area/station/cargo/storage/ghetto/depot
 	name = "Cargo Bay Depot Lower Floor"
-	icon_state = "cargo_bay"
-
-/area/station/cargo/mining_oresmeltery/ghetto
-	name = "Mining Ore Smeltery Lower Floor"
-	icon_state = "mining_production"
 
 /area/station/cargo/drone_bay/ghetto
 	name = "Drone Bay Lower Floor"
-	icon_state = "cargo_drone"
 
 /area/station/maintenance/department/engine/ghetto
 	name = "Engineering Abandoned Engine Lower Floor"
-	icon_state = "maint_engi"
 
 /area/station/maintenance/department/electrical/ghetto
 	name = "Electrical Maintenance Lower Floor"
-	icon_state = "maint_electrical"
 
 /area/station/maintenance/department/security/ghetto
 	name = "Brig Lower Floor"
-	icon_state = "maint_sec"
 
 /area/station/maintenance/department/security/ghetto/fore
 	name = "Security Maintenance Fore Lower Floor"
-	icon_state = "maint_sec"
 
 /area/station/maintenance/department/security/ghetto/aft
 	name = "Security Maintenance Aft Lower Floor"
-	icon_state = "maint_sec"
 
 /area/station/maintenance/department/medical/ghetto
 	name = "Ghetto Abandoned Medbay"
-	icon_state = "medbay_maint"
 
 /area/station/maintenance/department/medical/ghetto/morgue
 	name = "Ghetto Abandoned Medbay Morgue"


### PR DESCRIPTION
## Что этот PR делает
Изменения Брига. Читать чейнджлог.

## Changelog

:cl:
map: Кибериада: Бриг, Мехбэй был перемещен на старое место пыточной (ой, то есть комнаты углубленного допроса). Пыточная же была перемещена на нижний этаж в самый отдаленный край подальше от чужих глаз. Сам же нижний этаж был немного изменен. В Бриге был проведен водопровод, возможно не везде.
/:cl:

## Summary by Sourcery

Relocate the interrogation room to the lower floor of the brig, moving the mech bay to the former interrogation room location. Update the brig's lower floor layout and add plumbing.