### PR TITLE
Map: Cyberiad, minor armory fixes

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -31717,9 +31717,8 @@
 	pixel_x = 1;
 	pixel_y = -2
 	},
-/obj/item/storage/box/flashbangs{
-	pixel_x = -6;
-	pixel_y = 8
+/obj/item/storage/box/flashes{
+	pixel_x = 3
 	},
 /obj/item/gun/grenadelauncher,
 /turf/open/floor/iron/dark,

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -813,6 +813,7 @@
 /obj/item/gun/energy/temperature/security,
 /obj/effect/turf_decal/bot_white,
 /obj/structure/window/reinforced/spawner/directional/north,
+/obj/item/clothing/suit/hooded/ablative,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "alp" = (
@@ -31707,12 +31708,20 @@
 /area/station/maintenance/port/fore)
 "hTL" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/hooded/ablative,
 /obj/effect/turf_decal/bot_white,
 /obj/structure/window/reinforced/spawner/directional/east{
 	pixel_x = 3
 	},
 /obj/structure/window/reinforced/spawner/directional/north,
+/obj/item/storage/box/teargas{
+	pixel_x = 1;
+	pixel_y = -2
+	},
+/obj/item/storage/box/flashbangs{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/gun/grenadelauncher,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "hTP" = (
@@ -42307,6 +42316,7 @@
 	pixel_x = 6
 	},
 /obj/effect/turf_decal/bot_white,
+/obj/structure/rack,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "kFg" = (
@@ -43774,29 +43784,24 @@
 /turf/open/floor/plating,
 /area/station/engineering/transit_tube)
 "kWZ" = (
-/obj/item/grenade/barrier{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/grenade/barrier{
-	pixel_y = 4
-	},
-/obj/item/grenade/barrier{
-	pixel_y = 4;
-	pixel_x = 6
-	},
-/obj/item/grenade/barrier{
-	pixel_x = -6;
-	pixel_y = -4
-	},
-/obj/item/grenade/barrier{
-	pixel_y = -4
-	},
-/obj/item/grenade/barrier{
-	pixel_y = -4;
-	pixel_x = 6
-	},
 /obj/effect/turf_decal/bot_white,
+/obj/structure/rack,
+/obj/item/clothing/glasses/hud/security/sunglasses/gars{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/clothing/glasses/hud/security/sunglasses/gars{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/hud/security/sunglasses{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/hud/security/sunglasses{
+	pixel_x = -3;
+	pixel_y = -2
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "kXa" = (
@@ -44796,11 +44801,16 @@
 /area/station/engineering/atmos/mix/ghetto)
 "lka" = (
 /obj/item/storage/box/firingpins{
-	pixel_y = 5
+	pixel_y = 5;
+	pixel_x = -5
 	},
 /obj/effect/spawner/random/armory/barrier_grenades,
 /obj/effect/turf_decal/bot_white,
 /obj/structure/table/reinforced,
+/obj/item/storage/box/seccarts{
+	pixel_y = 8;
+	pixel_x = 6
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "lke" = (


### PR DESCRIPTION
## Что этот PR делает

Добавляет гранатомет который есть на всех тг картах и 4 пары худов, так же 2 потерянных рага. Убирает 6 неиспользуемых барьерок.

## Почему это хорошо для игры

Гранатомет круто, худы тоже

## Изображения изменений

![image](https://github.com/user-attachments/assets/c95aa33e-06a3-4bc4-8d4d-da29928bcf6c)

## Тестирование
## Changelog

:cl:
map: Добавлен, гранатомет и худы в оружейку Кибериады (они есть на всех картах). Удалены 6 барьерных гранат.

/:cl:
