### PR TITLE
Probably fixes Tramstation failing maplinter

### DIFF
--- a/_maps/bandastation/automapper/automapper_config.toml
+++ b/_maps/bandastation/automapper/automapper_config.toml
@@ -47,6 +47,20 @@ required_map = "DeltaStation2.dmm"
 coordinates = [146, 108, 1]
 trait_name = "Station"
 
+[templates.deltastation_cryo]
+map_files = ["deltastation_cryo.dmm"]
+directory = "_maps/bandastation/automapper/templates/deltastation/"
+required_map = "DeltaStation2.dmm"
+coordinates = [216, 93, 1]
+trait_name = "Station"
+
+[templates.deltastation_perma_cryo]
+map_files = ["deltastation_perma_cryo.dmm"]
+directory = "_maps/bandastation/automapper/templates/deltastation/"
+required_map = "DeltaStation2.dmm"
+coordinates = [206, 168, 1]
+trait_name = "Station"
+
 # MetaStation
 [templates.metastation_lawyer_office]
 map_files = ["metastation_lawyer_office.dmm"]
@@ -67,6 +81,20 @@ map_files = ["metastation_ntr_blueshield_office.dmm"]
 directory = "_maps/bandastation/automapper/templates/metastation/"
 required_map = "MetaStation.dmm"
 coordinates = [101, 115, 1]
+trait_name = "Station"
+
+[templates.metastation_cryo]
+map_files = ["metastation_cryo.dmm"]
+directory = "_maps/bandastation/automapper/templates/metastation/"
+required_map = "MetaStation.dmm"
+coordinates = [133, 182, 1]
+trait_name = "Station"
+
+[templates.metastation_perma_cryo]
+map_files = ["metastation_perma_cryo.dmm"]
+directory = "_maps/bandastation/automapper/templates/metastation/"
+required_map = "MetaStation.dmm"
+coordinates = [84, 189, 1]
 trait_name = "Station"
 
 # IceBoxStation
@@ -98,6 +126,20 @@ required_map = "IceBoxStation.dmm"
 coordinates = [92, 147, 2]
 trait_name = "Station"
 
+[templates.icebox_cryo]
+map_files = ["icebox_cryo.dmm"]
+directory = "_maps/bandastation/automapper/templates/iceboxstation/"
+required_map = "IceBoxStation.dmm"
+coordinates = [117, 142, 3]
+trait_name = "Station"
+
+[templates.icebox_perma_cryo]
+map_files = ["icebox_perma_cryo.dmm"]
+directory = "_maps/bandastation/automapper/templates/iceboxstation/"
+required_map = "IceBoxStation.dmm"
+coordinates = [108, 184, 2]
+trait_name = "Station"
+
 # TramStation
 [templates.tramstation_detective_office]
 map_files = ["tramstation_detective_office.dmm"]
@@ -119,55 +161,6 @@ directory = "_maps/bandastation/automapper/templates/tramstation/"
 required_map = "tramstation.dmm"
 coordinates = [79, 130, 2]
 
-# Metastation Cryo
-[templates.metastation_cryo]
-map_files = ["metastation_cryo.dmm"]
-directory = "_maps/bandastation/automapper/templates/metastation/"
-required_map = "MetaStation.dmm"
-coordinates = [133, 182, 1]
-trait_name = "Station"
-
-# Metastation Perma Cryo
-[templates.metastation_perma_cryo]
-map_files = ["metastation_perma_cryo.dmm"]
-directory = "_maps/bandastation/automapper/templates/metastation/"
-required_map = "MetaStation.dmm"
-coordinates = [84, 189, 1]
-trait_name = "Station"
-
-# Deltastation Cryo
-[templates.deltastation_cryo]
-map_files = ["deltastation_cryo.dmm"]
-directory = "_maps/bandastation/automapper/templates/deltastation/"
-required_map = "DeltaStation2.dmm"
-coordinates = [216, 93, 1]
-trait_name = "Station"
-
-# Deltastation Perma Cryo
-[templates.deltastation_perma_cryo]
-map_files = ["deltastation_perma_cryo.dmm"]
-directory = "_maps/bandastation/automapper/templates/deltastation/"
-required_map = "DeltaStation2.dmm"
-coordinates = [206, 168, 1]
-trait_name = "Station"
-
-# Icebox Cryo
-[templates.icebox_cryo]
-map_files = ["icebox_cryo.dmm"]
-directory = "_maps/bandastation/automapper/templates/iceboxstation/"
-required_map = "IceBoxStation.dmm"
-coordinates = [117, 142, 3]
-trait_name = "Station"
-
-# Icebox Perma Cryo
-[templates.icebox_perma_cryo]
-map_files = ["icebox_perma_cryo.dmm"]
-directory = "_maps/bandastation/automapper/templates/iceboxstation/"
-required_map = "IceBoxStation.dmm"
-coordinates = [108, 184, 2]
-trait_name = "Station"
-
-# Tramstation Cryo
 [templates.tramstation_cryo]
 map_files = ["tramstation_cryo.dmm"]
 directory = "_maps/bandastation/automapper/templates/tramstation/"
@@ -175,15 +168,14 @@ required_map = "tramstation.dmm"
 coordinates = [68, 102, 2]
 trait_name = "Station"
 
-# Tramstation Perma Cryo
 [templates.tramstation_perma_cryo]
 map_files = ["tramstation_perma_cryo.dmm"]
 directory = "_maps/bandastation/automapper/templates/tramstation/"
 required_map = "tramstation.dmm"
-coordinates = [79, 149, 1]
+coordinates = [70, 155, 1]
 trait_name = "Station"
 
-# Birdshot Cryo
+# Birdshot
 [templates.birdshot_cryo]
 map_files = ["birdshot_cryo.dmm"]
 directory = "_maps/bandastation/automapper/templates/birdshot/"
@@ -191,7 +183,6 @@ required_map = "birdshot.dmm"
 coordinates = [142, 84, 1]
 trait_name = "Station"
 
-# Birdshot Perma Cryo
 [templates.birdshot_perma_cryo]
 map_files = ["birdshot_perma_cryo.dmm"]
 directory = "_maps/bandastation/automapper/templates/birdshot/"
@@ -199,7 +190,7 @@ required_map = "birdshot.dmm"
 coordinates = [76, 33, 1]
 trait_name = "Station"
 
-# Nebulastation Cryo
+# Nebulastation
 [templates.nebulastation_cryo]
 map_files = ["nebulastation_cryo.dmm"]
 directory = "_maps/bandastation/automapper/templates/nebulastation/"
@@ -207,7 +198,6 @@ required_map = "NebulaStation.dmm"
 coordinates = [81, 145, 1]
 trait_name = "Station"
 
-# Nebulastation Perma Cryo
 [templates.nebulastation_perma_cryo]
 map_files = ["nebulastation_perma_cryo.dmm"]
 directory = "_maps/bandastation/automapper/templates/nebulastation/"

--- a/_maps/bandastation/automapper/automapper_config.toml
+++ b/_maps/bandastation/automapper/automapper_config.toml
@@ -160,6 +160,7 @@ map_files = ["tramstation_ntr_blueshield_office.dmm"]
 directory = "_maps/bandastation/automapper/templates/tramstation/"
 required_map = "tramstation.dmm"
 coordinates = [79, 130, 2]
+trait_name = "Station"
 
 [templates.tramstation_cryo]
 map_files = ["tramstation_cryo.dmm"]

--- a/_maps/bandastation/automapper/templates/tramstation/tramstation_perma_cryo.dmm
+++ b/_maps/bandastation/automapper/templates/tramstation/tramstation_perma_cryo.dmm
@@ -1,14 +1,150 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/machinery/computer/cryopod/directional/east,
-/turf/template_noop,
-/area/template_noop)
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/machinery/cryopod/prison/directional/north,
+/turf/open/floor/iron,
+/area/station/security/prison)
+"i" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/station/security/prison)
 "k" = (
-/obj/machinery/cryopod/prison/directional/east,
-/turf/template_noop,
-/area/template_noop)
+/turf/closed/wall,
+/area/station/security/prison)
+"n" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/duct,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/computer/cryopod/directional/north,
+/turf/open/floor/iron,
+/area/station/security/prison)
+"s" = (
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron,
+/area/station/security/prison)
+"u" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/station/security/prison)
+"v" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/station/security/prison)
+"x" = (
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/prison)
+"y" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/prison)
+"C" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/machinery/camera/directional/west{
+	network = list("ss13","Security","prison");
+	c_tag = "Security - Prison Main North"
+	},
+/turf/open/floor/iron,
+/area/station/security/prison)
+"D" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/security/prison)
+"Q" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/prison)
+"T" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/machinery/cryopod/prison/directional/north,
+/turf/open/floor/iron,
+/area/station/security/prison)
 
 (1,1,1) = {"
+C
 k
 a
+"}
+(2,1,1) = {"
+x
+D
+y
+"}
+(3,1,1) = {"
+s
+k
+n
+"}
+(4,1,1) = {"
+u
+i
+v
+"}
+(5,1,1) = {"
+Q
+k
+T
 "}


### PR DESCRIPTION
Возможно пофиксил падающий тест на Траме путем перемещения конфликтующих темплейтов автомаппера (правда я не ебу че они могут конфликтовать, когда карты находятся на разных уровнях, НО! Они пересекаются в одной координате, поэтому я надеюсь что изменение перма крио Трама пофиксит эту проблему.

## Summary by Sourcery

Bug Fixes:
- Resolve maplinter conflicts by repositioning the Tramstation perma cryo template.