### PR TITLE
enable mood by default

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -481,7 +481,7 @@ MICE_ROUNDSTART 10
 ROUNDSTART_TRAITS
 
 ## Uncomment to disable human moods.
-DISABLE_HUMAN_MOOD
+#DISABLE_HUMAN_MOOD
 
 ## Enable night shifts
 #ENABLE_NIGHT_SHIFTS


### PR DESCRIPTION
## Что этот PR делает

Включат mood по умолчанию

## Changelog

:cl:
config: Mood теперь включен по умолчанию
/:cl:

## Summary by Sourcery

Enhancements:
- Enable mood by default in the game options configuration.