### PR TITLE
Открытие шлюзов руками

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -494,16 +494,21 @@
 
 	if(!user.combat_mode)
 		// BANDASTATION EDIT START
-		if(welded || operating)
+		if(welded)
 			return
-		if(do_after(user, 5 SECONDS))
-			user.visible_message(
-				"<span class='notice'>[user] opens [src].</span>",
-				"<span class='notice'>You open [src].</span>")
-			if(density)
-				open()
-				if(active)
-					addtimer(CALLBACK(src, PROC_REF(correct_state)), 2 SECONDS, TIMER_UNIQUE)
+			
+		if(!do_after(user, 5 SECONDS))
+			return
+
+		if(!density)
+			return
+			
+		open()	
+		user.visible_message(span_notice("[user] opens [src].", span_notice("You open [src].")
+		if(!active)
+			return
+			
+		addtimer(CALLBACK(src, PROC_REF(correct_state)), 2 SECONDS, TIMER_UNIQUE)
 		// BANDASTATION EDIT STOP
 	else
 		user.visible_message(span_warning("[user] bashes [src]!"), \

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -493,9 +493,18 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 
 	if(!user.combat_mode)
-		user.visible_message(span_notice("[user] knocks on [src]."), \
-			span_notice("You knock on [src]."))
-		playsound(src, knock_sound, 50, TRUE)
+		// BANDASTATION EDIT START
+		if(welded || operating)
+			return
+		if(do_after(user, 5 SECONDS))
+			user.visible_message(
+				"<span class='notice'>[user] opens [src].</span>",
+				"<span class='notice'>You open [src].</span>")
+			if(density)
+				open()
+				if(active)
+					addtimer(CALLBACK(src, PROC_REF(correct_state)), 2 SECONDS, TIMER_UNIQUE)
+		// BANDASTATION EDIT STOP
 	else
 		user.visible_message(span_warning("[user] bashes [src]!"), \
 			span_warning("You bash [src]!"))

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -493,21 +493,26 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 
 	if(!user.combat_mode)
+		/* BandaStation Removal
+		user.visible_message(span_notice("[user] knocks on [src]."), \
+			span_notice("You knock on [src]."))
+		playsound(src, knock_sound, 50, TRUE)
+		*/
 		// BANDASTATION EDIT START
 		if(welded)
 			return
-			
+
 		if(!do_after(user, 5 SECONDS))
 			return
 
 		if(!density)
 			return
-			
-		open()	
-		user.visible_message(span_notice("[user] opens [src].", span_notice("You open [src].")
+
+		open()
+		user.visible_message(span_notice("[user] opens [src]."), span_notice("You open [src]."))
 		if(!active)
 			return
-			
+
 		addtimer(CALLBACK(src, PROC_REF(correct_state)), 2 SECONDS, TIMER_UNIQUE)
 		// BANDASTATION EDIT STOP
 	else


### PR DESCRIPTION
У каждого шлюза есть рычажок для экстренного открытия

## Что этот PR делает

Добавляет возможность открыть шлюз рукой, не в комбат моде

## Почему это хорошо для игры

Экипажу трудно перемещаться при разгермах, так как мало у кого есть лом

## Тестирование

Протестировал локально, шлюз открывается и закрывается через 2 секунды

## Changelog

:cl:
add: Теперь можно открывать шлюз рукой
/:cl:

## Summary by Sourcery

Allow opening firedoors by hand if not welded shut or already operating. Opening takes 5 seconds.

New Features:
- Added the ability to open firedoors by hand. Opening takes 5 seconds

Tests:
- Tested locally