### PR TITLE
Cyberiad: Standardize Sec. Checkpoints, Cleanup cameras

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -134,23 +134,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"acl" = (
-/obj/structure/table,
-/obj/machinery/camera{
-	c_tag = "Brig Labor Camp Airlock North";
-	dir = 1
-	},
-/obj/item/restraints/handcuffs,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner/skirt,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/item/clothing/shoes/sneakers/orange,
-/obj/structure/cable,
-/obj/machinery/gulag_item_reclaimer{
-	pixel_y = 28
-	},
-/turf/open/floor/iron,
-/area/station/security/processing)
 "acm" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron/smooth,
@@ -220,6 +203,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"adi" = (
+/obj/structure/grille,
+/obj/structure/barricade/wooden,
+/obj/machinery/door/poddoor/preopen{
+	name = "Engineering Security Doors";
+	id = "engineering_lockdown"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/electrical)
 "adk" = (
 /obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/plating,
@@ -606,21 +598,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
-"aig" = (
-/obj/structure/cable,
-/obj/machinery/power/port_gen/pacman,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/obj/machinery/camera{
-	c_tag = "Engineering Equipment Storage Hardsuits";
-	dir = 8;
-	network = list("SS13","Engineering")
-	},
-/obj/item/stack/sheet/mineral/plasma/five,
-/turf/open/floor/iron/dark,
-/area/station/engineering/main)
 "aip" = (
 /obj/structure/closet/emcloset,
 /obj/effect/landmark/start/hangover/closet,
@@ -737,9 +714,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"ajR" = (
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
 "aka" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
@@ -1079,6 +1053,19 @@
 /obj/effect/spawner/random/engineering/flashlight,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/fore)
+"aoq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/plating,
+/area/station/science/ordnance)
 "aot" = (
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
@@ -1110,20 +1097,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"aoV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/vending/coffee,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Dormitories West"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "aoW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/general{
 	dir = 1
@@ -1148,19 +1121,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/fore)
-"apl" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
 "apu" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
@@ -1259,6 +1219,17 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
+"aqy" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/landmark/start/depsec/engineering,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/engineering)
 "aqF" = (
 /obj/structure/railing{
 	dir = 10
@@ -1300,6 +1271,30 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"arc" = (
+/obj/structure/table/glass,
+/obj/machinery/camera/directional/north{
+	c_tag = "Virology - Workspace";
+	network = list("ss13","medbay")
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/obj/machinery/requests_console/directional/north{
+	department = "Virology";
+	name = "Virology Requests Console"
+	},
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/mapping_helpers/requests_console/ore_update,
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "are" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/spawner/random/trash/cigbutt,
@@ -1328,22 +1323,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
-"arM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/engineering/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/poddoor/preopen{
-	name = "Engineering Security Doors";
-	id_tag = "engineering_lockdown"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/turf/open/floor/iron,
-/area/station/engineering/hallway)
 "arN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1369,6 +1348,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"asi" = (
+/obj/machinery/door/airlock/security,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "asq" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
@@ -1486,6 +1475,16 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
+"atI" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/camera/directional/south{
+	c_tag = "Research - E.X.P.E.R.I-MENTOR Lab";
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/tile/purple/half,
+/turf/open/floor/iron/white,
+/area/station/science/explab)
 "atR" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
@@ -1555,15 +1554,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/service/library)
-"auX" = (
-/obj/effect/turf_decal/bot_red,
-/obj/item/beacon,
-/obj/machinery/camera/directional/east{
-	c_tag = "Research - Polygon - Center";
-	network = list("rd","ordnance")
-	},
-/turf/open/floor/iron/airless,
-/area/station/science/ordnance/bomb)
 "avf" = (
 /obj/structure/chair/sofa/bench/right,
 /turf/open/floor/plating,
@@ -1642,19 +1632,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
-"awf" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/camera{
-	c_tag = "Engineering Atmospherics Control Room - East";
-	network = list("SS13","Engineering");
-	dir = 6
-	},
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/engineering/atmos)
 "awk" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -1682,15 +1659,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"awD" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/radio/off,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
 "awS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1972,6 +1940,18 @@
 /obj/structure/bed/maint,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
+"azM" = (
+/obj/structure/cable,
+/obj/machinery/camera/directional/north{
+	c_tag = "Brig Warden's Office"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/status_display/evac/directional/north,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/security/warden)
 "azO" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/turf_decal/bot,
@@ -2014,6 +1994,15 @@
 	light_color = "#a659ff"
 	},
 /area/station/service/bar)
+"aAh" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Central Hallway East"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "aAk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance,
@@ -2202,6 +2191,15 @@
 "aCP" = (
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
+"aCU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/obj/machinery/camera/directional/south{
+	c_tag = "Engineering - Supermatter Room Aft";
+	network = list("ss13","engine","engineering")
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "aCZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 9
@@ -2262,14 +2260,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/iron/smooth,
 /area/station/commons/toilet/restrooms)
-"aDX" = (
-/obj/item/radio/intercom/directional/north,
-/obj/machinery/camera{
-	c_tag = "Brig Briefing Room";
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security/office)
 "aDZ" = (
 /obj/machinery/button/door/directional/north{
 	id = "kitchenbar";
@@ -2465,6 +2455,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
+"aGk" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/landmark/start/assistant,
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/station/service/cafeteria)
 "aGr" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/pew{
@@ -2683,30 +2681,15 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
-"aIC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera{
-	c_tag = "Prison Entry";
-	dir = 9;
-	network = list("Prison","SS13")
+"aIx" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/table,
+/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
 	},
-/obj/machinery/button/flasher{
-	id = "permaflash2";
-	name = "Flasher button";
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/flasher/directional/north{
-	id = "permaflash1";
-	pixel_x = 16
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/security/prison)
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/engineering)
 "aIE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2735,16 +2718,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
-"aIQ" = (
-/obj/structure/chair/sofa/bench/right{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Departure Lounge North-West";
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "aIW" = (
 /obj/item/reagent_containers/chem_pack,
 /obj/item/reagent_containers/chem_pack,
@@ -2796,14 +2769,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"aJF" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/camera{
-	c_tag = "Prison Forestry External";
-	network = list("ss13","prison")
-	},
-/turf/open/openspace,
-/area/station/security/prison)
 "aJL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -2842,19 +2807,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
-"aKi" = (
-/obj/effect/turf_decal/tile/red/fourcorners,
-/obj/structure/toilet{
-	pixel_y = 8;
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Prison Solitary 1";
-	dir = 8;
-	network = list("Prison","SS13")
-	},
-/turf/open/floor/iron,
-/area/station/security/prison)
 "aKo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -3135,14 +3087,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
-"aNT" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
-	},
-/obj/effect/landmark/start/depsec/medical,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/checkpoint/medical)
 "aNU" = (
 /obj/machinery/computer/crew,
 /obj/effect/turf_decal/tile/green/half/contrasted,
@@ -3201,11 +3145,27 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"aOK" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
+/obj/effect/landmark/start/depsec/supply,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
 "aOM" = (
 /obj/machinery/telecomms/server/presets/common,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /turf/open/floor/iron/telecomms,
 /area/station/tcommsat/server)
+"aOQ" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Secure Tech Storage";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/plating,
+/area/station/engineering/storage/tech)
 "aOV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3226,6 +3186,14 @@
 /obj/effect/mapping_helpers/requests_console/announcement,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
+"aPk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	name = "Engineering Security Doors";
+	id = "engineering_lockdown"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/dronefabricator)
 "aPm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -3474,30 +3442,18 @@
 	},
 /turf/open/misc/beach/sand,
 /area/station/service/hydroponics)
-"aSg" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "JimNortonKitchen"
+"aSi" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
 	},
-/obj/item/storage/fancy/coffee_condi_display{
-	pixel_y = 10;
-	pixel_x = 1
+/obj/machinery/camera/directional/north{
+	c_tag = "Research - Xenobiology Cell 1";
+	network = list("ss13","xeno","rd")
 	},
-/obj/item/reagent_containers/cup/bottle/syrup_bottle/liqueur{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/cup/bottle/syrup_bottle/korta_nectar{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/cup/bottle/syrup_bottle/caramel{
-	pixel_x = 12;
-	pixel_y = 4
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/wood,
-/area/station/service/cafeteria)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "aSj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -3520,13 +3476,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
-"aSA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera{
-	c_tag = "Brig Firing Range"
-	},
-/turf/open/floor/iron,
-/area/station/security/range)
 "aSB" = (
 /obj/item/clothing/glasses/sunglasses,
 /obj/structure/flora/bush/lavendergrass,
@@ -3675,6 +3624,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
+"aTV" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/engineering)
 "aTZ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -3817,13 +3772,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/stairs/medium,
 /area/station/hallway/primary/aft)
-"aWh" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals Auxiliary Docking South-East";
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "aWp" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /obj/effect/turf_decal/stripes/line{
@@ -3974,6 +3922,30 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"aXR" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "JimNortonKitchen"
+	},
+/obj/item/storage/fancy/coffee_condi_display{
+	pixel_y = 10;
+	pixel_x = 1
+	},
+/obj/item/reagent_containers/cup/bottle/syrup_bottle/liqueur{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/cup/bottle/syrup_bottle/korta_nectar{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/cup/bottle/syrup_bottle/caramel{
+	pixel_x = 12;
+	pixel_y = 4
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/wood,
+/area/station/service/cafeteria)
 "aXV" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/iron/white,
@@ -3988,6 +3960,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"aXX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - Freezers";
+	network = list("ss13","engine","engineering")
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "aXY" = (
 /obj/item/storage/backpack/duffelbag/clown,
 /obj/item/food/grown/banana,
@@ -4075,6 +4058,16 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/large,
 /area/station/service/theater)
+"aYX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/directional/east{
+	c_tag = "Engineering - Supermatter Room Starboard";
+	network = list("ss13","engine","engineering")
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "aZa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/loading_area{
@@ -4154,6 +4147,26 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/processing)
+"bad" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "JimNortonKitchen"
+	},
+/obj/structure/desk_bell{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/cup/glass/coffee{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/cup/rag{
+	pixel_y = 2;
+	pixel_x = -7
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/wood,
+/area/station/service/cafeteria)
 "bae" = (
 /obj/machinery/status_display/ai/directional/north,
 /obj/machinery/light/small/directional/north,
@@ -4173,30 +4186,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/kitchen/small,
 /area/station/maintenance/starboard/fore)
-"bao" = (
-/obj/structure/closet/secure_closet/security/sec,
-/obj/item/clothing/mask/balaclava,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/turf_decal/delivery/red,
-/obj/machinery/camera{
-	c_tag = "Brig Security Equipment Lockers";
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/lockers)
-"baA" = (
-/obj/structure/table/reinforced,
-/obj/item/radio/off,
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/tile/red/full,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/checkpoint/medical)
 "baF" = (
 /obj/machinery/camera/motion/directional/south{
 	c_tag = "MiniSat Foyer";
@@ -4389,20 +4378,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
-"bdh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Medbay Hallway South";
-	dir = 4
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "bdn" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -4668,6 +4643,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"bhc" = (
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/machinery/requests_console/directional/south{
+	department = "Cargo";
+	name = "Security Requests Console"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 4
+	},
+/obj/item/pen,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
 "bhg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/small/directional/west,
@@ -4777,18 +4770,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/commons/locker)
-"bis" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/donkpockets,
-/obj/machinery/camera{
-	c_tag = "Virology Break Room";
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "biw" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -5282,6 +5263,18 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"bpA" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Engineering - Atmos Control Room East";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/engineering/atmos)
 "bpJ" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/tile,
@@ -5515,19 +5508,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
-"brQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/corporate{
-	id_tag = "ntr_door"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/navigate_destination,
-/obj/effect/mapping_helpers/airlock/access/any/command/magistrate,
-/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
-/turf/open/floor/wood/tile,
-/area/station/command/heads_quarters/nanotrasen_representative)
 "brR" = (
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
@@ -5536,6 +5516,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
+"bsa" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Medbay - Lobby";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "bsf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5602,6 +5592,16 @@
 	},
 /turf/open/floor/carpet,
 /area/station/service/chapel)
+"bta" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Brig Main Hall West 1"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "btb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5743,16 +5743,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"bvj" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/hop,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
-/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
-/obj/effect/mapping_helpers/airlock/access/any/command/hop,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/hop)
 "bvz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5778,16 +5768,6 @@
 "bvP" = (
 /turf/open/floor/iron/white,
 /area/station/science/lower)
-"bvT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/general,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/science/research)
 "bvW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5911,16 +5891,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"bxp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/camera{
-	c_tag = "Medbay Lobby Reception";
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "bxt" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating,
@@ -6179,12 +6149,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/ghetto/central)
-"bBq" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
 "bBw" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -6299,26 +6263,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
-"bCM" = (
-/obj/machinery/camera{
-	c_tag = "Mime Office";
-	dir = 1
-	},
-/obj/structure/table/wood,
-/obj/structure/mirror/directional/north,
-/obj/item/lipstick/random{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/lipstick/random{
-	pixel_y = 4
-	},
-/obj/item/lipstick/random{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/service/theater)
 "bCN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6376,6 +6320,19 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
+"bDC" = (
+/obj/structure/closet/crate/wooden/toy,
+/obj/item/toy/mecha/honk,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/machinery/camera/directional/north{
+	c_tag = "Clown Office"
+	},
+/obj/structure/mirror/directional/north,
+/turf/open/floor/iron/kitchen,
+/area/station/service/theater)
 "bDE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -6408,6 +6365,16 @@
 /obj/structure/ore_box,
 /turf/open/floor/iron,
 /area/station/cargo/storage/ghetto/depot)
+"bDW" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Prison General North";
+	network = list("ss13","prison")
+	},
+/obj/structure/cable,
+/obj/structure/punching_bag,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/security/prison/ghetto)
 "bDX" = (
 /obj/structure/railing{
 	dir = 8
@@ -6468,14 +6435,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
-"bEP" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Xenobiology Pens Observation - Starboard Aft";
-	network = list("ss13","rd","xeno");
-	dir = 2
-	},
-/turf/open/openspace,
-/area/station/science/xenobiology)
 "bEY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6648,11 +6607,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"bHt" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "bHG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -6784,16 +6738,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
-"bJx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "bJE" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/yellow{
@@ -7091,6 +7035,20 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/engineering/atmos)
+"bMR" = (
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/camera/directional/south{
+	c_tag = "Engineering - Supermatter Engine Room South";
+	network = list("ss13","engine","engineering")
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/hallway/west)
 "bMV" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -7110,6 +7068,16 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
+"bNg" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Fore Primary Hallway South"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/sign/departments/court/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "bNl" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7246,6 +7214,24 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
+"bOU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Engineering - Supermatter Foyer";
+	network = list("ss13","engine","engineering")
+	},
+/obj/structure/rack,
+/obj/item/analyzer,
+/obj/item/geiger_counter,
+/obj/item/geiger_counter{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/engineering/hallway/west)
 "bOW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink/kitchen/directional/south,
@@ -7293,6 +7279,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"bPF" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Vacant Store"
+	},
+/obj/machinery/button/door/directional/north{
+	id = "vacantstore_north"
+	},
+/obj/effect/turf_decal/tile/neutral/full,
+/turf/open/floor/iron/dark/small,
+/area/station/commons/vacant_room/commissary)
 "bPK" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -7421,18 +7417,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/processing)
-"bQV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	name = "Engineering Security Doors";
-	id_tag = "engineering_lockdown"
-	},
-/turf/open/floor/iron/stairs/right{
-	dir = 8
-	},
-/area/station/engineering/transit_tube)
 "bQY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7544,15 +7528,6 @@
 "bSc" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/port/aft)
-"bSf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/effect/landmark/event_spawn,
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
 "bSi" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt,
@@ -7646,26 +7621,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/abandoned_gambling_den)
-"bUb" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/poddoor/preopen{
-	name = "Engineering Security Doors";
-	id_tag = "engineering_lockdown"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/break_room)
-"bUd" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
 "bUe" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/north,
@@ -7695,15 +7650,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
-"bUP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
 "bUT" = (
 /obj/structure/toilet{
 	pixel_y = -4;
@@ -7792,6 +7738,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"bWs" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "medical_break"
+	},
+/turf/open/floor/plating,
+/area/station/medical/break_room)
 "bWv" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral{
@@ -7834,14 +7788,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"bWV" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Xenobiology Pens Observation - Port Aft";
-	network = list("ss13","rd","xeno");
-	dir = 1
-	},
-/turf/open/openspace,
-/area/station/science/xenobiology)
 "bWX" = (
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 1
@@ -8015,6 +7961,16 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/entry)
+"bZv" = (
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Brig Main Hall South-West"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "bZw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -8693,16 +8649,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/sorting)
-"cif" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/camera{
-	c_tag = "Courtroom North";
-	dir = 4
-	},
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood/parquet,
-/area/station/security/courtroom)
 "cih" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -8774,6 +8720,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"ciO" = (
+/obj/machinery/door/airlock/security,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
 "ciP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8972,6 +8928,17 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"ckO" = (
+/obj/structure/table,
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - Reception";
+	network = list("ss13","engineering")
+	},
+/obj/machinery/computer/security/telescreen/engine/directional/north,
+/obj/item/folder/yellow,
+/obj/item/pen,
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "ckQ" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -9163,6 +9130,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"cni" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/light_switch/directional/north,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - Atmos North";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "cnm" = (
 /turf/open/floor/iron/stairs/left{
 	dir = 4
@@ -9341,6 +9320,21 @@
 /obj/structure/sign/poster/contraband/tools/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
+"cpS" = (
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Brig Secure Armory East"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "cpY" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -9446,16 +9440,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/station/service/library/ghetto)
-"cro" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/engineering/hallway)
 "crq" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -9533,6 +9517,18 @@
 /obj/item/clothing/shoes/magboots,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/command/storage/eva)
+"csr" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/status_display/ai/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - Atmos NorthEast";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "css" = (
 /obj/item/reagent_containers/cup/glass/bottle/beer{
 	pixel_y = -1;
@@ -9951,20 +9947,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
-"cxE" = (
-/obj/machinery/camera{
-	c_tag = "Prison Cafeteria External";
-	dir = 4;
-	network = list("Prison","SS13")
-	},
-/obj/structure/lattice,
-/turf/open/space/openspace,
-/area/space/nearstation)
 "cxI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/suit_storage_unit/industrial/loader,
 /turf/open/floor/iron,
 /area/station/cargo/storage/ghetto/depot)
+"cxR" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Cargo - Bay South";
+	network = list("ss13","cargo")
+	},
+/obj/effect/spawner/random/trash/box,
+/obj/structure/sign/poster/random/directional/south,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "cxU" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -9996,6 +9992,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/kitchen)
+"cyu" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "cyz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -10090,6 +10097,20 @@
 /obj/machinery/meter,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"czt" = (
+/obj/structure/cable,
+/obj/machinery/power/port_gen/pacman,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/obj/machinery/camera/directional/west{
+	c_tag = "Engineering - Equipment Storage Hardsuits";
+	network = list("ss13","engineering")
+	},
+/obj/item/stack/sheet/mineral/plasma/five,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "czF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -10397,6 +10418,20 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"cDQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/plating,
+/area/station/science/robotics/lab)
 "cDV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10472,6 +10507,10 @@
 /obj/structure/hedge/opaque,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"cEH" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/medical/cryo)
 "cEI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -10723,16 +10762,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/cult,
 /area/station/maintenance/starboard/fore)
-"cHS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/directional/east{
-	c_tag = "Engineering - Supermatter Room Starboard";
-	network = list("ss13","engine")
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
 "cHV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/half{
@@ -10808,27 +10837,6 @@
 /obj/machinery/cell_charger,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
-"cIw" = (
-/obj/structure/closet/secure_closet/freezer/kitchen/all_access,
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain,
-/obj/item/food/breadslice/plain,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/potato,
-/obj/item/food/grown/onion,
-/obj/item/food/grown/onion,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/sign/poster/ripped/directional/north,
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/camera{
-	c_tag = "Prison Cafeteria";
-	network = list("Prison","SS13");
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison)
 "cIJ" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -10935,6 +10943,17 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
+"cJF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/medical,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "cJM" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/airalarm/directional/south,
@@ -11022,6 +11041,36 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"cLb" = (
+/obj/structure/table/glass,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	name = "Quarantine Shutters";
+	id = "quarantine";
+	req_access = list("cmo");
+	pixel_y = 3;
+	pixel_x = -6;
+	color = "yellow"
+	},
+/obj/machinery/button/door{
+	name = "CMO Office Shutters";
+	id = "CMO";
+	req_access = list("cmo");
+	pixel_y = -2;
+	pixel_x = 6
+	},
+/obj/machinery/button/door{
+	name = "CMO Door Control";
+	id = "CMO_door";
+	req_access = list("cmo");
+	pixel_y = 8;
+	pixel_x = 6;
+	normaldoorcontrol = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/cmo)
 "cLd" = (
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/yellow{
@@ -11233,17 +11282,6 @@
 /obj/machinery/photocopier,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
-"cNl" = (
-/obj/machinery/camera{
-	c_tag = "Prison General North";
-	dir = 10;
-	network = list("Prison","SS13")
-	},
-/obj/structure/cable,
-/obj/structure/punching_bag,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/security/prison/ghetto)
 "cNA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11353,6 +11391,15 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"cOC" = (
+/obj/machinery/door/poddoor{
+	id = "xenobio_maint_fore";
+	name = "Xenobiology Blast Door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "cOM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11473,6 +11520,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
+"cQl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "cQm" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
 	dir = 1
@@ -11555,6 +11611,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/ghetto)
+"cRG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - Hallway West";
+	network = list("ss13","engineering")
+	},
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/hallway)
 "cRM" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -11629,11 +11699,6 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/entry)
-"cSD" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/machinery/computer/security/telescreen/ce/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/ce)
 "cSO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -11981,19 +12046,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
-"cWw" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/camera{
-	c_tag = "Engineering Atmospherics Control Room - West";
-	network = list("SS13","Engineering");
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "cWD" = (
 /obj/effect/spawner/random/structure/table_or_rack,
 /obj/item/reagent_containers/spray/cleaner,
@@ -12649,13 +12701,6 @@
 /obj/structure/sign/warning/radiation/directional/south,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
-"deu" = (
-/obj/machinery/camera{
-	c_tag = "Locker Room East";
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/commons/locker)
 "deF" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/wood/large,
@@ -13008,6 +13053,21 @@
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
+"dja" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/command/hop{
+	id_tag = "HoP_door"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/obj/effect/landmark/navigate_destination,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/effect/mapping_helpers/airlock/access/any/command/hop,
+/turf/open/floor/iron,
+/area/station/command/heads_quarters/hop)
 "djb" = (
 /obj/item/vending_refill/boozeomat,
 /turf/open/floor/plating,
@@ -13656,6 +13716,20 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
+"dpB" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/effect/landmark/start/depsec/medical,
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/machinery/computer/security/telescreen/med_sec/directional/east{
+	name = "Medbay Security Monitor";
+	pixel_y = 6
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/checkpoint/medical)
 "dpE" = (
 /obj/machinery/light/small/directional/south{
 	name = "maintenance light";
@@ -13725,6 +13799,23 @@
 /obj/item/banner/cargo,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"dru" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/tank_dispenser{
+	pixel_x = -1
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - Atmos Storage";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/storage/gas)
 "drv" = (
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
@@ -13918,6 +14009,16 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"dtb" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Brig Main Hall West 2"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "dtf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13940,14 +14041,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/wood,
 /area/station/service/library)
-"dtN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/camera{
-	c_tag = "Locker Room West"
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/station/commons/locker)
 "dtU" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -14019,17 +14112,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
-"duF" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/tile/red/full,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/checkpoint/medical)
 "duK" = (
 /obj/structure/sink/kitchen/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -14037,30 +14119,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/white,
 /area/station/maintenance/fore)
-"duN" = (
-/obj/machinery/camera{
-	c_tag = "Research Director's Office";
-	network = list("ss13","rd");
-	dir = 1
-	},
-/obj/structure/table/glass,
-/obj/item/radio/intercom/directional/north,
-/obj/item/computer_disk{
-	pixel_x = 7;
-	pixel_y = 2
-	},
-/obj/item/computer_disk/ordnance{
-	pixel_y = 4;
-	pixel_x = -5
-	},
-/obj/item/computer_disk/ordnance,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
 "duP" = (
 /obj/structure/rack,
 /obj/item/storage/fancy/candle_box{
@@ -14406,6 +14464,22 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
+"dzc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/engineering/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/poddoor/preopen{
+	name = "Engineering Security Doors";
+	id = "engineering_lockdown"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/turf/open/floor/iron,
+/area/station/engineering/hallway)
 "dzl" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
@@ -14446,6 +14520,11 @@
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical/ghetto)
+"dzP" = (
+/obj/structure/closet/wardrobe/white/medical,
+/obj/item/clothing/head/soft/paramedic,
+/turf/open/floor/iron/white,
+/area/station/medical/paramedic)
 "dzQ" = (
 /obj/structure/railing{
 	dir = 1
@@ -14552,12 +14631,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
-"dBq" = (
-/obj/machinery/camera{
-	c_tag = "Gravity Generator Foyer"
-	},
-/turf/open/floor/catwalk_floor/iron,
-/area/station/engineering/gravity_generator)
 "dBr" = (
 /obj/machinery/conveyor{
 	id = "QMLoad2"
@@ -14686,6 +14759,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"dCO" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Starboard Primary Hallway 3"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "dCQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14763,6 +14842,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
+"dEb" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Engineering - Supermatter Room Port";
+	network = list("ss13","engine","engineering")
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "dEd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -14898,11 +14988,6 @@
 "dFK" = (
 /turf/open/openspace,
 /area/station/service/library)
-"dFL" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
 "dFP" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -15070,16 +15155,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
-"dHF" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Dormitories East";
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "dHK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -15308,6 +15383,13 @@
 "dKJ" = (
 /turf/open/openspace,
 /area/station/maintenance/port/aft)
+"dKM" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/engineering/hallway)
 "dKN" = (
 /turf/closed/wall,
 /area/station/maintenance/solars/starboard/fore)
@@ -15319,19 +15401,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/fore)
-"dKV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/qm,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
-/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
-/obj/effect/mapping_helpers/airlock/access/any/supply/qm,
-/turf/open/floor/iron,
-/area/station/command/heads_quarters/qm)
 "dKW" = (
 /obj/machinery/computer/camera_advanced/base_construction/aux,
 /turf/open/floor/iron,
@@ -15467,16 +15536,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"dNa" = (
-/obj/machinery/dna_infuser,
-/obj/machinery/camera{
-	c_tag = "Research Genetics";
-	network = list("ss13","rd")
-	},
-/obj/item/infuser_book,
-/obj/effect/turf_decal/tile/purple/half,
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
 "dNb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15519,6 +15578,25 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
+"dNB" = (
+/obj/machinery/computer/records/security,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/button/door/directional/north{
+	id = "engsecprivacy";
+	name = "Privacy Shutter Control";
+	req_one_access = list("ce","security")
+	},
+/obj/machinery/requests_console/directional/east{
+	name = "Security Requests Console";
+	department = "engineering"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/engineering)
 "dND" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15664,15 +15742,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"dQi" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Break Room";
-	dir = 8;
-	network = list("SS13","Engineering")
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron,
-/area/station/engineering/break_room)
 "dQm" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/grimy,
@@ -15868,21 +15937,18 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
-"dTb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "dTf" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/cult/item_dispenser/archives/library,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
+"dTn" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Arrivals Auxiliary Docking South-East"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "dTr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -15936,15 +16002,6 @@
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/station/security/range)
-"dUd" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id = "rd_office_shutters";
-	name = "Privacy Shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/rd)
 "dUi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/plumbed{
@@ -15955,18 +16012,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
-"dUl" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/camera/directional/north{
-	c_tag = "Robotics Lab - North";
-	network = list("ss13","rd");
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
 "dUq" = (
 /obj/structure/table,
 /obj/item/assembly/flash/handheld{
@@ -16054,27 +16099,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
-"dVB" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/supply)
-"dVF" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Engineering - Supermatter Room Port";
-	network = list("ss13","engine")
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
 "dVT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16224,17 +16248,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"dXu" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/command/hos{
-	id_tag = "hos_door"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
-/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
-/obj/effect/mapping_helpers/airlock/access/any/security/hos,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/hos)
 "dXD" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/holopad,
@@ -16244,6 +16257,33 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
+"dXK" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "medsecprivacy";
+	name = "Privacy Shutters"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/full,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/window/brigdoor/right/directional/west{
+	name = "Security Desk";
+	req_access = list("brig_entrance")
+	},
+/obj/item/radio/off,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/checkpoint/medical)
 "dXQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -16340,14 +16380,6 @@
 "dZQ" = (
 /turf/open/floor/iron/stairs/medium,
 /area/station/hallway/secondary/exit/departure_lounge)
-"dZV" = (
-/obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Solars - North-East"
-	},
-/obj/machinery/power/smes,
-/turf/open/floor/plating,
-/area/station/maintenance/solars/starboard/fore)
 "dZX" = (
 /obj/structure/table/reinforced,
 /obj/item/wallframe/apc,
@@ -16362,6 +16394,15 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"eaa" = (
+/obj/structure/barricade/wooden,
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	name = "Engineering Security Doors";
+	id = "engineering_lockdown"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/electrical)
 "eab" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -16482,13 +16523,6 @@
 /obj/effect/spawner/random/structure/twelve_percent_spirit_board,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
-"ebw" = (
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 5";
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard/west)
 "ebB" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -16621,21 +16655,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
-"edr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 8
-	},
-/obj/machinery/light/directional/north,
-/obj/machinery/camera{
-	c_tag = "Engineering Atmos West";
-	network = list("SS13","Engineering");
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "edt" = (
 /turf/closed/wall,
 /area/station/service/janitor)
@@ -16942,12 +16961,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
-"ehw" = (
-/obj/structure/filingcabinet,
-/obj/structure/sign/poster/official/space_cops/directional/east,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
 "ehy" = (
 /obj/effect/spawner/random/structure/tank_holder,
 /obj/machinery/light/small/directional/north,
@@ -17090,19 +17103,31 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
+"ejw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/camera/directional/east{
+	c_tag = "Arrivals Hallway"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
+"ejH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rd_office_shutters";
+	name = "Privacy Shutters";
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/rd)
 "ejI" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /mob/living/basic/mouse,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison)
-"ejM" = (
-/obj/machinery/camera{
-	c_tag = "Brig Prisoner Processing West";
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/courtroom/holding)
 "ejN" = (
 /turf/open/floor/carpet/red,
 /area/station/maintenance/department/security/ghetto)
@@ -17111,6 +17136,17 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
+"ejQ" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - Lobby East";
+	network = list("ss13","engineering")
+	},
+/obj/structure/chair,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "ejR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1,
 /obj/effect/turf_decal/tile/yellow,
@@ -17152,6 +17188,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
+"ekm" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/normal/directional/north{
+	network = list("engine","engineering","tcomms","minisat");
+	name = "Engineering Security Monitor";
+	pixel_y = 35
+	},
+/obj/effect/landmark/start/depsec/engineering,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/engineering)
 "ekp" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/closet/radiation,
@@ -17186,27 +17238,23 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/qm)
+"ekJ" = (
+/obj/machinery/duct,
+/obj/machinery/camera/directional/north{
+	c_tag = "Atmospherics - Project Room Aft";
+	network = list("ss13","engineering")
+	},
+/obj/machinery/status_display/ai/directional/north,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/project)
 "ekQ" = (
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/locker)
-"elm" = (
-/obj/structure/table/reinforced/rglass,
-/obj/item/food/grown/banana,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/west,
-/obj/machinery/camera{
-	c_tag = "Virology Observation";
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "elu" = (
 /obj/machinery/duct,
 /turf/open/floor/plating,
@@ -17309,6 +17357,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
+"emM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/camera/directional/east{
+	c_tag = "Arrivals Auxiliary Docking North"
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "emP" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -17337,11 +17394,6 @@
 "eng" = (
 /turf/closed/wall,
 /area/station/medical/paramedic)
-"enq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/departments/exam_room,
-/turf/open/floor/plating,
-/area/station/medical/treatment_center)
 "env" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -17555,6 +17607,14 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
+"epP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	name = "Engineering Security Doors";
+	id = "engineering_lockdown"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/hallway)
 "epS" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/detective,
@@ -17597,6 +17657,33 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"eqp" = (
+/obj/machinery/modular_computer/preset/research{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 1
+	},
+/obj/machinery/button/door/directional/west{
+	id = "rd_office_shutters";
+	name = "Privacy Shutters Control";
+	req_access = list("rd");
+	pixel_y = -10
+	},
+/obj/machinery/button/door/directional/west{
+	id = "research_lockdown";
+	name = "Research Lockdown Control";
+	req_access = list("rd");
+	pixel_y = 10;
+	color = "yellow"
+	},
+/obj/machinery/button/door/directional/west{
+	id = "rd_robotics_window_shutters";
+	name = "Upper Privacy Shutters Control";
+	req_access = list("rd")
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "eqC" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17660,14 +17747,6 @@
 /obj/item/stack/cable_coil/thirty,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
-"erA" = (
-/obj/structure/bodycontainer/morgue,
-/obj/machinery/camera{
-	c_tag = "Chapel - Crematorium";
-	dir = 8
-	},
-/turf/open/floor/engine/cult,
-/area/station/service/chapel/office)
 "erF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17829,6 +17908,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"euI" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command/hop,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/effect/mapping_helpers/airlock/access/any/command/hop,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/hop)
 "euJ" = (
 /obj/machinery/duct,
 /turf/open/floor/plating,
@@ -17937,14 +18026,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"ewI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "ewU" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
@@ -17986,18 +18067,14 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
-"exv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"exw" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
 	},
+/obj/effect/landmark/start/depsec/supply,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
-/obj/machinery/door/airlock/research,
-/obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/iron,
-/area/station/science/research)
+/area/station/security/checkpoint/supply)
 "exB" = (
 /obj/effect/spawner/random/trash/box,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -18066,6 +18143,18 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
+"eyZ" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "Skynet_launch";
+	name = "Mech Bay"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/mechbay)
 "ezi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -18348,14 +18437,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
-"eDm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	name = "Engineering Security Doors";
-	id_tag = "engineering_lockdown"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/hallway)
 "eDr" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 6
@@ -18438,6 +18519,39 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
+"eEj" = (
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/button/door/directional/west{
+	pixel_y = 10;
+	id = "engineering_lockdown";
+	name = "Engineering Lockdown";
+	req_one_access = list("ce","security");
+	color = "yellow"
+	},
+/obj/machinery/button/door/directional/west{
+	id = "atmoslock";
+	name = "Atmos Lockdown";
+	req_one_access = list("ce","security")
+	},
+/obj/machinery/button/door/directional/west{
+	pixel_y = -10;
+	id = "transittube_lockdown";
+	name = "Transit Tube Lockdown";
+	req_one_access = list("ce","security")
+	},
+/obj/structure/table,
+/obj/machinery/recharger,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/engineering)
+"eEk" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/medical/surgery/aft)
 "eEx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/warning/docking/directional/south,
@@ -18668,6 +18782,20 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
+"eHE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/station/engineering/hallway)
 "eHP" = (
 /obj/structure/table,
 /obj/machinery/light/small/directional/north,
@@ -18899,6 +19027,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/abandoned)
+"eKx" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/landmark/start/depsec/engineering,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/engineering)
 "eKA" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai)
@@ -18914,18 +19049,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"eKF" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/camera{
-	c_tag = "Brig Main Hall East 1";
-	dir = 9
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
 "eKI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -19170,15 +19293,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"eOp" = (
-/obj/machinery/door/poddoor/preopen{
-	name = "Engineering Security Doors";
-	id_tag = "engineering_lockdown"
-	},
-/turf/open/floor/iron/stairs/left{
-	dir = 8
-	},
-/area/station/engineering/transit_tube)
 "eOq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -19410,14 +19524,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
-"eSd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "eSj" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -19614,12 +19720,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
-"eUS" = (
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 3"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "eUY" = (
 /obj/machinery/bluespace_vendor/directional/north,
 /turf/open/floor/iron,
@@ -19690,15 +19790,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"eVT" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/camera/directional/south{
-	c_tag = "Medbay Chemistry Lab - South";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
 "eWa" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -19853,6 +19944,25 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"eYb" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "JimNortonKitchen"
+	},
+/obj/item/reagent_containers/cup/glass/coffee{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/cup/glass/coffee{
+	pixel_x = 9;
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/cup/glass/coffee{
+	pixel_y = -1
+	},
+/turf/open/floor/wood,
+/area/station/service/cafeteria)
 "eYd" = (
 /obj/structure/railing{
 	dir = 8
@@ -19871,6 +19981,16 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"eYi" = (
+/obj/structure/table,
+/obj/machinery/camera/directional/south{
+	c_tag = "Departure Lounge South-West"
+	},
+/obj/item/stack/sheet/cardboard{
+	amount = 10
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "eYk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20008,14 +20128,6 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"faC" = (
-/obj/machinery/computer/security/mining{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown/anticorner/contrasted,
-/obj/machinery/camera/directional/south,
-/turf/open/floor/iron,
-/area/station/cargo/miningoffice)
 "faF" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red/half/contrasted,
@@ -20072,6 +20184,19 @@
 	dir = 1
 	},
 /area/station/engineering/atmos)
+"fbo" = (
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/scanning_module,
+/obj/item/stock_parts/scanning_module,
+/obj/effect/turf_decal/tile/purple/anticorner,
+/obj/item/stock_parts/capacitor,
+/obj/structure/table,
+/turf/open/floor/iron/white,
+/area/station/science/lab)
 "fbp" = (
 /turf/open/floor/wood/large,
 /area/station/maintenance/ghetto/port)
@@ -20101,6 +20226,18 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
+"fbR" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rnd";
+	name = "Research Lab Shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/plating,
+/area/station/science/lab)
 "fbS" = (
 /obj/item/kirbyplants/random/dead,
 /obj/effect/spawner/random/maintenance,
@@ -20211,17 +20348,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
-"fdt" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Foyer West";
-	network = list("SS13","Engineering");
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/hallway)
 "fdw" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -20339,15 +20465,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/station/commons/lounge)
-"ffb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/plating,
-/area/station/science/ordnance)
 "ffg" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -20427,25 +20544,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
-"fgd" = (
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/cup/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/dropper,
-/obj/machinery/camera{
-	c_tag = "Research Research and Development Lab";
-	dir = 4;
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/tile/purple/anticorner,
-/obj/structure/table,
-/turf/open/floor/iron/cafeteria,
-/area/station/science/lab)
 "fgl" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -20520,17 +20618,6 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
-"fgT" = (
-/obj/machinery/camera{
-	c_tag = "Prisoner Lockers";
-	dir = 8
-	},
-/obj/machinery/light_switch/directional/west,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/processing)
 "fgW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20851,6 +20938,18 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/small,
 /area/station/maintenance/ghetto/central)
+"fkx" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Research - Xenobiology East";
+	network = list("ss13","xeno","rd");
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "fkB" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 4
@@ -20926,6 +21025,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
+"flN" = (
+/obj/machinery/computer/records/security,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
 "flO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20958,6 +21065,47 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
+"flU" = (
+/obj/item/assembly/timer{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/assembly/timer{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/item/assembly/timer{
+	pixel_x = 8
+	},
+/obj/item/assembly/timer{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/item/assembly/igniter{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/assembly/igniter{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/assembly/igniter{
+	pixel_x = -6
+	},
+/obj/item/assembly/igniter{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/obj/structure/table/reinforced/rglass,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Medbay - Chemistry";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "fmj" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/engine/cult,
@@ -21278,6 +21426,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"fqP" = (
+/obj/structure/sign/warning/docking/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Arrivals Center"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "fqT" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/delivery/white{
@@ -21285,6 +21443,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"fqU" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Dormitories East"
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "fqZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/stasis{
@@ -21312,6 +21479,15 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
+"frs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera/directional/south{
+	c_tag = "Atmospherics - HFR South";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/hfr_room)
 "fru" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21963,17 +22139,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
-"fzl" = (
-/obj/machinery/light/small/directional/north,
-/obj/machinery/camera/directional/east{
-	c_tag = "Science - Server Room";
-	network = list("ss13","rd");
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/science/server)
 "fzs" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/wood,
@@ -22157,6 +22322,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
+"fCg" = (
+/obj/structure/table/wood,
+/obj/item/camera,
+/obj/item/storage/photo_album{
+	pixel_y = -10
+	},
+/obj/item/crowbar,
+/obj/machinery/camera/directional/east{
+	c_tag = "Captain's Office"
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/captain)
 "fCh" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -22218,6 +22395,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
+"fCO" = (
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Engineering - Atmos Mini-Hallway";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "fCS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22444,6 +22631,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/royalblack,
 /area/station/maintenance/ghetto/fore/starboard)
+"fFv" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Central Hallway North-East"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "fFB" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -22626,15 +22820,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"fHp" = (
-/obj/machinery/door/poddoor{
-	id = "xenobio_maint_fore";
-	name = "Xenobiology Blast Door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "fHt" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -22763,19 +22948,6 @@
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
-"fIX" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = 1
-	},
-/obj/item/pen,
-/obj/item/radio/off,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/third)
 "fIY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/yellow{
@@ -22824,6 +22996,15 @@
 	dir = 1
 	},
 /area/station/maintenance/starboard/fore)
+"fJy" = (
+/obj/machinery/modular_computer/preset/id,
+/obj/machinery/light/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Cargo - QM's Office";
+	network = list("ss13","cargo")
+	},
+/turf/open/floor/carpet,
+/area/station/command/heads_quarters/qm)
 "fJA" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -22890,22 +23071,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
-"fKp" = (
-/obj/structure/table/reinforced,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/core{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Atmospherics - HFR"
-	},
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/hfr_room)
 "fKw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23082,10 +23247,35 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
+"fMP" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "robotics_window";
+	name = "Robotics Lab Shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/plating,
+/area/station/science/robotics/mechbay)
 "fMS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/turf/open/floor/iron/dark,
+/area/station/engineering/hallway)
+"fMT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - Hallway East";
+	network = list("ss13","engineering")
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "fMX" = (
@@ -23307,17 +23497,6 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"fOZ" = (
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/third)
 "fPi" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L11"
@@ -23340,6 +23519,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/blueshield)
+"fPO" = (
+/obj/structure/closet/crate,
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - Engine Storage";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron,
+/area/station/engineering/storage_shared)
 "fPT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/filingcabinet/chestdrawer,
@@ -23593,16 +23780,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
-"fTm" = (
-/obj/machinery/camera{
-	c_tag = "Gravity Generator Room";
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/station/engineering/gravity_generator)
 "fTu" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/tile/red/half/contrasted,
@@ -23734,12 +23911,6 @@
 /obj/machinery/vending/sovietsoda,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"fVu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "fVw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24124,6 +24295,23 @@
 /obj/item/toy/figure/hos,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
+"gax" = (
+/obj/structure/table,
+/obj/machinery/camera/directional/north{
+	c_tag = "Research - Lobby";
+	network = list("ss13","rd")
+	},
+/obj/machinery/light_switch/directional/north,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/item/folder,
+/obj/item/pen,
+/turf/open/floor/iron,
+/area/station/science/lobby)
 "gaA" = (
 /obj/structure/table/wood/poker,
 /obj/item/coin/diamond,
@@ -24185,6 +24373,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"gbc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "gbf" = (
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
@@ -24264,18 +24459,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"gcB" = (
-/obj/structure/table,
-/obj/item/pen,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security/checkpoint/supply)
 "gcI" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
@@ -24437,6 +24620,17 @@
 	},
 /turf/open/floor/iron/telecomms,
 /area/station/tcommsat/server)
+"geB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Engineering - SMES Room";
+	network = list("ss13","engineering")
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron,
+/area/station/engineering/engine_smes)
 "geM" = (
 /obj/machinery/door/airlock/engineering/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -24520,6 +24714,16 @@
 /obj/effect/turf_decal/tile/dark/diagonal_centre,
 /turf/open/floor/iron/diagonal,
 /area/station/commons/dorms)
+"gft" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/obj/structure/closet/secure_closet/security/engine,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/engineering)
 "gfI" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal,
@@ -24551,10 +24755,6 @@
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical/ghetto)
-"ggg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/medical/cryo)
 "ggq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -24775,14 +24975,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"gju" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Atmospherics - Project Room Fore"
-	},
-/obj/machinery/status_display/evac/directional/south,
-/obj/effect/turf_decal/trimline/yellow/line,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/project)
 "gjv" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -24801,6 +24993,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
+"gjO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command/qm,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
+/obj/effect/mapping_helpers/airlock/access/any/supply/qm,
+/turf/open/floor/iron,
+/area/station/command/heads_quarters/qm)
 "gjP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/random/directional/north,
@@ -24951,6 +25156,14 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"gmG" = (
+/obj/structure/filingcabinet,
+/obj/structure/sign/poster/official/space_cops/directional/east,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "gmH" = (
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/ghetto/fore/starboard)
@@ -25151,10 +25364,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/abandoned_gambling_den)
-"goO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/security/checkpoint/third)
 "goP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -25207,6 +25416,24 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/kitchen)
+"gpz" = (
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	location = "engineering"
+	},
+/obj/machinery/door/poddoor/preopen{
+	name = "Engineering Security Doors";
+	id = "engineering_lockdown"
+	},
+/obj/machinery/door/window/left/directional/east{
+	name = "Drone Fabricator";
+	req_access = list("engine_equip")
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/engineering/dronefabricator)
 "gpE" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/random/maintenance/two,
@@ -25252,6 +25479,25 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/paramedic)
+"gqo" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "rnd";
+	name = "Research Lab Shutters"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/right/directional/east{
+	name = "Research and Development Desk";
+	req_access = list("science")
+	},
+/obj/structure/desk_bell,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/plating,
+/area/station/science/lab)
 "gqq" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
@@ -25388,24 +25634,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
-"gtd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "medsecprivacy";
-	name = "Privacy Shutters"
-	},
-/obj/structure/cable,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id = "quarantine";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/plating,
-/area/station/security/checkpoint/medical)
 "gtg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
@@ -25511,19 +25739,6 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/central)
-"guK" = (
-/obj/structure/table,
-/obj/item/radio/intercom/directional/south,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
-/obj/item/pen,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
 "guN" = (
 /turf/closed/wall,
 /area/station/maintenance/ghetto/central/fore)
@@ -25553,11 +25768,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage/ghetto)
-"gvF" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "gvH" = (
 /turf/open/floor/iron/smooth,
 /area/station/commons/toilet/restrooms)
@@ -25607,15 +25817,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"gwx" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/machinery/camera/directional/south{
-	c_tag = "Cargo - Security Post"
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/supply)
 "gwz" = (
 /obj/structure/marker_beacon/olive,
 /turf/open/floor/plating/airless,
@@ -25725,19 +25926,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
-"gxU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/command/rd,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
-/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
-/obj/effect/mapping_helpers/airlock/access/any/science/rd,
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/rd)
 "gxY" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/glass/waterbottle,
@@ -26558,21 +26746,6 @@
 "gJs" = (
 /turf/open/space/openspace,
 /area/space/nearstation)
-"gJY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/airlock/command/ce{
-	id_tag = "ce_door"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
-/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/ce,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/ce)
 "gKa" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/warm/directional/north,
@@ -26671,17 +26844,6 @@
 /obj/structure/closet/crate/preopen,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
-"gKP" = (
-/obj/structure/sign/departments/telecomms/directional/north,
-/obj/machinery/camera{
-	c_tag = "Central Primary Hallway South";
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "gKZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -26821,6 +26983,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"gMJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/command/rd,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/effect/mapping_helpers/airlock/access/any/science/rd,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "gML" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/box/white/corners,
@@ -26883,14 +27058,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
-"gNw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	name = "Engineering Security Doors";
-	id_tag = "engineering_lockdown"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/lobby)
 "gNy" = (
 /obj/structure/stairs/south{
 	dir = 4
@@ -26919,16 +27086,21 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
-"gNR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/medical,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+"gNS" = (
+/obj/machinery/requests_console/directional/west{
+	department = "Cargo";
+	name = "Quartermaster's Desk Requests Console"
+	},
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/machinery/computer/security/qm{
+	network = list("cargo","mine","auxbase","vault")
+	},
+/obj/machinery/digital_clock/directional/north,
+/turf/open/floor/carpet,
+/area/station/command/heads_quarters/qm)
 "gNV" = (
 /obj/machinery/computer/prisoner/management{
 	req_access = list("lawyer")
@@ -27004,17 +27176,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"gOr" = (
-/obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Brig Main Hall South-West";
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
 "gOs" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/ice{
@@ -27323,6 +27484,27 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/fore)
+"gSh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/landmark/start/depsec/science,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
+"gSn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/camera/directional/north{
+	c_tag = "Departure Lounge North-East"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "gSo" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/machinery/light/directional/south,
@@ -27415,6 +27597,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"gUb" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Prison Cafeteria External";
+	network = list("ss13","prison")
+	},
+/obj/structure/lattice,
+/turf/open/space/openspace,
+/area/space/nearstation)
 "gUf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -27468,17 +27658,6 @@
 "gUL" = (
 /turf/closed/wall,
 /area/station/service/library/artgallery)
-"gUN" = (
-/obj/machinery/door/poddoor/preopen{
-	name = "Engineering Security Doors";
-	id_tag = "engineering_lockdown"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/airlock/engineering/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/station/engineering/dronefabricator)
 "gUR" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -27575,6 +27754,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
+"gWc" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/camera/directional/south{
+	c_tag = "Vacant Office"
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood,
+/area/station/commons/vacant_room/office)
 "gWj" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -27801,6 +27991,23 @@
 /obj/effect/spawner/random/structure/barricade,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
+"gYU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/conveyor{
+	id = "mining_internal"
+	},
+/obj/machinery/bouldertech/refinery,
+/obj/machinery/camera/directional/east{
+	c_tag = "Cargo - Mining Ore Smeltery";
+	network = list("ss13","cargo","mine")
+	},
+/turf/open/floor/iron/small,
+/area/station/cargo/storage/ghetto)
 "gZc" = (
 /obj/structure/closet,
 /turf/open/floor/iron,
@@ -28090,6 +28297,14 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"hdn" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	name = "Engineering Security Doors";
+	id = "engineering_lockdown"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/lobby)
 "hdp" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -28107,6 +28322,20 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
+"hdx" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 8
+	},
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - Atmos West";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "hdJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair{
@@ -28144,12 +28373,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
-"hem" = (
-/obj/structure/filingcabinet,
-/obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/third)
 "hen" = (
 /obj/structure/reagent_dispensers/plumbed,
 /obj/effect/turf_decal/delivery/white{
@@ -28157,6 +28380,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
+"hep" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "heq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
@@ -28275,10 +28504,6 @@
 /obj/machinery/status_display/supply,
 /turf/closed/wall,
 /area/station/cargo/sorting)
-"hge" = (
-/obj/machinery/computer/crew,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "hgl" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/large,
@@ -28390,24 +28615,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"hhp" = (
-/obj/structure/table,
-/obj/machinery/camera{
-	c_tag = "Departure Lounge South-West"
-	},
-/obj/item/stack/sheet/cardboard{
-	amount = 10
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
-"hhr" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/engine/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/third)
 "hhF" = (
 /obj/item/vending_refill/cigarette,
 /obj/structure/sign/poster/contraband/rebels_unite/directional/south,
@@ -28533,6 +28740,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/ghetto)
+"hiO" = (
+/obj/structure/table,
+/obj/machinery/camera/directional/north{
+	c_tag = "Brig Labor Camp Airlock North"
+	},
+/obj/item/restraints/handcuffs,
+/obj/item/clothing/under/rank/prisoner,
+/obj/item/clothing/under/rank/prisoner/skirt,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/item/clothing/shoes/sneakers/orange,
+/obj/structure/cable,
+/obj/machinery/gulag_item_reclaimer{
+	pixel_y = 28
+	},
+/turf/open/floor/iron,
+/area/station/security/processing)
 "hiQ" = (
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
@@ -28713,14 +28936,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/asphalt,
 /area/station/maintenance/ghetto/garden)
-"hlV" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rnd";
-	name = "Research Lab Shutters"
+"hlO" = (
+/obj/structure/table,
+/obj/item/radio/off,
+/obj/item/screwdriver{
+	pixel_y = 10
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/science/lab)
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
 "hmb" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/sign/departments/science/directional/south,
@@ -28742,16 +28969,6 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"hmj" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Foyer East";
-	network = list("SS13","Engineering");
-	dir = 1
-	},
-/turf/open/floor/iron/stairs/right{
-	dir = 8
-	},
-/area/station/engineering/hallway)
 "hmw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
@@ -29070,6 +29287,14 @@
 /obj/machinery/vending/security,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"hpZ" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/camera/directional/east{
+	c_tag = "Research - Polygon East";
+	network = list("ss13","rd","ordnance")
+	},
+/turf/open/floor/iron/airless,
+/area/station/science/ordnance/bomb)
 "hql" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -29207,6 +29432,16 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/fore)
+"hrG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/light/directional/west,
+/obj/machinery/camera/directional/west{
+	c_tag = "Starboard Primary Hallway 4"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard/west)
 "hrP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/recharge_floor,
@@ -29338,6 +29573,13 @@
 "hub" = (
 /turf/closed/wall,
 /area/station/science/lab)
+"hug" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "rd_robotics_window_shutters"
+	},
+/turf/open/floor/plating,
+/area/station/science/robotics/lab)
 "hup" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -29414,6 +29656,19 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/iron/kitchen,
 /area/station/maintenance/ghetto/bar)
+"huJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/machinery/light/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - Supermatter Engine Room North";
+	network = list("ss13","engine","engineering")
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/hallway/west)
 "huO" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/effect/turf_decal/bot,
@@ -29568,6 +29823,29 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"hwR" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "medsecprivacy";
+	name = "Privacy Shutters"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/full,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/window/brigdoor/left/directional/west{
+	name = "Security Desk";
+	req_access = list("brig_entrance")
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/checkpoint/medical)
 "hwT" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -29860,6 +30138,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/service/janitor)
+"hAH" = (
+/obj/machinery/door/poddoor/preopen{
+	name = "Engineering Security Doors";
+	id = "engineering_lockdown"
+	},
+/turf/open/floor/iron/stairs/left{
+	dir = 8
+	},
+/area/station/engineering/transit_tube)
 "hAJ" = (
 /obj/structure/railing{
 	dir = 6
@@ -29983,6 +30270,19 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/wood,
 /area/station/service/kitchen/abandoned)
+"hCx" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/landmark/start/depsec/supply,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/computer/security/telescreen/cargo_sec/directional/north{
+	network = list("cargo","mine","auxbase","vault");
+	name = "Cargo Security Monitor";
+	pixel_y = 35
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
 "hCz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30261,6 +30561,20 @@
 /obj/item/reagent_containers/cup/watering_can,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
+"hFa" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/camera/directional/east{
+	c_tag = "Research - Xenobiology Maintenance Access";
+	network = list("ss13","xeno","rd")
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "hFb" = (
 /obj/machinery/iv_drip,
 /obj/item/reagent_containers/blood,
@@ -30480,6 +30794,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"hHL" = (
+/obj/structure/cable,
+/obj/machinery/camera/directional/north{
+	c_tag = "Turbine";
+	network = list("ss13","engineering")
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "hHU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -30911,6 +31234,23 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"hNn" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Atmospherics - HFR - East";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/hfr_room)
+"hNr" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
 "hNu" = (
 /obj/structure/chair/stool{
 	dir = 4
@@ -31071,6 +31411,20 @@
 "hPO" = (
 /turf/closed/wall,
 /area/station/cargo/sorting)
+"hPP" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Cargo - Mining Dock";
+	dir = 8;
+	network = list("ss13","cargo")
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningoffice)
 "hPQ" = (
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
 	color = "#0000ff";
@@ -31107,6 +31461,13 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"hQC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "hQF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31187,6 +31548,13 @@
 "hRA" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/ghetto/starboard)
+"hRC" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Gravity Generator Foyer";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/station/engineering/gravity_generator)
 "hRP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -31400,16 +31768,6 @@
 "hUE" = (
 /turf/closed/wall,
 /area/space/nearstation)
-"hUF" = (
-/obj/structure/closet/secure_closet/security/engine,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/third)
 "hUH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -31656,6 +32014,15 @@
 /obj/structure/sign/warning/secure_area/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
+"hYc" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/camera/directional/east{
+	c_tag = "Courtroom North"
+	},
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/parquet,
+/area/station/security/courtroom)
 "hYg" = (
 /obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/tile/red{
@@ -31769,6 +32136,14 @@
 "hZw" = (
 /turf/open/floor/iron,
 /area/station/maintenance/aft)
+"hZF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/landmark/start/depsec/supply,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
 "hZK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -31868,6 +32243,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/lawoffice)
+"ibb" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "rndsecprivacy";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/science)
 "ibc" = (
 /obj/structure/statue/station_map/cyberiad/w,
 /turf/open/floor/iron,
@@ -31910,6 +32295,14 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
+"icf" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Research - Xenobiology Pens Observation South";
+	network = list("ss13","rd","xeno");
+	dir = 2
+	},
+/turf/open/openspace,
+/area/station/science/xenobiology)
 "icg" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted,
@@ -32196,15 +32589,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/fore)
-"igO" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/landmark/start/depsec/engineering,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/third)
 "ihc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass,
@@ -32236,15 +32620,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
-"ihE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Atmospherics - HFR - East"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/hfr_room)
 "ihI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -32321,16 +32696,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/arrivals)
-"iiL" = (
-/obj/machinery/camera{
-	c_tag = "Central Hallway South East";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "iiS" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light/small/directional/east,
@@ -32565,15 +32930,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
-"ilH" = (
-/obj/machinery/camera{
-	c_tag = "Prison Library";
-	dir = 9;
-	network = list("Prison","SS13")
-	},
-/obj/effect/spawner/random/entertainment/arcade,
-/turf/open/floor/wood,
-/area/station/security/prison)
 "ilI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32683,6 +33039,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"inC" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Cargo - Security Post";
+	network = list("ss13","cargo")
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/machinery/airalarm/directional/south,
+/obj/structure/closet/secure_closet/security/cargo,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
 "inE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32746,17 +33113,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
-"ior" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/directional/south{
-	c_tag = "Atmospherics - Project Room Closet"
-	},
-/obj/machinery/status_display/evac/directional/south,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/half{
-	dir = 8
-	},
-/area/station/engineering/atmos/project)
 "ios" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33073,14 +33429,6 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
-"isr" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/landmark/start/assistant,
-/obj/machinery/holopad,
-/turf/open/floor/wood,
-/area/station/service/cafeteria)
 "isz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33402,17 +33750,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
-"iws" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering SMES Room";
-	network = list("SS13","Engineering")
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "iwu" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -33447,6 +33784,23 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"iwR" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsecprivacy";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/engineering)
+"iwT" = (
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/bot_white/left,
+/obj/machinery/camera/directional/north{
+	c_tag = "Brig Secure Armory North"
+	},
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "iwV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -33480,6 +33834,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
+"ixv" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "ixz" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -33506,47 +33864,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
-"iyA" = (
-/obj/item/assembly/timer{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/obj/item/assembly/timer{
-	pixel_x = 8;
-	pixel_y = 3
-	},
-/obj/item/assembly/timer{
-	pixel_x = 8
-	},
-/obj/item/assembly/timer{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/item/assembly/igniter{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/assembly/igniter{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/item/assembly/igniter{
-	pixel_x = -6
-	},
-/obj/item/assembly/igniter{
-	pixel_x = -6;
-	pixel_y = -3
-	},
-/obj/structure/table/reinforced/rglass,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay Chemistry";
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
 "iyE" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -33639,6 +33956,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
+"izY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/corporate,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/obj/effect/landmark/navigate_destination,
+/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/effect/mapping_helpers/airlock/access/any/command/magistrate,
+/turf/open/floor/wood/tile,
+/area/station/command/heads_quarters/magistrate)
 "iAi" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
@@ -33665,6 +33995,16 @@
 /obj/structure/bed/medical/anchored,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"iAu" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/obj/machinery/camera/directional/west{
+	c_tag = "Research - Ordnance Watching Room";
+	network = list("ss13","rd","ordnance");
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/science/ordnance/testlab)
 "iAD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34025,6 +34365,11 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/lower)
+"iFw" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/sign/poster/official/random/directional/south,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "iFy" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -34226,17 +34571,6 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs)
-"iHR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/research,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "iHU" = (
 /obj/structure/railing/corner/end/flip{
 	dir = 4
@@ -34354,18 +34688,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
-"iJu" = (
-/obj/structure/table,
-/obj/machinery/camera{
-	c_tag = "Engineering Reception";
-	network = list("SS13","Engineering");
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/engine/directional/north,
-/obj/item/folder/yellow,
-/obj/item/pen,
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
 "iJy" = (
 /obj/item/kirbyplants/random/dead,
 /turf/open/floor/plating,
@@ -34523,15 +34845,6 @@
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron,
 /area/station/security/range)
-"iKE" = (
-/obj/machinery/rnd/production/protolathe/department/engineering,
-/obj/effect/turf_decal/bot,
-/obj/machinery/camera/directional/east{
-	c_tag = "Engineering - Shared Storage"
-	},
-/obj/effect/turf_decal/tile/yellow/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage_shared)
 "iKI" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
@@ -34982,14 +35295,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/openspace,
 /area/station/security/prison)
-"iRu" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/third)
 "iRy" = (
 /obj/structure/bed/dogbed{
 	anchored = 1;
@@ -35135,17 +35440,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto/central)
-"iTm" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=8";
-	location = "Research Division"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "iTo" = (
 /obj/effect/spawner/random/trash,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -35249,14 +35543,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
-"iUo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
 "iUu" = (
 /turf/open/floor/plating,
 /area/station/hallway/secondary/dock)
@@ -35418,6 +35704,24 @@
 "iWG" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"iWM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/command/cmo{
+	id_tag = "CMO_door"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable,
+/obj/effect/landmark/navigate_destination,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
+/obj/effect/mapping_helpers/airlock/access/any/medical/cmo,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/cmo)
 "iWN" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plating,
@@ -35434,6 +35738,17 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
+"iXn" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/directional/east{
+	c_tag = "Cargo - Auxiliary Warehouse";
+	network = list("ss13","cargo")
+	},
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "iXs" = (
 /obj/structure/frame/machine,
 /obj/effect/decal/cleanable/dirt,
@@ -35711,17 +36026,6 @@
 /obj/machinery/vending/cola/blue,
 /turf/open/floor/wood/parquet,
 /area/station/security/courtroom)
-"jaU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/machinery/camera{
-	c_tag = "Kitchen";
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
 "jba" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -35768,6 +36072,18 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
+"jbw" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - Supermatter Emitters";
+	network = list("ss13","engine","engineering")
+	},
+/obj/effect/landmark/event_spawn,
+/obj/machinery/power/emitter{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "jbx" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
@@ -35982,6 +36298,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"jey" = (
+/obj/structure/table/wood,
+/obj/machinery/light/directional/south,
+/obj/machinery/microwave/engineering/cell_included,
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/camera/directional/south{
+	c_tag = "Medbay - Break Room";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/medical/break_room)
 "jeC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36121,6 +36448,12 @@
 /obj/effect/turf_decal/tile/purple/half,
 /turf/open/floor/iron/white,
 /area/station/science/lower)
+"jgo" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Starboard Primary Hallway 5"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard/west)
 "jgp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/table,
@@ -36286,15 +36619,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/service/lawoffice)
-"jih" = (
-/obj/structure/rack,
-/obj/item/multitool,
-/obj/machinery/camera{
-	c_tag = "Auxiliary Tool Storage";
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/commons/storage/emergency/port)
 "jir" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /obj/machinery/status_display/ai/directional/south,
@@ -36500,23 +36824,6 @@
 /obj/item/storage/lockbox/medal,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
-"jlt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/conveyor{
-	id = "mining_internal"
-	},
-/obj/machinery/bouldertech/refinery,
-/obj/machinery/camera/directional/east{
-	c_tag = "Mining Ore Smeltery";
-	network = list("ss13", "mine")
-	},
-/turf/open/floor/iron/small,
-/area/station/cargo/storage/ghetto)
 "jlu" = (
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -36525,6 +36832,25 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"jlM" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Mime Office"
+	},
+/obj/structure/table/wood,
+/obj/structure/mirror/directional/north,
+/obj/item/lipstick/random{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/lipstick/random{
+	pixel_y = 4
+	},
+/obj/item/lipstick/random{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/turf/open/floor/iron/kitchen,
+/area/station/service/theater)
 "jlW" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -36689,6 +37015,33 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/security/interrogation/ghetto)
+"joH" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/light_switch/directional/north,
+/obj/machinery/light/small/directional/north,
+/obj/structure/table,
+/obj/item/electronics/airalarm{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/electronics/firealarm{
+	pixel_y = 6;
+	pixel_x = 6
+	},
+/obj/item/electronics/firealarm{
+	pixel_x = 6
+	},
+/obj/item/electronics/airalarm{
+	pixel_x = -6
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - HFR Prep Room";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/hallway)
 "joL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 5
@@ -36828,6 +37181,15 @@
 /obj/effect/decal/nt_logo,
 /turf/open/floor/carpet/red,
 /area/station/maintenance/department/security/ghetto)
+"jrg" = (
+/obj/effect/turf_decal/tile/green/fourcorners,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/machinery/camera/directional/north{
+	c_tag = "Cryodorms"
+	},
+/turf/open/floor/iron/white,
+/area/station/common/cryopods)
 "jrj" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/spawner/random/maintenance/two,
@@ -36972,6 +37334,21 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/explab)
+"jsZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Arrivals North"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/station/hallway/secondary/entry)
 "jtc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
@@ -36989,6 +37366,30 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/wood/parquet,
 /area/station/hallway/secondary/service)
+"jtA" = (
+/obj/structure/table/glass,
+/obj/item/folder/white{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/clothing/neck/stethoscope{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Chief Medical Officer's Office";
+	network = list("ss13","medbay");
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/cmo)
 "jtG" = (
 /obj/machinery/button/door/directional{
 	id = "atmos_pro";
@@ -37089,12 +37490,6 @@
 "jvh" = (
 /turf/open/floor/iron/white,
 /area/station/science/explab)
-"jvm" = (
-/obj/structure/closet/wardrobe/white/medical,
-/obj/item/clothing/head/soft/paramedic,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/paramedic)
 "jvo" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -37112,6 +37507,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
+"jvy" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - Atmos East";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "jvF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -37380,6 +37786,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"jzh" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/medical/paramedic)
 "jzr" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
@@ -37460,18 +37877,6 @@
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"jAg" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/camera{
-	c_tag = "Engineering Atmos Center";
-	network = list("SS13","Engineering");
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "jAj" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37566,16 +37971,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/openspace,
 /area/space/nearstation)
-"jBW" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red/full,
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/landmark/start/depsec/engineering,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/third)
 "jCi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/multilayer/multiz,
@@ -37635,6 +38030,14 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/hallway/secondary/entry)
+"jCY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	name = "Engineering Security Doors";
+	id = "engineering_lockdown"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/ghetto)
 "jDa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37719,17 +38122,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"jEh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/camera{
-	c_tag = "Departure Lounge North-East";
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "jEk" = (
 /obj/structure/marker_beacon/indigo,
 /turf/open/floor/plating/airless,
@@ -37853,15 +38245,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
-"jFv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
-/obj/effect/landmark/start/depsec/medical,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/checkpoint/medical)
 "jFA" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/smooth,
@@ -38069,13 +38452,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/hallway/secondary/dock)
-"jHC" = (
-/obj/machinery/camera/autoname/directional/north{
-	dir = 9;
-	network = list("ss13","prison")
-	},
-/turf/open/openspace,
-/area/station/security/prison)
 "jHD" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/random/maintenance,
@@ -38482,16 +38858,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
-"jMH" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Theatre";
-	dir = 1
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/dark,
-/area/station/service/theater)
 "jMI" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/holopad,
@@ -38515,22 +38881,6 @@
 	},
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/starboard/aft)
-"jMY" = (
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Brig Secure Armory East";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "jNa" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/syringes,
@@ -38834,6 +39184,22 @@
 	},
 /turf/open/floor/eighties,
 /area/station/commons/dorms/apartment1)
+"jRY" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/camera/directional/south{
+	c_tag = "Brig Restroom"
+	},
+/obj/item/storage/fancy/donut_box{
+	pixel_y = 10
+	},
+/obj/item/storage/fancy/donut_box{
+	pixel_y = 6
+	},
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/iron/edge,
+/area/station/security/checkpoint/customs)
 "jRZ" = (
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/starboard/fore)
@@ -38875,6 +39241,16 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"jSG" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Gravity Generator Room";
+	network = list("ss13","engineering")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/station/engineering/gravity_generator)
 "jSH" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/ghetto/sorting)
@@ -38986,6 +39362,14 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"jUm" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/camera/directional/south{
+	c_tag = "Research - Polygon South";
+	network = list("ss13","rd","ordnance")
+	},
+/turf/open/floor/iron/airless,
+/area/station/science/ordnance/bomb)
 "jUq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -39306,19 +39690,6 @@
 "jXZ" = (
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
-"jYh" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Cargo - Mining Dock";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/cargo/miningoffice)
 "jYl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39415,19 +39786,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/fore)
-"jZn" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/corporate{
-	id_tag = "blueshield_door"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/navigate_destination,
-/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
-/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
-/turf/open/floor/wood/tile,
-/area/station/command/heads_quarters/blueshield)
 "jZr" = (
 /mob/living/basic/killer_tomato,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -39768,18 +40126,6 @@
 /obj/machinery/cell_charger,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"kdI" = (
-/obj/structure/cable,
-/obj/machinery/computer/station_alert{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Chief Engineer's Office"
-	},
-/obj/machinery/keycard_auth/wall_mounted/directional/south,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/ce)
 "kdO" = (
 /obj/item/kirbyplants/random/dead,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -39864,15 +40210,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"keK" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 1;
-	id = "Skynet_launch";
-	name = "Mech Bay"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
 "keQ" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -39881,6 +40218,27 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"keT" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "robotics_desk";
+	name = "Robotics Lab Shutters"
+	},
+/obj/machinery/door/window/left/directional/west{
+	name = "Robotics Desk";
+	req_access = list("robotics")
+	},
+/obj/structure/desk_bell{
+	pixel_y = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/plating,
+/area/station/science/robotics/lab)
 "keV" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
@@ -40005,30 +40363,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/holding_cell)
-"kgN" = (
-/obj/structure/table/glass,
-/obj/item/folder/white{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/clothing/neck/stethoscope{
-	pixel_y = 4;
-	pixel_x = 5
-	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Medbay - CMO Office";
-	network = list("ss13","medbay");
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/cmo)
 "kgT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40305,21 +40639,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison/visit)
-"kkV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/poddoor/preopen{
-	name = "Engineering Security Doors";
-	id_tag = "engineering_lockdown"
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/department/electrical)
 "kkY" = (
 /obj/structure/safe/floor,
 /obj/item/coin/mythril,
@@ -40790,6 +41109,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto)
+"kqg" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/effect/landmark/start/depsec/medical,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/checkpoint/medical)
 "kqk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -40826,18 +41155,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port)
-"krf" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/camera{
-	c_tag = "Engineering Atmos East";
-	network = list("SS13","Engineering");
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "krq" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/table_frame/wood,
@@ -41063,6 +41380,18 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/engine,
 /area/station/medical/pharmacy)
+"ktA" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/poddoor/preopen{
+	name = "Engineering Security Doors";
+	id = "engineering_lockdown"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/turf/open/floor/iron,
+/area/station/engineering/hallway)
 "ktC" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/siding/white{
@@ -41156,23 +41485,6 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
-"kuQ" = (
-/obj/machinery/computer/records/security,
-/obj/machinery/requests_console/directional/north{
-	department = "Engineering";
-	name = "Security Requests Console"
-	},
-/obj/effect/mapping_helpers/requests_console/information,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/machinery/newscaster/directional/east,
-/obj/machinery/camera/directional/east{
-	c_tag = "Security Post - Engineering"
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/third)
 "kuV" = (
 /obj/structure/table,
 /obj/item/electropack,
@@ -41312,6 +41624,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
+"kwy" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Atmospherics - Project Room Fore";
+	network = list("ss13","engineering")
+	},
+/obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/trimline/yellow/line,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/project)
 "kwz" = (
 /obj/structure/chair/stool/bar{
 	dir = 8
@@ -41532,6 +41853,16 @@
 "kAy" = (
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"kAA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/camera/directional/west{
+	c_tag = "Janitor Closet"
+	},
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/service/janitor)
 "kAC" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -41602,17 +41933,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"kBA" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Xenobiology - Killroom Chamber";
-	network = list("ss13","xeno","rd")
-	},
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/science/xenobiology)
 "kBH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/mineral/ore_redemption,
@@ -41836,15 +42156,6 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/iron,
 /area/station/cargo/storage/ghetto/depot)
-"kDR" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id = "robotics_window";
-	name = "Robotics Lab Shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/science/robotics/mechbay)
 "kDT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -41993,24 +42304,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
-"kFi" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	location = "Engineering"
-	},
-/obj/machinery/door/poddoor/preopen{
-	name = "Engineering Security Doors";
-	id_tag = "engineering_lockdown"
-	},
-/obj/machinery/door/window/left/directional/east{
-	name = "Drone Fabricator";
-	req_access = list("engine_equip")
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/dronefabricator)
 "kFk" = (
 /obj/structure/table/reinforced,
 /obj/item/megaphone{
@@ -42195,6 +42488,15 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/aft)
+"kGQ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "cargosecprivacy";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/supply)
 "kGU" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
@@ -42699,6 +43001,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
+"kMU" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Engineering - Break Room";
+	network = list("ss13","engineering")
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron,
+/area/station/engineering/break_room)
 "kMW" = (
 /obj/machinery/door/airlock/public,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -43056,24 +43366,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
-"kRK" = (
-/obj/structure/table,
-/obj/machinery/camera{
-	c_tag = "Research Lobby";
-	network = list("Research","SS13");
-	dir = 1
-	},
-/obj/machinery/light_switch/directional/north,
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
-	},
-/obj/item/folder,
-/obj/item/pen,
-/turf/open/floor/iron,
-/area/station/science/lobby)
 "kRR" = (
 /obj/structure/sign/warning/vacuum/directional/north,
 /obj/machinery/conveyor{
@@ -43368,6 +43660,21 @@
 /obj/effect/landmark/navigate_destination/vault,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
+"kVU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/research,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "kVX" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/blue{
@@ -43693,6 +44000,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"kZp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table/glass,
+/obj/item/folder/white{
+	pixel_x = 4
+	},
+/obj/item/pen{
+	pixel_x = 4
+	},
+/obj/item/stamp/head/rd{
+	pixel_x = 7;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "kZu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -43772,6 +44097,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
+"laT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/public,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	dir = 4;
+	id = "JimNortonBottom"
+	},
+/turf/open/floor/wood,
+/area/station/service/cafeteria)
 "laX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43911,17 +44249,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
-"lcp" = (
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/camera{
-	c_tag = "Engineering Drone Fabricator Room";
-	dir = 8;
-	network = list("SS13","Engineering")
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/dronefabricator)
 "lcq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/machinery/duct,
@@ -44045,6 +44372,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"leA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Arrivals Auxiliary Docking South"
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 4
+	},
+/area/station/hallway/secondary/entry)
 "leN" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -44086,6 +44425,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/ghetto/central/aft)
+"lfl" = (
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Departure Lounge North-West"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "lfw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -44316,6 +44664,42 @@
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/maintenance/aft)
+"liH" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/structure/table/glass,
+/obj/machinery/camera/directional/south{
+	c_tag = "Medbay - Cryogenics";
+	network = list("ss13","medbay")
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/pill_bottle/mannitol,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/requests_console/directional/south{
+	department = "Medbay";
+	name = "Medbay Requests Console"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "liP" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -44408,6 +44792,13 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"lke" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "lkr" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -44416,6 +44807,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"lkJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/checkpoint/medical)
 "lkU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -44474,14 +44873,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/fore)
-"llw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	dir = 1;
-	id = "rd_office_window_shutters"
-	},
-/turf/open/floor/plating,
-/area/station/science/robotics/lab)
 "llD" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4;
@@ -44657,19 +45048,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"lny" = (
-/obj/effect/mapping_helpers/requests_console/information,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/machinery/requests_console/directional/south{
-	department = "Cargo";
-	name = "Security Requests Console"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/supply)
 "lnB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -44912,6 +45290,20 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/blueshield)
+"lqk" = (
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/structure/sign/poster/official/random/directional/east,
+/obj/machinery/camera/directional/south{
+	c_tag = "Research - Break Room";
+	network = list("ss13","rd");
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/breakroom)
 "lql" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44928,20 +45320,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical/ghetto/morgue)
-"lqv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Engineering Hallway West";
-	dir = 1
-	},
-/obj/machinery/holopad,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/hallway)
 "lqy" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
@@ -45095,6 +45473,16 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
+"lrM" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/landmark/start/research_director,
+/obj/machinery/computer/security/telescreen/research/directional/south{
+	network = list("rd","xeno","test","ordnance")
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "lrR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -45234,6 +45622,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
+"ltl" = (
+/obj/structure/table,
+/obj/machinery/camera/directional/north{
+	c_tag = "Research - Test Lab";
+	network = list("ss13","rd")
+	},
+/obj/item/healthanalyzer/advanced,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = 4;
+	pixel_y = -2
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/lower)
 "ltw" = (
 /obj/structure/railing{
 	dir = 1
@@ -45278,6 +45684,18 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"lui" = (
+/obj/effect/turf_decal/tile/red/fourcorners,
+/obj/structure/toilet{
+	pixel_y = 8;
+	dir = 8
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Prison Solitary 2";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron,
+/area/station/security/prison)
 "luk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45358,18 +45776,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/station/engineering/storage)
-"lve" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/left/directional/north{
-	req_access = list("engine_equip");
-	name = "Engineering"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/electrical)
 "lvg" = (
 /obj/machinery/light/directional/east,
 /obj/structure/sign/poster/official/random/directional/east,
@@ -45717,16 +46123,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"lAd" = (
-/obj/effect/turf_decal/tile/green/fourcorners,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Cryodorms";
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/common/cryopods)
 "lAn" = (
 /obj/structure/table,
 /obj/machinery/light/directional/north,
@@ -45863,21 +46259,6 @@
 /obj/item/folder/red,
 /turf/open/floor/carpet,
 /area/station/maintenance/ghetto/fore/starboard)
-"lBO" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "rnd";
-	name = "Research Lab Shutters"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/right/directional/east{
-	name = "Research and Development Desk";
-	req_access = list("science")
-	},
-/obj/structure/desk_bell,
-/turf/open/floor/iron,
-/area/station/science/lab)
 "lBQ" = (
 /obj/structure/table/wood,
 /obj/item/clothing/gloves/latex/nitrile{
@@ -45943,17 +46324,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port/greater)
-"lCI" = (
-/obj/structure/table/wood,
-/obj/machinery/airalarm/directional/north,
-/obj/item/storage/crayons,
-/obj/item/book/bible,
-/obj/machinery/camera{
-	c_tag = "Chapel - Chaplain's Office";
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
-/area/station/service/chapel/office)
 "lCL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -45985,18 +46355,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"lDn" = (
-/obj/structure/barricade/wooden,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "Construction"
-	},
-/obj/machinery/door/poddoor/preopen{
-	name = "Engineering Security Doors";
-	id_tag = "engineering_lockdown"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/electrical)
 "lDx" = (
 /obj/effect/landmark/start/ai,
 /obj/item/radio/intercom/directional/west{
@@ -46029,28 +46387,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"lDC" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/camera/directional/south{
-	c_tag = "Ordnance Lower Mix Lab";
-	network = list("ss13","rd")
-	},
-/obj/structure/sign/warning/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
-"lDI" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/power/energy_accumulator/tesla_coil,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Secure Storage South";
-	network = list("SS13","Engineering")
-	},
-/turf/open/floor/plating,
-/area/station/engineering/storage)
 "lDW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46095,16 +46431,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"lEB" = (
-/obj/machinery/button/door/directional/north{
-	id = "medsecprivacy";
-	name = "Privacy Shutters Control";
-	req_access = list("security")
-	},
-/obj/machinery/computer/records/medical,
-/obj/effect/turf_decal/tile/red/full,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/checkpoint/medical)
 "lEK" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
@@ -46196,15 +46522,6 @@
 /obj/item/reagent_containers/dropper,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"lFO" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/camera{
-	c_tag = "Teleporter Room";
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/station/command/teleporter)
 "lFQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46259,6 +46576,10 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/station/maintenance/starboard/fore)
+"lGg" = (
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "lGn" = (
 /obj/machinery/light/directional/west,
 /obj/item/radio/intercom/prison/directional/north,
@@ -46617,25 +46938,25 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
+"lKy" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/machinery/newscaster/directional/east,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Research - Security Post";
+	network = list("ss13","rd");
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "lKC" = (
 /obj/machinery/netpod,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/cargo/bitrunning/den)
-"lKF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/yellow/fourcorners,
-/obj/machinery/light/directional/north,
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Engine Room North";
-	network = list("SS13","Singularity","Engineering");
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/hallway/west)
 "lKG" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /obj/effect/decal/cleanable/dirt,
@@ -46901,16 +47222,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/ghetto)
-"lNF" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/obj/machinery/camera/directional/west{
-	c_tag = "Science - Ordnance Watching Room";
-	network = list("ss13","rd");
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/science/ordnance/testlab)
 "lNJ" = (
 /obj/structure/table,
 /obj/item/hand_tele,
@@ -47000,21 +47311,6 @@
 /obj/item/multitool,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
-"lOJ" = (
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/scanning_module,
-/obj/item/stock_parts/scanning_module,
-/obj/effect/turf_decal/tile/purple/anticorner,
-/obj/item/stock_parts/capacitor,
-/obj/structure/table,
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
-/area/station/science/lab)
 "lOR" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/port)
@@ -47382,14 +47678,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical/ghetto)
-"lUq" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/research,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/science/research)
 "lUt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47424,6 +47712,29 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
+"lUJ" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Research Director's Office";
+	network = list("ss13","rd")
+	},
+/obj/structure/table/glass,
+/obj/item/radio/intercom/directional/north,
+/obj/item/computer_disk{
+	pixel_x = 7;
+	pixel_y = 2
+	},
+/obj/item/computer_disk/ordnance{
+	pixel_y = 4;
+	pixel_x = -5
+	},
+/obj/item/computer_disk/ordnance,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "lUN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /obj/machinery/light/directional/south,
@@ -47581,6 +47892,14 @@
 	},
 /turf/open/floor/grass,
 /area/station/maintenance/ghetto/garden)
+"lWk" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Prison Library";
+	network = list("ss13","prison")
+	},
+/obj/effect/spawner/random/entertainment/arcade,
+/turf/open/floor/wood,
+/area/station/security/prison)
 "lWl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47647,18 +47966,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/eighties,
 /area/station/commons/dorms/apartment1)
-"lWK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/poddoor/shutters{
-	dir = 1;
-	id = "Skynet_launch";
-	name = "Mech Bay"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
 "lWQ" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -47797,22 +48104,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"lYU" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral/half,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/camera{
-	c_tag = "Brig Restroom"
-	},
-/obj/item/storage/fancy/donut_box{
-	pixel_y = 10
-	},
-/obj/item/storage/fancy/donut_box{
-	pixel_y = 6
-	},
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/iron/edge,
-/area/station/security/checkpoint/customs)
 "lYW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48196,6 +48487,17 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/smooth,
 /area/station/commons/toilet/restrooms)
+"mdv" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Research - Xenobiology Cell 3";
+	network = list("ss13","xeno","rd")
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "mdx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -48220,6 +48522,22 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/medical)
+"mdU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
+/obj/machinery/door/airlock/research,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/iron,
+/area/station/science/research)
 "mdW" = (
 /obj/machinery/light/floor,
 /turf/open/floor/iron/white,
@@ -48329,6 +48647,15 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
+"mfM" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Research Hallway South"
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "mfO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48547,6 +48874,21 @@
 /obj/item/melee/baton/security/cattleprod,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"mjs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/camera/directional/south{
+	c_tag = "Dormitories Center"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "mjy" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/door/airlock/public/glass,
@@ -48963,19 +49305,6 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/atmos/storage/gas)
-"mqw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/requests_console/directional/east{
-	department = "Medbay";
-	name = "Medbay Requests Console"
-	},
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/machinery/light/directional/east,
-/obj/structure/filingcabinet/chestdrawer,
-/obj/item/folder/white,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "mqF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49006,17 +49335,15 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/airless,
 /area/station/science/ordnance/bomb)
-"mqP" = (
-/obj/machinery/camera{
-	c_tag = "Brig Main Hall West 2";
-	dir = 1
-	},
+"mqQ" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "JimNortonKitchen"
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
+/obj/item/modular_computer/laptop/preset/civilian,
+/obj/structure/table/reinforced,
+/turf/open/floor/wood,
+/area/station/service/cafeteria)
 "mqU" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -49033,6 +49360,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"mrb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/directional/south{
+	c_tag = "Brig Firing Range"
+	},
+/turf/open/floor/iron,
+/area/station/security/range)
 "mrf" = (
 /turf/closed/wall,
 /area/station/command/heads_quarters/magistrate)
@@ -49106,6 +49440,19 @@
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"mrM" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "rnd";
+	name = "Research Lab Shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/plating,
+/area/station/science/lab)
 "mrO" = (
 /obj/machinery/door/poddoor/massdriver_trash,
 /turf/open/floor/plating,
@@ -49638,12 +49985,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/holding_cell)
-"mzr" = (
-/obj/machinery/quantum_server,
-/obj/machinery/camera/directional/north,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/cargo/bitrunning/den)
 "mzy" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/conveyor{
@@ -49754,6 +50095,14 @@
 /obj/machinery/power/tracker,
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/port/fore)
+"mAL" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/tile/red/full,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/checkpoint/medical)
 "mAR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49807,6 +50156,16 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"mBx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Arrivals South"
+	},
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/entry)
 "mBC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50014,16 +50373,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
-"mEk" = (
-/obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Turbine";
-	network = list("SS13","Engineering");
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/disposal/incinerator)
 "mEo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50116,6 +50465,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"mEW" = (
+/obj/structure/chair/pew/left{
+	dir = 8
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Courtroom Lobby"
+	},
+/turf/open/floor/wood/parquet,
+/area/station/security/courtroom)
 "mEX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -50146,6 +50504,12 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"mFn" = (
+/obj/machinery/camera/autoname/directional/north{
+	network = list("ss13","prison")
+	},
+/turf/open/openspace,
+/area/station/security/prison)
 "mFv" = (
 /obj/item/exodrone,
 /obj/machinery/exodrone_launcher,
@@ -50199,6 +50563,17 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/small,
 /area/station/security/interrogation/ghetto)
+"mFL" = (
+/obj/machinery/requests_console/directional/east{
+	department = "Medbay";
+	name = "Medbay Requests Console"
+	},
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/machinery/light/directional/east,
+/obj/structure/filingcabinet/chestdrawer,
+/obj/item/folder/white,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "mFR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -50234,16 +50609,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
-"mGr" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Departure Lounge Security";
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/hallway/secondary/exit/departure_lounge)
 "mGt" = (
 /obj/structure/closet/secure_closet/freezer/empty/open,
 /obj/item/reagent_containers/condiment/sugar{
@@ -50658,15 +51023,6 @@
 /obj/item/chair/stool,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"mKJ" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "rnd";
-	name = "Research Lab Shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/science/lab)
 "mKL" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
@@ -50680,21 +51036,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
-"mKV" = (
-/obj/structure/dresser,
-/obj/item/radio/intercom/directional/east,
-/obj/machinery/camera{
-	c_tag = "Chief Medical Officer's Quarters";
-	network = list("Medical","SS13");
-	dir = 1
-	},
-/obj/machinery/button/door/directional/north{
-	id = "CMO_bedroom";
-	name = "CMO Office Shutters";
-	req_access = list("cmo")
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/cmo)
+"mKS" = (
+/obj/structure/closet/secure_closet/security/med,
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/south,
+/obj/effect/turf_decal/tile/red/full,
+/obj/machinery/light/directional/south,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/checkpoint/medical)
 "mKX" = (
 /obj/effect/landmark/start/security_officer,
 /obj/structure/curtain/cloth/fancy,
@@ -50749,17 +51099,16 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/station/common/cryopods)
-"mLF" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 1
+"mLy" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Xenobiology - Cell 8";
-	network = list("ss13","xeno","rd")
+/obj/machinery/camera/directional/west{
+	c_tag = "Medbay - Hallway Center";
+	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "mLI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50944,14 +51293,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/station/maintenance/starboard/aft)
-"mPa" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/landmark/start/depsec/supply,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/supply)
 "mPi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -51056,31 +51397,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"mPV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/table/glass,
-/obj/machinery/button/door/directional/south{
-	id = "Biohazard";
-	name = "Biohazard Shutter Control";
-	req_access = list("research");
-	pixel_y = 0;
-	pixel_x = -4
-	},
-/obj/item/folder/white{
-	pixel_x = 4
-	},
-/obj/item/pen{
-	pixel_x = 4
-	},
-/obj/item/stamp/head/rd{
-	pixel_x = 7;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
 "mQa" = (
 /obj/effect/turf_decal/tile/dark/half,
 /obj/structure/weightmachine/weightlifter,
@@ -51095,19 +51411,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/ghetto/starboard)
-"mQl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/corporate,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/effect/landmark/navigate_destination,
-/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
-/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
-/obj/effect/mapping_helpers/airlock/access/any/command/magistrate,
-/turf/open/floor/wood/tile,
-/area/station/command/heads_quarters/magistrate)
 "mQo" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -51640,6 +51943,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
+"mYd" = (
+/obj/structure/table/reinforced,
+/obj/machinery/camera/directional/south{
+	c_tag = "EVA"
+	},
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/power_store/cell/high,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/ai_monitored/command/storage/eva)
 "mYf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -51838,6 +52150,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
+"nad" = (
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/camera/directional/west{
+	c_tag = "Engineering - Drone Fabricator Room";
+	network = list("ss13","engineering")
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/engineering/dronefabricator)
 "nai" = (
 /obj/machinery/vending/coffee,
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -52142,6 +52464,13 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
+"nff" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Research - Secure Lab Test Chamber";
+	network = list("ss13","rd","test")
+	},
+/turf/open/floor/engine,
+/area/station/science/lower)
 "nfi" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
@@ -52293,17 +52622,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/ghetto/starboard/aft)
-"nhl" = (
-/obj/machinery/camera{
-	c_tag = "Vacant Store";
-	dir = 1
-	},
-/obj/machinery/button/door/directional/north{
-	id = "vacantstore_north"
-	},
-/obj/effect/turf_decal/tile/neutral/full,
-/turf/open/floor/iron/dark/small,
-/area/station/commons/vacant_room/commissary)
 "nho" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -52347,16 +52665,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
-"nhQ" = (
-/obj/structure/chair/comfy/teal{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Virology Lobby"
-	},
-/obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "nhU" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
@@ -52393,6 +52701,16 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
+"niD" = (
+/obj/machinery/dna_infuser,
+/obj/machinery/camera/directional/south{
+	c_tag = "Research - Genetics";
+	network = list("ss13","rd")
+	},
+/obj/item/infuser_book,
+/obj/effect/turf_decal/tile/purple/half,
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "niE" = (
 /turf/open/floor/catwalk_floor,
 /area/station/cargo/drone_bay/ghetto)
@@ -52420,18 +52738,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/security/processing)
-"njj" = (
-/obj/machinery/camera{
-	c_tag = "Research Toxins Mixing";
-	dir = 8;
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance/office)
 "njk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -52589,12 +52895,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"nkO" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/third)
 "nkT" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
@@ -52822,6 +53122,21 @@
 /obj/structure/fireaxecabinet/empty/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port/aft)
+"nnH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/poddoor/shutters{
+	id = "Skynet_launch";
+	name = "Mech Bay"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/mechbay)
 "nnJ" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -53374,6 +53689,14 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"nup" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/obj/structure/sign/poster/official/random/directional/east,
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "nuu" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -53552,6 +53875,13 @@
 "nwx" = (
 /turf/closed/wall/r_wall,
 /area/station/security/execution)
+"nwy" = (
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Brig Briefing Room"
+	},
+/turf/open/floor/iron,
+/area/station/security/office)
 "nwz" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -53654,6 +53984,17 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
+"nyt" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/command/hos{
+	id_tag = "hos_door"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/effect/mapping_helpers/airlock/access/any/security/hos,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/hos)
 "nyv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54098,6 +54439,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/ghetto)
+"nDC" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Cargo - Entrance";
+	network = list("ss13","cargo")
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "nDE" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -54147,21 +54498,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
-"nEo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Dormitories Center"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "nEs" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -54263,6 +54599,13 @@
 "nFL" = (
 /turf/open/floor/carpet,
 /area/station/maintenance/aft)
+"nFS" = (
+/obj/machinery/computer/security/mining{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted,
+/turf/open/floor/iron,
+/area/station/cargo/miningoffice)
 "nFU" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance)
@@ -54475,13 +54818,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
-"nIn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
 "nIo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -54491,22 +54827,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/starboard)
-"nIF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Arrivals North";
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 1
-	},
-/area/station/hallway/secondary/entry)
 "nIQ" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -54863,6 +55183,20 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
+"nNP" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/obj/machinery/light/small/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Medbay - Hallway North";
+	network = list("ss13","medbay")
+	},
+/obj/structure/sign/departments/morgue/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "nNQ" = (
 /obj/structure/closet/secure_closet/personal{
 	anchored = 1
@@ -54966,6 +55300,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
+"nOL" = (
+/obj/machinery/computer/crew,
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "nPb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -55057,6 +55396,19 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"nQc" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Research - Xenobiology Access";
+	network = list("ss13","rd","xeno")
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "nQf" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/status_display/evac/directional/north,
@@ -55192,6 +55544,15 @@
 	},
 /turf/open/floor/iron/airless,
 /area/station/science/ordnance/bomb)
+"nRT" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Prison Forestry North";
+	network = list("ss13","prison")
+	},
+/obj/structure/flora/bush/jungle,
+/obj/machinery/airalarm/directional/north,
+/turf/open/misc/grass,
+/area/station/security/prison/garden)
 "nSf" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -55577,20 +55938,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"nWF" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/radio/intercom/directional/east,
-/obj/machinery/camera/directional/east{
-	c_tag = "Xeniobiology - Maintenance Access";
-	network = list("ss13","xeno","rd")
+"nWG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "engsecprivacy";
+	name = "Privacy Shutters"
 	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/turf/open/floor/plating,
+/area/station/security/checkpoint/engineering)
 "nXa" = (
 /obj/machinery/bookbinder,
 /turf/open/floor/iron/dark,
@@ -55864,6 +56221,19 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"oao" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Engineering - Secure Storage West";
+	network = list("ss13","engineering")
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage)
 "oar" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -55941,15 +56311,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/starboard)
-"obr" = (
-/obj/structure/grille,
-/obj/structure/barricade/wooden,
-/obj/machinery/door/poddoor/preopen{
-	name = "Engineering Security Doors";
-	id_tag = "engineering_lockdown"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/electrical)
 "obs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56042,18 +56403,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
-"ocm" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Xenobiology East";
-	network = list("ss13","xeno","rd");
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "ocp" = (
 /obj/structure/filingcabinet/security,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -56177,20 +56526,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"odm" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Secure Storage West";
-	dir = 8;
-	network = list("SS13","Engineering")
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage)
 "odo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56308,24 +56643,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
-"ofp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+"ofc" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/plasticflaps{
+	opacity = 1
 	},
-/obj/machinery/camera/directional/east{
-	c_tag = "Engineering - Supermatter Foyer";
-	network = list("ss13","engine")
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/left/directional/north{
+	req_access = list("engine_equip");
+	name = "engineering"
 	},
-/obj/structure/rack,
-/obj/item/analyzer,
-/obj/item/geiger_counter,
-/obj/item/geiger_counter{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/engineering/hallway/west)
+/turf/open/floor/plating,
+/area/station/maintenance/department/electrical)
 "ofq" = (
 /obj/machinery/bluespace_beacon,
 /obj/effect/turf_decal/stripes/line{
@@ -56495,6 +56824,15 @@
 /obj/structure/sign/directions/arrival/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
+"ohZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "oib" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/machinery/door/airlock/maintenance,
@@ -56516,6 +56854,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
+"oir" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/iron,
+/area/station/engineering/hallway)
 "oiw" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -56594,6 +56939,34 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"ojf" = (
+/obj/machinery/modular_computer/preset/id{
+	dir = 4
+	},
+/obj/machinery/light_switch/directional/south,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 8
+	},
+/obj/machinery/button/door/directional/west{
+	pixel_y = 10;
+	id = "engineering_lockdown";
+	name = "Engineering Lockdown";
+	req_access = list("ce");
+	color = "yellow"
+	},
+/obj/machinery/button/door/directional/west{
+	id = "atmoslock";
+	name = "Atmos Lockdown";
+	req_access = list("ce")
+	},
+/obj/machinery/button/door/directional/west{
+	pixel_y = -10;
+	id = "transittube_lockdown";
+	name = "Transit Tube Lockdown";
+	req_access = list("ce")
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/ce)
 "ojh" = (
 /obj/machinery/light/directional/north,
 /obj/structure/rack,
@@ -56616,21 +56989,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/service/janitor)
-"ojk" = (
-/obj/structure/rack,
-/obj/machinery/camera{
-	c_tag = "Engineering Atmos SM Equipment Room";
-	network = list("SS13","Engineering")
-	},
-/obj/item/clothing/gloves/color/black{
-	pixel_x = -6
-	},
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black{
-	pixel_x = 6
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/hallway)
 "ojo" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/effect/turf_decal/stripes/corner{
@@ -56705,6 +57063,19 @@
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"okz" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/radio/off,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "okD" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -56712,14 +57083,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical/ghetto/morgue)
-"okJ" = (
-/obj/structure/closet/secure_closet/security/cargo,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/supply)
 "okM" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -56841,6 +57204,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"omI" = (
+/obj/structure/cable,
+/obj/machinery/camera/directional/south{
+	c_tag = "Solars - North-East"
+	},
+/obj/machinery/power/smes,
+/turf/open/floor/plating,
+/area/station/maintenance/solars/starboard/fore)
 "omR" = (
 /obj/structure/table,
 /turf/open/floor/iron,
@@ -56879,6 +57250,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/arrivals)
+"onf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "robotics_desk";
+	name = "Robotics Lab Shutters"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/plating,
+/area/station/science/robotics/lab)
 "onk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -57144,6 +57528,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"oqi" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Prisoner Lockers"
+	},
+/obj/machinery/light_switch/directional/west,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/processing)
 "oqj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57403,6 +57797,22 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"oti" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
+/obj/machinery/door/airlock/research,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/iron,
+/area/station/science/ordnance/office)
 "otj" = (
 /obj/machinery/button/door/directional/east{
 	id = "brig_courtroom";
@@ -57463,6 +57873,17 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
+"otU" = (
+/obj/structure/chair/comfy/teal{
+	dir = 4
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Virology - Lobby";
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/trimline/green/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "ouf" = (
 /obj/structure/table/wood,
 /obj/item/vending_refill/boozeomat,
@@ -57648,31 +58069,6 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"owb" = (
-/obj/machinery/rnd/production/techfab/department/cargo,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/machinery/requests_console/directional/west{
-	department = "Cargo Bay";
-	name = "Cargo Bay Requests Console"
-	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Cargo - Office"
-	},
-/turf/open/floor/iron,
-/area/station/cargo/office)
-"owe" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/camera{
-	c_tag = "Engineering Atmos Center North";
-	network = list("SS13","Engineering");
-	dir = 1
-	},
-/obj/machinery/light_switch/directional/north,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "owg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -57686,6 +58082,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"owD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/plating,
+/area/station/science/ordnance/office)
 "owG" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -57843,20 +58247,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/fore/starboard)
-"oyw" = (
-/obj/machinery/camera{
-	c_tag = "Xenobiology Access";
-	network = list("ss13","rd");
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "oyA" = (
 /obj/machinery/light/small/broken/directional/north,
 /turf/open/floor/iron/cafeteria,
@@ -58137,6 +58527,16 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/carpet/red,
 /area/station/maintenance/department/security/ghetto)
+"oDa" = (
+/obj/structure/sign/departments/telecomms/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Central Primary Hallway South"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "oDc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58377,6 +58777,16 @@
 /obj/effect/mapping_helpers/broken_machine,
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
+"oFN" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/camera/directional/west{
+	c_tag = "Brig Lobby West"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
 "oFW" = (
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/blueshield)
@@ -58500,15 +58910,6 @@
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
-"oIm" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/science/general,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "oIo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58589,6 +58990,15 @@
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
+"oJu" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/landmark/start/depsec/engineering,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/engineering)
 "oJz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -58653,33 +59063,20 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
-"oKd" = (
-/obj/structure/table/glass,
-/obj/machinery/camera{
-	c_tag = "Virology Workspace";
-	dir = 1
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 8;
-	pixel_y = 12
-	},
-/obj/machinery/requests_console/directional/north{
-	department = "Virology";
-	name = "Virology Requests Console"
-	},
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/effect/mapping_helpers/requests_console/ore_update,
-/obj/effect/mapping_helpers/requests_console/supplies,
-/obj/effect/mapping_helpers/requests_console/announcement,
-/obj/effect/mapping_helpers/requests_console/information,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "oKg" = (
 /turf/open/floor/cult,
 /area/station/maintenance/starboard/fore)
+"oKi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "oKn" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/sign/departments/engineering/directional/west,
@@ -58847,10 +59244,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
-"oLU" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "oLX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
@@ -58915,6 +59308,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"oMR" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/engineering)
 "oNg" = (
 /obj/structure/table/wood,
 /obj/item/food/pistachios,
@@ -58967,6 +59370,17 @@
 /obj/structure/sign/directions/arrival/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
+"oNW" = (
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/security,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/engineering)
 "oOa" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/structure/closet/crate,
@@ -59280,6 +59694,14 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/magistrate,
 /turf/open/floor/plating,
 /area/station/security/courtroom)
+"oSK" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/camera/directional/north{
+	c_tag = "Fore Starboard Solar Access"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/fore)
 "oSL" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral{
@@ -59396,29 +59818,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"oUx" = (
-/obj/machinery/modular_computer/preset/research{
-	dir = 4
+"oUp" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/machinery/camera/directional/north{
+	c_tag = "Theatre"
 	},
-/obj/machinery/button/door{
-	pixel_x = -24;
-	pixel_y = -5;
-	req_access = list("rd");
-	id = "rd_office_shutters";
-	name = "Privacy Control"
-	},
-/obj/machinery/button/door{
-	pixel_x = -24;
-	pixel_y = 3;
-	req_access = list("rd");
-	id = "rd_office_window_shutters";
-	name = "Privacy Control"
-	},
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 1
-	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
+/area/station/service/theater)
 "oUL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -59441,6 +59849,18 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"oVb" = (
+/obj/effect/turf_decal/tile/red/fourcorners,
+/obj/structure/toilet{
+	pixel_y = 8;
+	dir = 4
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Prison Solitary 1";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron,
+/area/station/security/prison)
 "oVh" = (
 /obj/structure/bed,
 /obj/item/bedsheet/clown,
@@ -59886,6 +60306,26 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"paG" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/radio/off{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/item/pen{
+	pixel_x = 6
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/engineering)
 "paX" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -59958,6 +60398,15 @@
 	},
 /turf/open/floor/iron/telecomms,
 /area/station/tcommsat/server)
+"pck" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - Foyer East";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron/stairs/right{
+	dir = 8
+	},
+/area/station/engineering/hallway)
 "pcn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -60095,17 +60544,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
-"pdL" = (
-/obj/machinery/camera{
-	c_tag = "Brig Main Hall West 1";
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/security/brig)
 "ped" = (
 /obj/structure/railing{
 	dir = 1
@@ -60394,25 +60832,6 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
-"phH" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "JimNortonKitchen"
-	},
-/obj/item/reagent_containers/cup/glass/coffee{
-	pixel_x = -3;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/cup/glass/coffee{
-	pixel_x = 9;
-	pixel_y = 3
-	},
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/cup/glass/coffee{
-	pixel_y = -1
-	},
-/turf/open/floor/wood,
-/area/station/service/cafeteria)
 "phI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -60445,14 +60864,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
-"piv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "medical_break"
-	},
-/turf/open/floor/plating,
-/area/station/medical/break_room)
 "piw" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/firealarm/directional/south,
@@ -60461,6 +60872,17 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"piz" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/poddoor/preopen{
+	name = "Engineering Security Doors";
+	id = "engineering_lockdown"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "piI" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 4;
@@ -60492,15 +60914,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
-"piM" = (
-/obj/structure/barricade/wooden,
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	name = "Engineering Security Doors";
-	id_tag = "engineering_lockdown"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/electrical)
 "piQ" = (
 /obj/structure/chair/sofa/right/brown{
 	dir = 1
@@ -60805,6 +61218,18 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/aft)
+"pmt" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Research - Xenobiology Cell 6";
+	network = list("ss13","xeno","rd")
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "pmx" = (
 /obj/structure/frame/computer{
 	dir = 1
@@ -60933,6 +61358,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
+"pol" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Locker Room East"
+	},
+/turf/open/floor/iron,
+/area/station/commons/locker)
 "pop" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/entry)
@@ -60964,6 +61395,17 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
+"poA" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - Lobby West";
+	network = list("ss13","engineering")
+	},
+/obj/structure/chair,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "poO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -61106,6 +61548,11 @@
 /obj/item/bedsheet/brown,
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
+"pre" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/sign/departments/exam_room,
+/turf/open/floor/plating,
+/area/station/medical/treatment_center)
 "prg" = (
 /obj/structure/chair{
 	dir = 8
@@ -61182,6 +61629,12 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"psk" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Starboard Primary Hallway 1"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "psq" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters{
@@ -61200,16 +61653,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
-"psv" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/camera{
-	c_tag = "Tech Storage";
-	network = list("SS13","Engineering");
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/engineering/storage/tech)
 "psw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
@@ -61275,15 +61718,6 @@
 /obj/structure/chair/comfy/beige,
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
-"ptF" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id = "robotics_window";
-	name = "Robotics Lab Shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/science/robotics/lab)
 "ptO" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -61478,6 +61912,14 @@
 /obj/machinery/vending/drugs,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"pvw" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Research - Polygon North";
+	network = list("ss13","rd","ordnance")
+	},
+/turf/open/floor/iron/airless,
+/area/station/science/ordnance/bomb)
 "pvD" = (
 /turf/closed/wall/r_wall,
 /area/station/science/breakroom)
@@ -61643,6 +62085,21 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
+"pxt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/airlock/command/ce{
+	id_tag = "ce_door"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/ce,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/ce)
 "pxu" = (
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 1
@@ -61772,6 +62229,20 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"pyZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/vending/coffee,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Dormitories West"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "pzh" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -61789,6 +62260,11 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"pzu" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/sign/warning/no_smoking/circle,
+/turf/open/floor/plating,
+/area/station/medical/surgery/theatre)
 "pzD" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/table/reinforced,
@@ -61798,18 +62274,6 @@
 /obj/item/reagent_containers/cup/glass/drinkingglass,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
-"pzQ" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/camera{
-	c_tag = "Research Hallway North";
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "pzS" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -61863,16 +62327,6 @@
 /obj/structure/broken_flooring/pile/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
-"pAv" = (
-/obj/machinery/camera{
-	c_tag = "Cargo - Entrance";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/aft)
 "pAw" = (
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
@@ -61895,6 +62349,14 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"pAO" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Construction Area";
+	network = list("ss13","engineering")
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/construction)
 "pAP" = (
 /obj/structure/table,
 /obj/item/hand_labeler{
@@ -61913,10 +62375,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/openspace,
 /area/space/nearstation)
-"pBh" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
 "pBm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -62066,6 +62524,20 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
+"pCo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/iron,
+/area/station/science/research)
 "pCt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -62086,19 +62558,6 @@
 /obj/effect/spawner/random/structure/barricade,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
-"pCF" = (
-/obj/effect/turf_decal/tile/red/fourcorners,
-/obj/structure/toilet{
-	pixel_y = 8;
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Prison Solitary 2";
-	dir = 4;
-	network = list("Prison","SS13")
-	},
-/turf/open/floor/iron,
-/area/station/security/prison)
 "pCG" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
@@ -62298,6 +62757,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"pFg" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "pFk" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
@@ -62335,29 +62807,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
-"pFM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/camera{
-	c_tag = "Arrivals Auxiliary Docking North";
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "pFT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"pGg" = (
-/obj/machinery/modular_computer/preset/id,
-/obj/machinery/light/directional/north,
-/obj/machinery/camera/autoname/directional/north{
-	c_tag = "Cargo - QM's Office"
-	},
-/turf/open/floor/carpet,
-/area/station/command/heads_quarters/qm)
 "pGi" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -62441,6 +62895,17 @@
 	},
 /turf/open/floor/grass,
 /area/station/maintenance/ghetto/garden)
+"pHf" = (
+/obj/machinery/light/small/directional/north,
+/obj/machinery/camera/directional/east{
+	c_tag = "Research - Server Room";
+	network = list("ss13","rd");
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "pHh" = (
 /turf/closed/wall,
 /area/station/service/kitchen)
@@ -62534,11 +62999,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"pIl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/no_smoking/circle,
-/turf/open/floor/plating,
-/area/station/medical/surgery/theatre)
 "pIn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -62585,6 +63045,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"pIB" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsecprivacy";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/engineering)
 "pIJ" = (
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron,
@@ -62674,6 +63144,14 @@
 /obj/effect/landmark/start/coroner,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
+"pKb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/camera/directional/east{
+	c_tag = "Arrivals East"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "pKc" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -62852,6 +63330,14 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
+"pLR" = (
+/obj/effect/spawner/random/structure/crate,
+/obj/machinery/camera/directional/west{
+	c_tag = "Cargo - Warehouse";
+	network = list("ss13","cargo")
+	},
+/turf/open/floor/iron,
+/area/station/cargo/warehouse)
 "pLV" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
@@ -62914,6 +63400,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
+"pNv" = (
+/obj/machinery/door/airlock/hatch,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	name = "Transit Security Doors";
+	id = "transittube_lockdown"
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/transit_tube)
 "pNw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -63133,21 +63632,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"pQj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/command/hop{
-	id_tag = "HoP_door"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/effect/landmark/navigate_destination,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
-/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
-/obj/effect/mapping_helpers/airlock/access/any/command/hop,
-/turf/open/floor/iron,
-/area/station/command/heads_quarters/hop)
 "pQs" = (
 /obj/item/book/random,
 /obj/structure/table/wood,
@@ -63159,16 +63643,6 @@
 /obj/machinery/defibrillator_mount,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"pQL" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/table,
-/obj/machinery/recharger,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/third)
 "pQT" = (
 /obj/structure/lattice,
 /obj/machinery/camera/directional/west{
@@ -63195,15 +63669,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"pRj" = (
-/obj/machinery/camera{
-	c_tag = "Prison Forestry South";
-	network = list("Prison","SS13")
-	},
-/obj/structure/sign/poster/contraband/ambrosia_vulgaris/directional/south,
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/iron,
-/area/station/security/prison/garden)
 "pRl" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -63268,6 +63733,13 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"pRE" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "pRF" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -63439,20 +63911,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"pTx" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
-/obj/item/radio/intercom/directional/south,
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Engine Room South";
-	network = list("SS13","Singularity","Engineering")
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/hallway/west)
 "pTN" = (
 /obj/machinery/modular_computer/preset/cargochat/engineering{
 	dir = 4
@@ -63693,6 +64151,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"pWv" = (
+/obj/machinery/holopad,
+/obj/structure/cable,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "pWy" = (
 /obj/structure/rack,
 /obj/item/mop{
@@ -63724,21 +64188,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/common/cryopods)
-"pWG" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = 7
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/security/checkpoint/supply)
 "pWT" = (
 /obj/structure/table/glass,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -63798,17 +64247,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"pXm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Arrivals Hallway";
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "pXp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -63818,6 +64256,21 @@
 	},
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
+"pXq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/poddoor/preopen{
+	name = "Engineering Security Doors";
+	id = "engineering_lockdown"
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/department/electrical)
 "pXB" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
@@ -63851,6 +64304,17 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
+"pYq" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/camera/directional/north{
+	c_tag = "Brig Main Hall East 1"
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "pYr" = (
 /obj/structure/railing/corner,
 /turf/open/floor/iron/dark/smooth_edge,
@@ -63931,6 +64395,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"pZE" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Security - Permabrig Chapel Enterance"
+	},
+/turf/open/floor/iron,
+/area/station/security/prison/ghetto)
 "pZF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -63998,20 +64471,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
-"qan" = (
-/obj/structure/table,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/structure/sign/poster/official/random/directional/east,
-/obj/machinery/camera/directional/south{
-	c_tag = "Research Division Break Room";
-	network = list("ss13","rd");
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/breakroom)
 "qau" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -64503,13 +64962,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark/small,
 /area/station/security/mechbay)
-"qiC" = (
-/obj/structure/reagent_dispensers/wall/peppertank/directional/north,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
 "qiH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -64646,17 +65098,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/fore)
-"qjX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Janitor Closet";
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/service/janitor)
 "qke" = (
 /obj/structure/table,
 /obj/machinery/fax{
@@ -64768,18 +65209,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/interrogation/ghetto)
-"qlK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/door/airlock/command/hos,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
-/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
-/obj/effect/mapping_helpers/airlock/access/any/security/hos,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/hos)
 "qlM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -64872,17 +65301,27 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/customs)
+"qmK" = (
+/obj/structure/table/reinforced,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/core{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Atmospherics - HFR";
+	network = list("ss13","engineering")
+	},
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/hfr_room)
 "qmN" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
-"qmO" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
-	},
-/obj/effect/landmark/start/depsec/medical,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/checkpoint/medical)
 "qnb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -64911,16 +65350,6 @@
 	},
 /turf/open/floor/iron/herringbone,
 /area/station/maintenance/aft)
-"qnr" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/machinery/camera{
-	c_tag = "Research E.X.P.E.R.I-MENTOR Lab";
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/tile/purple/half,
-/turf/open/floor/iron/white,
-/area/station/science/explab)
 "qnH" = (
 /obj/machinery/door/airlock/public/glass{
 	autoclose = 0;
@@ -65044,15 +65473,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"qph" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Xenobiology - Secure Cell Interior";
-	network = list("ss13","xeno","rd")
-	},
-/obj/machinery/status_display/ai/directional/west,
-/obj/machinery/light/cold/directional/west,
-/turf/open/floor/engine/xenobio,
-/area/station/science/xenobiology)
 "qpj" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/status_display/evac/directional/south,
@@ -65168,14 +65588,6 @@
 "qqN" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/ghetto/starboard/aft)
-"qqR" = (
-/obj/machinery/camera{
-	c_tag = "Secure Lab - Test Chamber";
-	dir = 4;
-	network = list("ss13","rd","test")
-	},
-/turf/open/floor/engine,
-/area/station/science/lower)
 "qqT" = (
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
@@ -65274,19 +65686,6 @@
 /obj/item/stack/tile/wood,
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
-"qtg" = (
-/obj/machinery/requests_console/directional/west{
-	department = "Cargo";
-	name = "Quartermaster's Desk Requests Console"
-	},
-/obj/effect/mapping_helpers/requests_console/information,
-/obj/effect/mapping_helpers/requests_console/supplies,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/effect/mapping_helpers/requests_console/announcement,
-/obj/machinery/computer/security/qm,
-/obj/machinery/digital_clock/directional/north,
-/turf/open/floor/carpet,
-/area/station/command/heads_quarters/qm)
 "qtp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65323,6 +65722,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"qtH" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/camera/directional/south{
+	c_tag = "Research - Ordnance Lower Mix Lab";
+	network = list("ss13","rd")
+	},
+/obj/structure/sign/warning/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "qtM" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/decal/cleanable/dirt,
@@ -65370,6 +65779,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"quF" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/machinery/computer/security/telescreen/ce/directional/south{
+	network = list("engine","engineering","tcomms","minisat")
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/ce)
 "quH" = (
 /obj/structure/sink/directional/north,
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
@@ -65458,6 +65874,19 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/station/engineering/storage)
+"qvL" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio_maint_aft";
+	name = "Xenobiology Blast Door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor{
+	id = "xenobio_maint_fore";
+	name = "Xenobiology Blast Door"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "qvQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/dark_green{
@@ -65493,6 +65922,16 @@
 /obj/effect/spawner/random/trash/box,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
+"qww" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Research - Hallway Center";
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "qwS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -65588,16 +66027,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood,
 /area/station/service/library)
-"qxA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Arrivals South"
-	},
-/turf/open/floor/iron/white/corner,
-/area/station/hallway/secondary/entry)
 "qxD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -65749,17 +66178,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"qzG" = (
-/obj/machinery/duct,
-/obj/machinery/camera/directional/north{
-	c_tag = "Atmospherics - Project Room Aft"
-	},
-/obj/machinery/status_display/ai/directional/north,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/project)
 "qzJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66116,14 +66534,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
-"qFb" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Engineering - Supermatter";
-	network = list("ss13","engine")
-	},
-/obj/structure/sign/warning/radiation/directional/east,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter)
 "qFm" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -66424,6 +66834,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
+"qIu" = (
+/obj/structure/barricade/wooden,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "Construction"
+	},
+/obj/machinery/door/poddoor/preopen{
+	name = "Engineering Security Doors";
+	id = "engineering_lockdown"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/electrical)
 "qIF" = (
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
@@ -66489,6 +66911,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"qJF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/camera/directional/east{
+	c_tag = "Brig Prisoner Processing east"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/holding_cell)
 "qJH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66506,6 +66939,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
+"qJT" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/engineering)
 "qKe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -66649,20 +67090,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"qLN" = (
-/obj/structure/table/reinforced,
-/obj/machinery/requests_console/directional/east{
-	department = "Security";
-	name = "Security Requests Console"
-	},
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/effect/mapping_helpers/requests_console/information,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/tile/red/full,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/checkpoint/medical)
 "qLP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66742,6 +67169,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"qMT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/door/airlock/command/hos,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/effect/mapping_helpers/airlock/access/any/security/hos,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/hos)
 "qMU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66883,24 +67322,6 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"qOc" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Atmos Storage";
-	network = list("SS13","Engineering");
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/tank_dispenser{
-	pixel_x = -1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/storage/gas)
 "qOf" = (
 /obj/structure/table,
 /turf/open/floor/wood,
@@ -67028,6 +67449,18 @@
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/maintenance/ghetto/kitchen)
+"qQd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Engineering - Atmos Control Room West";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "qQf" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
@@ -67040,6 +67473,17 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
+"qQk" = (
+/obj/structure/table/reinforced,
+/obj/machinery/requests_console/directional/east{
+	department = "Security";
+	name = "Security Requests Console"
+	},
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/turf_decal/tile/red/full,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/checkpoint/medical)
 "qQo" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -67101,28 +67545,6 @@
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
-"qRa" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/camera{
-	c_tag = "Engineering Atmos Northeast";
-	network = list("SS13","Engineering");
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
-"qRi" = (
-/obj/structure/table/reinforced,
-/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/checkpoint/medical)
 "qRm" = (
 /obj/effect/spawner/random/trash/bin,
 /obj/machinery/light/directional/south,
@@ -67214,6 +67636,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
+"qSj" = (
+/obj/vehicle/sealed/mecha/ripley/cargo,
+/obj/machinery/camera/directional/north{
+	c_tag = "Cargo - Depot Lower Floor";
+	network = list("ss13","cargo")
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage/ghetto/depot)
 "qSz" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow,
@@ -67346,13 +67776,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"qUk" = (
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 2";
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "qUr" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -67374,14 +67797,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"qUD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera/directional/south{
-	c_tag = "Atmospherics - HFR South"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/hfr_room)
 "qUG" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -67419,6 +67834,14 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"qVi" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Medbay - Chemistry Lab North";
+	network = list("ss13","medbay")
+	},
+/obj/machinery/chem_master,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/medical/chemistry/ghetto)
 "qVj" = (
 /turf/closed/wall,
 /area/station/maintenance/ghetto/kitchen)
@@ -67682,6 +68105,17 @@
 /obj/machinery/mecha_part_fabricator/maint,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"qXP" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - Atmos Center";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "qXZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -67732,6 +68166,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
+"qYU" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/machinery/camera/directional/south{
+	c_tag = "Courtroom South"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
+/area/station/security/courtroom)
 "qZb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -67851,25 +68295,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/security/range)
-"ran" = (
-/obj/structure/table,
-/obj/machinery/camera{
-	c_tag = "Research Test Lab";
-	network = list("ss13","rd");
-	dir = 1
-	},
-/obj/item/healthanalyzer/advanced,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = 4;
-	pixel_y = -2
-	},
-/obj/machinery/firealarm/directional/north,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/science/lower)
 "raq" = (
 /obj/machinery/door/window/left/directional/north{
 	name = "AI Core Door";
@@ -67878,6 +68303,26 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
+"rar" = (
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Cargo - Delivery Office";
+	network = list("ss13","cargo")
+	},
+/turf/open/floor/iron,
+/area/station/cargo/sorting)
+"raw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/barricade/wooden/crude,
+/obj/machinery/door/poddoor/preopen{
+	name = "Engineering Security Doors";
+	id = "engineering_lockdown"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/ghetto)
 "rax" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -67932,6 +68377,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"raT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	name = "Engineering Security Doors";
+	id = "engineering_lockdown"
+	},
+/turf/open/floor/iron/stairs/right{
+	dir = 8
+	},
+/area/station/engineering/transit_tube)
 "raZ" = (
 /obj/machinery/light_switch/directional/west,
 /obj/structure/table/reinforced,
@@ -68131,18 +68588,6 @@
 /obj/structure/sink/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"rdF" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Lobby East";
-	network = list("SS13","Engineering");
-	dir = 1
-	},
-/obj/structure/chair,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "rdN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -68157,6 +68602,12 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
+"rdX" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Starboard Primary Hallway 2"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "reb" = (
 /obj/structure/table/reinforced,
 /obj/item/food/sandwich/cheese/grilled,
@@ -68280,6 +68731,23 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
+"rfz" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/north{
+	id = "cargosecprivacy";
+	name = "Privacy Shutter Control";
+	req_one_access = list("qm","security")
+	},
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
 "rfD" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin{
@@ -68464,18 +68932,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"rhE" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 1
-	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Xenobiology - Cell 6";
-	network = list("ss13","xeno","rd")
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "rhY" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/generic,
@@ -68711,15 +69167,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
-"rkW" = (
-/obj/machinery/camera{
-	c_tag = "Construction Area";
-	dir = 8;
-	network = list("SS13","Engineering")
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/construction)
 "rkX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -68832,13 +69279,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"rml" = (
-/obj/machinery/computer/records/security,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/security/checkpoint/supply)
 "rms" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
@@ -69519,6 +69959,20 @@
 	},
 /turf/open/floor/wood,
 /area/station/maintenance/aft)
+"run" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 5
+	},
+/obj/item/storage/belt/utility,
+/obj/item/radio,
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - Equipment Storage Lockers";
+	network = list("ss13","engineering")
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/engineering/main)
 "ruq" = (
 /obj/machinery/button/door/directional/west{
 	id = "Toilet2";
@@ -69662,16 +70116,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/interrogation/ghetto)
-"rwF" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/camera{
-	c_tag = "Engineering Secure Storage East";
-	dir = 6;
-	network = list("SS13","Engineering")
-	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/station/engineering/storage)
 "rwH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
@@ -69736,6 +70180,17 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical/ghetto)
+"rym" = (
+/obj/machinery/status_display/supply{
+	pixel_y = 32
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Cargo - Bay Lower Floor";
+	network = list("ss13","cargo")
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/station/cargo/storage/ghetto)
 "ryq" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/cigar,
@@ -69953,35 +70408,6 @@
 /obj/item/reagent_containers/cup/glass/drinkingglass,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/upper)
-"rBW" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/button/door{
-	name = "Quarantine Shutters";
-	id = "quarantine";
-	req_access = list("cmo");
-	pixel_y = 3;
-	pixel_x = -6
-	},
-/obj/machinery/button/door{
-	name = "CMO Office Shutters";
-	id = "CMO";
-	req_access = list("cmo");
-	pixel_y = -2;
-	pixel_x = 6
-	},
-/obj/machinery/button/door{
-	name = "CMO Door Control";
-	id = "CMO_door";
-	req_access = list("cmo");
-	pixel_y = 8;
-	pixel_x = 6;
-	normaldoorcontrol = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/cmo)
 "rBZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
@@ -70278,13 +70704,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"rGu" = (
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 1";
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "rGH" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -70334,15 +70753,6 @@
 	light_color = "#a659ff"
 	},
 /area/station/commons/lounge)
-"rHM" = (
-/obj/machinery/flasher/portable,
-/obj/effect/turf_decal/bot_white/left,
-/obj/machinery/camera{
-	c_tag = "Brig Secure Armory North";
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "rHU" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
@@ -70566,6 +70976,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"rKp" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Departure Lounge South-East"
+	},
+/obj/structure/closet/emcloset,
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "rKx" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
@@ -70681,6 +71099,15 @@
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/central)
+"rMd" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Prison Forestry South";
+	network = list("ss13","prison")
+	},
+/obj/structure/sign/poster/contraband/ambrosia_vulgaris/directional/south,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/iron,
+/area/station/security/prison/garden)
 "rMg" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -70704,10 +71131,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"rMl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/medical/treatment_center)
 "rMm" = (
 /obj/machinery/door/airlock/public,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -70828,6 +71251,29 @@
 /obj/machinery/power/smes/engineering,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/ghetto)
+"rNS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/directional/north{
+	c_tag = "Prison Entry";
+	network = list("ss13","prison")
+	},
+/obj/machinery/button/flasher{
+	id = "permaflash2";
+	name = "Flasher button";
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/flasher/directional/north{
+	id = "permaflash1";
+	pixel_x = 16
+	},
+/turf/open/floor/iron/textured_large,
+/area/station/security/prison)
 "rNV" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/effect/turf_decal/bot,
@@ -71125,6 +71571,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"rSM" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/light/directional/south,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/landmark/start/depsec/science,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "rSN" = (
 /obj/structure/chair,
 /obj/machinery/camera/directional/east{
@@ -71244,14 +71699,6 @@
 /obj/effect/turf_decal/tile/purple/half,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
-"rUk" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/camera/directional/south{
-	c_tag = "Research - Polygon - South";
-	network = list("rd","ordnance")
-	},
-/turf/open/floor/iron/airless,
-/area/station/science/ordnance/bomb)
 "rUn" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -71380,6 +71827,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"rVA" = (
+/obj/structure/bodycontainer/morgue,
+/obj/machinery/camera/directional/west{
+	c_tag = "Chapel - Crematorium"
+	},
+/turf/open/floor/engine/cult,
+/area/station/service/chapel/office)
 "rVC" = (
 /obj/structure/closet/secure_closet/personal/cabinet{
 	name = "clown's closet"
@@ -71451,21 +71905,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"rWk" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 5
-	},
-/obj/item/storage/belt/utility,
-/obj/item/radio,
-/obj/machinery/camera{
-	c_tag = "Engineering Equipment Storage Lockers";
-	network = list("SS13","Engineering");
-	dir = 1
-	},
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/engineering/main)
 "rWq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -71908,6 +72347,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/fore)
+"sbz" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/corporate{
+	id_tag = "blueshield_door"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/navigate_destination,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
+/turf/open/floor/wood/tile,
+/area/station/command/heads_quarters/blueshield)
 "sbF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -72168,6 +72620,22 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port/aft)
+"seA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/genetics,
+/obj/machinery/duct,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "seE" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -72179,6 +72647,34 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/iron/grimy,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"seG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door_buttons/access_button{
+	idDoor = "xeno_airlock_interior";
+	idSelf = "xeno_airlock_control";
+	name = "Xeno Access Button";
+	pixel_x = -24;
+	req_access = list("xenobiology")
+	},
+/obj/machinery/door/airlock/research{
+	frequency = 1450;
+	autoclose = 0;
+	id_tag = "xeno_airlock_interior"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "seJ" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -72203,17 +72699,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
-"sfn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/poddoor/preopen{
-	name = "Engineering Security Doors";
-	id_tag = "engineering_lockdown"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/hallway/west)
 "sfs" = (
 /obj/structure/table/wood,
 /obj/item/book/bible,
@@ -72271,30 +72756,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
-"sga" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/science/general,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door_buttons/access_button{
-	idDoor = "xeno_airlock_interior";
-	idSelf = "xeno_airlock_control";
-	name = "Xeno Access Button";
-	pixel_x = -24;
-	req_access = list("xenobiology")
-	},
-/obj/machinery/door/airlock/research{
-	frequency = 1450;
-	autoclose = 0;
-	id_tag = "xeno_airlock_interior"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "sgc" = (
 /obj/structure/urinal/directional/north,
 /obj/effect/turf_decal/trimline/white/line{
@@ -72321,6 +72782,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/aft)
+"sgs" = (
+/obj/structure/rack,
+/obj/item/multitool,
+/obj/machinery/camera/directional/north{
+	c_tag = "Auxiliary Tool Storage"
+	},
+/turf/open/floor/iron,
+/area/station/commons/storage/emergency/port)
 "sgv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72334,19 +72803,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/sorting)
-"sgQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Arrivals Auxiliary Docking South";
-	dir = 1
-	},
-/turf/open/floor/iron/white/corner{
-	dir = 4
-	},
-/area/station/hallway/secondary/entry)
 "sgS" = (
 /obj/machinery/power/apc/worn_out/directional/west,
 /obj/structure/cable,
@@ -72413,14 +72869,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"shx" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Xenobiology Pens Observation - Starboard Fore";
-	network = list("ss13","rd","xeno");
-	dir = 2
-	},
-/turf/open/openspace,
-/area/station/science/xenobiology)
 "shy" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
@@ -72450,16 +72898,6 @@
 	dir = 1
 	},
 /area/station/commons/storage/primary)
-"sid" = (
-/obj/machinery/status_display/supply{
-	pixel_y = 32
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Cargo - Bay Lower Floor North"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/station/cargo/storage/ghetto)
 "sif" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -72935,6 +73373,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
+"sns" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/engineering)
 "snv" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass,
@@ -72952,14 +73397,6 @@
 /obj/machinery/keycard_auth/wall_mounted/directional/west,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/qm)
-"snO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/landmark/start/depsec/medical,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/checkpoint/medical)
 "snW" = (
 /obj/structure/closet/firecloset,
 /obj/effect/landmark/start/hangover/closet,
@@ -73132,6 +73569,16 @@
 /obj/effect/turf_decal/siding/wideplating_new/corner,
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
+"sqo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Arrivals Lounge"
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "sqp" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -73151,12 +73598,6 @@
 /obj/structure/easel,
 /turf/open/floor/wood,
 /area/station/security/prison)
-"sqr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/cable,
-/obj/effect/landmark/start/depsec/supply,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/supply)
 "sqv" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/disposalpipe/segment{
@@ -73293,6 +73734,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"sso" = (
+/obj/effect/turf_decal/bot_red,
+/obj/item/beacon,
+/obj/machinery/camera/directional/east{
+	c_tag = "Research - Polygon Center";
+	network = list("ss13","rd","ordnance")
+	},
+/turf/open/floor/iron/airless,
+/area/station/science/ordnance/bomb)
 "sss" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -73315,18 +73765,6 @@
 /obj/structure/sign/plaques/kiddie,
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"ssJ" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Lobby West";
-	network = list("SS13","Engineering");
-	dir = 1
-	},
-/obj/structure/chair,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/aft)
 "ssS" = (
 /obj/structure/chair,
 /obj/machinery/light/small/directional/north,
@@ -73393,34 +73831,6 @@
 /obj/structure/chair,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
-"stG" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 8
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Xenobiology - Cell 3";
-	network = list("ss13","xeno","rd")
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
-"stI" = (
-/obj/machinery/camera{
-	c_tag = "Research Mech Bay";
-	dir = 4;
-	network = list("ss13","rd")
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
-"stJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 4;
-	id = "robotics_desk";
-	name = "Robotics Lab Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/science/robotics/lab)
 "stY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -73488,6 +73898,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/fore/starboard)
+"suY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/machinery/camera/directional/north{
+	c_tag = "Kitchen"
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "svg" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/door/airlock/medical/glass,
@@ -73537,15 +73957,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"svu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id = "rd_office_shutters";
-	name = "Privacy Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/rd)
 "svw" = (
 /obj/structure/flora/tree/jungle/small/style_random,
 /obj/structure/flora/rock/pile/jungle/style_random,
@@ -73623,15 +74034,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
-"swo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/computer/security/telescreen/med_sec/directional/east,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
-/obj/effect/landmark/start/depsec/medical,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/checkpoint/medical)
 "swr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -73837,17 +74239,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"szw" = (
-/obj/machinery/camera{
-	c_tag = "Fore Primary Hallway South";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/sign/departments/court/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/fore)
 "szz" = (
 /obj/structure/railing{
 	dir = 8
@@ -73924,41 +74315,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
-"sAU" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/obj/structure/table/glass,
-/obj/machinery/camera/directional/south{
-	c_tag = "Medbay - Cryogenics"
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/storage/pill_bottle/mannitol,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/machinery/requests_console/directional/south{
-	department = "Medbay";
-	name = "Medbay Requests Console"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
 "sAW" = (
 /obj/machinery/light/broken/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -74037,6 +74393,26 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"sCj" = (
+/obj/structure/closet/secure_closet/freezer/kitchen/all_access,
+/obj/item/food/breadslice/plain,
+/obj/item/food/breadslice/plain,
+/obj/item/food/breadslice/plain,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/onion,
+/obj/item/food/grown/onion,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/sign/poster/ripped/directional/north,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/camera/directional/north{
+	c_tag = "Prison Cafeteria";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/security/prison)
 "sCm" = (
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
@@ -74131,6 +74507,17 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/engine,
 /area/station/science/lower)
+"sDn" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/effect/landmark/start/depsec/medical,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/checkpoint/medical)
 "sDw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -74538,18 +74925,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/aft)
-"sIk" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id = "quarantine";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/medical/paramedic)
 "sIn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/small/directional/east,
@@ -74568,6 +74943,14 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
+"sII" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/plating,
+/area/station/science/ordnance/testlab)
 "sIK" = (
 /obj/structure/table/wood,
 /obj/machinery/airalarm/directional/south,
@@ -74622,19 +75005,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/openspace,
 /area/station/solars/starboard/fore)
-"sJC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/hallway)
 "sJI" = (
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
@@ -74803,15 +75173,6 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/ghetto/bar)
-"sLZ" = (
-/obj/machinery/door/airlock/corporate,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/command/magistrate,
-/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
-/turf/open/floor/wood/tile,
-/area/station/command/heads_quarters/magistrate)
 "sMd" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/entertainment/drugs,
@@ -74848,6 +75209,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto)
+"sMO" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Teleporter Room"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/station/command/teleporter)
 "sMU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/engine,
@@ -75180,6 +75549,28 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
+"sSB" = (
+/obj/structure/table/reinforced,
+/obj/machinery/airalarm/directional/east,
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/red/full,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Medbay - Security Post";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/checkpoint/medical)
+"sSK" = (
+/obj/structure/reagent_dispensers/wall/peppertank/directional/north,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/effect/landmark/start/depsec/science,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "sSO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -75505,13 +75896,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port)
-"sXF" = (
-/obj/effect/spawner/random/structure/crate,
-/obj/machinery/camera/directional/west{
-	c_tag = "Cargo - Warehouse"
-	},
-/turf/open/floor/iron,
-/area/station/cargo/warehouse)
 "sXG" = (
 /obj/effect/spawner/random/trash/graffiti{
 	spawn_loot_chance = 50
@@ -75525,18 +75909,6 @@
 	dir = 4
 	},
 /area/station/engineering/hallway/west)
-"sXL" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/poddoor/preopen{
-	name = "Engineering Security Doors";
-	id_tag = "engineering_lockdown"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
-/turf/open/floor/iron,
-/area/station/engineering/hallway)
 "sXO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -75688,18 +76060,6 @@
 /obj/effect/spawner/random/clothing/wardrobe_closet_colored,
 /turf/open/floor/iron,
 /area/station/commons/locker)
-"taB" = (
-/obj/machinery/light_switch/directional/east{
-	pixel_y = -6
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
-/obj/effect/landmark/start/depsec/supply,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/supply)
 "taM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -75815,6 +76175,23 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/commons/vacant_room/office)
+"tcI" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/left/directional/south{
+	name = "Engineering Desk";
+	req_access = list("engine_equip")
+	},
+/obj/structure/desk_bell{
+	pixel_x = 6
+	},
+/obj/machinery/door/poddoor/preopen{
+	name = "Engineering Security Doors";
+	id = "engineering_lockdown"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "tcJ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -76115,6 +76492,16 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/wood,
 /area/station/maintenance/aft)
+"thE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "thQ" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -76258,6 +76645,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
+"tjw" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Research - Toxins Mixing";
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance/office)
 "tjE" = (
 /obj/effect/spawner/random/structure/barricade,
 /obj/machinery/door/airlock,
@@ -76447,6 +76845,18 @@
 /obj/structure/lattice,
 /turf/open/space/openspace,
 /area/space/nearstation)
+"tlV" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/obj/machinery/camera/directional/south{
+	c_tag = "Research - Hallway North";
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "tlX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -76545,15 +76955,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"tmM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id = "robotics_window";
-	name = "Robotics Lab Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/science/robotics/lab)
 "tmN" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -76595,17 +76996,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"tni" = (
-/obj/machinery/camera{
-	c_tag = "Research Hallway Center";
-	dir = 1;
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "tnl" = (
 /obj/structure/flora/bush/leafy,
 /turf/open/misc/beach/sand,
@@ -76696,15 +77086,6 @@
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"tnK" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/camera{
-	c_tag = "Fore Starboard Solar Access";
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/fore)
 "tnR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -77336,6 +77717,15 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"tuX" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/camera/directional/east{
+	c_tag = "Engineering - Secure Storage East";
+	network = list("ss13","engineering")
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/engineering/storage)
 "tuZ" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/cable,
@@ -77453,6 +77843,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/ghetto/starboard/aft)
+"twg" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Central Hallway South East"
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "twh" = (
 /turf/open/floor/glass/reinforced,
 /area/station/service/chapel/monastery)
@@ -77518,6 +77917,15 @@
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/carpet/green,
 /area/station/command/bridge)
+"txh" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/light/directional/south,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron,
+/area/station/security/checkpoint/supply)
 "txk" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -77568,6 +77976,17 @@
 /obj/item/crowbar/red,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
+"txV" = (
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/structure/cable,
+/obj/structure/filingcabinet,
+/obj/machinery/camera/directional/east{
+	c_tag = "Engineering - Security Post";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/engineering)
 "tya" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/wood,
@@ -77578,6 +77997,17 @@
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/ghetto/port)
+"tyf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/poddoor/preopen{
+	name = "Engineering Security Doors";
+	id = "engineering_lockdown"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/hallway/west)
 "tyl" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -77647,11 +78077,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"tAf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/security/checkpoint/third)
 "tAh" = (
 /obj/machinery/light/directional/west,
 /turf/open/openspace,
@@ -77754,16 +78179,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
-"tBz" = (
-/obj/machinery/camera{
-	c_tag = "Central Hallway East";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "tBB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -77797,23 +78212,6 @@
 	},
 /turf/open/water/alternative/muddy/no_fishing,
 /area/station/service/kitchen/abandoned)
-"tBV" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/left/directional/south{
-	name = "Engineering Desk";
-	req_access = list("engine_equip")
-	},
-/obj/structure/desk_bell{
-	pixel_x = 6
-	},
-/obj/machinery/door/poddoor/preopen{
-	name = "Engineering Security Doors";
-	id_tag = "engineering_lockdown"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
 "tCb" = (
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
@@ -77935,12 +78333,6 @@
 /obj/effect/spawner/random/structure/barricade,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
-"tDv" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/third)
 "tDF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -78089,15 +78481,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"tFl" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/camera/autoname/directional/east{
-	c_tag = "Security - Permabrig Chapel Enterance"
-	},
-/turf/open/floor/iron,
-/area/station/security/prison/ghetto)
 "tFm" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/bot,
@@ -78131,6 +78514,16 @@
 "tFO" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/visit)
+"tGa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rndsecprivacy";
+	name = "Privacy Shutters";
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/science)
 "tGb" = (
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
@@ -78242,18 +78635,6 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"tHy" = (
-/obj/machinery/camera{
-	c_tag = "Virology Airlock";
-	dir = 1
-	},
-/obj/structure/sink/directional/west,
-/obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "tHH" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 8
@@ -78666,17 +79047,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
-"tMo" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/camera{
-	c_tag = "Brig Lobby West";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/security/brig/entrance)
 "tMr" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/port/greater)
@@ -78718,13 +79088,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
-"tMW" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
-	},
-/obj/effect/landmark/start/depsec/supply,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/supply)
 "tNe" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 9
@@ -78747,17 +79110,6 @@
 "tNr" = (
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
-"tNz" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Atmos Mini-Hallway";
-	dir = 8;
-	network = list("SS13","Engineering")
-	},
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "tNF" = (
 /obj/structure/table/wood,
 /obj/item/trash/candle,
@@ -78880,6 +79232,23 @@
 "tOZ" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/port/fore)
+"tPa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "medsecprivacy";
+	name = "Privacy Shutters"
+	},
+/obj/structure/cable,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical)
 "tPd" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
@@ -78924,18 +79293,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"tPH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id = "quarantine";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/turf/open/floor/plating,
-/area/station/medical/paramedic)
 "tPP" = (
 /obj/structure/falsewall,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -78978,6 +79335,14 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
+"tQx" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "tQJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -79153,18 +79518,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/commons/storage/emergency)
-"tTQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/table,
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/third)
 "tTU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -79214,6 +79567,20 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"tUG" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	name = "Engineering Security Doors";
+	id = "engineering_lockdown"
+	},
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsecprivacy";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/engineering)
 "tUK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -79245,23 +79612,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"tVf" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 4;
-	id = "robotics_desk";
-	name = "Robotics Lab Shutters"
-	},
-/obj/machinery/door/window/left/directional/west{
-	name = "Robotics Desk";
-	req_access = list("robotics")
-	},
-/obj/structure/desk_bell{
-	pixel_y = 8
-	},
-/turf/open/floor/plating,
-/area/station/science/robotics/lab)
 "tVg" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -79358,6 +79708,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/asphalt,
 /area/station/maintenance/ghetto/garden)
+"tVD" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "robotics_window";
+	name = "Robotics Lab Shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/plating,
+/area/station/science/robotics/lab)
 "tVE" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/hos)
@@ -79514,10 +79876,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
-"tXj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/security/checkpoint/science)
 "tXm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -79632,10 +79990,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"tYC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/medical/surgery/aft)
 "tYD" = (
 /turf/open/space/openspace,
 /area/space)
@@ -79896,17 +80250,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/openspace,
 /area/space/nearstation)
-"ubF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/light/directional/west,
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 4";
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard/west)
 "ubI" = (
 /obj/structure/sign/warning/electric_shock/directional/west,
 /obj/structure/lattice,
@@ -79965,16 +80308,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
-"ucL" = (
-/obj/structure/table/wood,
-/obj/machinery/light/directional/south,
-/obj/machinery/microwave/engineering/cell_included,
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/camera{
-	c_tag = "Medbay Cloning"
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
 "ucN" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall/r_wall,
@@ -80009,17 +80342,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
-"udy" = (
-/obj/structure/sign/warning/docking/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Arrivals Center";
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "udD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -80064,37 +80386,11 @@
 "uej" = (
 /turf/open/openspace,
 /area/station/security/brig)
-"uem" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/camera/directional/east{
-	c_tag = "Research - Polygon - East";
-	network = list("rd","ordnance")
-	},
-/turf/open/floor/iron/airless,
-/area/station/science/ordnance/bomb)
 "ueq" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
-"ues" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/command/cmo{
-	id_tag = "CMO_door"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable,
-/obj/effect/landmark/navigate_destination,
-/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
-/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
-/obj/effect/mapping_helpers/airlock/access/any/medical/cmo,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/cmo)
 "ueH" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/dark_blue/line{
@@ -80224,15 +80520,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"ufV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/camera{
-	c_tag = "Arrivals East";
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "ufY" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -80284,6 +80571,18 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
+"ugL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/directional/south{
+	c_tag = "Atmospherics - Project Room Closet";
+	network = list("ss13","engineering")
+	},
+/obj/machinery/status_display/evac/directional/south,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/half{
+	dir = 8
+	},
+/area/station/engineering/atmos/project)
 "ugS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -80489,6 +80788,18 @@
 /obj/effect/spawner/random/clothing/pirate_or_bandana,
 /turf/open/floor/wood,
 /area/station/service/kitchen/abandoned)
+"ujt" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/plating,
+/area/station/science/research)
 "ujA" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
@@ -80631,21 +80942,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/lobby)
-"ulP" = (
-/turf/closed/wall,
-/area/station/security/checkpoint/third)
 "ulV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/purple/half,
 /turf/open/floor/iron,
 /area/station/science/lab)
-"umb" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/third)
 "umd" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
@@ -80801,6 +81102,17 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
+"uoz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/camera/directional/east{
+	c_tag = "Medbay - Lobby Reception";
+	network = list("ss13","medbay")
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "uoO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -80818,6 +81130,12 @@
 /obj/effect/spawner/random/structure/barricade,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto/central)
+"upa" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Brig Prisoner Processing West"
+	},
+/turf/open/floor/iron,
+/area/station/security/courtroom/holding)
 "upd" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/meter,
@@ -80941,16 +81259,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"uri" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay Hallway Center";
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "url" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow{
@@ -80984,16 +81292,6 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/garden)
-"urM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
-/turf/open/floor/plating,
-/area/station/science/robotics/lab)
 "urR" = (
 /obj/machinery/requests_console/directional/south{
 	department = "Research Director's Desk";
@@ -81009,6 +81307,17 @@
 /obj/effect/turf_decal/tile/purple/half,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"urS" = (
+/obj/structure/sink/directional/west,
+/obj/machinery/camera/directional/north{
+	c_tag = "Research - Access";
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "usf" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -81108,6 +81417,28 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
+"utT" = (
+/obj/machinery/rnd/production/protolathe/department/engineering,
+/obj/effect/turf_decal/bot,
+/obj/machinery/camera/directional/east{
+	c_tag = "Engineering - Shared Storage";
+	network = list("ss13","engineering")
+	},
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage_shared)
+"utY" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/donkpockets,
+/obj/machinery/camera/directional/east{
+	c_tag = "Virology - Break Room";
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "uub" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/mess,
@@ -81201,6 +81532,15 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"uvm" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Departure Lounge Security"
+	},
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/exit/departure_lounge)
 "uvo" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/glass{
@@ -81377,6 +81717,10 @@
 /obj/effect/spawner/random/trash/deluxe_garbage,
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/port/aft)
+"uxG" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/medical/treatment_center)
 "uxH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -81461,6 +81805,16 @@
 "uyT" = (
 /turf/closed/wall,
 /area/station/maintenance/ghetto/abandoned_gambling_den)
+"uyY" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "uzk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -81486,6 +81840,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
+"uzK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red/full,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/checkpoint/medical)
 "uzL" = (
 /turf/closed/wall,
 /area/station/science/lower)
@@ -81510,18 +81871,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"uzW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
-/obj/machinery/door/airlock/research,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/iron,
-/area/station/science/ordnance/office)
 "uAa" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -81775,6 +82124,15 @@
 /obj/effect/turf_decal/siding/white,
 /turf/open/water/alternative/muddy/no_fishing,
 /area/station/service/kitchen/abandoned)
+"uDt" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/camera/directional/south{
+	c_tag = "Medbay - Chemistry Lab South";
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/ghetto)
 "uDC" = (
 /obj/structure/table/optable,
 /obj/item/autopsy_scanner,
@@ -81815,17 +82173,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/construction)
-"uEN" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/south,
-/obj/machinery/camera{
-	c_tag = "Vacant Office"
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood,
-/area/station/commons/vacant_room/office)
 "uEO" = (
 /obj/machinery/flasher/portable,
 /obj/effect/turf_decal/bot_white/left,
@@ -81958,20 +82305,6 @@
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
-"uGM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/button/door/directional/north{
-	id = "Biohazard";
-	name = "Biohazard Shutter Control";
-	req_access = list("research")
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
 "uGO" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/trash/cigbutt,
@@ -81986,13 +82319,21 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
-"uGQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/science/ordnance/testlab)
 "uGR" = (
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
+"uHa" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - Atmos NorthWest";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "uHg" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -82020,17 +82361,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
-"uHu" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron,
-/area/station/engineering/hallway)
 "uHz" = (
 /obj/structure/statue/station_map/cyberiad/north,
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"uHC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "uHG" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/smooth,
@@ -82288,21 +82630,6 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"uKL" = (
-/obj/machinery/button/elevator/directional/north{
-	id = "aft_vator"
-	},
-/obj/machinery/lift_indicator/directional/north{
-	linked_elevator_id = "aft_vator"
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Cargo - Bay North"
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "uKR" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -82376,6 +82703,17 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/plating,
 /area/station/service/chapel/monastery)
+"uMc" = (
+/obj/machinery/door/poddoor/preopen{
+	name = "Engineering Security Doors";
+	id = "engineering_lockdown"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/airlock/engineering/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/engineering/dronefabricator)
 "uMd" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -82590,20 +82928,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/cargo/miningoffice)
-"uOi" = (
-/obj/structure/closet/crate/wooden/toy,
-/obj/item/toy/mecha/honk,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/machinery/camera{
-	c_tag = "Clown Office";
-	dir = 1
-	},
-/obj/structure/mirror/directional/north,
-/turf/open/floor/iron/kitchen,
-/area/station/service/theater)
 "uOl" = (
 /obj/effect/turf_decal/loading_area,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -82683,6 +83007,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"uPd" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/camera/directional/south{
+	c_tag = "Prison Forestry External";
+	network = list("ss13","prison")
+	},
+/turf/open/openspace,
+/area/station/security/prison)
 "uPq" = (
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 1
@@ -82691,18 +83023,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
-"uPr" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 8
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Xenobiology - Cell 1";
-	network = list("ss13","xeno","rd")
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "uPs" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/structure/cable,
@@ -82901,13 +83221,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/bar)
-"uSD" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/research,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
 "uSG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -82950,26 +83263,6 @@
 /obj/item/pen,
 /turf/open/floor/carpet/black,
 /area/station/security/courtroom)
-"uTs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/obj/machinery/camera/directional/south{
-	c_tag = "Engineering - Supermatter Room Aft";
-	network = list("ss13","engine")
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
-"uTz" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/poddoor/preopen{
-	name = "Engineering Security Doors";
-	id_tag = "engineering_lockdown"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "uTA" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/random/maintenance,
@@ -83157,28 +83450,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
-"uWr" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/left/directional/east{
-	req_access = list("brig_entrance")
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "medsecprivacy";
-	name = "Privacy Shutters"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id = "quarantine";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/checkpoint/medical)
 "uWB" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space/openspace,
@@ -83216,19 +83487,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/aft)
-"uXJ" = (
-/obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Brig Warden's Office";
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/status_display/evac/directional/north,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/security/warden)
 "uXQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general{
 	dir = 5
@@ -83296,6 +83554,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
+"uYK" = (
+/obj/structure/table/wood,
+/obj/machinery/airalarm/directional/north,
+/obj/item/storage/crayons,
+/obj/item/book/bible,
+/obj/machinery/camera/directional/north{
+	c_tag = "Chapel - Chaplain's Office"
+	},
+/turf/open/floor/carpet/black,
+/area/station/service/chapel/office)
 "uYL" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -83466,6 +83734,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
+"vaU" = (
+/obj/machinery/rnd/production/techfab/department/cargo,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/machinery/requests_console/directional/west{
+	department = "Cargo Bay";
+	name = "Cargo Bay Requests Console"
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Cargo - Office";
+	network = list("ss13","cargo")
+	},
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "vaX" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -83504,6 +83785,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"vbA" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/poddoor/preopen{
+	name = "Engineering Security Doors";
+	id = "engineering_lockdown"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/break_room)
 "vbG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
@@ -83589,15 +83880,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/lower)
-"vcT" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	name = "Engineering Security Doors";
-	id_tag = "engineering_lockdown"
-	},
-/turf/open/floor/plating,
-/area/station/security/checkpoint/third)
 "vcU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -83618,14 +83900,6 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
-"vcY" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Medbay Chemistry Lab - North";
-	network = list("ss13","medbay")
-	},
-/obj/machinery/chem_master,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/medical/chemistry/ghetto)
 "vdd" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/paper/guides/jobs/hydroponics,
@@ -83817,14 +84091,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/fore)
-"vfW" = (
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 6";
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard/west)
 "vga" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -83975,6 +84241,15 @@
 "vix" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/service)
+"viB" = (
+/obj/machinery/door/airlock/corporate,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/command/magistrate,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/turf/open/floor/wood/tile,
+/area/station/command/heads_quarters/magistrate)
 "viJ" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 4
@@ -84002,6 +84277,18 @@
 /obj/structure/sign/poster/official/help_others/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"viS" = (
+/obj/machinery/light/directional/north,
+/obj/structure/table,
+/obj/machinery/microwave/engineering/cell_included,
+/obj/machinery/requests_console/directional/north{
+	department = "engineering"
+	},
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/effect/mapping_helpers/requests_console/announcement,
+/turf/open/floor/iron,
+/area/station/engineering/break_room)
 "viW" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/stairs/west,
@@ -84201,18 +84488,6 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/engine/atmos)
-"vkI" = (
-/obj/structure/sink/directional/west,
-/obj/machinery/camera{
-	c_tag = "Research Access";
-	network = list("ss13","rd");
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "vkK" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
@@ -84560,6 +84835,19 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/station/security/office)
+"voI" = (
+/obj/machinery/light/small/directional/south{
+	name = "maintenance light";
+	nightshift_allowed = 0;
+	nightshift_enabled = 1
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Medbay - Morgue South"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "voK" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/grass,
@@ -85001,6 +85289,14 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"vsY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/camera/directional/south{
+	c_tag = "Locker Room West"
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/station/commons/locker)
 "vtb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -85018,19 +85314,6 @@
 /obj/effect/spawner/random/trash/ghetto_containers,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"vtf" = (
-/obj/machinery/door/airlock/hatch,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/command/minisat,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	name = "Transit Security Doors";
-	id_tag = "transittube_lockdown"
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/transit_tube)
 "vti" = (
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
@@ -85047,15 +85330,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"vts" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/camera/autoname/directional/west{
-	c_tag = "Research Hallway South"
-	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "vtu" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/iron,
@@ -85388,6 +85662,19 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos/project)
+"vxT" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/corporate{
+	id_tag = "ntr_door"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/navigate_destination,
+/obj/effect/mapping_helpers/airlock/access/any/command/magistrate,
+/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
+/turf/open/floor/wood/tile,
+/area/station/command/heads_quarters/nanotrasen_representative)
 "vxW" = (
 /obj/structure/chair{
 	dir = 8
@@ -85469,6 +85756,28 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"vzp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/button/door/directional/north{
+	id = "research_lockdown";
+	name = "Research Lockdown Control";
+	pixel_x = 6;
+	req_one_access = list("rd","security");
+	color = "yellow"
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/button/door/directional/north{
+	id = "rndsecprivacy";
+	name = "Privacy Shutter Control";
+	pixel_x = -6;
+	req_one_access = list("rd","security")
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "vzr" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/starboard/fore)
@@ -85724,10 +86033,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
-"vCD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/science/ordnance/office)
+"vCN" = (
+/obj/structure/cable,
+/obj/machinery/computer/station_alert{
+	dir = 1
+	},
+/obj/machinery/keycard_auth/wall_mounted/directional/south,
+/obj/machinery/light/directional/south,
+/obj/machinery/camera/directional/south{
+	network = list("ss13","engineering");
+	c_tag = "Chief Engineer's Office"
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/ce)
 "vDk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -85935,15 +86253,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/plating,
 /area/station/commons/storage/emergency)
-"vFQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Port Hallway"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/port)
 "vFW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -85951,6 +86260,9 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"vGb" = (
+/turf/closed/wall,
+/area/station/security/checkpoint/engineering)
 "vGh" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes/cigpack_shadyjims,
@@ -86033,6 +86345,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
+"vHi" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Starboard Primary Hallway 6"
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard/west)
 "vHl" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/light/directional/south,
@@ -86140,19 +86459,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance)
-"vIB" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/machinery/newscaster/directional/east,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Security Post - Science";
-	network = list("ss13","rd");
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
 "vIE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -86191,15 +86497,6 @@
 	dir = 4
 	},
 /area/station/maintenance/ghetto/central)
-"vJd" = (
-/obj/structure/table/reinforced,
-/obj/machinery/camera{
-	c_tag = "EVA"
-	},
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/power_store/cell/high,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/command/storage/eva)
 "vJf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -86282,6 +86579,18 @@
 /obj/effect/turf_decal/tile/dark,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
+"vJT" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "robotics_window";
+	name = "Robotics Lab Shutters"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/plating,
+/area/station/science/robotics/lab)
 "vJV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 6
@@ -86468,19 +86777,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
-"vMr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/public,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/window/preopen{
-	dir = 4;
-	id = "JimNortonBottom"
-	},
-/turf/open/floor/wood,
-/area/station/service/cafeteria)
 "vMy" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/megaphone,
@@ -86534,6 +86830,21 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"vNl" = (
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/black{
+	pixel_x = -6
+	},
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black{
+	pixel_x = 6
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Engineering - Atmos HFR Equipment Room";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/hallway)
 "vNo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -86750,6 +87061,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"vRH" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 8
+	},
+/obj/item/pen,
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "vRI" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
@@ -86759,16 +87082,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
-"vRO" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/machinery/camera{
-	c_tag = "Courtroom South"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood/parquet,
-/area/station/security/courtroom)
 "vRP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -86840,14 +87153,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"vTe" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Xenobiology Pens Observation - Port Fore";
-	network = list("ss13","rd","xeno");
-	dir = 1
-	},
-/turf/open/openspace,
-/area/station/science/xenobiology)
 "vTj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -86876,26 +87181,6 @@
 /obj/structure/chair/comfy/black,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"vTw" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "JimNortonKitchen"
-	},
-/obj/structure/desk_bell{
-	pixel_x = -1;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/cup/glass/coffee{
-	pixel_x = 9;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/cup/rag{
-	pixel_y = 2;
-	pixel_x = -7
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/wood,
-/area/station/service/cafeteria)
 "vTz" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -87127,6 +87412,21 @@
 	dir = 8
 	},
 /area/station/command/gateway)
+"vWq" = (
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	location = "Research Division"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "vWx" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -87174,14 +87474,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"vWZ" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/effect/landmark/start/research_director,
-/obj/machinery/computer/security/telescreen/research/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
 "vXb" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/directional/north,
@@ -87282,17 +87574,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"vYi" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
-/obj/machinery/camera/directional/north{
-	c_tag = "Engineering - Freezers";
-	network = list("ss13","engine")
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
 "vYk" = (
 /obj/structure/flora/bush/jungle/b/style_random,
 /obj/machinery/light/directional/north,
@@ -87368,16 +87649,6 @@
 	},
 /turf/open/floor/engine/cult,
 /area/station/service/library)
-"vZD" = (
-/obj/machinery/camera{
-	c_tag = "Prison Forestry North";
-	dir = 9;
-	network = list("Prison","SS13")
-	},
-/obj/structure/flora/bush/jungle,
-/obj/machinery/airalarm/directional/north,
-/turf/open/misc/grass,
-/area/station/security/prison/garden)
 "vZT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -87426,19 +87697,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"wat" = (
-/obj/machinery/light/small/directional/south{
-	name = "maintenance light";
-	nightshift_allowed = 0;
-	nightshift_enabled = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay Morgue South"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
 "wav" = (
 /obj/machinery/light/directional/west,
 /obj/structure/cable,
@@ -87454,6 +87712,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/ghetto/central/aft)
+"waG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/security,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/turf_decal/tile/red/full,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/checkpoint/medical)
 "waJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/rack,
@@ -87639,29 +87907,11 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
-"wcK" = (
-/obj/structure/chair/pew/left{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Courtroom Lobby";
-	dir = 1
-	},
-/turf/open/floor/wood/parquet,
-/area/station/security/courtroom)
 "wcM" = (
 /obj/structure/transit_tube/horizontal,
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"wcY" = (
-/obj/machinery/camera{
-	c_tag = "Departure Lounge South-East"
-	},
-/obj/structure/closet/emcloset,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "wdj" = (
 /obj/structure/frame,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -87833,19 +88083,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
 /area/station/security/prison)
-"wgc" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio_maint_aft";
-	name = "Xenobiology Blast Door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor{
-	id = "xenobio_maint_fore";
-	name = "Xenobiology Blast Door"
-	},
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "wgj" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Bridge - Telecomms Chamber Starboard";
@@ -88100,16 +88337,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/ghetto/fore/starboard)
-"wis" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/directional/east{
-	c_tag = "Cargo - Auxiliary Warehouse"
-	},
-/turf/open/floor/iron,
-/area/station/cargo/office)
 "wix" = (
 /obj/structure/sink/directional/west,
 /obj/effect/turf_decal/tile/neutral/half{
@@ -88261,6 +88488,15 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/station/service/chapel/monastery)
+"wki" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Port Hallway"
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "wkn" = (
 /obj/structure/water_source/puddle,
 /turf/open/misc/beach/sand,
@@ -88394,10 +88630,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
-"wmu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/security/checkpoint/supply)
 "wmw" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
@@ -88504,27 +88736,6 @@
 	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/cargo/storage/ghetto)
-"woz" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Atmos NorthWest";
-	network = list("SS13","Engineering");
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
-"woC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	name = "Engineering Security Doors";
-	id_tag = "engineering_lockdown"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/dronefabricator)
 "woE" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
@@ -88554,6 +88765,17 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/red,
 /area/station/commons/dorms/apartment1)
+"woX" = (
+/obj/machinery/photocopier,
+/obj/machinery/camera/directional/west{
+	c_tag = "Lawyer's Office"
+	},
+/obj/structure/secure_safe/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/station/service/lawoffice)
 "woY" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
@@ -88600,6 +88822,22 @@
 /obj/effect/turf_decal/tile/neutral/half,
 /turf/open/floor/iron/edge,
 /area/station/security/checkpoint/customs)
+"wpL" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/food/grown/banana,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/west,
+/obj/machinery/camera/directional/west{
+	c_tag = "Virology - Observation";
+	network = list("ss13","medbay")
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "wpY" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -88657,15 +88895,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/commons/vacant_room/office)
-"wqP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/barricade/wooden/crude,
-/obj/machinery/door/poddoor/preopen{
-	name = "Engineering Security Doors";
-	id_tag = "engineering_lockdown"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/ghetto)
 "wqQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/purple,
@@ -88907,6 +89136,24 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"wtV" = (
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/cup/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/dropper,
+/obj/machinery/camera/directional/east{
+	c_tag = "Research - Research and Development Lab";
+	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/tile/purple/anticorner,
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/station/science/lab)
 "wua" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/machinery/light/small/directional/south,
@@ -88951,14 +89198,6 @@
 /obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
-"wuB" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red/full,
-/obj/effect/landmark/start/depsec/engineering,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/third)
 "wuK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -89026,18 +89265,6 @@
 /mob/living/basic/slime,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"wvp" = (
-/obj/machinery/photocopier,
-/obj/machinery/camera{
-	c_tag = "Lawyer's Office";
-	dir = 8
-	},
-/obj/structure/secure_safe/directional/west,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood/tile,
-/area/station/service/lawoffice)
 "wvz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /obj/structure/sign/directions/engineering{
@@ -89422,14 +89649,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"wAz" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/camera{
-	c_tag = "Central Hallway North-East";
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
 "wAG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -89642,20 +89861,6 @@
 /obj/effect/mob_spawn/corpse/human/skeleton,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
-"wCG" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/obj/machinery/light/small/directional/north,
-/obj/machinery/camera/directional/north{
-	c_tag = "Medbay - Hallway - North";
-	network = list("ss13","medbay")
-	},
-/obj/structure/sign/departments/morgue/directional/north,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
 "wCH" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -90008,14 +90213,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/service)
-"wFY" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/camera/directional/north{
-	c_tag = "Research - Polygon - North";
-	network = list("rd","ordnance")
-	},
-/turf/open/floor/iron/airless,
-/area/station/science/ordnance/bomb)
 "wGc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblack,
@@ -90048,6 +90245,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
+"wGL" = (
+/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
+/obj/effect/turf_decal/tile/red/full,
+/obj/machinery/holopad,
+/obj/effect/landmark/start/depsec/medical,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/checkpoint/medical)
 "wGV" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port/fore)
@@ -90087,17 +90291,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood/parquet,
 /area/station/security/courtroom)
-"wIa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/camera/autoname/directional/east{
-	c_tag = "Brig Prisoner Processing east"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/holding_cell)
+"wHY" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/medical/surgery/fore)
 "wIg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -90139,6 +90336,15 @@
 /obj/structure/sign/departments/court/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"wIB" = (
+/obj/machinery/quantum_server,
+/obj/machinery/camera/directional/north{
+	c_tag = "Cargo - Bitrunning Den";
+	network = list("ss13","cargo")
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "wID" = (
 /obj/structure/table/wood,
 /obj/machinery/fax{
@@ -90183,18 +90389,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical/ghetto)
-"wJD" = (
-/obj/structure/table,
-/obj/item/radio/off,
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
-	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron,
-/area/station/security/checkpoint/supply)
 "wJL" = (
 /obj/structure/mop_bucket/janitorialcart,
 /obj/effect/turf_decal/tile/neutral/anticorner{
@@ -90787,12 +90981,31 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"wQZ" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Research - Xenobiology Cell 8";
+	network = list("ss13","xeno","rd")
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "wRm" = (
 /obj/structure/railing{
 	dir = 1
 	},
 /turf/open/floor/glass/reinforced,
 /area/station/hallway/secondary/dock)
+"wRo" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Research - Xenobiology Pens Observation North";
+	network = list("ss13","rd","xeno");
+	dir = 1
+	},
+/turf/open/openspace,
+/area/station/science/xenobiology)
 "wRp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -90901,10 +91114,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"wSD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/medical/surgery/fore)
 "wSH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -91021,6 +91230,18 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/aft)
+"wUd" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Virology - Airlock";
+	network = list("ss13","medbay")
+	},
+/obj/structure/sink/directional/west,
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "wUk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -91241,6 +91462,20 @@
 /obj/machinery/digital_clock/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
+"wXM" = (
+/obj/structure/dresser,
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/camera/directional/north{
+	c_tag = "Chief Medical Officer's Quarters";
+	network = list("ss13","medbay")
+	},
+/obj/machinery/button/door/directional/north{
+	id = "CMO_bedroom";
+	name = "CMO Office Shutters";
+	req_access = list("cmo")
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/cmo)
 "wXN" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/decal/cleanable/blood/old,
@@ -91357,6 +91592,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
+"wZs" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - Foyer West";
+	network = list("ss13","engineering")
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/hallway)
 "wZB" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -91403,6 +91648,14 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"xax" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/engineering)
 "xaB" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
@@ -91475,6 +91728,13 @@
 /obj/effect/mapping_helpers/requests_console/information,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
+"xbx" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Research - Mech Bay";
+	network = list("ss13","rd")
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/mechbay)
 "xbG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -91547,16 +91807,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
-"xcp" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay Lobby";
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "xcz" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/security/armory)
@@ -91730,6 +91980,24 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"xep" = (
+/obj/machinery/button/door/directional/north{
+	id = "medsecprivacy";
+	name = "Privacy Shutters Control";
+	req_one_access = list("cmo","security");
+	pixel_x = 6
+	},
+/obj/machinery/computer/records/medical,
+/obj/effect/turf_decal/tile/red/full,
+/obj/machinery/button/door/directional/north{
+	id = "quarantine";
+	name = "Quarantine Lockdown Control";
+	req_one_access = list("cmo","security");
+	pixel_x = -6;
+	color = "yellow"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/security/checkpoint/medical)
 "xes" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
@@ -91851,14 +92119,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
-"xfr" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Cargo - Bay South"
-	},
-/obj/effect/spawner/random/trash/box,
-/obj/structure/sign/poster/random/directional/south,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "xft" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -92124,6 +92384,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"xiY" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/computer/security/telescreen/research/directional/north{
+	network = list("rd","xeno","test","ordnance");
+	pixel_y = 35;
+	name = "Research Security Monitor"
+	},
+/obj/effect/landmark/start/depsec/science,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "xjf" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/tile/yellow,
@@ -92224,6 +92497,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"xjS" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Research - Xenobiology Killroom Chamber";
+	network = list("ss13","xeno","rd")
+	},
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark/telecomms,
+/area/station/science/xenobiology)
 "xjT" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -92268,15 +92552,6 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"xkn" = (
-/obj/structure/closet/crate,
-/obj/machinery/camera{
-	c_tag = "Engineering Engine Storage";
-	network = list("SS13","Engineering");
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/storage_shared)
 "xkq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/reagent_dispensers/watertank/high,
@@ -92462,18 +92737,6 @@
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
-"xnw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/genetics,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
 "xnz" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -92632,25 +92895,18 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/station/maintenance/fore)
-"xpR" = (
-/obj/machinery/camera{
-	c_tag = "Secure Tech Storage";
-	network = list("SS13","Engineering");
-	dir = 1
+"xpQ" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/camera/directional/north{
+	c_tag = "Research - Robotics Lab North";
+	network = list("ss13","rd");
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/engineering/storage/tech)
-"xpX" = (
-/obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/tile/brown/half/contrasted{
+/obj/effect/turf_decal/tile/purple/half{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Cargo - Delivery Office";
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/cargo/sorting)
+/turf/open/floor/iron/white,
+/area/station/science/robotics/lab)
 "xpY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -92695,33 +92951,6 @@
 /obj/structure/cable,
 /turf/closed/wall,
 /area/station/ai_monitored/turret_protected/ai)
-"xri" = (
-/obj/machinery/modular_computer/preset/id{
-	dir = 4
-	},
-/obj/machinery/light_switch/directional/south,
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 8
-	},
-/obj/machinery/button/door/directional/west{
-	pixel_y = 10;
-	id = "engineering_lockdown";
-	name = "Engineering Lockdown";
-	req_access = list("ce")
-	},
-/obj/machinery/button/door/directional/west{
-	id = "atmoslock";
-	name = "Atmos Lockdown";
-	req_access = list("ce")
-	},
-/obj/machinery/button/door/directional/west{
-	pixel_y = -10;
-	id = "transittube_lockdown";
-	name = "Transit Tube Lockdown";
-	req_access = list("ce")
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/ce)
 "xrj" = (
 /obj/structure/chair/stool{
 	dir = 8
@@ -92774,14 +93003,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"xrT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/checkpoint/medical)
 "xrZ" = (
 /obj/item/stack/rods,
 /obj/item/shard{
@@ -93045,18 +93266,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"xuD" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Engineering - Supermatter Emitters";
-	network = list("ss13","engine")
+"xuy" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Research - Xenobiology Secure Cell Interior";
+	network = list("ss13","xeno","rd")
 	},
-/obj/effect/landmark/event_spawn,
-/obj/machinery/power/emitter{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
+/obj/machinery/status_display/ai/directional/west,
+/obj/machinery/light/cold/directional/west,
+/turf/open/floor/engine/xenobio,
+/area/station/science/xenobiology)
 "xuG" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/assistant,
@@ -93221,6 +93439,17 @@
 /obj/structure/sign/warning/secure_area/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
+"xxA" = (
+/obj/structure/closet/secure_closet/security/sec,
+/obj/item/clothing/mask/balaclava,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/effect/turf_decal/delivery/red,
+/obj/machinery/camera/directional/west{
+	c_tag = "Brig Security Equipment Lockers"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/lockers)
 "xxO" = (
 /obj/item/seeds/potato,
 /obj/effect/spawner/random/structure/closet_maintenance,
@@ -93347,6 +93576,20 @@
 /obj/effect/spawner/random/trash/hobo_squat,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/port)
+"xzu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/camera/directional/east{
+	c_tag = "Medbay - Hallway South";
+	network = list("ss13","medbay")
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "xzQ" = (
 /obj/item/taperecorder{
 	pixel_x = -6;
@@ -93458,10 +93701,6 @@
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
-"xBM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/lobby)
 "xBP" = (
 /obj/item/clothing/mask/breath,
 /obj/structure/rack,
@@ -93533,20 +93772,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/dronefabricator)
-"xDd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Engineering Hallway East";
-	network = list("SS13","Engineering");
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/hallway)
 "xDh" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -93578,17 +93803,6 @@
 /obj/structure/railing/corner,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"xDx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/directional/north,
-/obj/machinery/camera{
-	c_tag = "Arrivals Lounge";
-	dir = 1
-	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
 "xDz" = (
 /obj/machinery/conveyor{
 	dir = 6;
@@ -93607,18 +93821,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"xDT" = (
-/obj/machinery/light/directional/north,
-/obj/structure/table,
-/obj/machinery/microwave/engineering/cell_included,
-/obj/machinery/requests_console/directional/north{
-	department = "Engineering"
-	},
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/effect/mapping_helpers/requests_console/supplies,
-/obj/effect/mapping_helpers/requests_console/announcement,
-/turf/open/floor/iron,
-/area/station/engineering/break_room)
 "xEg" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -93800,34 +94002,6 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/command/storage/eva)
-"xGg" = (
-/obj/machinery/camera{
-	c_tag = "Engineering SM Prep Room";
-	network = list("SS13","Engineering");
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/light_switch/directional/north,
-/obj/machinery/light/small/directional/north,
-/obj/structure/table,
-/obj/item/electronics/airalarm{
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/obj/item/electronics/firealarm{
-	pixel_y = 6;
-	pixel_x = 6
-	},
-/obj/item/electronics/firealarm{
-	pixel_x = 6
-	},
-/obj/item/electronics/airalarm{
-	pixel_x = -6
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/hallway)
 "xGq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -93992,6 +94166,14 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/smooth,
 /area/station/commons/toilet/restrooms)
+"xIz" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Engineering - Supermatter";
+	network = list("ss13","engine","engineering")
+	},
+/obj/structure/sign/warning/radiation/directional/east,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter)
 "xIE" = (
 /obj/structure/rack,
 /obj/item/flashlight,
@@ -94562,38 +94744,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
-"xPV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder{
-	pixel_x = -1;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_x = 3;
-	pixel_y = -8
-	},
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_x = -3;
-	pixel_y = -8
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	pixel_y = -6
-	},
-/obj/item/reagent_containers/dropper{
-	pixel_y = -7
-	},
-/obj/structure/sign/warning/no_smoking/directional/north,
-/obj/machinery/camera/directional/north{
-	c_tag = "Medbay Chemistry Lab - East";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/station/medical/chemistry/ghetto)
 "xQe" = (
 /obj/structure/chair/sofa/bench,
 /obj/machinery/light/small/directional/north,
@@ -94851,6 +95001,17 @@
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/fore)
+"xTz" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/turf/open/floor/plating,
+/area/station/medical/paramedic)
 "xTF" = (
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/carpet/green,
@@ -94875,14 +95036,6 @@
 	dir = 8
 	},
 /area/station/service/chapel)
-"xTM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	name = "Engineering Security Doors";
-	id_tag = "engineering_lockdown"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/ghetto)
 "xTO" = (
 /obj/structure/table,
 /obj/item/pizzabox/vegetable,
@@ -95162,16 +95315,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/station/command/meeting_room)
-"xYc" = (
-/obj/structure/closet/secure_closet/security/med,
-/obj/structure/cable,
-/obj/machinery/light_switch/directional/south{
-	pixel_x = -6
-	},
-/obj/effect/turf_decal/tile/red/full,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/security/checkpoint/medical)
 "xYd" = (
 /obj/effect/turf_decal/siding/white,
 /obj/effect/turf_decal/siding/white{
@@ -95179,13 +95322,6 @@
 	},
 /turf/open/misc/beach/sand,
 /area/station/service/hydroponics)
-"xYi" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
 "xYj" = (
 /obj/machinery/door/airlock,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -95316,13 +95452,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
-"xZW" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/computer/security,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
 "xZX" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister{
@@ -95359,19 +95488,42 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
-"yan" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "JimNortonKitchen"
-	},
-/obj/item/modular_computer/laptop/preset/civilian,
-/obj/structure/table/reinforced,
-/turf/open/floor/wood,
-/area/station/service/cafeteria)
 "yaq" = (
 /obj/structure/sink/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"yar" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = 3;
+	pixel_y = -8
+	},
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = -3;
+	pixel_y = -8
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_y = -6
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_y = -7
+	},
+/obj/structure/sign/warning/no_smoking/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Medbay - Chemistry Lab East";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/station/medical/chemistry/ghetto)
 "yay" = (
 /obj/effect/spawner/random/trash/graffiti{
 	spawn_loot_chance = 50
@@ -95614,18 +95766,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/small,
 /area/station/maintenance/ghetto/central)
+"ydA" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Tech Storage";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/plating,
+/area/station/engineering/storage/tech)
 "ydD" = (
 /obj/structure/window/fulltile,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/command/bridge)
-"ydP" = (
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/station/cargo/office)
 "ydU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -95794,6 +95948,22 @@
 "ygq" = (
 /turf/open/floor/carpet/black,
 /area/station/commons/lounge)
+"ygG" = (
+/obj/machinery/button/elevator/directional/north{
+	id = "aft_vator"
+	},
+/obj/machinery/lift_indicator/directional/north{
+	linked_elevator_id = "aft_vator"
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Cargo - Bay North";
+	network = list("ss13","cargo")
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "ygO" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -96006,6 +96176,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
+"yjx" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/power/energy_accumulator/tesla_coil,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Engineering - Secure Storage South";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/plating,
+/area/station/engineering/storage)
 "yjy" = (
 /obj/structure/table/optable,
 /turf/open/floor/iron/dark,
@@ -96138,19 +96320,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/service/chapel)
-"ylh" = (
-/obj/structure/table/wood,
-/obj/item/camera,
-/obj/item/storage/photo_album{
-	pixel_y = -10
-	},
-/obj/item/crowbar,
-/obj/machinery/camera{
-	c_tag = "Captain's Office";
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/captain)
 "ylm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -96182,13 +96351,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
-"ylH" = (
-/obj/vehicle/sealed/mecha/ripley/cargo,
-/obj/machinery/camera/directional/north{
-	c_tag = "Cargo - Bay Lower Floor North"
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage/ghetto/depot)
 "ylO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/effect/turf_decal/tile/blue{
@@ -114316,7 +114478,7 @@ aaH
 eee
 rHY
 vED
-cNl
+bDW
 mQa
 rRj
 xdk
@@ -114899,7 +115061,7 @@ rQU
 rQU
 rQU
 jJz
-mzr
+wIB
 ifO
 bDI
 cxd
@@ -115405,7 +115567,7 @@ rQU
 rQU
 rQU
 rQU
-sid
+rym
 bCN
 fGH
 oBo
@@ -116125,7 +116287,7 @@ rgK
 rgK
 vEj
 nkc
-vZD
+nRT
 tJb
 tJb
 tJb
@@ -116180,7 +116342,7 @@ oBo
 bCN
 xtd
 jIW
-jlt
+gYU
 org
 hBj
 oZU
@@ -116391,7 +116553,7 @@ mLR
 jRd
 jRd
 vzY
-pRj
+rMd
 aPt
 isY
 doz
@@ -116696,7 +116858,7 @@ bNC
 rZD
 eVn
 aOJ
-jYh
+hPP
 mTM
 riE
 plE
@@ -117144,7 +117306,7 @@ htA
 htA
 htA
 tuh
-tFl
+pZE
 ekb
 wfs
 pam
@@ -117214,7 +117376,7 @@ oKG
 oKG
 tkt
 qCm
-faC
+nFS
 hBj
 doz
 doz
@@ -117713,7 +117875,7 @@ hxl
 wbn
 yfu
 qUy
-ylH
+qSj
 hET
 hET
 eRV
@@ -119307,13 +119469,13 @@ job
 doz
 doz
 doz
-xTM
-wqP
-xTM
-wqP
-xTM
-wqP
-xTM
+jCY
+raw
+jCY
+raw
+jCY
+raw
+jCY
 doz
 doz
 doz
@@ -119561,19 +119723,19 @@ lcw
 pMA
 dKo
 dKo
-xTM
-wqP
-wqP
-xTM
+jCY
+raw
+raw
+jCY
 pMA
 pMA
 pMA
 pMA
 cKv
-xTM
-wqP
-xTM
-wqP
+jCY
+raw
+jCY
+raw
 dKo
 dKo
 pMA
@@ -131109,7 +131271,7 @@ eDZ
 eDZ
 eWD
 kos
-eVT
+uDt
 vzJ
 xXv
 rQp
@@ -132124,7 +132286,7 @@ vbK
 doz
 doz
 vzJ
-vcY
+qVi
 xvz
 gMr
 hFR
@@ -133414,7 +133576,7 @@ doz
 doz
 doz
 vzJ
-xPV
+yar
 pBD
 iAJ
 rEd
@@ -136265,13 +136427,13 @@ llq
 ltF
 opS
 xXv
-aPQ
-aPQ
-aPQ
-aPQ
-aPQ
-aPQ
-aPQ
+etx
+etx
+etx
+etx
+etx
+etx
+etx
 xXv
 xXv
 fzk
@@ -136521,15 +136683,15 @@ mwW
 rKW
 ltF
 opS
-aPQ
-aPQ
+etx
+etx
 tLJ
 tLJ
-qph
+xuy
 tLJ
 tLJ
-aPQ
-aPQ
+etx
+etx
 xXv
 fif
 doz
@@ -136778,7 +136940,7 @@ mhF
 chV
 fif
 opS
-aPQ
+etx
 tLJ
 tLJ
 tLJ
@@ -136786,7 +136948,7 @@ qEp
 tLJ
 tLJ
 tLJ
-aPQ
+etx
 xXv
 fzk
 doz
@@ -137035,7 +137197,7 @@ ltF
 fif
 fif
 gVQ
-aPQ
+etx
 tLJ
 erd
 huV
@@ -137043,7 +137205,7 @@ tLJ
 pUv
 tLJ
 tLJ
-aPQ
+etx
 xXv
 fif
 doz
@@ -137292,7 +137454,7 @@ kDW
 wfp
 fif
 jGR
-aPQ
+etx
 tLJ
 tLJ
 tLJ
@@ -137300,7 +137462,7 @@ tLJ
 tLJ
 tLJ
 tLJ
-aPQ
+etx
 xXv
 fif
 fif
@@ -137549,7 +137711,7 @@ wiD
 ocX
 fif
 dLc
-aPQ
+etx
 bZr
 bZr
 vVf
@@ -137557,7 +137719,7 @@ tLJ
 fhJ
 aPQ
 aPQ
-aPQ
+etx
 oax
 xXv
 xXv
@@ -137806,7 +137968,7 @@ kwo
 ocX
 dLc
 dLc
-aPQ
+etx
 jNy
 jyC
 jyC
@@ -137814,10 +137976,10 @@ tMe
 qfp
 hfD
 hOD
-aPQ
-aPQ
-aPQ
-aPQ
+etx
+etx
+etx
+etx
 rQp
 xXv
 qFZ
@@ -138062,8 +138224,8 @@ fif
 fif
 fif
 xtC
-aPQ
-aPQ
+etx
+etx
 mir
 fVc
 rBg
@@ -138074,7 +138236,7 @@ pvt
 aPQ
 pjh
 piI
-aPQ
+etx
 cDt
 emy
 fif
@@ -138319,7 +138481,7 @@ lBj
 eZq
 fif
 dLc
-aPQ
+etx
 ksf
 bDa
 cFX
@@ -138331,7 +138493,7 @@ las
 xnV
 fRk
 fRk
-aPQ
+etx
 qFZ
 gKM
 ocX
@@ -138576,7 +138738,7 @@ fif
 fif
 fif
 hdh
-oIm
+pFg
 wCv
 cQI
 lSo
@@ -138588,7 +138750,7 @@ bKc
 vCB
 ezO
 fRk
-aPQ
+etx
 rQp
 fTZ
 fif
@@ -138833,9 +138995,9 @@ cAC
 cAC
 egU
 cAC
-aPQ
+etx
 mSc
-nWF
+hFa
 wuS
 viO
 mpE
@@ -138843,9 +139005,9 @@ iXB
 fJa
 swe
 aPQ
-kBA
+xjS
 vrD
-aPQ
+etx
 rQp
 xXv
 wfp
@@ -139088,9 +139250,9 @@ xXv
 rQp
 iJV
 xXv
-aPQ
-aPQ
-aPQ
+etx
+etx
+etx
 aPQ
 aPQ
 aPQ
@@ -139102,7 +139264,7 @@ aPQ
 aPQ
 aPQ
 aPQ
-aPQ
+etx
 xXv
 fTZ
 wfp
@@ -139345,7 +139507,7 @@ fif
 etx
 xod
 bAH
-aPQ
+etx
 aNd
 pgF
 eso
@@ -139359,7 +139521,7 @@ tBB
 gnl
 pgF
 rtt
-aPQ
+etx
 cmE
 ooa
 wfp
@@ -139602,7 +139764,7 @@ doz
 etx
 xrG
 mrE
-fHp
+cOC
 mpE
 mWc
 mpE
@@ -139616,7 +139778,7 @@ ntO
 mpE
 mua
 mpE
-wgc
+qvL
 xXv
 rQp
 yfi
@@ -139859,7 +140021,7 @@ doz
 etx
 hhW
 oWA
-aPQ
+etx
 uyR
 iXB
 bwl
@@ -139872,8 +140034,8 @@ srh
 jhg
 fKC
 iXB
-mLF
-aPQ
+wQZ
+etx
 qFZ
 rQp
 nnJ
@@ -140116,7 +140278,7 @@ oVL
 etx
 uiT
 mrE
-aPQ
+etx
 gML
 tcd
 qvj
@@ -140130,7 +140292,7 @@ vps
 pxn
 tcd
 xJn
-aPQ
+etx
 xXv
 rQp
 jXs
@@ -140373,7 +140535,7 @@ doz
 etx
 qyx
 oWA
-fHp
+cOC
 mpE
 mWc
 mpE
@@ -140387,7 +140549,7 @@ cjR
 mpE
 mWc
 mpE
-wgc
+qvL
 rQp
 xXv
 qQf
@@ -140630,8 +140792,8 @@ oVL
 etx
 uhq
 mrE
-aPQ
-stG
+etx
+mdv
 iXB
 bwl
 sbO
@@ -140644,7 +140806,7 @@ khv
 fKC
 iXB
 wue
-aPQ
+etx
 rQp
 tVq
 wfp
@@ -140887,7 +141049,7 @@ doz
 etx
 dyr
 mrE
-aPQ
+etx
 pxn
 tcd
 qvj
@@ -140901,7 +141063,7 @@ jIc
 pxn
 tcd
 qvj
-aPQ
+etx
 rQp
 jCI
 wfp
@@ -141144,7 +141306,7 @@ doz
 etx
 hhW
 xXv
-fHp
+cOC
 mpE
 mWc
 mpE
@@ -141158,7 +141320,7 @@ fIA
 mpE
 mua
 mpE
-wgc
+qvL
 roD
 fTZ
 wfp
@@ -141401,7 +141563,7 @@ doz
 etx
 bBc
 kDW
-aPQ
+etx
 sKi
 iXB
 bwl
@@ -141414,8 +141576,8 @@ srh
 luu
 fKC
 iXB
-rhE
-aPQ
+pmt
+etx
 cmE
 xHx
 wfp
@@ -141658,7 +141820,7 @@ doz
 etx
 bBc
 xXv
-aPQ
+etx
 pxn
 tcd
 qvj
@@ -141672,7 +141834,7 @@ rKG
 pxn
 tcd
 qvj
-aPQ
+etx
 xXv
 xXv
 wfp
@@ -141915,7 +142077,7 @@ oVL
 etx
 uhq
 oWA
-fHp
+cOC
 mpE
 mua
 mpE
@@ -141929,7 +142091,7 @@ sun
 mpE
 mWc
 mpE
-wgc
+qvL
 xXv
 xXv
 wfp
@@ -142172,8 +142334,8 @@ doz
 etx
 bBc
 qTy
-aPQ
-uPr
+etx
+aSi
 qll
 bwl
 goo
@@ -142186,7 +142348,7 @@ vGw
 fKC
 qll
 rrM
-aPQ
+etx
 xXv
 roD
 wfp
@@ -142433,7 +142595,7 @@ etx
 etx
 etx
 etx
-aPQ
+etx
 bPr
 elW
 bIq
@@ -142443,7 +142605,7 @@ aPQ
 aPQ
 aPQ
 aPQ
-aPQ
+etx
 cbS
 rQp
 fif
@@ -142622,7 +142784,7 @@ vBZ
 vBZ
 qWU
 vBZ
-lCI
+uYK
 lFT
 auR
 csF
@@ -142690,8 +142852,8 @@ etx
 wfp
 wfp
 wfp
-aPQ
-ocm
+etx
+fkx
 cMA
 uNF
 vnE
@@ -142700,7 +142862,7 @@ hBh
 sha
 sha
 eQp
-aPQ
+etx
 xXv
 rQp
 fif
@@ -142876,7 +143038,7 @@ pgT
 veO
 ryU
 vBZ
-erA
+rVA
 vGI
 vBZ
 mCJ
@@ -142947,7 +143109,7 @@ bqL
 wfp
 loJ
 wfp
-aPQ
+etx
 aXx
 vjE
 ydt
@@ -142957,7 +143119,7 @@ aPQ
 aZA
 aZA
 mKL
-aPQ
+etx
 cDt
 emy
 fif
@@ -143204,7 +143366,7 @@ etx
 wfp
 wfp
 wfp
-aPQ
+etx
 umd
 oSc
 nZt
@@ -143214,7 +143376,7 @@ aPQ
 aZA
 aZA
 tCx
-aPQ
+etx
 qFZ
 xXv
 iJV
@@ -143461,17 +143623,17 @@ etx
 etx
 etx
 etx
-aPQ
-aPQ
-aPQ
-aPQ
-aPQ
-aPQ
-aPQ
-aPQ
-aPQ
-aPQ
-aPQ
+etx
+etx
+etx
+etx
+etx
+etx
+etx
+etx
+etx
+etx
+etx
 fTZ
 fTZ
 iJV
@@ -147031,7 +147193,7 @@ nFU
 nFU
 nFU
 nFU
-ffb
+aoq
 nFU
 nFU
 nFU
@@ -148577,7 +148739,7 @@ mLI
 oGf
 xLW
 aWU
-lDC
+qtH
 nFU
 pTl
 fKk
@@ -172171,7 +172333,7 @@ tYD
 hqz
 nDE
 hqz
-nIF
+jsZ
 xmL
 xmL
 iNK
@@ -172444,7 +172606,7 @@ hbD
 cSx
 xmL
 xmL
-qxA
+mBx
 hbD
 tYD
 tYD
@@ -172458,7 +172620,7 @@ tYD
 tYD
 tYD
 hbD
-sgQ
+leA
 xmL
 aip
 hbD
@@ -174240,7 +174402,7 @@ hZL
 iuR
 rYS
 yfg
-udy
+fqP
 rUn
 xmL
 otq
@@ -174256,7 +174418,7 @@ bcK
 uYj
 rUn
 xmL
-aWh
+dTn
 otq
 xmL
 eoS
@@ -174489,7 +174651,7 @@ uJS
 uuG
 vsl
 uKE
-ufV
+pKb
 otq
 otq
 otq
@@ -174502,7 +174664,7 @@ xmL
 xmL
 otq
 ftc
-pFM
+emM
 otq
 otq
 olE
@@ -175793,7 +175955,7 @@ qHg
 njA
 muZ
 bVv
-jih
+sgs
 sHW
 wOT
 tvz
@@ -176048,7 +176210,7 @@ kpb
 nGE
 tcB
 fse
-uEN
+gWc
 xPx
 xPx
 xPx
@@ -176292,7 +176454,7 @@ buL
 icD
 jcc
 nwJ
-xDx
+sqo
 vub
 lBb
 uuD
@@ -177069,7 +177231,7 @@ otq
 nQu
 vlh
 lIr
-pXm
+ejw
 vlh
 olm
 bIw
@@ -178052,7 +178214,7 @@ ddm
 ddm
 ddm
 ddm
-cxE
+gUb
 tYD
 tYD
 tYD
@@ -178872,7 +179034,7 @@ pDI
 xtx
 xtx
 xtx
-dtN
+vsY
 jal
 ekQ
 fMy
@@ -179334,7 +179496,7 @@ tYD
 tYD
 tYD
 ddm
-cIw
+sCj
 iLe
 sQV
 lYv
@@ -180735,7 +180897,7 @@ dmU
 svM
 kZJ
 giG
-dVF
+dEb
 jcP
 mlQ
 svM
@@ -181208,7 +181370,7 @@ dBr
 itr
 nTK
 hsX
-xfr
+cxR
 dMR
 gJs
 gJs
@@ -181388,7 +181550,7 @@ tYD
 trM
 isY
 ddm
-ilH
+lWk
 cmj
 aiD
 vjs
@@ -181439,7 +181601,7 @@ eao
 vFW
 rAW
 bzp
-deu
+pol
 nNQ
 sVx
 gib
@@ -181661,7 +181823,7 @@ frJ
 xRv
 wmw
 kLL
-jHC
+mFn
 nUk
 nUk
 nUk
@@ -181968,7 +182130,7 @@ xPx
 xPx
 xPx
 xPx
-uKL
+ygG
 kGz
 njk
 njk
@@ -182184,7 +182346,7 @@ nUk
 nUk
 nUk
 nUk
-aJF
+uPd
 ddm
 kJd
 qsJ
@@ -182464,7 +182626,7 @@ gLn
 gLn
 dlT
 cTW
-vFQ
+wki
 tXc
 tXc
 tXc
@@ -182494,7 +182656,7 @@ beH
 nQa
 hLf
 oXI
-sXF
+pLR
 pje
 nrT
 beH
@@ -182524,7 +182686,7 @@ oXc
 kJd
 xRt
 rLg
-xuD
+jbw
 wQD
 pgU
 cte
@@ -182680,7 +182842,7 @@ ddm
 ddm
 ddm
 lFA
-aKi
+oVb
 ddm
 hCm
 oAi
@@ -182731,12 +182893,12 @@ oRn
 tXc
 uWj
 xPx
-qtg
+gNS
 snN
 ekG
 osx
 wgD
-dKV
+gjO
 vvw
 vvw
 vvw
@@ -182795,7 +182957,7 @@ sMU
 kUx
 kih
 qDM
-qFb
+xIz
 qlX
 jrp
 eSR
@@ -183056,7 +183218,7 @@ aKp
 aKp
 kom
 bGL
-uTs
+aCU
 rLg
 xRt
 tYD
@@ -183245,7 +183407,7 @@ xaB
 tXc
 nzI
 xPx
-pGg
+fJy
 jsH
 eHn
 lqS
@@ -183514,7 +183676,7 @@ cPg
 les
 gLy
 mes
-owb
+vaU
 ixb
 qds
 jng
@@ -184222,7 +184384,7 @@ kJd
 gOj
 ddm
 iNS
-pCF
+lui
 ddm
 mvm
 xRv
@@ -184549,8 +184711,8 @@ bFM
 lRl
 mOF
 aDM
-ydP
-wis
+nup
+iXn
 mAy
 icg
 lRl
@@ -184580,7 +184742,7 @@ coz
 kJd
 xRt
 rLg
-vYi
+aXX
 bkh
 pcP
 xdF
@@ -184789,7 +184951,7 @@ pQe
 raR
 vRY
 dKy
-xpX
+rar
 eaQ
 xnP
 wry
@@ -184804,8 +184966,8 @@ jSS
 lRl
 uhZ
 uhZ
-wmu
-dVB
+kGQ
+ciO
 oXc
 oXc
 oXc
@@ -184849,7 +185011,7 @@ qaY
 wmT
 tUT
 tUT
-cHS
+aYX
 gbs
 mbG
 mKo
@@ -184995,7 +185157,7 @@ lMG
 lrv
 kKz
 nRB
-aIC
+rNS
 cZx
 jdP
 tFO
@@ -185060,8 +185222,8 @@ hnZ
 clU
 vzR
 uhZ
-wJD
-tMW
+hlO
+exw
 shG
 oXc
 iTs
@@ -185316,10 +185478,10 @@ bDk
 jHw
 tXR
 uNh
-wmu
-gcB
-mPa
-lny
+kGQ
+hNr
+hCx
+bhc
 oXc
 vtu
 qfY
@@ -185504,7 +185666,7 @@ tYD
 tYD
 tYD
 nRB
-acl
+hiO
 vrG
 mxh
 seo
@@ -185551,7 +185713,7 @@ cTW
 nQA
 scY
 scY
-nhl
+bPF
 mbT
 mbT
 mLO
@@ -185573,10 +185735,10 @@ qZs
 kNa
 wQX
 oMO
-wmu
-rml
-sqr
-okJ
+kGQ
+flN
+hZF
+txh
 oXc
 ngQ
 mKa
@@ -185831,9 +185993,9 @@ uNh
 wDU
 hUQ
 uhZ
-pWG
-taB
-gwx
+rfz
+aOK
+inC
 oXc
 oyc
 tVz
@@ -185876,7 +186038,7 @@ mcZ
 qWM
 eBL
 xbR
-ofp
+bOU
 bAZ
 cxz
 fur
@@ -186120,7 +186282,7 @@ nZg
 nbf
 eqE
 qcz
-sfn
+tyf
 ofF
 qqC
 iuf
@@ -186288,7 +186450,7 @@ ngW
 ngW
 ngW
 eLF
-gOr
+bZv
 cjz
 ngW
 ngW
@@ -186345,7 +186507,7 @@ mty
 sLh
 mty
 wzR
-pAv
+nDC
 bUW
 mty
 mty
@@ -186383,7 +186545,7 @@ fjs
 fjs
 fjs
 fjs
-lKF
+huJ
 jnB
 hgK
 qtO
@@ -186394,7 +186556,7 @@ hVY
 kDb
 tMA
 fur
-pTx
+bMR
 bAZ
 rgH
 rgH
@@ -186625,7 +186787,7 @@ cDB
 eKL
 jbX
 prJ
-lve
+ofc
 qYT
 tAz
 tYi
@@ -186663,7 +186825,7 @@ idm
 hnb
 idP
 cZJ
-mEk
+hHL
 hZK
 fjb
 nkA
@@ -186793,7 +186955,7 @@ seo
 cxa
 seo
 seo
-mqP
+dtb
 vAf
 qAN
 acI
@@ -186801,7 +186963,7 @@ uAf
 eIT
 aqp
 eeM
-wvp
+woX
 kJI
 nvN
 eXB
@@ -186893,7 +187055,7 @@ tAz
 qKe
 wHl
 fjs
-xkn
+fPO
 rae
 adg
 fyc
@@ -187046,7 +187208,7 @@ tYD
 tYD
 nRB
 gKx
-fgT
+oqi
 bQU
 img
 seo
@@ -187332,7 +187494,7 @@ nhU
 ehs
 ehs
 ehs
-vRO
+qYU
 qsJ
 fmX
 bKu
@@ -187838,7 +188000,7 @@ ruP
 iSW
 aZz
 oLc
-cif
+hYc
 ifN
 uTn
 ehs
@@ -187903,7 +188065,7 @@ fvD
 qzN
 qzN
 sBm
-rkW
+pAO
 iXV
 xHB
 oXc
@@ -187913,13 +188075,13 @@ mez
 dWQ
 dWQ
 qZv
-lcp
+nad
 otr
 dWQ
-lDn
-kkV
-piM
-obr
+qIu
+pXq
+eaa
+adi
 fjs
 fjs
 fjs
@@ -187936,7 +188098,7 @@ tFm
 cUs
 bmd
 jvr
-odm
+oao
 cvJ
 lCN
 uLk
@@ -188093,7 +188255,7 @@ acI
 mrf
 mrf
 gyL
-sLZ
+viB
 mrf
 mrf
 lvi
@@ -188198,7 +188360,7 @@ xrx
 vgG
 isj
 nXm
-lDI
+yjx
 awU
 rgH
 rgH
@@ -188345,7 +188507,7 @@ khF
 izL
 iNx
 juX
-tMo
+oFN
 nKK
 mrf
 gNV
@@ -188392,7 +188554,7 @@ xMK
 pbY
 jro
 sOa
-bvj
+euI
 ooE
 cbf
 oYV
@@ -188443,7 +188605,7 @@ bRg
 bRg
 bRg
 bRg
-lqv
+cRG
 jdk
 awU
 lKb
@@ -188610,7 +188772,7 @@ hVK
 beb
 gnb
 mrf
-wcK
+mEW
 rfH
 gIk
 xse
@@ -188686,17 +188848,17 @@ aDx
 mxC
 jeV
 kqR
-ulP
-ulP
-ulP
-ulP
-ulP
-fdt
+vGb
+vGb
+vGb
+vGb
+vGb
+wZs
 ftL
 hZh
 wUN
 oil
-aig
+czt
 bJE
 wUN
 hZh
@@ -188849,7 +189011,7 @@ tCv
 tCv
 tCv
 tCv
-pdL
+bta
 uqx
 rSI
 wLg
@@ -188915,7 +189077,7 @@ hqt
 iwB
 dKZ
 ndG
-pQj
+dja
 sRE
 tEb
 dyi
@@ -188939,15 +189101,15 @@ oXc
 oXc
 rxQ
 dWQ
-woC
-gUN
-kFi
-ulP
-ulP
-umb
-hUF
-pQL
-ulP
+aPk
+uMc
+gpz
+vGb
+vGb
+eEj
+gft
+oMR
+vGb
 opB
 mwx
 hZh
@@ -188971,7 +189133,7 @@ jmW
 jmW
 jmW
 hfG
-woz
+uHa
 jkQ
 mmp
 vfD
@@ -189199,12 +189361,12 @@ kYD
 rVa
 qkP
 nyc
-vcT
-tTQ
-hhr
-igO
-nkO
-tAf
+tUG
+aIx
+ekm
+oJu
+eKx
+pIB
 snl
 fxA
 hZh
@@ -189218,7 +189380,7 @@ qsB
 jdk
 awU
 lmH
-rwF
+tuX
 qjL
 awU
 aqO
@@ -189399,7 +189561,7 @@ wGV
 drA
 yme
 vML
-vJd
+mYd
 uxD
 ntU
 sTa
@@ -189433,7 +189595,7 @@ yjA
 knx
 jQZ
 cbZ
-brQ
+vxT
 vbt
 aNe
 lZy
@@ -189450,18 +189612,18 @@ nUo
 pmy
 gnh
 kzc
-ssJ
+poA
 vNo
 thw
 vku
 wYk
 nWw
-vcT
-fIX
-jBW
-wuB
-iRu
-fOZ
+tUG
+paG
+aTV
+qJT
+xax
+oNW
 bOu
 pBN
 iMb
@@ -189493,7 +189655,7 @@ pbS
 jGU
 byM
 xWN
-edr
+hdx
 ada
 bbY
 fre
@@ -189637,7 +189799,7 @@ eMl
 feV
 gWs
 dwz
-mQl
+izY
 rpJ
 xTZ
 cnL
@@ -189713,12 +189875,12 @@ tdc
 sqy
 rgS
 lbA
-ulP
-kuQ
-tDv
-tDv
-hem
-goO
+vGb
+dNB
+aqy
+sns
+txV
+iwR
 vyg
 uTC
 uRF
@@ -189970,13 +190132,13 @@ vNo
 uQm
 eLO
 pRd
-vBz
-vBz
-xBM
-xBM
-vBz
-vBz
-uHu
+vGb
+vGb
+nWG
+nWG
+vGb
+vGb
+oir
 eel
 hZh
 qrA
@@ -190129,7 +190291,7 @@ xcz
 xcz
 xcz
 hlp
-uXJ
+azM
 dmB
 ktb
 ovJ
@@ -190225,10 +190387,10 @@ aVO
 oDj
 lCn
 oth
-gNw
-gNw
+hdn
+hdn
 vBz
-iJu
+ckO
 jJG
 vVU
 xAa
@@ -190247,7 +190409,7 @@ iro
 alL
 orZ
 jLz
-iws
+geB
 qHG
 qJI
 gLS
@@ -190416,7 +190578,7 @@ ajN
 hRz
 hRz
 jOv
-szw
+bNg
 kVX
 gfe
 vpN
@@ -190482,7 +190644,7 @@ svZ
 mcX
 mcX
 xKc
-gNw
+hdn
 tPy
 axq
 xur
@@ -190506,7 +190668,7 @@ nvj
 tmO
 jcM
 qHG
-qOc
+dru
 ifg
 aHh
 gZw
@@ -190739,7 +190901,7 @@ iRd
 ikG
 xRd
 pIx
-tBV
+tcI
 rQq
 oQv
 oQv
@@ -190996,7 +191158,7 @@ ggR
 rwa
 rwa
 rPd
-gNw
+hdn
 iTy
 cLd
 jTW
@@ -191253,8 +191415,8 @@ keQ
 plD
 plD
 btJ
-gNw
-gNw
+hdn
+hdn
 vBz
 jiR
 eGn
@@ -191264,13 +191426,13 @@ vBz
 gsm
 xdz
 hZh
-rWk
+run
 aDC
 cap
 xKS
 sHV
 hZh
-cro
+jLC
 goS
 alL
 jmE
@@ -191452,7 +191614,7 @@ sxb
 lSM
 nvt
 qXz
-yan
+mqQ
 bDu
 uKn
 wzo
@@ -191486,7 +191648,7 @@ hpn
 lWQ
 pTr
 jHL
-gKP
+oDa
 hLh
 ufP
 aqt
@@ -191502,7 +191664,7 @@ xPg
 dRA
 oSf
 ojj
-qjX
+kAA
 fig
 cgh
 edt
@@ -191511,7 +191673,7 @@ lGu
 kZI
 aIE
 bJL
-eDm
+epP
 pJa
 pJa
 aIp
@@ -191519,7 +191681,7 @@ pJa
 gYd
 pzS
 opB
-sJC
+eHE
 hZh
 pPI
 pPI
@@ -191528,7 +191690,7 @@ pPI
 pPI
 hZh
 qsB
-aPB
+dKM
 qHG
 qHG
 qHG
@@ -191541,7 +191703,7 @@ jQC
 jmW
 jmW
 hfG
-owe
+cni
 soq
 mHY
 sLI
@@ -191549,7 +191711,7 @@ hlr
 rqY
 xUQ
 dcs
-jAg
+qXP
 ada
 spB
 hGk
@@ -191662,7 +191824,7 @@ tYD
 tYD
 tYD
 xcz
-rHM
+iwT
 oEy
 glP
 alh
@@ -191709,7 +191871,7 @@ nEu
 lSM
 qCd
 rpk
-phH
+eYb
 ghS
 olq
 wzo
@@ -191768,7 +191930,7 @@ oBE
 gUC
 onX
 nzF
-sXL
+ktA
 wxi
 wxi
 gxS
@@ -191795,7 +191957,7 @@ wND
 jHX
 qWg
 blL
-cWw
+qQd
 pZC
 kob
 ubk
@@ -191923,7 +192085,7 @@ xMu
 hAu
 iOh
 vdS
-jMY
+cpS
 vdS
 vdS
 kst
@@ -191958,7 +192120,7 @@ jCS
 ffA
 pXd
 fgy
-lAd
+jrg
 agg
 pDv
 pDv
@@ -191966,8 +192128,8 @@ jzY
 lSM
 qCd
 rpk
-vTw
-isr
+bad
+aGk
 qjA
 whP
 wzo
@@ -192003,7 +192165,7 @@ jHL
 kBL
 cNA
 tbn
-jZn
+sbz
 vvO
 vkr
 vtR
@@ -192020,12 +192182,12 @@ hAG
 hxV
 cYg
 edt
-rdF
+ejQ
 gQF
 spb
 rnG
 rnG
-arM
+dzc
 fRP
 fRP
 fRP
@@ -192223,7 +192385,7 @@ ccg
 lSM
 nvt
 gZj
-aSg
+aXR
 bpk
 wUk
 gOs
@@ -192282,7 +192444,7 @@ seJ
 spq
 lPh
 qqT
-eDm
+epP
 jOG
 fdL
 qKK
@@ -192546,7 +192708,7 @@ cnU
 kzp
 cnU
 cnU
-hmj
+pck
 odo
 jsN
 noe
@@ -192561,7 +192723,7 @@ dGP
 qam
 kKV
 yaQ
-xri
+ojf
 dGP
 ncV
 ydU
@@ -192739,7 +192901,7 @@ dQQ
 uFf
 wzo
 kXl
-vMr
+laT
 kXl
 wzo
 ssw
@@ -192818,7 +192980,7 @@ xfb
 maU
 rez
 hnp
-cSD
+quF
 dGP
 tfR
 lsc
@@ -192955,7 +193117,7 @@ ufm
 eWL
 nkz
 nTy
-bao
+xxA
 rVX
 pLs
 pLs
@@ -192986,7 +193148,7 @@ fgy
 chx
 brR
 fgy
-bCM
+jlM
 lrU
 ycw
 qxD
@@ -193225,7 +193387,7 @@ tIT
 iqo
 fHS
 fHS
-wIa
+qJF
 lUF
 fHS
 lhG
@@ -193312,7 +193474,7 @@ cda
 lHn
 sDD
 wwy
-xpR
+aOQ
 oPw
 nTW
 doz
@@ -193323,17 +193485,17 @@ jsN
 xMS
 kdj
 rJv
-iKE
+utT
 sZB
 kpf
 vKv
 goP
-gJY
+pxt
 hlo
 hhT
 tuv
 rbB
-kdI
+vCN
 dGP
 dGP
 peX
@@ -193537,7 +193699,7 @@ opI
 hDM
 vqZ
 oBG
-lFO
+sMO
 veN
 tEP
 tEP
@@ -193563,7 +193725,7 @@ faO
 pxq
 rUO
 rUO
-psv
+ydA
 wiR
 uUX
 uUX
@@ -193605,7 +193767,7 @@ jGU
 vAw
 kII
 dcs
-krf
+jvy
 ada
 qMq
 cyO
@@ -193721,7 +193883,7 @@ gaN
 eOL
 eMs
 cqN
-aSA
+mrb
 ufm
 ovm
 kBS
@@ -193739,7 +193901,7 @@ kJB
 mJo
 sHK
 kXa
-ejM
+upa
 vjL
 nFi
 kJB
@@ -193770,7 +193932,7 @@ iJW
 iGO
 toP
 kNp
-wAz
+fFv
 kfK
 gaM
 lmV
@@ -193835,7 +193997,7 @@ urB
 kmI
 ozm
 ouZ
-dQi
+kMU
 kpk
 ozm
 xjf
@@ -194042,7 +194204,7 @@ jOr
 ezF
 jlq
 cul
-ylh
+fCg
 wnX
 fzs
 lRk
@@ -194362,7 +194524,7 @@ ovV
 ovV
 dGP
 dGP
-awf
+bpA
 nwu
 ocK
 pwa
@@ -194527,7 +194689,7 @@ fgy
 fgy
 bHX
 fgy
-jMH
+oUp
 jJy
 nUy
 hri
@@ -194553,7 +194715,7 @@ xoC
 acd
 xkX
 mZJ
-tBz
+aAh
 gzo
 vxp
 vxp
@@ -194567,7 +194729,7 @@ qoM
 eui
 fod
 vRG
-iiL
+twg
 qoM
 hEi
 qoM
@@ -194602,7 +194764,7 @@ hpN
 hpN
 hpN
 lVu
-xDT
+viS
 ouW
 pty
 gOQ
@@ -194625,7 +194787,7 @@ xPD
 hnA
 hfG
 hfG
-qRa
+csr
 jyw
 jGU
 jGU
@@ -194796,7 +194958,7 @@ xyb
 kok
 iJW
 iGO
-aoV
+pyZ
 kNp
 xru
 kfK
@@ -194857,7 +195019,7 @@ vTH
 ezU
 hXT
 ezU
-bUb
+vbA
 urB
 urB
 nHE
@@ -194876,7 +195038,7 @@ jxn
 fmq
 dzv
 cMU
-tNz
+fCO
 cZI
 peF
 geR
@@ -195007,7 +195169,7 @@ lLX
 nMz
 hTt
 bnt
-lYU
+jRY
 nMz
 dsE
 pZs
@@ -195589,7 +195751,7 @@ eiG
 vhF
 xeh
 xWl
-iyA
+flU
 mIn
 ktr
 bhZ
@@ -195645,7 +195807,7 @@ jJC
 oqH
 jxn
 oOX
-ojk
+vNl
 cnU
 hfG
 hfG
@@ -195780,7 +195942,7 @@ dkq
 wix
 xBb
 nMz
-aDX
+nwy
 hTq
 slm
 iqO
@@ -195896,7 +196058,7 @@ xLZ
 xLZ
 mxX
 cnU
-xDd
+fMT
 lbQ
 cnU
 oqH
@@ -196070,7 +196232,7 @@ cjL
 eUA
 eUA
 fgy
-uOi
+bDC
 ivD
 dCq
 kFR
@@ -196302,7 +196464,7 @@ prg
 prg
 mka
 ewd
-eKF
+pYq
 lFQ
 qsV
 wtn
@@ -196554,7 +196716,7 @@ tVE
 tVE
 wba
 wba
-dXu
+nyt
 wba
 wba
 tVE
@@ -196846,7 +197008,7 @@ nyv
 kcP
 oAt
 oAt
-nEo
+mjs
 gnf
 qiU
 iPQ
@@ -196884,9 +197046,9 @@ lcZ
 fwl
 jyF
 cFr
-rMl
-enq
-rMl
+uxG
+pre
+uxG
 dVg
 dVg
 dVg
@@ -197405,7 +197567,7 @@ gLx
 lnZ
 pki
 sqv
-wSD
+wHY
 jwd
 dpI
 kRS
@@ -197457,7 +197619,7 @@ akp
 hfT
 vmJ
 dSW
-fKp
+qmK
 mGz
 cRN
 erx
@@ -197586,7 +197748,7 @@ lZr
 upr
 tUS
 bGZ
-qlK
+qMT
 rEF
 icU
 pSj
@@ -197649,7 +197811,7 @@ eng
 aQK
 ren
 oCm
-jvm
+dzP
 gqk
 sNS
 jxk
@@ -197658,11 +197820,11 @@ hkd
 lqQ
 ahj
 nHf
-pIl
+pzu
 yfI
 spc
 lVp
-wSD
+wHY
 gkB
 lZi
 yjy
@@ -197894,7 +198056,7 @@ wFA
 eUM
 bOe
 vOa
-rGu
+psk
 nke
 cef
 dJK
@@ -197903,10 +198065,10 @@ ptS
 sdA
 fid
 eng
-tPH
-sIk
-sIk
-sIk
+xTz
+jzh
+jzh
+jzh
 eng
 nBq
 rTc
@@ -197919,7 +198081,7 @@ gLx
 hFE
 oZN
 lVp
-wSD
+wHY
 ejV
 wkN
 edY
@@ -198159,7 +198321,7 @@ jcf
 ptS
 sdA
 fWP
-xcp
+bsa
 pJi
 hZO
 flS
@@ -198208,17 +198370,17 @@ npX
 bMD
 hIt
 cnU
-xGg
+joH
 pwz
 akm
 rjU
 dQP
 aXv
 siT
-gju
+kwy
 xkP
 xkP
-qzG
+ekJ
 siT
 nEz
 pYB
@@ -198433,7 +198595,7 @@ oew
 tqI
 oZN
 oJD
-wSD
+wHY
 nAz
 tkp
 tkp
@@ -198460,7 +198622,7 @@ aFs
 nRd
 qCU
 pbo
-dBq
+hRC
 qCU
 bRq
 wTK
@@ -198488,7 +198650,7 @@ hjX
 xFS
 xhh
 pVg
-qUD
+frs
 akp
 job
 kJd
@@ -198671,8 +198833,8 @@ sjr
 dOD
 rbv
 huB
-eSd
-bJx
+hQC
+cQl
 omG
 omG
 omG
@@ -198899,7 +199061,7 @@ qSL
 eEF
 vMM
 eEF
-dHF
+fqU
 eEF
 nEu
 caW
@@ -198928,7 +199090,7 @@ uiL
 rqF
 ixz
 pzr
-xYi
+jbx
 vrL
 oWu
 sdA
@@ -198947,7 +199109,7 @@ cUp
 uRn
 oZN
 oJD
-tYC
+eEk
 ovf
 kux
 kux
@@ -199185,7 +199347,7 @@ uiL
 dIk
 qNg
 sdA
-oLU
+sdA
 gMN
 kQI
 hDR
@@ -199442,7 +199604,7 @@ cef
 dJK
 lyK
 sdA
-gvF
+lGg
 pwS
 dJK
 wxM
@@ -199461,7 +199623,7 @@ gLx
 eSO
 dUK
 iPv
-tYC
+eEk
 amF
 wtQ
 wEf
@@ -199510,7 +199672,7 @@ pYB
 hen
 akp
 akp
-ihE
+hNn
 dKq
 hlc
 cBo
@@ -199684,7 +199846,7 @@ oOG
 fxV
 fgR
 wkX
-jaU
+suY
 dKr
 jWz
 mcM
@@ -199699,7 +199861,7 @@ tfQ
 dJK
 sPC
 ixz
-bHt
+nfS
 loc
 nTe
 ykl
@@ -199714,11 +199876,11 @@ uQg
 uJF
 gTc
 iFU
-pIl
+pzu
 yfI
 oZN
 iPv
-tYC
+eEk
 qvd
 hgo
 xkb
@@ -199952,19 +200114,19 @@ dKr
 dEt
 ckR
 nke
-ckR
+uDV
 jFQ
-gtd
-uWr
-uWr
-gtd
+tPa
+dXK
+hwR
+tPa
 jFQ
-hge
-sdA
-sdA
-ewI
-gNR
-bUP
+nOL
+hep
+lke
+ohZ
+cJF
+thE
 tRu
 uJF
 qBf
@@ -199975,7 +200137,7 @@ gLx
 jHx
 oZN
 iPv
-tYC
+eEk
 hhK
 rJd
 vwI
@@ -200005,11 +200167,11 @@ rYA
 qCU
 ceC
 hpN
-uTz
+piz
 hpN
 xFx
-bQV
-eOp
+raT
+hAH
 oQf
 aXv
 aXv
@@ -200207,19 +200369,19 @@ dKr
 iuz
 aDZ
 pHh
-qUk
+rdX
 nke
-uDV
+ckR
 jFQ
-lEB
-aNT
-jFv
-snO
-xrT
-fVu
-bxp
-mqw
-dTb
+xep
+sDn
+lkJ
+uzK
+waG
+gbc
+uoz
+mFL
+pRE
 ptj
 nTm
 qtE
@@ -200469,9 +200631,9 @@ nke
 ckR
 jFQ
 dKA
-qmO
-swo
-xYc
+dpB
+kqg
+mKS
 jFQ
 dJK
 dJK
@@ -200482,9 +200644,9 @@ lcZ
 mSJ
 jyF
 cFr
-rMl
-enq
-rMl
+uxG
+pre
+uxG
 gLx
 mTv
 oZN
@@ -200535,7 +200697,7 @@ wZQ
 jzE
 tna
 aSj
-ior
+ugL
 oQf
 tYD
 tYD
@@ -200725,17 +200887,17 @@ ckR
 nke
 ckR
 jFQ
-duF
-qLN
-qRi
-baA
+sSB
+qQk
+wGL
+mAL
 jFQ
 tuq
 iNF
 cZU
 cCS
 lCk
-wCG
+nNP
 kEh
 qbQ
 iov
@@ -200746,7 +200908,7 @@ alU
 bBw
 qbQ
 fCK
-uri
+mLy
 sqG
 twT
 alU
@@ -200770,7 +200932,7 @@ doz
 qCU
 llT
 hCq
-fTm
+jSG
 hCq
 kQR
 qCU
@@ -200783,7 +200945,7 @@ qQo
 qwo
 oPo
 snr
-vtf
+pNv
 lVb
 iWC
 oQf
@@ -201014,7 +201176,7 @@ upv
 upv
 pOi
 vIE
-bdh
+xzu
 jYl
 jmB
 iyG
@@ -201249,16 +201411,16 @@ xJM
 pKC
 iJZ
 adA
-ggg
+cEH
 cMB
 tnR
-ggg
+cEH
 nnU
 nnU
 rOZ
 htm
 xoo
-ues
+iWM
 ndZ
 ndZ
 ndZ
@@ -201509,7 +201671,7 @@ adA
 hIG
 qWw
 pMa
-sAU
+liH
 nnU
 pPG
 elu
@@ -201518,7 +201680,7 @@ chc
 wdz
 jvO
 vVr
-rBW
+cLb
 lpB
 xoo
 qIi
@@ -201789,7 +201951,7 @@ uIF
 ueU
 xNK
 fys
-nhQ
+otU
 dRA
 nGm
 aOV
@@ -202285,7 +202447,7 @@ nnU
 dIf
 lpq
 htm
-kgN
+jtA
 mcn
 sYg
 sYg
@@ -202296,7 +202458,7 @@ agU
 wwS
 vTG
 xoo
-oKd
+arc
 rqK
 gTy
 oTG
@@ -202549,7 +202711,7 @@ bKm
 vVi
 emv
 xoo
-mKV
+wXM
 qsO
 gHg
 xoo
@@ -202789,11 +202951,11 @@ fwy
 dCQ
 fwy
 ucd
-wat
+voI
 yeD
-piv
+bWs
 wqA
-piv
+bWs
 yeD
 nnU
 lpq
@@ -203063,7 +203225,7 @@ awe
 xun
 htm
 eEz
-elm
+wpL
 sTP
 xpY
 puQ
@@ -203293,7 +203455,7 @@ xul
 qjt
 uap
 iur
-eUS
+dCO
 lCk
 sjf
 kko
@@ -203565,7 +203727,7 @@ yeD
 dic
 qqM
 oOE
-ucL
+jey
 nnU
 bIa
 htm
@@ -203586,7 +203748,7 @@ uYQ
 fLX
 hIA
 aDt
-tHy
+wUd
 npt
 pTw
 hpN
@@ -204059,7 +204221,7 @@ nBv
 nBv
 jxy
 kkl
-ubF
+hrG
 kkl
 kkl
 kkl
@@ -204095,7 +204257,7 @@ oiR
 fcj
 xpY
 rCF
-bis
+utY
 rFm
 aWA
 vkj
@@ -204277,9 +204439,9 @@ nwo
 xeX
 xCx
 mzJ
-dZV
+omI
 dKN
-tnK
+oSK
 lry
 lry
 gnf
@@ -205094,7 +205256,7 @@ ocr
 kkl
 naE
 soG
-lWK
+nnH
 erF
 xhj
 afW
@@ -205351,7 +205513,7 @@ sKd
 kkl
 sKd
 rYC
-keK
+eyZ
 asx
 txo
 gLG
@@ -205653,7 +205815,7 @@ rzl
 ltz
 nnU
 htm
-bWV
+cuq
 cuq
 cuq
 xcZ
@@ -205665,7 +205827,7 @@ sWX
 aEf
 cuq
 cuq
-bEP
+cuq
 hpN
 hpN
 vQV
@@ -206121,7 +206283,7 @@ wfV
 ugB
 kkl
 niF
-kDR
+fMP
 iEn
 aIl
 lNS
@@ -206149,8 +206311,8 @@ fZm
 nnU
 nnU
 nnU
-nIn
-xnw
+oKi
+seA
 nnU
 nnU
 ceC
@@ -206378,10 +206540,10 @@ wfV
 qEI
 kkl
 niF
-kDR
+fMP
 hnT
 wBw
-stI
+xbx
 msO
 ufk
 lYy
@@ -206390,7 +206552,7 @@ ufk
 nvl
 vlt
 htm
-urM
+cDQ
 htm
 htm
 brm
@@ -206424,7 +206586,7 @@ gMn
 eWp
 nPZ
 htm
-cuq
+wRo
 cuq
 cuq
 xcZ
@@ -206436,7 +206598,7 @@ tHY
 aEf
 cuq
 cuq
-cuq
+icf
 hpN
 axX
 blM
@@ -206892,7 +207054,7 @@ wfV
 qpn
 kkl
 niF
-ptF
+tVD
 lbS
 sHs
 oWo
@@ -207149,7 +207311,7 @@ wfV
 xJU
 kkl
 niF
-ptF
+tVD
 egv
 sHs
 rJT
@@ -207164,7 +207326,7 @@ taN
 vTk
 osV
 ugh
-oUx
+eqp
 uiY
 rQM
 htm
@@ -207420,7 +207582,7 @@ ugh
 maY
 ngX
 pdo
-llw
+hug
 nqn
 eIh
 oLe
@@ -207452,7 +207614,7 @@ nnU
 eWp
 nqw
 htm
-vTe
+cuq
 cuq
 cuq
 xcZ
@@ -207464,7 +207626,7 @@ nQs
 aEf
 cuq
 cuq
-shx
+cuq
 hpN
 hpN
 dRA
@@ -207679,7 +207841,7 @@ rGV
 cOZ
 ugh
 udb
-vWZ
+lrM
 wSc
 xMU
 urR
@@ -207920,7 +208082,7 @@ wfV
 bMt
 kkl
 niF
-tmM
+vJT
 kvp
 tfT
 nCR
@@ -207935,9 +208097,9 @@ ugh
 ugh
 ugh
 ugh
-duN
+lUJ
 aVh
-mPV
+kZp
 brs
 cpi
 gNu
@@ -207950,14 +208112,14 @@ upi
 lVn
 hZc
 aqm
-dNa
+niD
 axZ
 bWX
 jvh
 lXy
 cZo
 sRe
-uSD
+cyu
 lpq
 nPZ
 nPZ
@@ -208174,15 +208336,15 @@ ksn
 mjy
 epI
 epI
-ebw
+jgo
 kkl
 niF
-tmM
+vJT
 ymg
 ckQ
 kDm
 ePl
-dUl
+xpQ
 ePl
 ePl
 fTg
@@ -208191,7 +208353,7 @@ lmZ
 esC
 gzg
 khb
-svu
+ejH
 vgI
 isn
 knL
@@ -208213,7 +208375,7 @@ mCa
 ffg
 nKH
 sGs
-qnr
+atI
 nnU
 sDE
 amm
@@ -208436,9 +208598,9 @@ kkl
 hmb
 ugh
 ugh
-stJ
-tVf
-stJ
+onf
+keT
+onf
 ugh
 lWh
 kBY
@@ -208448,7 +208610,7 @@ vwY
 gVF
 rEu
 lPH
-gxU
+gMJ
 tWs
 tWs
 tWs
@@ -208705,14 +208867,14 @@ lmZ
 xdc
 uUN
 kQc
-svu
+ejH
 mZH
 kXk
 sdy
 myR
 rUy
 ndV
-fzl
+pHf
 tsW
 lCP
 kaw
@@ -208962,7 +209124,7 @@ ugh
 xdc
 uUN
 kQc
-dUd
+iJe
 fhA
 fhA
 fhA
@@ -209243,7 +209405,7 @@ eyE
 vVN
 reB
 eyE
-vts
+mfM
 ape
 mvt
 ppF
@@ -209468,7 +209630,7 @@ fGz
 baH
 fzN
 xNr
-iHR
+kVU
 jGZ
 jGZ
 dCJ
@@ -209503,11 +209665,11 @@ fDn
 lYW
 lYW
 lYW
-bvT
+pCo
 pKt
 hqy
 mRd
-sga
+seG
 kel
 kel
 jqR
@@ -209726,7 +209888,7 @@ uiF
 gLA
 dmb
 ppF
-vkI
+urS
 hJI
 dVb
 ppF
@@ -209765,7 +209927,7 @@ iwl
 apA
 tcJ
 aPQ
-oyw
+nQc
 kHF
 wAt
 ppI
@@ -209977,7 +210139,7 @@ sKd
 frw
 bMM
 oKR
-kRK
+gax
 diI
 goj
 kbG
@@ -209990,7 +210152,7 @@ hub
 dyW
 vVN
 qIF
-pzQ
+tlV
 pvD
 pvD
 kuE
@@ -209998,14 +210160,14 @@ kuE
 kuE
 pvD
 pvD
-tni
+qww
 vVN
 uUN
-qIF
-tXj
-tXj
-tXj
-tXj
+iFw
+bej
+ibb
+ibb
+ibb
 uzL
 uzL
 hbu
@@ -210259,10 +210421,10 @@ ukQ
 vVN
 uUN
 qIF
-tXj
-apl
-awD
-guK
+tGa
+uyY
+okz
+vRH
 uzL
 tnn
 kKF
@@ -210492,9 +210654,9 @@ frw
 igt
 ord
 ord
-lBO
-mKJ
-mKJ
+gqo
+mrM
+mrM
 ord
 opl
 sJI
@@ -210516,9 +210678,9 @@ sSW
 vVN
 uUN
 qIF
-tXj
-xZW
-bBq
+tGa
+tQx
+xiY
 rMt
 uzL
 pxu
@@ -210773,10 +210935,10 @@ lYW
 vVN
 lYW
 lYW
-bUd
+asi
 uHZ
 bkE
-iUo
+gSh
 uzL
 pxu
 byv
@@ -211004,7 +211166,7 @@ sKd
 sKd
 frw
 bMM
-hlV
+fbR
 fmJ
 snc
 qKv
@@ -211016,7 +211178,7 @@ nEE
 xjo
 jqC
 jqC
-lUq
+ujt
 jqC
 jqC
 sjx
@@ -211031,9 +211193,9 @@ vVN
 uUN
 sJo
 bej
-uGM
-pBh
-bSf
+vzp
+pWv
+uHC
 uzL
 kuV
 wqQ
@@ -211258,10 +211420,10 @@ epI
 epI
 epI
 epI
-vfW
+vHi
 frw
 bMM
-hlV
+fbR
 tTI
 mTH
 naH
@@ -211279,7 +211441,7 @@ jqC
 pDR
 wDG
 tXh
-qan
+lqk
 pvP
 bQl
 pvD
@@ -211288,11 +211450,11 @@ vVN
 uUN
 uKw
 bej
-qiC
-ajR
-dFL
+sSK
+ixv
+rSM
 uzL
-ran
+ltl
 jDM
 hsn
 rZm
@@ -211518,7 +211680,7 @@ ljw
 sKd
 frw
 bMM
-hlV
+fbR
 slk
 whT
 nqx
@@ -211541,13 +211703,13 @@ jqC
 jqC
 jqC
 bTH
-exv
+mdU
 bTH
 bTH
 bej
 dbD
-vIB
-ehw
+lKy
+gmG
 uzL
 xPQ
 ggE
@@ -211780,11 +211942,11 @@ dzT
 kMh
 drZ
 tbp
-fgd
+wtV
 nKg
 fCh
 tda
-lOJ
+fbo
 jqC
 jaj
 mxz
@@ -211814,7 +211976,7 @@ sDi
 qhM
 qed
 qed
-qqR
+nff
 nNJ
 jqC
 jqC
@@ -212039,7 +212201,7 @@ ord
 ord
 jqC
 jqC
-iTm
+vWq
 jqC
 jqC
 jqC
@@ -212285,7 +212447,7 @@ dna
 btQ
 dbc
 uWT
-aIQ
+lfl
 eTa
 lVS
 nlH
@@ -212569,7 +212731,7 @@ jqC
 jqC
 jqC
 jqC
-uzW
+oti
 jqC
 jqC
 jqC
@@ -212822,7 +212984,7 @@ rMZ
 eaK
 jqC
 wdk
-njj
+tjw
 uIe
 rNn
 wbH
@@ -213578,7 +213740,7 @@ qcQ
 vLH
 oqb
 eTa
-hhp
+eYi
 bTH
 rMZ
 qKu
@@ -214875,9 +215037,9 @@ kiD
 ecc
 nxp
 cCP
-vCD
-vCD
-vCD
+owD
+owD
+owD
 vLK
 vLK
 rfn
@@ -215138,7 +215300,7 @@ xRt
 vLK
 sXs
 aXI
-lNF
+iAu
 bhw
 lEd
 vLK
@@ -215891,7 +216053,7 @@ ecx
 dQB
 pJp
 eTa
-wcY
+rKp
 dna
 tYD
 tYD
@@ -215907,9 +216069,9 @@ jLS
 kTP
 fwd
 vLK
-uGQ
-uGQ
-uGQ
+sII
+sII
+sII
 vLK
 vjX
 vLK
@@ -216138,7 +216300,7 @@ pZd
 njQ
 xys
 xys
-jEh
+gSn
 eTa
 eTa
 eTa
@@ -217675,7 +217837,7 @@ tYD
 tYD
 tYD
 xys
-mGr
+uvm
 lNW
 sCR
 wiO
@@ -221559,19 +221721,19 @@ tYD
 kJd
 grt
 cZN
-wFY
+pvw
 fyN
 fyN
 xHV
 fyN
 fyN
-auX
+sso
 fyN
 fyN
 xHV
 fyN
 fyN
-rUk
+jUm
 cZN
 grt
 kJd
@@ -223107,7 +223269,7 @@ grt
 grt
 fyN
 fyN
-uem
+hpZ
 fyN
 fyN
 grt

--- a/tools/UpdatePaths/Scripts/ss220/1017_cameras_to_dir.txt
+++ b/tools/UpdatePaths/Scripts/ss220/1017_cameras_to_dir.txt
@@ -1,0 +1,9 @@
+/obj/machinery/camera{dir = 1} : /obj/machinery/camera/directional/north{@OLD;dir=@SKIP}
+/obj/machinery/camera{dir = 2} : /obj/machinery/camera/directional/south{@OLD;dir=@SKIP}
+/obj/machinery/camera{dir = 4} : /obj/machinery/camera/directional/east{@OLD;dir=@SKIP}
+/obj/machinery/camera{dir = 5} : /obj/machinery/camera/directional/south{@OLD;dir=@SKIP}
+/obj/machinery/camera{dir = 6} : /obj/machinery/camera/directional/east{@OLD;dir=@SKIP}
+/obj/machinery/camera{dir = 8} : /obj/machinery/camera/directional/west{@OLD;dir=@SKIP}
+/obj/machinery/camera{dir = 9} : /obj/machinery/camera/directional/north{@OLD;dir=@SKIP}
+/obj/machinery/camera{dir = 10} : /obj/machinery/camera/directional/west{@OLD;dir=@SKIP}
+/obj/machinery/camera : /obj/machinery/camera/directional/south{@OLD;dir=@SKIP}

--- a/tools/maplint/lints/telescreen_varedits.yml
+++ b/tools/maplint/lints/telescreen_varedits.yml
@@ -1,5 +1,5 @@
 help: "Use the directional variants when possible."
-/obj/machinery/computer/security/telescreen:
+=/obj/machinery/computer/security/telescreen: # BANDASTATION EDIT - check =
   banned_variables:
     pixel_x:
     pixel_y:


### PR DESCRIPTION
## Что этот PR делает
Читать чейнджлог.

## Тестирование
Проверял в игре.

## Changelog

:cl:
map: Кибериада: Стандартизировал все охранные пункты службы безопасности. Они все обзавелись камерами в прикрепленном отделе и соответствующей мониторинговой консолью, а также кнопками локдаунов отделов.
map: Кибериада: Стандартизировал тэги камер в отделах карго, рнд, инженерка, медбей.
map: Кибериада: Общая чистка типов камер, которые находились не в соответствующем типе. Ошибки еще могут присутствовать.
map: Кибериада: РнД обзавелся локдауном. Доступ у РД и СБ на охранном пункте.
map: Кибериада: Починил кнопки локдаунов транзит трубы и инженерки.
map: Кибериада: Некоторые окна в Медбее были заменены на обычные (не укрепленные).
/:cl:

## Summary by Sourcery

Standardize security checkpoints across Cyberiad station by adding cameras, monitoring consoles, and lockdown buttons. Clean up camera tags and types, and fix lockdown buttons for transit and engineering. Replace reinforced windows in medbay with standard windows. Add lockdown to R&D, accessible by R&D and security.