### PR TITLE
Remove shitty toys

### DIFF
--- a/code/_globalvars/arcade.dm
+++ b/code/_globalvars/arcade.dm
@@ -37,14 +37,16 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	/obj/item/toy/talking/owl = 2,
 	/obj/item/toy/talking/griffin = 2,
 	/obj/item/coin/antagtoken = 2,
-	/obj/item/stack/tile/fakepit/loaded = 2,
+	// /obj/item/stack/tile/fakepit/loaded = 2, /// BANDASATION REMOVAL - Remove Fun
 	/obj/item/stack/tile/eighties/loaded = 2,
 	/obj/item/toy/toy_xeno = 2,
 	/obj/item/storage/box/actionfigure = 1,
 	/obj/item/restraints/handcuffs/fake = 2,
-	/obj/item/grenade/chem_grenade/glitter/pink = 1,
-	/obj/item/grenade/chem_grenade/glitter/blue = 1,
-	/obj/item/grenade/chem_grenade/glitter/white = 1,
+	/// BANDASATION REMOVAL START - Remove Fun
+	// /obj/item/grenade/chem_grenade/glitter/pink = 1,
+	// /obj/item/grenade/chem_grenade/glitter/blue = 1,
+	// /obj/item/grenade/chem_grenade/glitter/white = 1,
+	/// BANDASATION REMOVAL END - Remove Fun
 	/obj/item/toy/eightball = 2,
 	/obj/item/toy/windup_toolbox = 2,
 	/obj/item/toy/clockwork_watch = 2,

--- a/code/game/objects/effects/spawners/random/contraband.dm
+++ b/code/game/objects/effects/spawners/random/contraband.dm
@@ -161,7 +161,7 @@
 	loot = list(
 		/obj/item/grenade/chem_grenade/metalfoam,
 		/obj/item/grenade/chem_grenade/cleaner,
-		/obj/effect/spawner/random/entertainment/colorful_grenades,
+		// /obj/effect/spawner/random/entertainment/colorful_grenades, /// BANDASATION REMOVAL - Remove Fun
 		/obj/item/grenade/smokebomb,
 		/obj/item/grenade/chem_grenade/antiweed,
 		/obj/item/grenade/spawnergrenade/syndiesoap,


### PR DESCRIPTION
## Что этот PR делает

closes https://github.com/ss220club/BandaStation/issues/1091

Удаляет игрушки красящих блестками гранат (блестки похожи на газы типа плазмы, пара), а так же полы которые выглядят как чазмы.

## Почему это хорошо для игры

Эти игрушки не привносят ничего хорошего в игру, только путают игроков.
Этого в целом никогда не должно было быть в игре

## Changelog

:cl:
del: Удаляет игрушки красящих блестками гранат (блестки похожи на газы типа плазмы, пара), а так же полы которые выглядят как чазмы.
/:cl: