### PR TITLE
Remove some absurd fishing spotes

### DIFF
--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -85,7 +85,7 @@
 /obj/effect/visible_heretic_influence/Initialize(mapload)
 	. = ..()
 	addtimer(CALLBACK(src, PROC_REF(show_presence)), 15 SECONDS)
-	AddComponent(/datum/component/fishing_spot, GLOB.preset_fish_sources[/datum/fish_source/dimensional_rift])
+	// AddComponent(/datum/component/fishing_spot, GLOB.preset_fish_sources[/datum/fish_source/dimensional_rift]) // BANDASTATION REMOVAL
 
 	var/image/silicon_image = image('icons/effects/eldritch.dmi', src, null, OBJ_LAYER)
 	silicon_image.override = TRUE

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -170,7 +170,7 @@
 	AddComponent(/datum/component/simple_rotation)
 	AddComponent(/datum/component/plumbing/hydroponics)
 	AddComponent(/datum/component/usb_port, list(/obj/item/circuit_component/hydroponics))
-	AddComponent(/datum/component/fishing_spot, /datum/fish_source/hydro_tray)
+	// AddComponent(/datum/component/fishing_spot, /datum/fish_source/hydro_tray) // BANDASTATION REMOVAL
 
 /obj/machinery/hydroponics/constructable/RefreshParts()
 	. = ..()

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -32,7 +32,7 @@
 	if(HAS_TRAIT(target, TRAIT_FISHING_SPOT))
 		return
 
-	target.AddComponent(/datum/component/fishing_spot, /datum/fish_source/surgery)
+	// target.AddComponent(/datum/component/fishing_spot, /datum/fish_source/surgery) // BANDASTATION REMOVAL
 
 /datum/surgery/organ_manipulation/Destroy()
 	if(QDELETED(target) || !HAS_TRAIT(target, TRAIT_FISHING_SPOT))


### PR DESCRIPTION
## Что этот PR делает
Вырезаем рыбалку в:
1. Рифтах еретика
2. Трупах
3. Гидропониках

## Почему это хорошо для игры
Если это не сделать сейчас, Гахер вырежет гораздо больше

## Тестирование
Нет

## Changelog

:cl:
del: Вырезаны максимально абсурдные места для рыбалки: Рифты еретика, трупы и гидропоники
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
