### PR TITLE
Fix late-join silicons have lobby screen

### DIFF
--- a/modular_bandastation/title_screen/code/new_player.dm
+++ b/modular_bandastation/title_screen/code/new_player.dm
@@ -1,10 +1,6 @@
 /mob/dead/new_player
 	var/title_collapsed = FALSE
 
-/mob/living/silicon/Initialize(mapload)
-	. = ..()
-	SStitle.hide_title_screen_from(client)
-
 /mob/living/silicon/ai/Initialize(mapload, datum/ai_laws/L, mob/target_ai)
 	. = ..()
 	SStitle.hide_title_screen_from(client)

--- a/modular_bandastation/title_screen/code/new_player.dm
+++ b/modular_bandastation/title_screen/code/new_player.dm
@@ -3,7 +3,7 @@
 
 /mob/living/silicon/ai/Initialize(mapload, datum/ai_laws/L, mob/target_ai)
 	. = ..()
-	if(isnewplayer(target_ai)
+	if(isnewplayer(target_ai))
 		SStitle.hide_title_screen_from(client)
 
 /mob/dead/new_player/Topic(href, href_list[])

--- a/modular_bandastation/title_screen/code/new_player.dm
+++ b/modular_bandastation/title_screen/code/new_player.dm
@@ -1,6 +1,14 @@
 /mob/dead/new_player
 	var/title_collapsed = FALSE
 
+/mob/living/silicon/Initialize(mapload)
+	. = ..()
+	SStitle.hide_title_screen_from(client)
+
+/mob/living/silicon/ai/Initialize(mapload, datum/ai_laws/L, mob/target_ai)
+	. = ..()
+	SStitle.hide_title_screen_from(client)
+
 /mob/dead/new_player/Topic(href, href_list[])
 	if(src != usr)
 		return

--- a/modular_bandastation/title_screen/code/new_player.dm
+++ b/modular_bandastation/title_screen/code/new_player.dm
@@ -3,7 +3,8 @@
 
 /mob/living/silicon/ai/Initialize(mapload, datum/ai_laws/L, mob/target_ai)
 	. = ..()
-	SStitle.hide_title_screen_from(client)
+	if(isnewplayer(target_ai)
+		SStitle.hide_title_screen_from(client)
 
 /mob/dead/new_player/Topic(href, href_list[])
 	if(src != usr)

--- a/modular_bandastation/title_screen/code/title_screen_controls.dm
+++ b/modular_bandastation/title_screen/code/title_screen_controls.dm
@@ -61,6 +61,7 @@ ADMIN_VERB(change_title_screen_css, R_DEBUG, "Title Screen: Set CSS", ADMIN_VERB
 	set category = "Special"
 
 	if(!isnewplayer(src.mob))
+		SStitle.hide_title_screen_from(src)
 		return
 
 	SStitle.show_title_screen_to(src)


### PR DESCRIPTION
## Что этот PR делает
Fixes #1002 
Так же, Fix Lobby Screen верб, теперь закрывает лобби скрин если типочек в игре. На всякий случай

## Почему это хорошо для игры
ИИ при лейт джоине не висит в лобби общаясь в IC, арты конечно красивые, но наблюдать тоже надо

## Changelog

:cl:
fix: Лейтджоин ИИ, больше не будут смотреть на лобби арт и общаться IC
/:cl:
