### PR TITLE
fix linter warnings because of icon index operations

### DIFF
--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -399,7 +399,7 @@ There are several things that need to be remembered:
 		var/mutant_override = FALSE
 
 		var/obj/item/bodypart/head/bodypart_head = src.get_bodypart(BODY_ZONE_HEAD)
-		if(worn_item.worn_icon_species && worn_item.worn_icon_species[bodypart_head.species_bodytype])
+		if(worn_item.worn_icon_species?[bodypart_head.species_bodytype])
 			icon_file = worn_item.worn_icon_species[bodypart_head.species_bodytype]
 			mutant_override = TRUE
 		else if(bodypart_head.species_bodytype in icon_files_species)
@@ -468,7 +468,7 @@ There are several things that need to be remembered:
 		var/mutant_override = FALSE
 
 		var/obj/item/bodypart/chest/bodypart_chest = src.get_bodypart(BODY_ZONE_CHEST)
-		if(worn_item.worn_icon_species && worn_item.worn_icon_species[bodypart_chest.species_bodytype])
+		if(worn_item.worn_icon_species?[bodypart_chest.species_bodytype])
 			icon_file = worn_item.worn_icon_species[bodypart_chest.species_bodytype]
 			mutant_override = TRUE
 		else if(bodypart_chest.species_bodytype in icon_files_species)
@@ -538,7 +538,7 @@ There are several things that need to be remembered:
 		var/mutant_override = FALSE
 
 		var/obj/item/bodypart/head/bodypart_head = src.get_bodypart(BODY_ZONE_HEAD)
-		if(worn_item.worn_icon_species && worn_item.worn_icon_species[bodypart_head.species_bodytype])
+		if(worn_item.worn_icon_species?[bodypart_head.species_bodytype])
 			icon_file = worn_item.worn_icon_species[bodypart_head.species_bodytype]
 			mutant_override = TRUE
 		else if(bodypart_head.species_bodytype in icon_files_species)

--- a/modular_bandastation/species/code/clothing/items.dm
+++ b/modular_bandastation/species/code/clothing/items.dm
@@ -1,5 +1,5 @@
 /obj/item
-	var/icon/worn_icon_species
+	var/list/worn_icon_species
 
 /obj/item/clothing/head/mod
 	worn_icon_species = list(

--- a/modular_bandastation/species/code/clothing/mod.dm
+++ b/modular_bandastation/species/code/clothing/mod.dm
@@ -15,7 +15,7 @@
 	var/mob/living/carbon/user = usr
 	if(istype(user))
 		var/obj/item/bodypart/head/bodypart_head = user.get_bodypart(BODY_ZONE_HEAD)
-		if(bodypart_head && worn_icon_species && worn_icon_species[bodypart_head.species_bodytype])
+		if(bodypart_head && worn_icon_species?[bodypart_head.species_bodytype])
 			module_icon = mutable_appearance(worn_icon_species[bodypart_head.species_bodytype], used_overlay, layer = standing.layer + 0.1)
 	if(!use_mod_colors)
 		module_icon.appearance_flags |= RESET_COLOR


### PR DESCRIPTION
## Что этот PR делает

Меняет тип переменной `worn_icon_species` с `icon` на `list`, потому что это список.

## Тестирование

Компилируется

## Summary by Sourcery

Bug Fixes:
- Fix linter warnings by changing the type of 'worn_icon_species' from 'icon' to 'list' to accurately reflect its usage as a list.