### PR TITLE
Removed SM hotwiring on Cyberiad

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -8338,7 +8338,6 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "ccQ" = (
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "ccU" = (
@@ -37143,7 +37142,6 @@
 "jqL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/duct,
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
@@ -42446,8 +42444,6 @@
 "kFP" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/duct,
-/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "kFR" = (
@@ -47590,6 +47586,7 @@
 "lTR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "lTT" = (
@@ -70026,6 +70023,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"rwc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage)
 "rwp" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -80795,12 +80799,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
-"uiq" = (
-/obj/machinery/firealarm/directional/east,
-/obj/machinery/portable_atmospherics/canister/plasma,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plating,
-/area/station/engineering/storage)
 "uiw" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red{
@@ -94450,6 +94448,7 @@
 "xKG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "xKI" = (
@@ -188992,9 +188991,9 @@ jdk
 awU
 qvI
 smq
-nXm
+rwc
 uMv
-uiq
+izJ
 djZ
 xLD
 put

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -18378,6 +18378,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/prison)
+"eBO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/gravity_generator)
 "eBS" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/item/restraints/handcuffs/cable/pink,
@@ -24877,7 +24882,6 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/bitrunning/den)
 "ghU" = (
-/obj/structure/cable,
 /obj/structure/chair/office/light,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/gravity_generator)
@@ -27859,7 +27863,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/layer1,
 /obj/structure/cable/multilayer/connected,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
@@ -87464,10 +87467,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"vVR" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/station/engineering/gravity_generator)
 "vVS" = (
 /obj/structure/firelock_frame{
 	anchored = 1
@@ -199515,8 +199514,8 @@ alC
 ceC
 qCU
 tCF
-vVR
-xtX
+bWk
+eBO
 ghU
 sVv
 qCU

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -20298,12 +20298,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
-"fdw" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/engine_smes)
 "fdy" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "MiniSat Teleporter";
@@ -36227,7 +36221,7 @@
 	c_tag = "Engineering - SMES Room";
 	network = list("ss13","engineering")
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
+/turf/open/floor/plating,
 /area/station/engineering/engine_smes)
 "jcP" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -65022,14 +65016,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
-"qjh" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 8
-	},
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/engine_smes)
 "qjk" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -88019,7 +88005,7 @@
 "wcN" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron_dark,
+/turf/open/floor/plating,
 /area/station/engineering/engine_smes)
 "wdj" = (
 /obj/structure/frame,
@@ -95987,10 +95973,9 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "yeX" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/structure/cable,
 /obj/machinery/power/smes/engineering,
-/turf/open/floor/catwalk_floor/iron_dark,
+/turf/open/floor/plating,
 /area/station/engineering/engine_smes)
 "yfg" = (
 /obj/effect/turf_decal/stripes/line{
@@ -190020,7 +190005,7 @@ qkY
 qHG
 cKg
 ayW
-qjh
+wcN
 qHG
 aqO
 wFk
@@ -190277,7 +190262,7 @@ jdk
 qHG
 dGf
 pEo
-fdw
+wcN
 qHG
 uKr
 iUU
@@ -191048,7 +191033,7 @@ aPB
 qHG
 oKz
 lFq
-fdw
+wcN
 qHG
 wAJ
 xKA

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -46477,14 +46477,6 @@
 /obj/effect/landmark/start/chaplain,
 /turf/open/floor/carpet/black,
 /area/station/service/chapel/office)
-"lFU" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/engineering/engine_smes)
 "lFX" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm/directional/south,
@@ -59105,7 +59097,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/north,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "oKA" = (
@@ -75069,6 +75061,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/central/aft)
+"sIU" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/engineering/engine_smes)
 "sIX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -190275,7 +190275,7 @@ hZh
 xHY
 jdk
 qHG
-lFU
+dGf
 pEo
 fdw
 qHG
@@ -190789,7 +190789,7 @@ pPI
 jLC
 aPB
 qHG
-dGf
+sIU
 tmO
 jcM
 qHG
@@ -196425,7 +196425,7 @@ kot
 fsZ
 hXT
 nGm
-hXT
+qyb
 hpN
 doz
 doz

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -65021,7 +65021,6 @@
 	},
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/engine_smes)
 "qjk" = (
@@ -88020,6 +88019,7 @@
 /area/space/nearstation)
 "wcN" = (
 /obj/machinery/power/smes/engineering,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/engine_smes)
 "wdj" = (

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -1903,6 +1903,7 @@
 /obj/structure/cable,
 /obj/machinery/power/terminal,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "azb" = (
@@ -6118,6 +6119,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"bzt" = (
+/obj/machinery/door/airlock/engineering/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer1,
+/turf/open/floor/iron/dark,
+/area/station/engineering/engine_smes)
 "bzw" = (
 /turf/closed/wall/rust,
 /area/station/cargo/drone_bay/ghetto)
@@ -10995,10 +11006,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
 "cKg" = (
-/obj/machinery/light_switch/directional/north,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "cKl" = (
@@ -15017,6 +15028,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"dGf" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/engineering/engine_smes)
 "dGo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/siding/wood{
@@ -19002,6 +19021,15 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"eKX" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer1,
+/turf/open/floor/iron/dark,
+/area/station/engineering/hallway)
 "eLb" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/duct,
@@ -20269,8 +20297,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/engine_smes)
 "fdy" = (
 /obj/machinery/camera/directional/south{
@@ -27826,6 +27853,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/black,
 /area/station/command/meeting_room)
+"gWT" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer1,
+/obj/structure/cable/multilayer/connected,
+/turf/open/floor/iron/dark,
+/area/station/engineering/engine_smes)
 "gWW" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
@@ -28234,13 +28271,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"hch" = (
-/obj/structure/cable,
-/obj/machinery/power/terminal,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark,
-/area/station/engineering/engine_smes)
 "hcl" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/computer/slot_machine,
@@ -36194,7 +36224,7 @@
 	c_tag = "Engineering - SMES Room";
 	network = list("ss13","engineering")
 	},
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/engine_smes)
 "jcP" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -37452,15 +37482,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"juF" = (
-/obj/structure/cable/layer1,
-/obj/machinery/door/airlock/engineering/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/engineering/engine_smes)
 "juX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38797,6 +38818,8 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "jLB" = (
@@ -40598,7 +40621,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "kkg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
@@ -42779,7 +42801,6 @@
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "kJY" = (
-/obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -43236,11 +43257,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "kPC" = (
-/obj/structure/cable/multilayer/connected,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "kPF" = (
@@ -46385,6 +46405,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
+"lFq" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/cable,
+/obj/machinery/power/terminal,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/engineering/engine_smes)
 "lFt" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/plasticflaps{
@@ -46425,14 +46453,6 @@
 /obj/item/reagent_containers/dropper,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"lFO" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/engineering/hallway)
 "lFQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46459,6 +46479,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "lFX" = (
@@ -59078,10 +59099,10 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "oKz" = (
-/obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "oKA" = (
@@ -61792,12 +61813,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
-"pun" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/engineering/engine_smes)
 "pus" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -65018,7 +65033,7 @@
 	},
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/engine_smes)
 "qjk" = (
 /obj/machinery/door/airlock/external,
@@ -65170,6 +65185,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "qkZ" = (
@@ -67906,14 +67922,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"qWt" = (
-/obj/machinery/door/airlock/engineering/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/engineering/engine_smes)
 "qWu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -77005,6 +77013,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "tmR" = (
@@ -77457,13 +77466,6 @@
 /obj/effect/landmark/navigate_destination/bridge,
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"trp" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/engineering/hallway)
 "trz" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -88018,7 +88020,7 @@
 "wcN" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/engine_smes)
 "wdj" = (
 /obj/structure/frame,
@@ -95989,7 +95991,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/structure/cable,
 /obj/machinery/power/smes/engineering,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/engine_smes)
 "yfg" = (
 /obj/effect/turf_decal/stripes/line{
@@ -189758,8 +189760,8 @@ pNN
 lvu
 uRF
 jLC
-lFO
-juF
+jdk
+tey
 kPC
 pEo
 wcN
@@ -190272,10 +190274,10 @@ xKS
 qau
 hZh
 xHY
-aPB
-tey
+jdk
+qHG
 lFU
-hch
+pEo
 fdw
 qHG
 uKr
@@ -190529,9 +190531,9 @@ ijr
 ruK
 pPI
 jLC
-aPB
-tey
-lFU
+eKX
+bzt
+gWT
 jLz
 aoY
 qHG
@@ -190787,8 +190789,8 @@ ruK
 pPI
 jLC
 aPB
-tey
-lFU
+qHG
+dGf
 tmO
 jcM
 qHG
@@ -191046,8 +191048,8 @@ jLC
 aPB
 qHG
 oKz
-ayW
-pun
+lFq
+fdw
 qHG
 wAJ
 xKA
@@ -191300,8 +191302,8 @@ xKS
 njW
 hZh
 piJ
-trp
-qWt
+aPB
+tey
 kkg
 eAy
 yeX

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -1134,14 +1134,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "aoY" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Engineering - SMES Room";
-	network = list("ss13","engineering")
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "apb" = (
 /obj/structure/closet,
@@ -1897,13 +1899,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
 "ayW" = (
-/obj/effect/turf_decal/tile/yellow/full,
 /obj/effect/turf_decal/bot,
-/obj/machinery/light_switch/directional/west,
 /obj/structure/cable,
 /obj/machinery/power/terminal,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "azb" = (
 /obj/machinery/vending/clothing,
@@ -2416,22 +2416,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/gravity_generator)
-"aFu" = (
-/obj/effect/turf_decal/bot,
-/obj/item/stack/rods{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/sheet/mineral/plasma/five,
-/obj/item/gps,
-/obj/structure/closet/crate/engineering,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/stock_parts/power_store/cell/high,
-/turf/open/floor/plating,
-/area/station/engineering/storage)
 "aFv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11012,13 +10996,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
 "cKg" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+/obj/machinery/light_switch/directional/north,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/table,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "cKl" = (
 /obj/structure/disposalpipe/segment{
@@ -13170,6 +13152,13 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/starboard/aft)
+"djZ" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/engineering/storage)
 "dkb" = (
 /obj/structure/railing{
 	dir = 4
@@ -17659,16 +17648,6 @@
 /obj/structure/mineral_door/wood,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"epX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/engineering/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/layer1,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "eqe" = (
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/floor/plating,
@@ -18257,6 +18236,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"eAy" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/bot,
+/obj/machinery/power/terminal,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/engineering/engine_smes)
 "eAB" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/iron/dark,
@@ -20283,7 +20270,8 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/plating,
 /area/station/engineering/engine_smes)
 "fdy" = (
 /obj/machinery/camera/directional/south{
@@ -24603,15 +24591,6 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"geN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable/layer1,
-/turf/open/floor/iron/dark,
-/area/station/engineering/hallway)
 "geP" = (
 /obj/machinery/suit_storage_unit/captain,
 /obj/item/radio/intercom/directional/west,
@@ -25372,13 +25351,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "goS" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "goV" = (
@@ -28259,10 +28238,9 @@
 "hch" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal,
-/obj/effect/turf_decal/tile/yellow/full,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "hcl" = (
 /obj/effect/turf_decal/siding/wood,
@@ -32946,12 +32924,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
-"ilr" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/power/emitter,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/station/engineering/storage)
 "ils" = (
 /obj/machinery/light/small/directional/west{
 	name = "maintenance light";
@@ -33381,14 +33353,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"iro" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable/layer1,
-/turf/open/floor/iron/dark,
-/area/station/engineering/hallway)
 "irq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -33632,15 +33596,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"ius" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow/full,
-/obj/effect/turf_decal/bot,
-/obj/structure/cable,
-/obj/machinery/power/terminal,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "iux" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
@@ -36234,20 +36189,13 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "jcM" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/electrical,
-/obj/machinery/light/directional/south,
-/obj/item/radio/intercom/directional/south,
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/power/smes/engineering,
+/obj/machinery/camera/directional/south{
+	c_tag = "Engineering - SMES Room";
+	network = list("ss13","engineering")
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/engineering/engine_smes)
 "jcP" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -36956,13 +36904,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "jmE" = (
+/obj/machinery/computer/monitor,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "jmF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37193,6 +37140,13 @@
 /obj/effect/spawner/random/bureaucracy/pen,
 /turf/open/floor/iron/large,
 /area/station/maintenance/ghetto/central)
+"jqL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/iron,
+/area/station/engineering/storage_shared)
 "jqR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37500,6 +37454,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"juF" = (
+/obj/structure/cable/layer1,
+/obj/machinery/door/airlock/engineering/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/engineering/engine_smes)
 "juX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38831,13 +38794,12 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
 "jLz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/yellow/full,
-/obj/effect/turf_decal/bot,
-/obj/structure/cable,
-/obj/machinery/power/terminal,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "jLB" = (
 /obj/structure/closet/emcloset,
@@ -40637,6 +40599,13 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"kkg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/engine_smes)
 "kkl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42478,6 +42447,7 @@
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "kFR" = (
@@ -42813,14 +42783,16 @@
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "kJY" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/camera/directional/east{
-	c_tag = "Engineering - Secure Storage East";
-	network = list("ss13","engineering")
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/station/engineering/storage)
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/engine_smes)
 "kKa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
@@ -43267,6 +43239,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"kPC" = (
+/obj/structure/cable/multilayer/connected,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/engine_smes)
 "kPF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44900,25 +44880,13 @@
 /turf/open/misc/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "lmH" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate{
-	name = "solar pack crate"
+/obj/machinery/computer/monitor,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 1
 	},
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/turf/open/floor/plating,
-/area/station/engineering/storage)
+/turf/open/floor/iron/dark,
+/area/station/engineering/engine_smes)
 "lmL" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/iron,
@@ -45706,10 +45674,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
-"lvd" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plating,
-/area/station/engineering/storage)
 "lvg" = (
 /obj/machinery/light/directional/east,
 /obj/structure/sign/poster/official/random/directional/east,
@@ -46465,6 +46429,14 @@
 /obj/item/reagent_containers/dropper,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"lFO" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/cable/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/engineering/hallway)
 "lFQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46487,11 +46459,11 @@
 /turf/open/floor/carpet/black,
 /area/station/service/chapel/office)
 "lFU" = (
-/obj/machinery/computer/monitor,
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "lFX" = (
 /obj/structure/table/reinforced,
@@ -46814,7 +46786,18 @@
 /area/station/science/xenobiology)
 "lKb" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/reagent_dispensers/watertank,
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/stack/sheet/mineral/plasma/five,
+/obj/item/gps,
+/obj/structure/closet/crate/engineering,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/stock_parts/power_store/cell/high,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -49454,6 +49437,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
+"msJ" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/field/generator,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/engineering/storage)
 "msN" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -53797,12 +53786,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/common/cryopods)
-"nvj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/layer1,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "nvl" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
@@ -57698,14 +57681,6 @@
 /obj/item/melee/baton/security/cattleprod,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"orZ" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "osh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59106,12 +59081,11 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "oKz" = (
-/obj/structure/cable,
+/obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "oKA" = (
 /obj/structure/cable,
@@ -61821,6 +61795,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
+"pun" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/engineering/engine_smes)
 "pus" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -62701,6 +62681,14 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
+"pEo" = (
+/obj/structure/cable,
+/obj/machinery/power/terminal,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/engineering/engine_smes)
 "pEq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -65033,7 +65021,8 @@
 	},
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/station/engineering/engine_smes)
 "qjk" = (
 /obj/machinery/door/airlock/external,
@@ -65179,14 +65168,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "qkY" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "qkZ" = (
@@ -65904,9 +65891,23 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
 "qvI" = (
-/obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/bot,
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/closet/crate{
+	name = "solar pack crate"
+	},
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/station/engineering/storage)
@@ -67909,6 +67910,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"qWt" = (
+/obj/machinery/door/airlock/engineering/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/engineering/engine_smes)
 "qWu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -73290,6 +73299,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Engineering - Secure Storage East";
+	network = list("ss13","engineering")
+	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "smv" = (
@@ -76984,15 +76998,11 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "tmO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/holopad,
-/obj/structure/cable/multilayer/connected,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "tmR" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
@@ -77444,6 +77454,13 @@
 /obj/effect/landmark/navigate_destination/bridge,
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"trp" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/engineering/hallway)
 "trz" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -79747,10 +79764,16 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "tVG" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "tVJ" = (
 /obj/effect/landmark/blobstart,
@@ -81129,6 +81152,17 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"unx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/engineering/hallway)
 "unz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -82823,6 +82857,7 @@
 "uMv" = (
 /obj/effect/turf_decal/bot,
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/station/engineering/storage)
 "uMw" = (
@@ -84684,13 +84719,16 @@
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/department/security/ghetto)
 "vlU" = (
-/obj/effect/turf_decal/tile/yellow/full,
-/obj/effect/turf_decal/bot,
-/obj/structure/cable,
-/obj/machinery/power/terminal,
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "vmb" = (
 /obj/machinery/hydroponics/constructable,
@@ -87980,6 +88018,10 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"wcN" = (
+/obj/machinery/power/smes/engineering,
+/turf/open/floor/plating,
+/area/station/engineering/engine_smes)
 "wdj" = (
 /obj/structure/frame,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -89196,17 +89238,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"wuw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
-/turf/open/floor/iron/dark,
-/area/station/engineering/hallway)
 "wuA" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
@@ -92765,6 +92796,17 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
+"xmO" = (
+/obj/structure/table,
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/engine_smes)
 "xmP" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor2-old"
@@ -95944,6 +95986,12 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
+"yeX" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/structure/cable,
+/obj/machinery/power/smes/engineering,
+/turf/open/floor/plating,
+/area/station/engineering/engine_smes)
 "yfg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -95960,13 +96008,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
-"yfl" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/hallway)
 "yfn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/table,
@@ -187912,7 +187953,7 @@ wWQ
 fjs
 vpx
 lTR
-fyD
+jqL
 fjs
 sWD
 fur
@@ -188695,7 +188736,7 @@ awU
 lKb
 cGC
 lFp
-lvd
+qjL
 izJ
 pOs
 xLD
@@ -188954,10 +188995,10 @@ smq
 nXm
 uMv
 uiq
-pOs
-ilr
+djZ
+xLD
 put
-kUU
+msJ
 kUU
 awU
 iWx
@@ -189205,11 +189246,11 @@ qcu
 hZh
 jLC
 boY
-awU
-aFu
-lvd
-qjL
-awU
+qHG
+qHG
+qHG
+qHG
+qHG
 jmW
 jmW
 jmW
@@ -189462,11 +189503,11 @@ evB
 hZh
 qsB
 jdk
-awU
+tey
 lmH
 kJY
-qjL
-awU
+xmO
+qHG
 aqO
 wFk
 oDh
@@ -189718,11 +189759,11 @@ pNN
 lvu
 uRF
 jLC
-jdk
-qHG
-qHG
-qHG
-qHG
+lFO
+juF
+kPC
+pEo
+wcN
 qHG
 aqO
 wFk
@@ -189976,7 +190017,7 @@ hVl
 uRF
 jLC
 qkY
-alL
+qHG
 cKg
 ayW
 qjh
@@ -190232,7 +190273,7 @@ xKS
 qau
 hZh
 xHY
-jdk
+aPB
 tey
 lFU
 hch
@@ -190489,9 +190530,9 @@ ijr
 ruK
 pPI
 jLC
-iro
-alL
-orZ
+aPB
+tey
+lFU
 jLz
 aoY
 qHG
@@ -190746,9 +190787,9 @@ xWW
 ruK
 pPI
 jLC
-geN
-epX
-nvj
+aPB
+tey
+lFU
 tmO
 jcM
 qHG
@@ -191003,11 +191044,11 @@ gpv
 ruK
 pPI
 jLC
-yfl
-alL
+aPB
+qHG
 oKz
-ius
-fdw
+ayW
+pun
 qHG
 wAJ
 xKA
@@ -191260,11 +191301,11 @@ xKS
 njW
 hZh
 piJ
-aPB
-tey
-lFU
-hch
-fdw
+trp
+qWt
+kkg
+eAy
+yeX
 qHG
 nle
 svV
@@ -191777,8 +191818,8 @@ qsB
 pDl
 qHG
 qHG
-qHG
-qHG
+tey
+alL
 qHG
 jmW
 jQC
@@ -192034,9 +192075,9 @@ lAq
 rjh
 bfN
 rjh
-wuw
 rjh
 rjh
+unx
 wND
 jHX
 qWg

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -38802,6 +38802,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/layer1,
 /obj/structure/cable,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "jLB" = (
@@ -92770,7 +92771,6 @@
 /area/station/command/heads_quarters/cmo)
 "xmO" = (
 /obj/structure/table,
-/obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -192047,9 +192047,9 @@ lAq
 rjh
 bfN
 rjh
-rjh
-rjh
 unx
+rjh
+rjh
 wND
 jHX
 qWg

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -889,11 +889,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/fore/starboard)
-"alL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/engineering/engine_smes)
 "alO" = (
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
@@ -1134,8 +1129,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "aoY" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1143,6 +1136,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "apb" = (
@@ -1900,10 +1895,12 @@
 /area/station/engineering/atmos/mix/ghetto)
 "ayW" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/cable,
-/obj/machinery/power/terminal,
+/obj/machinery/power/terminal{
+	cable_layer = 1
+	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "azb" = (
@@ -6126,6 +6123,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
@@ -11005,13 +11003,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
-"cKg" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/engineering/engine_smes)
 "cKl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15029,7 +15020,6 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "dGf" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
@@ -18254,14 +18244,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
-"eAy" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/bot,
-/obj/machinery/power/terminal,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/engineering/engine_smes)
 "eAB" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/iron/dark,
@@ -19032,6 +19014,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
@@ -25381,7 +25364,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "goV" = (
@@ -27857,7 +27839,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/multilayer/connected,
+/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "gWW" = (
@@ -38817,6 +38800,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "jLB" = (
@@ -42805,6 +42790,8 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
+/obj/structure/cable/layer1,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "kKa" = (
@@ -44894,10 +44881,10 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "lmH" = (
 /obj/machinery/computer/monitor,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "lmL" = (
@@ -46404,10 +46391,12 @@
 /area/station/engineering/storage)
 "lFq" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/cable,
-/obj/machinery/power/terminal,
+/obj/machinery/power/terminal{
+	cable_layer = 1
+	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "lFt" = (
@@ -59087,13 +59076,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"oKz" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/engineering/engine_smes)
 "oKA" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/old,
@@ -62683,11 +62665,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
 "pEo" = (
-/obj/structure/cable,
-/obj/machinery/power/terminal,
+/obj/machinery/power/terminal{
+	cable_layer = 1
+	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "pEq" = (
@@ -75048,11 +75032,11 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/central/aft)
 "sIU" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/north,
+/obj/machinery/light_switch/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "sIX" = (
@@ -76998,11 +76982,13 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "tmO" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable,
+/obj/machinery/power/terminal{
+	cable_layer = 1
+	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "tmR" = (
@@ -79758,7 +79744,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "tVG" = (
-/obj/structure/cable,
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical,
 /obj/effect/turf_decal/stripes/line{
@@ -84716,6 +84701,8 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "vmb" = (
@@ -189488,7 +189475,7 @@ evB
 hZh
 qsB
 jdk
-tey
+qHG
 lmH
 kJY
 xmO
@@ -189746,7 +189733,7 @@ uRF
 jLC
 jdk
 tey
-kPC
+kkg
 pEo
 wcN
 qHG
@@ -190002,8 +189989,8 @@ hVl
 uRF
 jLC
 qkY
-qHG
-cKg
+tey
+kkg
 ayW
 wcN
 qHG
@@ -191030,8 +191017,8 @@ ruK
 pPI
 jLC
 aPB
-qHG
-oKz
+tey
+kPC
 lFq
 wcN
 qHG
@@ -191288,8 +191275,8 @@ hZh
 piJ
 aPB
 tey
-kkg
-eAy
+kPC
+lFq
 yeX
 qHG
 nle
@@ -191544,7 +191531,7 @@ sHV
 hZh
 jLC
 goS
-alL
+qHG
 jmE
 vlU
 tVG
@@ -191803,8 +191790,8 @@ qsB
 pDl
 qHG
 qHG
-tey
-alL
+qHG
+qHG
 qHG
 jmW
 jQC


### PR DESCRIPTION
## Что этот PR делает

Разносит контуры СМ и станции в комнате с батареями. 
И батарея гравгена больше не питает станцию.

## Почему это хорошо для игры

Контуры нельзя замыкать. 
Мониторы показывают разные контуры, а не один и тот же.

Также разомкнул контур гравгена и станции, т.к. батарея гравгена питала станцию. 
Теперь гравитация не будет вырубаться сразу как станция теряет энергию.

## Изображения изменений

![image](https://github.com/user-attachments/assets/aae8907f-5601-486a-b651-ed052bd7385b)

![image](https://github.com/user-attachments/assets/ebaf5b7b-214d-4c53-ba02-db29c9fb0c15)


## Тестирование

Запустил на локалке.
## Changelog

:cl:
map: Кибериада: Контуры питания станции и СМ разделены
map: Кибериада: Контуры питания станции и грав. генератора разделены
/:cl:
