### PR TITLE
NTR & BlueShiled access fix

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -3477,7 +3477,7 @@
 "aSg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = "JimNorton"
+	id = "JimNortonKitchen"
 	},
 /obj/item/storage/fancy/coffee_condi_display{
 	pixel_y = 10;
@@ -5521,10 +5521,11 @@
 	id_tag = "ntr_door"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/command/nanotrasen_representative,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/navigate_destination,
+/obj/effect/mapping_helpers/airlock/access/any/command/magistrate,
+/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/nanotrasen_representative)
 "brR" = (
@@ -5746,8 +5747,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/hop,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/command/hop,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/effect/mapping_helpers/airlock/access/any/command/hop,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "bvz" = (
@@ -15320,11 +15323,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/supply/qm,
 /obj/machinery/door/airlock/command/qm,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
+/obj/effect/mapping_helpers/airlock/access/any/supply/qm,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "dKW" = (
@@ -16225,7 +16230,9 @@
 	id_tag = "hos_door"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/hos,
+/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/effect/mapping_helpers/airlock/access/any/security/hos,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "dXD" = (
@@ -25722,11 +25729,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/science/rd,
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/command/rd,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/effect/mapping_helpers/airlock/access/any/science/rd,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "gxY" = (
@@ -26558,8 +26567,10 @@
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/ce,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "gKa" = (
@@ -33067,6 +33078,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
+/obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "isz" = (
@@ -39409,10 +39421,11 @@
 	id_tag = "blueshield_door"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/command/blueshield,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/navigate_destination,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/blueshield)
 "jZr" = (
@@ -51089,8 +51102,10 @@
 /obj/machinery/door/airlock/corporate,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/command/magistrate,
 /obj/effect/landmark/navigate_destination,
+/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/effect/mapping_helpers/airlock/access/any/command/magistrate,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/magistrate)
 "mQo" = (
@@ -60382,7 +60397,7 @@
 "phH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = "JimNorton"
+	id = "JimNortonKitchen"
 	},
 /obj/item/reagent_containers/cup/glass/coffee{
 	pixel_x = -3;
@@ -63121,7 +63136,6 @@
 "pQj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/command/hop,
 /obj/machinery/door/airlock/command/hop{
 	id_tag = "HoP_door"
 	},
@@ -63129,6 +63143,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/navigate_destination,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/effect/mapping_helpers/airlock/access/any/command/hop,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hop)
 "pQs" = (
@@ -64758,7 +64775,9 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/command/hos,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/security/hos,
+/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/effect/mapping_helpers/airlock/access/any/security/hos,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "qlM" = (
@@ -74789,7 +74808,8 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/command/magistrate,
+/obj/effect/mapping_helpers/airlock/access/any/command/magistrate,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/magistrate)
 "sMd" = (
@@ -80068,9 +80088,11 @@
 	id_tag = "CMO_door"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
 /obj/structure/cable,
 /obj/effect/landmark/navigate_destination,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
+/obj/effect/mapping_helpers/airlock/access/any/medical/cmo,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "ueH" = (
@@ -86453,6 +86475,10 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	dir = 4;
+	id = "JimNortonBottom"
+	},
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "vMy" = (
@@ -86853,7 +86879,7 @@
 "vTw" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = "JimNorton"
+	id = "JimNortonKitchen"
 	},
 /obj/structure/desk_bell{
 	pixel_x = -1;
@@ -95336,7 +95362,7 @@
 "yan" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = "JimNorton"
+	id = "JimNortonKitchen"
 	},
 /obj/item/modular_computer/laptop/preset/civilian,
 /obj/structure/table/reinforced,

--- a/modular_bandastation/objects/code/items/devices/radio.dm
+++ b/modular_bandastation/objects/code/items/devices/radio.dm
@@ -27,7 +27,7 @@
 /obj/item/encryptionkey/heads/nanotrasen_representative
 	name = "nanotrasen representative's encryption key"
 	icon_state = "cypherkey_centcom"
-	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_JUSTICE = 1)
+	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_JUSTICE = 1, RADIO_CHANNEL_SECURITY = 1, RADIO_CHANNEL_ENGINEERING = 0, RADIO_CHANNEL_SCIENCE = 0, RADIO_CHANNEL_MEDICAL = 0, RADIO_CHANNEL_SUPPLY = 0, RADIO_CHANNEL_SERVICE = 0)
 	greyscale_config = /datum/greyscale_config/encryptionkey_centcom
 	greyscale_colors = "#1d2657#dca01b"
 


### PR DESCRIPTION

## Что этот PR делает

Попытка номер два.

Представителю и Щиту добавлены доступы в прямые точки их интереса - кабинеты глав. Пока что только на Кибериаде.
Наушник Представителя теперь ловит радиочастоты всех отделов.
Небольшой фикс кнопочки в кофейне на Кибериаде - был не привязан id.

## Почему это хорошо для игры

НТР есть заноза в задница

## Изображения изменений

Локалка, работает

## Тестирование
## Changelog

:cl:
fix: НТР и БЩ теперь имеют доступы в кабинеты глав на Кибериаде. НТР имеет доступ ко всем радиочастотам станции. Фикс кнопки в кофейне Кибериады.
/:cl:
