### PR TITLE
TTS only for announcement body

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -126,7 +126,7 @@
  * should_play_sound - Whether the notice sound should be played or not. This can also be a callback, if you only want mobs to hear the sound based off of specific criteria.
  * color_override - optional, use the passed color instead of the default notice color.
  */
-/proc/minor_announce(message, title = "Внимание:", alert = FALSE, html_encode = TRUE, list/players, sound_override, should_play_sound = TRUE, color_override, tts_override) // BANDASTATION ADDITION - "tts_override"
+/proc/minor_announce(message, title = "Attention:", alert = FALSE, html_encode = TRUE, list/players, sound_override, should_play_sound = TRUE, color_override, tts_override) // BANDASTATION ADDITION - "tts_override"
 	if(!message)
 		return
 

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -83,7 +83,7 @@
 	else
 		finalized_announcement = CHAT_ALERT_DEFAULT_SPAN(jointext(announcement_strings, ""))
 
-	dispatch_announcement_to_players(finalized_announcement, players, sound, tts_override = tts_override) // Bandastation Addition: "tts_override = tts_override"
+	dispatch_announcement_to_players(finalized_announcement, players, sound, tts_override = tts_override, tts_message = text) // Bandastation Addition: "tts_override = tts_override" & "tts_message"
 
 	if(isnull(sender_override) && players == GLOB.player_list)
 		if(length(title) > 0)
@@ -186,7 +186,7 @@
 
 /// Proc that just dispatches the announcement to our applicable audience. Only the announcement is a mandatory arg.
 /// `should_play_sound` can also be a callback, if you want to only play the sound to specific players.
-/proc/dispatch_announcement_to_players(announcement, list/players = GLOB.player_list, sound_override = null, should_play_sound = TRUE, datum/component/tts_component/tts_override = null) // Bandastation Addition: "datum/component/tts_component/tts_override = null"
+/proc/dispatch_announcement_to_players(announcement, list/players = GLOB.player_list, sound_override = null, should_play_sound = TRUE, datum/component/tts_component/tts_override = null, tts_message = "") // Bandastation Addition: "datum/component/tts_component/tts_override = null" & "tts_message"
 	var/sound_to_play = !isnull(sound_override) ? sound_override : 'sound/announcer/notice/notice2.ogg'
 
 	// note for later: low-hanging fruit to convert to astype() behind an experiment define whenever the 516 beta releases
@@ -217,7 +217,7 @@
 				TYPE_PROC_REF(/datum/controller/subsystem/tts220, get_tts), \
 				null, \
 				target, \
-				announcement, \
+				tts_message, \
 				announcement_tts_seed, \
 				FALSE, \
 				tts_effects, \

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -83,7 +83,7 @@
 	else
 		finalized_announcement = CHAT_ALERT_DEFAULT_SPAN(jointext(announcement_strings, ""))
 
-// BANDASTATION EDIT - START
+	// BANDASTATION EDIT - START
 	var/tts_message = (SSstation.announcer.custom_alert_message && !has_important_message) ? SSstation.announcer.custom_alert_message : text
 	dispatch_announcement_to_players(finalized_announcement, players, sound, tts_override = tts_override, tts_message = tts_message)
 	// BANDASTATION EDIT - END
@@ -126,7 +126,7 @@
  * should_play_sound - Whether the notice sound should be played or not. This can also be a callback, if you only want mobs to hear the sound based off of specific criteria.
  * color_override - optional, use the passed color instead of the default notice color.
  */
-/proc/minor_announce(message, title = "Attention:", alert = FALSE, html_encode = TRUE, list/players, sound_override, should_play_sound = TRUE, color_override, mob/user)
+/proc/minor_announce(message, title = "Attention:", alert = FALSE, html_encode = TRUE, list/players, sound_override, should_play_sound = TRUE, color_override, tts_override)
 	if(!message)
 		return
 
@@ -146,7 +146,7 @@
 		finalized_announcement = CHAT_ALERT_DEFAULT_SPAN(jointext(minor_announcement_strings, ""))
 
 	var/custom_sound = sound_override || (alert ? 'sound/announcer/notice/notice1.ogg' : 'sound/announcer/notice/notice2.ogg')
