### PR TITLE
Fix: Non-donor colored OOC ckey

### DIFF
--- a/modular_bandastation/chat_badges/code/badges.dm
+++ b/modular_bandastation/chat_badges/code/badges.dm
@@ -16,7 +16,12 @@ GLOBAL_LIST(badge_icons_cache)
 	var/list/parts = list()
 	if(length(badge_parts))
 		parts += badge_parts
-	parts += "<font color='[prefs.read_preference(/datum/preference/color/ooc_color) || GLOB.normal_ooc_colour]'>[key]</font>"
+
+	if(donator_level && prefs.read_preference(/datum/preference/toggle/donor_public) || prefs.unlock_content && (prefs.toggles & MEMBER_PUBLIC))
+		parts += "<font color='[prefs.read_preference(/datum/preference/color/ooc_color) || GLOB.normal_ooc_colour]'>[key]</font>"
+	else
+		parts += "[key]"
+
 	return jointext(parts, "<div style='display: inline-block; width: 3px;'></div>")
 
 /client/proc/get_donator_badge()


### PR DESCRIPTION
## Что этот PR делает
Фикс красных ников в чате у НЕ бустеров

## Почему это хорошо для игры
Цветной ник вообще должен цениться

## Изображения изменений
![image](https://github.com/user-attachments/assets/57a02f44-dae2-423d-ae34-abf48c0fa24e)

## Changelog

:cl:
fix: Цветной ckey в OOC теперь не доступен тем, кто не поддержал проект на бусти или не админ. Byond Member тоже имеет цветной ник.
/:cl:
