### PR TITLE
Fix: null reference window for Access Checker component 

### DIFF
--- a/tgui/packages/tgui/interfaces/CircuitAccessChecker.tsx
+++ b/tgui/packages/tgui/interfaces/CircuitAccessChecker.tsx
@@ -29,7 +29,7 @@ export const CircuitAccessChecker = (props) => {
         </LabeledList>
         <AccessConfig
           accesses={regions}
-          selectedList={accesses}
+          selectedList={accesses || []}
           accessMod={(ref) =>
             act('set', {
               access: ref,


### PR DESCRIPTION

## Что этот PR делает
Исправляет null reference ошибку у интерфейса модуля access_checker для циркутов
Fixes #1131 
## Почему это хорошо для игры
Рабочий модуль без синих экранов
## Изображения изменений
![image](https://github.com/user-attachments/assets/d6a5ccc8-fd54-482b-acd3-6ad4ee8851b2)
## Тестирование
Запустил локалку, тыкнул на модуль в руках, засунул в интегралку, тыкнул в интегралке.
## Changelog

:cl: Ez-Briz
fix: Access Checker component interface fix
/:cl:
