### PR TITLE
Change vulpkanin brain size

### DIFF
--- a/modular_bandastation/species/code/surgery/organs/internal/vulpkanin_internal.dm
+++ b/modular_bandastation/species/code/surgery/organs/internal/vulpkanin_internal.dm
@@ -58,6 +58,8 @@
 /obj/item/organ/brain/vulpkanin
 	icon = 'modular_bandastation/species/icons/mob/species/vulpkanin/organs.dmi'
 	actions_types = list(/datum/action/cooldown/sniff)
+	brain_size = 0.75
+
 
 /obj/item/organ/lungs/vulpkanin
 	name = "vulpkanin lungs"


### PR DESCRIPTION

## Что этот PR делает

Изменяет размер мозга вульпы
Идея пришла после просмотра новой нарезки муни.

## Почему это хорошо для игры

Смешная лорная фича.

## Изображения изменений

Мозги в сравнении:
![image](https://github.com/user-attachments/assets/de81b65a-c5fe-4a7b-b4a5-748b901207fd)
Нормальный, мозг феленида, мозг вульпы 

## Тестирование

Билд запускал, мозг доставал.

## Changelog

:cl:
balance: Уменьшен размер мозга вульпы
/:cl:
