### PR TITLE
Add AutoWiki module & autowiki emoji

### DIFF
--- a/modular_bandastation/autowiki/_autowiki.dm
+++ b/modular_bandastation/autowiki/_autowiki.dm
@@ -1,0 +1,16 @@
+/datum/modpack/autowiki
+	/// A string name for the modpack. Used for looking up other modpacks in init.
+	name = "Автовики"
+	/// A string desc for the modpack. Can be used for modpack verb list as description.
+	desc = "Заменяем редакторов вики кодом."
+	/// A string with authors of this modpack.
+	author = "Aylong"
+
+/datum/modpack/autowiki/pre_initialize()
+	. = ..()
+
+/datum/modpack/autowiki/initialize()
+	. = ..()
+
+/datum/modpack/autowiki/post_initialize()
+	. = ..()

--- a/modular_bandastation/autowiki/_autowiki.dme
+++ b/modular_bandastation/autowiki/_autowiki.dme
@@ -1,0 +1,3 @@
+#include "_autowiki.dm"
+
+#include "code/autowiki_emoji.dm"

--- a/modular_bandastation/autowiki/code/autowiki_emoji.dm
+++ b/modular_bandastation/autowiki/code/autowiki_emoji.dm
@@ -1,0 +1,20 @@
+/datum/autowiki/emoji
+	page = "Template:Autowiki/Content/Emojis"
+
+/datum/autowiki/stock_parts/generate()
+	var/output = ""
+	var/list/icon_states = icon_states(EMOJI_SET)
+
+	for(var/icon_state in icon_states)
+		var/filename = SANITIZE_FILENAME(escape_value("[icon_state]_wiki_emoji"))
+
+		output += include_template("Autowiki/Emoji", list(
+			"name" = ":[escape_value(icon_state)]:",
+			"icon" = filename,
+		))
+
+		// It would be cool to make this support gifs someday, but not now
+		upload_icon(icon(EMOJI_SET, icon_state, frame = 1), filename)
+
+	return output
+

--- a/modular_bandastation/modular_bandastation.dme
+++ b/modular_bandastation/modular_bandastation.dme
@@ -15,6 +15,7 @@
 #include "autohiss/_autohiss.dme"
 #include "automapper/_automapper.dme"
 #include "automatic_crew_transfer/_automatic_crew_transfer.dme"
+#include "autowiki/_autowiki.dme"
 #include "balance/_balance.dme"
 #include "barsigns/_barsigns.dme"
 #include "changelog/_changelog.dme"


### PR DESCRIPTION
## Что этот PR делает
Добавляет автовики для эмодзи, на вики будет всегда актуальный список всех эмодзи
Из минусов - насрано файлами

## Changelog

:cl:
add: На вики появился актуальный список всех эмодзи для чата/мессенджера
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