-	dispatch_announcement_to_players(finalized_announcement, players, custom_sound, should_play_sound, tts_override = user.GetComponent(/datum/component/tts_component), tts_message = message) // BANDASTATION ADDITION - "tts_override" & "tts_message"
+	dispatch_announcement_to_players(finalized_announcement, players, custom_sound, should_play_sound, tts_override = tts_override, tts_message = message) // BANDASTATION ADDITION - "tts_override" & "tts_message"
 
 /// Sends an announcement about the level changing to players. Uses the passed in datum and the subsystem's previous security level to generate the message.
 /proc/level_announce(datum/security_level/selected_level, previous_level_number)

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -83,7 +83,13 @@
 	else
 		finalized_announcement = CHAT_ALERT_DEFAULT_SPAN(jointext(announcement_strings, ""))
 
-	dispatch_announcement_to_players(finalized_announcement, players, sound, tts_override = tts_override, tts_message = text) // Bandastation Addition: "tts_override = tts_override" & "tts_message"
+	// BANDASTATION EDIT - START
+	if(SSstation.announcer.custom_alert_message && !has_important_message)
+		dispatch_announcement_to_players(finalized_announcement, players, sound, tts_override = tts_override, tts_message = SSstation.announcer.custom_alert_message)
+	else
+		// Bandastation Addition: "tts_override = tts_override" & "tts_message = text"
+		dispatch_announcement_to_players(finalized_announcement, players, sound, tts_override = tts_override, tts_message = text)
+	// BANDASTATION EDIT - END
 
 	if(isnull(sender_override) && players == GLOB.player_list)
 		if(length(title) > 0)
@@ -143,7 +149,7 @@
 		finalized_announcement = CHAT_ALERT_DEFAULT_SPAN(jointext(minor_announcement_strings, ""))
 
 	var/custom_sound = sound_override || (alert ? 'sound/announcer/notice/notice1.ogg' : 'sound/announcer/notice/notice2.ogg')
-	dispatch_announcement_to_players(finalized_announcement, players, custom_sound, should_play_sound)
+	dispatch_announcement_to_players(finalized_announcement, players, custom_sound, should_play_sound, tts_message = message) // BANDASTATION ADDITION - "tts_message = message"
 
 /// Sends an announcement about the level changing to players. Uses the passed in datum and the subsystem's previous security level to generate the message.
 /proc/level_announce(datum/security_level/selected_level, previous_level_number)
@@ -168,7 +174,7 @@
 
 	var/finalized_announcement = CHAT_ALERT_COLORED_SPAN(current_level_color, jointext(level_announcement_strings, ""))
 
-	dispatch_announcement_to_players(finalized_announcement, GLOB.player_list, current_level_sound)
+	dispatch_announcement_to_players(finalized_announcement, GLOB.player_list, current_level_sound, tts_message = finalized_announcement) // BANDASTATION ADDITION - "tts_message = finalized_announcement"
 
 /// Proc that just generates a custom header based on variables fed into `priority_announce()`
 /// Will return a string.

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -126,7 +126,7 @@
  * should_play_sound - Whether the notice sound should be played or not. This can also be a callback, if you only want mobs to hear the sound based off of specific criteria.
  * color_override - optional, use the passed color instead of the default notice color.
  */
-/proc/minor_announce(message, title = "Attention:", alert = FALSE, html_encode = TRUE, list/players, sound_override, should_play_sound = TRUE, color_override, tts_override) // BANDASTATION ADDITION - "tts_override"
+/proc/minor_announce(message, title = "Внимание:", alert = FALSE, html_encode = TRUE, list/players, sound_override, should_play_sound = TRUE, color_override, tts_override) // BANDASTATION ADDITION - "tts_override"
 	if(!message)
 		return
 
@@ -189,7 +189,7 @@
 
 /// Proc that just dispatches the announcement to our applicable audience. Only the announcement is a mandatory arg.
 /// `should_play_sound` can also be a callback, if you want to only play the sound to specific players.
-/proc/dispatch_announcement_to_players(announcement, list/players = GLOB.player_list, sound_override = null, should_play_sound = TRUE, datum/component/tts_component/tts_override = null, tts_message = "") // BANDASTATION ADDITION: "datum/component/tts_component/tts_override = null" & "tts_message"
+/proc/dispatch_announcement_to_players(announcement, list/players = GLOB.player_list, sound_override = null, should_play_sound = TRUE, datum/component/tts_component/tts_override = null, tts_message) // BANDASTATION ADDITION: "datum/component/tts_component/tts_override = null" & "tts_message"
 	var/sound_to_play = !isnull(sound_override) ? sound_override : 'sound/announcer/notice/notice2.ogg'
 
 	// note for later: low-hanging fruit to convert to astype() behind an experiment define whenever the 516 beta releases

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -83,7 +83,7 @@
 	else
 		finalized_announcement = CHAT_ALERT_DEFAULT_SPAN(jointext(announcement_strings, ""))
 
-	// BANDASTATION EDIT - START
+	// BANDASTATION EDIT - START - add tts_message
 	var/tts_message = (SSstation.announcer.custom_alert_message && !has_important_message) ? SSstation.announcer.custom_alert_message : text
 	dispatch_announcement_to_players(finalized_announcement, players, sound, tts_override = tts_override, tts_message = tts_message)
 	// BANDASTATION EDIT - END
@@ -126,7 +126,7 @@
  * should_play_sound - Whether the notice sound should be played or not. This can also be a callback, if you only want mobs to hear the sound based off of specific criteria.
  * color_override - optional, use the passed color instead of the default notice color.
  */
-/proc/minor_announce(message, title = "Attention:", alert = FALSE, html_encode = TRUE, list/players, sound_override, should_play_sound = TRUE, color_override, tts_override)
+/proc/minor_announce(message, title = "Attention:", alert = FALSE, html_encode = TRUE, list/players, sound_override, should_play_sound = TRUE, color_override, tts_override) // BANDASTATION ADDITION - "tts_override"
 	if(!message)
 		return
 
@@ -189,7 +189,7 @@
 
 /// Proc that just dispatches the announcement to our applicable audience. Only the announcement is a mandatory arg.
 /// `should_play_sound` can also be a callback, if you want to only play the sound to specific players.
-/proc/dispatch_announcement_to_players(announcement, list/players = GLOB.player_list, sound_override = null, should_play_sound = TRUE, datum/component/tts_component/tts_override = null, tts_message = "") // Bandastation Addition: "datum/component/tts_component/tts_override = null" & "tts_message"
+/proc/dispatch_announcement_to_players(announcement, list/players = GLOB.player_list, sound_override = null, should_play_sound = TRUE, datum/component/tts_component/tts_override = null, tts_message = "") // BANDASTATION ADDITION: "datum/component/tts_component/tts_override = null" & "tts_message"
 	var/sound_to_play = !isnull(sound_override) ? sound_override : 'sound/announcer/notice/notice2.ogg'
 
 	// note for later: low-hanging fruit to convert to astype() behind an experiment define whenever the 516 beta releases

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -129,7 +129,7 @@
  * should_play_sound - Whether the notice sound should be played or not. This can also be a callback, if you only want mobs to hear the sound based off of specific criteria.
  * color_override - optional, use the passed color instead of the default notice color.
  */
-/proc/minor_announce(message, title = "Attention:", alert = FALSE, html_encode = TRUE, list/players, sound_override, should_play_sound = TRUE, color_override)
+/proc/minor_announce(message, title = "Attention:", alert = FALSE, html_encode = TRUE, list/players, sound_override, should_play_sound = TRUE, color_override, mob/user)
 	if(!message)
 		return
 
@@ -149,7 +149,7 @@
 		finalized_announcement = CHAT_ALERT_DEFAULT_SPAN(jointext(minor_announcement_strings, ""))
 
 	var/custom_sound = sound_override || (alert ? 'sound/announcer/notice/notice1.ogg' : 'sound/announcer/notice/notice2.ogg')
-	dispatch_announcement_to_players(finalized_announcement, players, custom_sound, should_play_sound, tts_message = message) // BANDASTATION ADDITION - "tts_message = message"
+	dispatch_announcement_to_players(finalized_announcement, players, custom_sound, should_play_sound, tts_override = user.GetComponent(/datum/component/tts_component), tts_message = message) // BANDASTATION ADDITION - "tts_override" & "tts_message"
 
 /// Sends an announcement about the level changing to players. Uses the passed in datum and the subsystem's previous security level to generate the message.
 /proc/level_announce(datum/security_level/selected_level, previous_level_number)

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -83,6 +83,7 @@
 	else
 		finalized_announcement = CHAT_ALERT_DEFAULT_SPAN(jointext(announcement_strings, ""))
 
+// BANDASTATION EDIT - START
 	var/tts_message = (SSstation.announcer.custom_alert_message && !has_important_message) ? SSstation.announcer.custom_alert_message : text
 	dispatch_announcement_to_players(finalized_announcement, players, sound, tts_override = tts_override, tts_message = tts_message)
 	// BANDASTATION EDIT - END

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -200,7 +200,7 @@ GLOBAL_LIST_EMPTY(req_console_ckey_departments)
 				var/mob/living/L = usr
 				message = L.treat_message(message)["message"]
 
-			minor_announce(message, "[department] Announcement:", html_encode = FALSE, sound_override = 'sound/announcer/announcement/announce_dig.ogg')
+			minor_announce(message, "[department] Announcement:", html_encode = FALSE, sound_override = 'sound/announcer/announcement/announce_dig.ogg', user = usr) // BANDASTATION ADDITION: "user = usr"
 			GLOB.news_network.submit_article(message, department, "Station Announcements", null)
 			usr.log_talk(message, LOG_SAY, tag="station announcement from [src]")
 			message_admins("[ADMIN_LOOKUPFLW(usr)] has made a station announcement from [src] at [AREACOORD(usr)].")

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -200,7 +200,7 @@ GLOBAL_LIST_EMPTY(req_console_ckey_departments)
 				var/mob/living/L = usr
 				message = L.treat_message(message)["message"]
 
-			minor_announce(message, "[department] Announcement:", html_encode = FALSE, sound_override = 'sound/announcer/announcement/announce_dig.ogg', user = usr) // BANDASTATION ADDITION: "user = usr"
+			minor_announce(message, "[department] Announcement:", html_encode = FALSE, sound_override = 'sound/announcer/announcement/announce_dig.ogg', tts_override = usr.GetComponent(/datum/component/tts_component)) // BANDASTATION ADDITION: "tts_override"
 			GLOB.news_network.submit_article(message, department, "Station Announcements", null)
 			usr.log_talk(message, LOG_SAY, tag="station announcement from [src]")
 			message_admins("[ADMIN_LOOKUPFLW(usr)] has made a station announcement from [src] at [AREACOORD(usr)].")

--- a/html/changelogs/bandastation/AutoChangeLog-pr-811.yml
+++ b/html/changelogs/bandastation/AutoChangeLog-pr-811.yml
@@ -1,0 +1,4 @@
+author: "konushi"
+delete-after: True
+changes:
+  - rscadd: "Новый Трурль."


### PR DESCRIPTION
## Что этот PR делает
ТТС теперь должен озвучивать только текст анонса, а не от кого анонс, какой тип анонса и в честь чего анонс

## Почему это хорошо для игры
ТТС меньше тараторит из-за отсутствия знаков препинания у вышеперечисленного говна

## Тестирование
Надеюсь работает :clueless:

## Changelog

:cl:
qol: ТТС теперь озвучивает только текст оповещения, а не всё подряд в оповещении
fix: Анонсы через реквест консоль, теперь говорят голосом анонсирующего
/:cl:

## Summary by Sourcery

Send only the announcement text to the text-to-speech (TTS) system, rather than the entire announcement message. This improves the TTS output by reducing unnecessary chatter.

New Features:
- Added a feature to send only the body of announcements to the TTS system.

Tests:
- Tested the changes to ensure the TTS system only receives the announcement text.