### PR TITLE
head dismembering is back, craial fissure is now can only be caused by blunt damage

### DIFF
--- a/modular_bandastation/balance/_balance.dme
+++ b/modular_bandastation/balance/_balance.dme
@@ -2,12 +2,14 @@
 
 #include "code/~defines.dm"
 
-#include "code/speed/base_speed.dm"
-#include "code/speed/movespeed_modifier.dm"
+#include "code/bodyparts/head.dm"
+#include "code/crew_manifest.dm"
 #include "code/dynamic.dm"
 #include "code/events.dm"
+#include "code/speed/base_speed.dm"
+#include "code/speed/movespeed_modifier.dm"
 #include "code/station_traits.dm"
 #include "code/supply_packs.dm"
-#include "code/crew_manifest.dm"
+#include "code/wounds/cranial_fissure.dm"
 
 #include "code/~undefs.dm"

--- a/modular_bandastation/balance/code/bodyparts/head.dm
+++ b/modular_bandastation/balance/code/bodyparts/head.dm
@@ -1,0 +1,2 @@
+/obj/item/bodypart/head
+	can_dismember = TRUE

--- a/modular_bandastation/balance/code/wounds/cranial_fissure.dm
+++ b/modular_bandastation/balance/code/wounds/cranial_fissure.dm
@@ -1,0 +1,2 @@
+/datum/wound_pregen_data/cranial_fissure
+	required_wounding_types = list(WOUND_BLUNT)


### PR DESCRIPTION
## Что этот PR делает

Возвращает отрубание головы для всех типов голов просто уроном
Травма "трещина черепа" (cranial fissure) теперь может быть вызвана только тупым уроном

## Почему это хорошо для игры

Отрубание головы это весело и было отлючено для всех кроме зомби просто потому что

## Изображения изменений

<details>
<summary>
Ужасные картинки с молью
</summary>

![image](https://github.com/user-attachments/assets/2a2ca0b3-5803-4887-815f-254af213647e)
![image](https://github.com/user-attachments/assets/943e8422-6071-4333-b398-d5d3beff659c)
</details>

## Тестирование

В изображениях всё есть :jokerge:

## Changelog

:cl:
balance: Возвращает отрубание головы нанесением урона
balance: Травма "трещина черепа" (cranial fissure) теперь может быть вызвана только уроном тупыми предметами
/:cl:

## Summary by Sourcery

Re-enable head dismemberment for all head types by damage and restrict cranial fissure trauma to blunt damage only.

New Features:
- Re-enabled head dismemberment for all creature types.

Tests:
- Changes verified visually.