### PR TITLE
Cyberiad: Adds lower bar atrium, adjusts coldroom and barman room location

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -3293,6 +3293,12 @@
 /obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/button/door/directional/west{
+	id = "vip_room2";
+	name = "Door Control";
+	specialfunctions = 4;
+	normaldoorcontrol = 1
+	},
 /turf/open/floor/iron/checker,
 /area/station/service/bar/atrium/ghetto)
 "aPQ" = (
@@ -6480,6 +6486,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/button/door/directional/west{
+	id = "vip_room1";
+	name = "Door Control";
+	specialfunctions = 4;
+	normaldoorcontrol = 1
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/bar/atrium/ghetto)
 "bCJ" = (
@@ -8158,7 +8170,6 @@
 /obj/item/circuitboard/computer/slot_machine,
 /obj/item/vending_refill/cigarette,
 /obj/item/vending_refill/coffee,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/backroom/ghetto)
 "bYr" = (
@@ -14973,7 +14984,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/checker,
 /area/station/service/bar/atrium/ghetto)
 "dAB" = (
@@ -18391,6 +18401,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/button/door/directional/east{
+	id = "vip_room1";
+	name = "Door Control";
+	specialfunctions = 4;
+	normaldoorcontrol = 1;
+	req_access = list("kitchen", "bar")
+	},
 /turf/open/floor/wood/large,
 /area/station/service/bar/atrium/ghetto)
 "euX" = (
@@ -31772,6 +31789,7 @@
 "hHb" = (
 /obj/machinery/holopad,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/stone,
 /area/station/service/hydroponics/ghetto)
 "hHe" = (
@@ -31887,6 +31905,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public{
+	id_tag = "vip_room2"
+	},
 /obj/structure/curtain/cloth/fancy,
 /turf/open/floor/iron/checker,
 /area/station/service/bar/atrium/ghetto)
@@ -50286,6 +50307,10 @@
 "miI" = (
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"miQ" = (
+/obj/machinery/gibber,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom/ghetto)
 "miT" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/reagent_containers/cup/glass/bottle/whiskey{
@@ -62148,8 +62173,6 @@
 /obj/effect/turf_decal/trimline/dark/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/checker,
 /area/station/service/bar/atrium/ghetto)
 "paX" = (
@@ -86799,6 +86822,13 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/button/door/directional/east{
+	id = "vip_room2";
+	name = "Door Control";
+	specialfunctions = 4;
+	normaldoorcontrol = 1;
+	req_access = list("kitchen", "bar")
+	},
 /turf/open/floor/wood/large,
 /area/station/service/bar/atrium/ghetto)
 "vhi" = (
@@ -91229,7 +91259,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/railing{
 	dir = 1;
 	color = "#6e6e6e"
@@ -96756,8 +96785,6 @@
 /obj/effect/turf_decal/trimline/dark/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -97281,8 +97308,6 @@
 /obj/effect/turf_decal/trimline/dark/warning{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/reagent_containers/cup/rag{
 	pixel_x = 6;
 	pixel_y = 12
@@ -98287,8 +98312,11 @@
 "xWy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/curtain/cloth/fancy,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public{
+	id_tag = "vip_room1"
+	},
+/obj/structure/curtain/cloth/fancy,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/bar/atrium/ghetto)
 "xWE" = (
@@ -133547,7 +133575,7 @@ raA
 nbO
 vPK
 paU
-oqM
+ckY
 hzy
 wFf
 mca
@@ -135346,7 +135374,7 @@ vCA
 ayP
 hiq
 xCG
-qST
+ckY
 mMv
 gsW
 eIx
@@ -137908,7 +137936,7 @@ klF
 wWh
 ugR
 lyW
-lyW
+miQ
 gyK
 cXX
 wWh

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -16205,7 +16205,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "dQW" = (
-/obj/machinery/door/airlock/service,
+/obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/firedoor,
 /obj/machinery/duct,
@@ -20282,6 +20282,13 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
+"eVb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/meter,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "eVl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26670,13 +26677,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/locker)
-"gxo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/meter,
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/maintenance/ghetto/central)
 "gxu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance,
@@ -49235,7 +49235,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/door/airlock/service,
+/obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
@@ -49911,6 +49911,13 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/smooth,
 /area/station/commons/toilet/restrooms)
+"mdv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/meter,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central)
 "mdx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -131741,7 +131748,7 @@ bsv
 bsv
 aNR
 liU
-bsv
+eVb
 rqb
 bCC
 mOI
@@ -132004,9 +132011,9 @@ gJQ
 bBe
 dEJ
 bBe
-gxo
+bBe
 rqb
-dlM
+mdv
 dlM
 mOI
 doz

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -57843,10 +57843,6 @@
 "nZT" = (
 /turf/closed/wall,
 /area/station/service/bar)
-"nZU" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space)
 "nZZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 9
@@ -129382,7 +129378,7 @@ txs
 guN
 bsv
 guN
-nZU
+vbK
 doz
 doz
 doz
@@ -129639,7 +129635,7 @@ doz
 guN
 skM
 guN
-nZU
+vbK
 doz
 doz
 doz

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -19216,7 +19216,7 @@
 	dir = 8;
 	color = "#6e6e6e"
 	},
-/obj/machinery/light/small/blacklight/directional/south,
+/obj/machinery/light/small/directional/south,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
@@ -42199,9 +42199,7 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "knI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "knL" = (
@@ -46160,6 +46158,21 @@
 /obj/effect/turf_decal/tile/dark_red/full,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
+"lkf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/structure/table/wood,
+/obj/item/kitchen/rollingpin{
+	pixel_y = 4
+	},
+/obj/item/clothing/head/utility/chefhat,
+/turf/open/floor/wood/parquet,
+/area/station/hallway/secondary/service)
 "lkr" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -47364,6 +47377,9 @@
 /area/station/ai_monitored/turret_protected/aisat/service)
 "lya" = (
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "lyd" = (
@@ -50020,10 +50036,6 @@
 /obj/effect/spawner/random/food_or_drink/donkpockets{
 	pixel_y = 4
 	},
-/obj/item/kitchen/rollingpin{
-	pixel_y = 4
-	},
-/obj/item/clothing/head/utility/chefhat,
 /turf/open/floor/wood/parquet,
 /area/station/hallway/secondary/service)
 "mfG" = (
@@ -55556,6 +55568,15 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/atmos)
+"nwv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "nwx" = (
 /turf/closed/wall/r_wall,
 /area/station/security/execution)
@@ -58031,9 +58052,7 @@
 /area/station/maintenance/ghetto/port)
 "obW" = (
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
+/obj/structure/disposalpipe/trunk,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
@@ -63434,6 +63453,12 @@
 /obj/item/bedsheet/brown,
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
+"pqR" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
+/area/station/hallway/secondary/service)
 "prg" = (
 /obj/structure/chair{
 	dir = 8
@@ -64082,7 +64107,6 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/atmos/hfr_room)
 "pyx" = (
-/obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
@@ -73364,6 +73388,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
+"rOi" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "rOk" = (
 /obj/structure/sink/directional/west,
 /obj/structure/mirror/directional/east,
@@ -73891,9 +73922,6 @@
 	},
 /obj/structure/table,
 /obj/machinery/airalarm/directional/north,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "rVa" = (
@@ -81052,9 +81080,6 @@
 "tIt" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "tIw" = (
@@ -81219,9 +81244,6 @@
 /area/station/maintenance/ghetto/central/aft)
 "tKk" = (
 /obj/machinery/smartfridge/drying,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/sign/poster/official/fruit_bowl/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
@@ -83753,9 +83775,6 @@
 	pixel_y = 8
 	},
 /obj/structure/table,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "uqw" = (
@@ -84181,9 +84200,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/item/kirbyplants/random,
 /obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/chair/wood{
+	dir = 1
+	},
 /turf/open/floor/wood/parquet,
 /area/station/hallway/secondary/service)
 "uxw" = (
@@ -87309,7 +87330,6 @@
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics/ghetto)
 "vnc" = (
@@ -203151,7 +203171,7 @@ nvd
 vix
 rlr
 xFd
-tli
+pqR
 sTZ
 kAC
 eMv
@@ -203159,7 +203179,7 @@ qbT
 lNm
 sTZ
 rUZ
-lya
+rOi
 gVV
 gry
 lWz
@@ -203416,7 +203436,7 @@ dmh
 fPT
 sTZ
 tKk
-lya
+rOi
 dKr
 dKr
 dKr
@@ -203665,7 +203685,7 @@ wdZ
 vix
 mfF
 rzJ
-dRD
+lkf
 sTZ
 sTZ
 sTZ
@@ -203673,7 +203693,7 @@ sTZ
 fSS
 sTZ
 uqu
-lya
+rOi
 dKr
 unf
 pLB
@@ -203930,7 +203950,7 @@ rOn
 tli
 pHh
 tIt
-lya
+rOi
 dKr
 kIg
 kvX
@@ -204187,7 +204207,7 @@ iSS
 iSS
 iEj
 knI
-hJN
+nwv
 fxv
 mdc
 wCj

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -96,7 +96,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/parquet,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "abw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -583,10 +583,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "ahU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/maint,
 /obj/effect/spawner/random/bedsheet/any,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "ahV" = (
@@ -1269,7 +1269,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "aqx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
@@ -1861,7 +1861,7 @@
 	dir = 9
 	},
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "ayF" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/dark,
@@ -1902,7 +1902,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/curtain/cloth/fancy/mechanical/start_closed,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "ayQ" = (
 /obj/structure/flora/tree/jungle{
 	pixel_y = -14
@@ -2005,7 +2005,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/maintenance/department/medical/ghetto)
+/area/station/maintenance/department/security/ghetto/aft)
 "azO" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/turf_decal/bot,
@@ -2049,7 +2049,7 @@
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "aAf" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -2173,7 +2173,6 @@
 /area/station/service/chapel/office)
 "aCd" = (
 /obj/structure/railing{
-	dir = 2;
 	color = "#6e6e6e"
 	},
 /obj/structure/railing/corner/end/flip{
@@ -2186,7 +2185,7 @@
 	color = "#6e6e6e"
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "aCe" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 1
@@ -2296,7 +2295,7 @@
 /obj/effect/turf_decal/stripes/box,
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "aDs" = (
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 8
@@ -2409,6 +2408,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
+"aEx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
 "aEC" = (
 /obj/structure/sign/warning/radiation/directional/north,
 /turf/open/floor/engine,
@@ -2826,14 +2831,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
-"aJw" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet/black,
-/area/station/commons/lounge)
 "aJA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -2927,7 +2924,7 @@
 	name = "Hydroponics Shutter Control"
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "aKY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3162,6 +3159,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
+"aNR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "aNU" = (
 /obj/machinery/computer/crew,
 /obj/effect/turf_decal/tile/green/half/contrasted,
@@ -3171,7 +3175,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "aOe" = (
 /obj/effect/landmark/start/shaft_miner,
 /obj/effect/landmark/start/shaft_miner,
@@ -3229,7 +3233,7 @@
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/beebox,
 /turf/open/floor/grass,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "aOV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3265,7 +3269,7 @@
 /obj/structure/chair/stool/bar/directional/north,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/black,
-/area/station/commons/lounge)
+/area/station/service/bar)
 "aPt" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/garden)
@@ -3286,8 +3290,9 @@
 "aPM" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/checker,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "aPQ" = (
 /turf/closed/wall/r_wall,
 /area/station/science/xenobiology)
@@ -3412,7 +3417,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "aQY" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 8
@@ -3525,7 +3530,7 @@
 	color = "#777777"
 	},
 /turf/open/misc/sandy_dirt,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "aSg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -3623,6 +3628,18 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
+"aTe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
 "aTg" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L5"
@@ -3697,7 +3714,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "aTP" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/vending/autodrobe,
@@ -3873,7 +3890,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "aWp" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /obj/effect/turf_decal/stripes/line{
@@ -4032,7 +4049,7 @@
 	},
 /obj/effect/turf_decal/trimline/white/corner,
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "aXQ" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating,
@@ -4458,6 +4475,7 @@
 /area/station/security/holding_cell)
 "bdK" = (
 /obj/structure/closet/l3closet/virology,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "bdV" = (
@@ -4648,6 +4666,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
+"bgA" = (
+/obj/effect/spawner/random/medical/injector,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "bgE" = (
 /turf/open/openspace,
 /area/station/maintenance/port)
@@ -4912,6 +4934,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
+"bjm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
 "bjo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4985,7 +5012,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/area/station/service/kitchen/coldroom/ghetto)
 "bkf" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow{
@@ -5486,7 +5513,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "bqM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
@@ -5728,13 +5754,13 @@
 	},
 /area/station/holodeck/rec_center)
 "bti" = (
-/obj/effect/spawner/structure/window,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "botany_apiary";
 	name = "Apiary Shutters"
 	},
 /turf/open/floor/plating,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "bto" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden/crude,
@@ -5925,7 +5951,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "bwa" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 8
@@ -6187,7 +6213,7 @@
 /area/station/maintenance/ghetto/auxiliary)
 "byC" = (
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "byD" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -6354,15 +6380,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
-"bBM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/dark_green{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
 "bBN" = (
 /obj/effect/spawner/random/trash/bin,
 /turf/open/floor/iron,
@@ -6458,7 +6475,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/cafeteria,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "bCJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red{
@@ -6594,7 +6611,6 @@
 	color = "#6e6e6e"
 	},
 /obj/structure/railing{
-	dir = 2;
 	color = "#6e6e6e"
 	},
 /turf/open/openspace,
@@ -6697,7 +6713,7 @@
 /obj/structure/chair/sofa/left/maroon,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/carpet/red,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "bFB" = (
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
@@ -6728,6 +6744,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"bFX" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "bFZ" = (
 /obj/machinery/door/poddoor{
 	name = "Incinerator Vent";
@@ -7196,8 +7218,6 @@
 "bMl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical/ghetto/morgue)
 "bMt" = (
@@ -7226,6 +7246,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "bML" = (
@@ -7288,8 +7309,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark/small,
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "bNv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -7515,7 +7537,7 @@
 	color = "#6e6e6e"
 	},
 /turf/closed/wall,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "bQo" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -7737,8 +7759,9 @@
 /obj/item/food/meat/slab/pig,
 /obj/item/food/meat/slab/pig,
 /obj/item/food/meat/slab/pig,
+/obj/effect/mapping_helpers/airalarm/tlv_cold_room,
 /turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/area/station/service/kitchen/coldroom/ghetto)
 "bSX" = (
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 1
@@ -7852,7 +7875,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto/morgue)
 "bUW" = (
@@ -7979,7 +8001,7 @@
 	},
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/wood,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "bWR" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/atmospherics/pipe/smart/simple/general{
@@ -8132,7 +8154,7 @@
 /obj/item/vending_refill/coffee,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood/parquet,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "bYr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -8177,6 +8199,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/large,
 /area/station/commons/dorms)
 "bZr" = (
@@ -8394,7 +8417,7 @@
 /area/station/maintenance/ghetto/port/greater)
 "cbl" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock,
+/obj/machinery/door/airlock/public,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
 /obj/effect/mapping_helpers/airlock/access/any/service/bar,
@@ -8473,7 +8496,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "cbR" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -8536,6 +8559,10 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
+"ccS" = (
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "ccU" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/table/glass,
@@ -8695,12 +8722,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"cfl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "cfm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/floor,
 /turf/open/floor/iron/checker,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "cfp" = (
 /obj/effect/turf_decal/tile/green/half{
 	dir = 1
@@ -8708,15 +8739,7 @@
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
-/area/station/service/hydroponics/upper)
-"cfA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/light/small/directional/west,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central/fore)
+/area/station/service/hydroponics)
 "cfF" = (
 /obj/structure/closet/secure_closet/security/med,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8737,7 +8760,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "cfY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8774,9 +8797,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "cgz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/dark_green,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "cgA" = (
@@ -8914,7 +8937,7 @@
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "chY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/bar/fourcorners,
@@ -9031,7 +9054,6 @@
 /area/station/maintenance/ghetto/starboard)
 "cjh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/closet/l3closet/virology,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
@@ -9156,7 +9178,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "ckj" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
@@ -9167,7 +9189,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "ckk" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
@@ -9264,7 +9286,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "cla" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9379,7 +9401,6 @@
 /area/station/security/prison)
 "cmt" = (
 /obj/structure/railing{
-	dir = 2;
 	color = "#6e6e6e"
 	},
 /obj/structure/railing{
@@ -9387,7 +9408,7 @@
 	color = "#6e6e6e"
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "cmE" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
@@ -9518,7 +9539,6 @@
 "col" = (
 /obj/effect/turf_decal/siding/dark/corner,
 /obj/structure/railing/corner{
-	dir = 2;
 	color = "#6e6e6e"
 	},
 /obj/effect/turf_decal/siding/wood/corner{
@@ -9527,7 +9547,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "cop" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9659,6 +9679,9 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
@@ -9936,7 +9959,7 @@
 	},
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "ctJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -10056,6 +10079,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"cvk" = (
+/obj/structure/closet/secure_closet/medical1,
+/obj/effect/spawner/random/maintenance/four,
+/turf/open/floor/iron,
+/area/station/maintenance/department/medical/ghetto)
 "cvn" = (
 /obj/structure/reflector/double,
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -10071,9 +10099,8 @@
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 1
 	},
-/obj/structure/closet/emcloset,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "cvE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10145,12 +10172,12 @@
 /obj/effect/turf_decal/trimline/white/line,
 /obj/machinery/camera/directional/south{
 	dir = 5;
-	c_tag = "Lower Service Hall Alt"
+	c_tag = "Kitchen - Backroom Lower Floor East"
 	},
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "cwd" = (
 /turf/open/floor/iron/stairs/right{
 	dir = 8
@@ -10450,7 +10477,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "czX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
@@ -10829,7 +10856,7 @@
 	pixel_y = -8
 	},
 /turf/open/misc/dirt/dark/station,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "cEP" = (
 /obj/effect/turf_decal/tile/red,
 /obj/item/kirbyplants/random/dead,
@@ -10964,7 +10991,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/carpet/green,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "cGC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -11033,7 +11060,7 @@
 	},
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "cHo" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -11138,7 +11165,6 @@
 /area/station/command/meeting_room)
 "cIu" = (
 /obj/structure/railing{
-	dir = 2;
 	color = "#6e6e6e"
 	},
 /obj/structure/railing{
@@ -11149,7 +11175,7 @@
 	color = "#555559"
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "cIx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11181,7 +11207,7 @@
 "cIN" = (
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/carpet/black,
-/area/station/commons/lounge)
+/area/station/service/bar)
 "cIS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -11192,7 +11218,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/command/storage/eva)
 "cJj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
 	},
@@ -11292,7 +11317,7 @@
 	slogan_delay = 700
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "cJZ" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -11684,11 +11709,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"cOR" = (
-/obj/structure/grille/broken,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "cOY" = (
 /obj/effect/turf_decal/tile/dark_green/anticorner{
 	dir = 4
@@ -11793,6 +11813,15 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"cQc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/department/security/ghetto/aft)
 "cQk" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -11867,7 +11896,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/area/station/service/kitchen/coldroom/ghetto)
 "cRo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11880,7 +11909,7 @@
 	},
 /obj/machinery/light/small/blacklight/directional/west,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "cRx" = (
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 4
@@ -11897,7 +11926,7 @@
 	},
 /obj/machinery/light/floor,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "cRA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -11950,7 +11979,7 @@
 /obj/structure/chair/sofa/right/maroon,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/glass,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "cSo" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
@@ -12011,9 +12040,6 @@
 /area/station/cargo/storage)
 "cTa" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
 /obj/effect/spawner/random/trash/mess,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -12079,6 +12105,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood/parquet,
 /area/station/hallway/secondary/service)
 "cTV" = (
@@ -12086,6 +12113,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "cTW" = (
@@ -12359,6 +12387,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "cWD" = (
@@ -12466,7 +12495,7 @@
 "cXX" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/area/station/service/kitchen/coldroom/ghetto)
 "cXY" = (
 /obj/structure/railing{
 	dir = 1
@@ -12900,7 +12929,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /obj/structure/curtain/bounty,
 /obj/machinery/door/airlock/service,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "dcd" = (
@@ -12929,7 +12957,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/area/station/service/kitchen/coldroom/ghetto)
 "dcn" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -13531,12 +13559,10 @@
 "dkf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/structure/chair/office{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
 "dkj" = (
@@ -13667,7 +13693,7 @@
 "dlg" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "dlm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/trash/mess,
@@ -13754,10 +13780,11 @@
 /obj/effect/turf_decal/trimline/tram/line{
 	dir = 4
 	},
+/obj/item/book/manual/chef_recipes,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "dmj" = (
 /obj/machinery/status_display/ai/directional/north,
 /obj/effect/turf_decal/bot_white/right,
@@ -13905,14 +13932,6 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
-"dog" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/service/bar)
 "dok" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -14068,14 +14087,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/security/prison/mess)
-"dpr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/dark_green{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
 "dpz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14187,7 +14198,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/iron/dark/smooth_edge,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "drA" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/glass{
@@ -14211,7 +14222,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/command/storage/eva)
 "drD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 8
 	},
@@ -14618,7 +14628,7 @@
 	},
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/iron/dark/smooth_corner,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "dwg" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
@@ -14966,7 +14976,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/checker,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "dAB" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -15708,22 +15718,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay/ghetto)
-"dJX" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 8;
-	color = "#6e6e6e"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
 "dKd" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/bodycontainer/morgue{
@@ -16014,7 +16008,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "dNF" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/white,
@@ -16218,7 +16212,7 @@
 /obj/machinery/duct,
 /obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /turf/open/floor/iron/dark,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "dRl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
 	dir = 10
@@ -16250,14 +16244,6 @@
 /area/station/commons/locker)
 "dRC" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/door/window/right/directional/south{
-	name = "Bar Deliverys";
-	req_access = list("bar")
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/bar)
 "dRD" = (
@@ -16538,6 +16524,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"dVO" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "botany_apiary";
+	name = "Apiary Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/service/hydroponics/ghetto)
 "dVT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16637,9 +16631,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/garden)
-"dWX" = (
-/turf/closed/wall,
-/area/station/service/hydroponics/upper)
 "dWZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 5
@@ -16733,6 +16724,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical/ghetto/morgue)
 "dXY" = (
@@ -16820,6 +16812,13 @@
 "dZQ" = (
 /turf/open/floor/iron/stairs/medium,
 /area/station/hallway/secondary/exit/departure_lounge)
+"dZS" = (
+/obj/structure/sign/warning/vacuum/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "dZX" = (
 /obj/item/ammo_casing/rebar/paperball{
 	pixel_x = 11;
@@ -16832,7 +16831,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "dZZ" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -16883,7 +16882,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "eao" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17153,6 +17152,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/wood,
 /area/station/service/kitchen/abandoned)
+"edE" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "edG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -17202,7 +17205,7 @@
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 1
 	},
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "eeh" = (
 /obj/effect/spawner/random/engineering/tank,
 /turf/open/floor/plating,
@@ -17608,7 +17611,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/checker,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "ejI" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /mob/living/basic/mouse,
@@ -18042,10 +18045,13 @@
 "epA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/holopad,
 /obj/machinery/duct,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "epC" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/signaler{
@@ -18387,7 +18393,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "euX" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine,
@@ -18413,6 +18419,13 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"evs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/table,
+/obj/effect/spawner/random/food_or_drink,
+/obj/effect/spawner/random/food_or_drink/booze,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
 "evA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -18548,7 +18561,7 @@
 /obj/structure/chair/sofa/middle/maroon,
 /obj/machinery/light/small/blacklight/directional/north,
 /turf/open/floor/carpet/red,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "eyu" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -18619,7 +18632,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "ezB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -18765,6 +18778,13 @@
 /obj/effect/spawner/random/structure/furniture_parts,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
+"eAV" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/wood/large,
+/area/station/commons/lounge)
 "eBh" = (
 /obj/machinery/vending/snack,
 /obj/machinery/light/small/directional/east,
@@ -18865,6 +18885,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/station/maintenance/aft)
+"eCv" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/dark_green/half,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "eCM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18900,7 +18928,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "eDr" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 6
@@ -18948,7 +18976,7 @@
 	c_tag = "Hydroponics - Pasture"
 	},
 /turf/open/floor/stone,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "eDR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -19086,8 +19114,12 @@
 	pixel_x = -8;
 	pixel_y = 7
 	},
+/obj/machinery/button/door/directional/south{
+	id = "botany_apiary";
+	name = "Bee Protection Shutters"
+	},
 /turf/open/floor/stone,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "eGj" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/directional/north,
@@ -19144,7 +19176,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/checker,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "eGA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -19176,7 +19208,17 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "eGV" = (
-/obj/machinery/light/small/blacklight/directional/north,
+/obj/structure/railing/corner/end{
+	dir = 8;
+	color = "#6e6e6e"
+	},
+/obj/structure/railing/corner/end/flip{
+	dir = 8;
+	color = "#6e6e6e"
+	},
+/obj/machinery/light/small/blacklight/directional/south,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "eHe" = (
@@ -19249,9 +19291,9 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "eHP" = (
 /obj/structure/table,
 /obj/machinery/light/small/directional/north,
@@ -19273,6 +19315,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"eHU" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "eHV" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -19330,7 +19381,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/cafeteria,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "eIq" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -19349,7 +19400,7 @@
 	},
 /obj/machinery/light/floor,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "eIA" = (
 /turf/closed/wall,
 /area/station/maintenance/department/engine/ghetto)
@@ -19488,7 +19539,7 @@
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "eJY" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
@@ -19514,7 +19565,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "eKq" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/port/fore)
@@ -19606,7 +19657,7 @@
 /obj/structure/chair/sofa/left/maroon,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/red,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "eLY" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Pure to Mix";
@@ -19660,7 +19711,7 @@
 "eMv" = (
 /obj/effect/landmark/start/cook,
 /turf/open/floor/iron/dark/small,
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "eME" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
@@ -19948,6 +19999,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
+"eRj" = (
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "eRl" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -20098,7 +20153,7 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/machinery/light/floor,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "eTt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -20390,7 +20445,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "eXh" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -20556,7 +20611,7 @@
 "eZs" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/glass,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "eZv" = (
 /obj/structure/rack,
 /obj/item/storage/fancy/candle_box{
@@ -20596,6 +20651,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "faf" = (
@@ -20937,7 +20993,6 @@
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
 "feU" = (
-/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/iron,
 /area/station/maintenance/department/security/ghetto/aft)
 "feV" = (
@@ -21103,12 +21158,24 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "fgR" = (
-/obj/machinery/duct,
 /obj/effect/turf_decal/trimline/tram/line,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 1
 	},
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
+"fgU" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/obj/machinery/door/airlock/service,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/service)
 "fgW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21300,7 +21367,7 @@
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "fiV" = (
 /obj/structure/railing{
 	dir = 1
@@ -21365,9 +21432,6 @@
 /area/station/maintenance/department/engine/ghetto)
 "fjz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21450,9 +21514,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"fkt" = (
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
 "fkv" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 8
@@ -21792,11 +21853,17 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "foN" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"foT" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "foW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -21888,15 +21955,6 @@
 /obj/machinery/meter,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
-"fqC" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "fqE" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/airalarm/directional/west,
@@ -21933,7 +21991,7 @@
 	},
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "fqZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/stasis{
@@ -22036,7 +22094,7 @@
 "frW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "fse" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22270,11 +22328,8 @@
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "fuM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "fuT" = (
@@ -22296,7 +22351,7 @@
 "fvf" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/cafeteria,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "fvi" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -22357,7 +22412,6 @@
 /turf/open/floor/wood,
 /area/station/service/library/ghetto)
 "fvT" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/public/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/firedoor,
@@ -22537,20 +22591,19 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/neon/simple/violet,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "fxO" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "fxV" = (
-/obj/machinery/duct,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/small,
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "fyb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22825,7 +22878,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_edge,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "fBN" = (
 /obj/machinery/door/airlock{
 	id_tag = "AuxToilet2"
@@ -22839,13 +22892,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"fBU" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/department/security/ghetto/aft)
 "fBV" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -22881,7 +22927,7 @@
 	},
 /obj/machinery/restaurant_portal/bar,
 /turf/open/floor/wood/large,
-/area/station/commons/lounge)
+/area/station/service/bar)
 "fCl" = (
 /obj/structure/cable,
 /obj/machinery/camera/directional/west{
@@ -22967,11 +23013,10 @@
 	color = "#6e6e6e"
 	},
 /obj/structure/railing/corner{
-	dir = 2;
 	color = "#6e6e6e"
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "fDn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23019,7 +23064,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "fDS" = (
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
@@ -23095,7 +23140,7 @@
 	dir = 5
 	},
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "fEG" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/bot,
@@ -23164,8 +23209,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "fFk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23799,7 +23847,7 @@
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "fMF" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres{
@@ -24064,6 +24112,9 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "fPu" = (
@@ -24080,7 +24131,7 @@
 /obj/machinery/door/window/right/directional/west,
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/dark/textured,
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "fPZ" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
@@ -24306,7 +24357,7 @@
 	location = "Kitchen"
 	},
 /turf/open/floor/plating,
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "fSY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -24362,8 +24413,9 @@
 /obj/effect/turf_decal/trimline/white/end{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "fTI" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -24800,6 +24852,11 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/upper)
+"fZq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/department/medical/ghetto)
 "fZs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -25044,7 +25101,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/checker,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "gbT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/south,
@@ -25366,16 +25423,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "gfU" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/dark_green{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "gga" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -25388,21 +25438,18 @@
 /obj/machinery/status_display/evac/directional/north,
 /obj/structure/rack,
 /obj/item/chair/plastic{
-	pixel_x = 0;
 	pixel_y = 8
 	},
 /obj/item/chair/plastic{
-	pixel_x = 0;
 	pixel_y = 14
 	},
 /obj/item/chair/plastic{
-	pixel_x = 0;
 	pixel_y = 19
 	},
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
 	},
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "ggc" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -25443,6 +25490,12 @@
 /obj/item/hand_labeler,
 /turf/open/floor/carpet/black,
 /area/station/command/meeting_room)
+"ggA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "ggB" = (
 /obj/structure/table/wood,
 /obj/machinery/cell_charger,
@@ -25703,7 +25756,7 @@
 	color = "#6e6e6e"
 	},
 /turf/open/openspace,
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "gkn" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
@@ -26001,7 +26054,7 @@
 	id = "viphall"
 	},
 /turf/open/floor/plating,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "gnK" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -26337,7 +26390,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "gsZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -26674,7 +26727,7 @@
 "gyK" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/area/station/service/kitchen/coldroom/ghetto)
 "gyL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -26832,6 +26885,9 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/service)
 "gAV" = (
@@ -26983,7 +27039,6 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "gCL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/dark_green/half{
 	dir = 1
@@ -27223,14 +27278,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/railing/corner{
-	dir = 2;
 	color = "#6e6e6e"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "gGp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27412,10 +27468,10 @@
 /obj/item/seeds/sunflower,
 /obj/machinery/camera/directional/north{
 	dir = 9;
-	c_tag = "Apiary"
+	c_tag = "Hydroponics - Lower Floor"
 	},
 /turf/open/floor/stone,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "gHN" = (
 /obj/structure/table/wood/fancy/red,
 /obj/item/flashlight/flare/candle{
@@ -27423,7 +27479,7 @@
 	},
 /obj/item/storage/wallet,
 /turf/open/floor/carpet/red,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "gHR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -27541,6 +27597,13 @@
 "gJs" = (
 /turf/open/space/openspace,
 /area/space/nearstation)
+"gJQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/meter,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/ghetto/central)
 "gJY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27706,11 +27769,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "gLw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "gLx" = (
@@ -27858,7 +27921,7 @@
 /obj/effect/turf_decal/trimline/tram/mid_joiner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_edge,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "gNf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27882,8 +27945,11 @@
 	},
 /obj/effect/turf_decal/siding/dark,
 /obj/machinery/duct,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "gNt" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -27895,7 +27961,7 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/cable,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "gNu" = (
 /turf/closed/wall/r_wall,
 /area/station/science/server)
@@ -27918,7 +27984,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/checker,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "gNN" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/machinery/computer/atmos_control/oxygen_tank{
@@ -28048,9 +28114,8 @@
 "gOu" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical/ghetto/morgue)
 "gOB" = (
@@ -28375,7 +28440,7 @@
 "gSq" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
+/area/station/maintenance/department/security/ghetto/aft)
 "gSs" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/iron/dark,
@@ -28451,7 +28516,7 @@
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 4
 	},
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "gTQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
@@ -28519,11 +28584,8 @@
 /turf/closed/wall,
 /area/station/service/library/artgallery)
 "gUN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "gUR" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -28627,7 +28689,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "gWj" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -28758,11 +28820,10 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "gXC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -29120,7 +29181,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/carpet/red,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "hcA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29147,7 +29208,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "hdb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -29204,7 +29265,6 @@
 "hds" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/ghetto)
 "hdu" = (
@@ -29333,11 +29393,11 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "hfN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/dark_green,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
 "hfO" = (
@@ -29573,7 +29633,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/checker,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "hir" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/effect/spawner/random/trash,
@@ -29745,11 +29805,13 @@
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 8
 	},
-/obj/effect/landmark/event_spawn,
 /obj/machinery/duct,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "hki" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -29768,7 +29830,7 @@
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "hkz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -29800,7 +29862,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/parquet,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "hlc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -29964,7 +30026,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/area/station/service/kitchen/coldroom/ghetto)
 "hmV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -29987,7 +30049,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "hne" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -30661,6 +30723,8 @@
 /obj/structure/sign/directions/security/directional/north{
 	pixel_y = 39
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "hvJ" = (
@@ -30682,10 +30746,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/science/ordnance)
-"hvU" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central/fore)
 "hvV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -30738,7 +30798,7 @@
 	color = "#555559"
 	},
 /turf/open/floor/iron/dark/smooth_edge,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "hwC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30784,7 +30844,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "hwT" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -30910,7 +30970,7 @@
 	},
 /obj/effect/turf_decal/trimline/dark/corner,
 /turf/open/floor/iron/checker,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "hyi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 6
@@ -31018,7 +31078,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "hzz" = (
 /obj/effect/turf_decal/tile/purple/half,
 /turf/open/floor/iron,
@@ -31475,7 +31535,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "hEO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31518,7 +31578,7 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/item/reagent_containers/cup/watering_can,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "hFa" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -31542,7 +31602,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/area/station/service/kitchen/coldroom/ghetto)
 "hFm" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -31711,7 +31771,7 @@
 /obj/machinery/holopad,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "hHe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31827,7 +31887,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/curtain/cloth/fancy,
 /turf/open/floor/iron/checker,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "hIA" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/structure/cable,
@@ -31959,10 +32019,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
-"hKc" = (
-/obj/machinery/duct,
-/turf/closed/wall,
-/area/station/service/kitchen)
 "hKf" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
@@ -32053,6 +32109,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"hLk" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "hLr" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -32429,10 +32492,10 @@
 /obj/structure/flora/bush/jungle/b/style_2,
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/camera/directional/north{
-	c_tag = "Lower Bar - South"
+	c_tag = "Bar - Lower Floor South"
 	},
 /turf/open/misc/dirt/dark/station,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "hQN" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -32566,6 +32629,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "hSK" = (
@@ -32923,26 +32987,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
-"hWY" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/frame/computer,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto/aft)
 "hXl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
-"hXp" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
 "hXB" = (
 /obj/structure/chair/sofa/left/maroon,
 /turf/open/floor/glass,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "hXF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32996,6 +33049,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
+"hYm" = (
+/obj/effect/turf_decal/tile/dark_green,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "hYw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/west,
@@ -33198,7 +33261,7 @@
 	color = "#777777"
 	},
 /turf/open/floor/grass,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "iaC" = (
 /obj/machinery/computer/accounting{
 	dir = 8
@@ -33287,7 +33350,7 @@
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "icg" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted,
@@ -33414,6 +33477,11 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"ieg" = (
+/obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/kitchen/small,
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "iej" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -33426,7 +33494,7 @@
 	pixel_y = 2
 	},
 /turf/open/misc/dirt/dark/station,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "ieH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33857,11 +33925,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/engine/ghetto)
-"ijC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/medical/ghetto/morgue)
 "ijG" = (
 /obj/structure/chair/sofa/middle/brown{
 	dir = 4
@@ -34510,7 +34573,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "isq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/plasma_output{
 	dir = 1
@@ -34595,6 +34658,7 @@
 	name = "HoochMaster Deluxe"
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "itp" = (
@@ -34713,7 +34777,7 @@
 "iuM" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "iuP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34935,7 +34999,7 @@
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light/warm/directional/west,
 /turf/open/floor/grass,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "iyn" = (
 /obj/machinery/door/poddoor/massdriver_chapel,
 /obj/structure/fans/tiny,
@@ -35073,12 +35137,6 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/chemistry/ghetto)
-"iAM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet/black,
-/area/station/commons/lounge)
 "iAQ" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -35118,6 +35176,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"iBi" = (
+/turf/closed/wall,
+/area/station/service/hydroponics/ghetto)
 "iBk" = (
 /obj/structure/table/glass,
 /obj/item/cultivator,
@@ -35172,13 +35233,8 @@
 /area/station/maintenance/starboard/aft)
 "iCg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/closet/l3closet/virology,
+/turf/open/floor/iron,
 /area/station/maintenance/department/medical/ghetto)
 "iCi" = (
 /obj/machinery/light/small/directional/north,
@@ -35322,14 +35378,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
-"iEa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/mess,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/central)
 "iEh" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -36032,8 +36080,9 @@
 	dir = 4;
 	color = "#6e6e6e"
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet/red,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "iMm" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -36077,7 +36126,7 @@
 /obj/structure/flora/bush/grassy/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "iMQ" = (
 /obj/machinery/vending/boozeomat{
 	req_access = list(1)
@@ -36150,7 +36199,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white/corner,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "iNx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36218,11 +36267,10 @@
 	pixel_y = 14
 	},
 /obj/effect/spawner/random/food_or_drink/dinner{
-	pixel_x = 0;
 	pixel_y = 5
 	},
 /turf/open/floor/glass,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "iOh" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -36414,7 +36462,7 @@
 	color = "#6e6e6e"
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "iRa" = (
 /obj/machinery/power/smes,
 /obj/structure/cable,
@@ -36588,6 +36636,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto/central)
 "iTo" = (
@@ -36843,7 +36892,7 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
 	},
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "iWF" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -37038,7 +37087,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/curtain/cloth/fancy,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "iYF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37071,7 +37120,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "iYX" = (
 /obj/structure/sink/directional/west,
 /obj/machinery/camera/directional/north{
@@ -37101,7 +37150,7 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "iZh" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/engine/hull/reinforced,
@@ -37125,7 +37174,7 @@
 	id = "viphall"
 	},
 /turf/open/floor/plating/airless,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "iZB" = (
 /obj/structure/rack,
 /obj/item/electronics/airlock,
@@ -37429,7 +37478,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/floor,
 /turf/open/floor/iron/cafeteria,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "jdK" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/cafeteria,
@@ -37657,8 +37706,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "botany_apiary";
+	name = "Apiary Shutters"
+	},
 /turf/open/floor/stone,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "jgi" = (
 /obj/structure/table/reinforced,
 /obj/item/tape/random{
@@ -37681,7 +37734,7 @@
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "jgy" = (
 /obj/effect/spawner/random/maintenance,
 /obj/item/reagent_containers/syringe,
@@ -37806,7 +37859,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "jhU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
@@ -37994,7 +38046,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "jkB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
@@ -38111,6 +38163,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
+"jmO" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "jmR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -38145,18 +38201,6 @@
 /obj/machinery/papershredder,
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"jnj" = (
-/obj/structure/railing/corner/end/flip{
-	dir = 4;
-	color = "#6e6e6e"
-	},
-/obj/structure/railing/corner/end{
-	dir = 4;
-	color = "#6e6e6e"
-	},
-/obj/machinery/light/small/blacklight/directional/west,
-/turf/open/openspace,
-/area/station/service/bar)
 "jnm" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -38335,7 +38379,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "jqG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
@@ -38404,6 +38448,13 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"jrB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/glass_debris,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
 "jrC" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -38429,7 +38480,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small/blacklight/directional/east,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "jrF" = (
 /obj/machinery/duct,
 /turf/open/floor/plating,
@@ -38617,7 +38668,7 @@
 /obj/effect/mapping_helpers/requests_console/assistance,
 /obj/effect/mapping_helpers/requests_console/information,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "jtQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38643,7 +38694,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/carpet/neon/simple/violet,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "jua" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -38980,7 +39031,7 @@
 	pixel_x = -4
 	},
 /turf/open/floor/iron/cafeteria,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "jyX" = (
 /obj/machinery/light/broken/directional/north,
 /turf/open/floor/plating,
@@ -39145,7 +39196,7 @@
 /obj/structure/flora/bush/pointy/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "jBn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39242,11 +39293,9 @@
 /turf/open/floor/carpet/black,
 /area/station/security/courtroom)
 "jDu" = (
-/obj/structure/chair/comfy/black{
-	dir = 2
-	},
+/obj/structure/chair/comfy/black,
 /turf/open/floor/wood/parquet,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "jDE" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 5
@@ -39789,7 +39838,7 @@
 /area/station/science/server)
 "jJb" = (
 /turf/closed/wall/rust,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "jJh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/chair/wood,
@@ -39863,7 +39912,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured_edge,
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "jJM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -39902,7 +39951,7 @@
 "jKd" = (
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "jKe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/camera/directional/north{
@@ -39925,7 +39974,6 @@
 "jKr" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/railing{
-	dir = 2;
 	color = "#6e6e6e"
 	},
 /obj/effect/turf_decal/siding/wood{
@@ -39934,7 +39982,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "jKt" = (
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hop)
@@ -40724,9 +40772,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
 "jVn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
 	},
@@ -40808,7 +40853,7 @@
 /obj/effect/turf_decal/stripes/box,
 /obj/structure/ladder,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "jWg" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance/two,
@@ -40848,9 +40893,9 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "jWy" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -40987,7 +41032,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "jYA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -41190,13 +41235,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
-"kaz" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/dark_green/half,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
 "kaA" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -41482,7 +41520,7 @@
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "keD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41772,7 +41810,6 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "kiG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/effect/turf_decal/tile/dark_green{
@@ -41899,7 +41936,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "kkH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/grille/broken,
@@ -41908,20 +41945,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"kkI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/ghetto/central/fore)
 "kkK" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -41986,7 +42009,7 @@
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "klO" = (
 /obj/machinery/seed_extractor,
 /obj/machinery/status_display/evac/directional/north,
@@ -42199,12 +42222,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage/ghetto)
-"knZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
 "kob" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -42416,6 +42433,9 @@
 /area/station/security/range)
 "kpI" = (
 /obj/effect/turf_decal/tile/dark_green/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "kpJ" = (
@@ -42489,6 +42509,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /obj/machinery/door/airlock/service,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "krH" = (
@@ -42897,7 +42918,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
@@ -42906,7 +42926,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "kvS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42923,7 +42943,7 @@
 	color = "#777777"
 	},
 /turf/open/misc/sandy_dirt,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "kwf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/bag/trash,
@@ -42990,7 +43010,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/freezer,
 /turf/open/floor/iron/freezer,
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "kxa" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -43188,7 +43208,6 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/theater)
 "kAm" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
@@ -43223,7 +43242,7 @@
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark/textured_edge,
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "kAD" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -43292,7 +43311,7 @@
 	pixel_y = -10
 	},
 /turf/open/floor/iron/checker,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "kBw" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
@@ -43492,7 +43511,7 @@
 "kDA" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "kDD" = (
 /turf/open/floor/carpet,
 /area/station/service/library/ghetto)
@@ -43791,7 +43810,7 @@
 "kFW" = (
 /obj/structure/chair/sofa/right/maroon,
 /turf/open/floor/carpet/red,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "kFX" = (
 /obj/structure/railing{
 	dir = 4
@@ -43841,7 +43860,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/parquet,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "kGB" = (
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
@@ -43942,7 +43961,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
+/area/station/maintenance/department/security/ghetto/aft)
 "kHR" = (
 /obj/machinery/duct,
 /obj/effect/turf_decal/stripes/line{
@@ -43968,7 +43987,7 @@
 	color = "#777777"
 	},
 /turf/open/misc/sandy_dirt,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "kIk" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/ambrosia,
@@ -44383,6 +44402,8 @@
 "kMk" = (
 /obj/effect/turf_decal/tile/dark_green/fourcorners,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "kMs" = (
@@ -44548,7 +44569,7 @@
 "kOU" = (
 /obj/structure/chair/sofa/middle/maroon,
 /turf/open/floor/glass,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "kOV" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
@@ -44575,7 +44596,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "kPp" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -44780,9 +44801,8 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "kRJ" = (
 /obj/structure/broken_flooring/pile/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -44869,9 +44889,6 @@
 /area/station/maintenance/fore)
 "kSN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -44940,7 +44957,7 @@
 /area/station/maintenance/starboard/fore)
 "kTA" = (
 /turf/open/floor/glass,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "kTN" = (
 /obj/structure/table,
 /obj/effect/spawner/random/decoration/material,
@@ -45681,7 +45698,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/area/station/service/kitchen/coldroom/ghetto)
 "ldi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45702,7 +45719,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/green,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "ldU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 1
@@ -46417,7 +46434,7 @@
 	},
 /obj/item/toy/figure/botanist,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "lnI" = (
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/eighties,
@@ -46434,7 +46451,7 @@
 /obj/structure/closet/secure_closet/freezer/empty,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/checker,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "lnZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -46643,7 +46660,7 @@
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "lqb" = (
 /obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
 /obj/effect/turf_decal/siding/thinplating_new/light/end{
@@ -46655,10 +46672,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/diagonal,
 /area/station/maintenance/ghetto/starboard/aft)
-"lqh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "lqi" = (
 /obj/structure/table/wood,
 /obj/machinery/firealarm/directional/north,
@@ -46693,7 +46706,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/wood/parquet,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "lqy" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
@@ -46782,7 +46795,7 @@
 "lre" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/area/station/service/kitchen/coldroom/ghetto)
 "lrf" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
@@ -46864,7 +46877,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/iron,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "lrR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -47152,7 +47165,7 @@
 /obj/item/food/monkeycube/bee,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/stone,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "luY" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -47376,7 +47389,7 @@
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "lyK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -47401,7 +47414,7 @@
 /area/station/maintenance/ghetto/port)
 "lyW" = (
 /turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/area/station/service/kitchen/coldroom/ghetto)
 "lyZ" = (
 /obj/item/kirbyplants/random,
 /obj/effect/spawner/random/trash/graffiti{
@@ -47568,7 +47581,7 @@
 /obj/structure/reagent_dispensers/plumbed,
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "lAJ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -47624,11 +47637,6 @@
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/aft)
-"lBq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
 "lBx" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/service)
@@ -47826,25 +47834,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/parquet,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "lEP" = (
 /obj/item/kirbyplants/random,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
-"lEU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "lEW" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -48200,7 +48195,7 @@
 /obj/structure/chair/sofa/middle/maroon,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/glass,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "lJp" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
@@ -48336,11 +48331,13 @@
 "lKu" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
 	color = "#ff0000";
-	name = "Scrubbers multi deck pipe adapter"
+	name = "Scrubbers multi deck pipe adapter";
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
 	color = "#0000ff";
-	name = "Supply multi deck pipe adapter"
+	name = "Supply multi deck pipe adapter";
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
@@ -48450,7 +48447,7 @@
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "lLH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
 	dir = 9
@@ -48570,7 +48567,7 @@
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 1
 	},
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "lNn" = (
 /obj/item/stack/rods{
 	amount = 10
@@ -48597,6 +48594,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
+"lNw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "lND" = (
 /obj/structure/frame,
 /obj/effect/decal/cleanable/dirt,
@@ -48676,7 +48678,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "lOC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48732,7 +48734,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/glass,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "lPb" = (
 /obj/machinery/door/window/brigdoor/right/directional/east{
 	name = "Forensic Laboratory";
@@ -48909,7 +48911,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/parquet,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "lQJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -48924,7 +48926,7 @@
 "lRd" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "lRk" = (
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -49011,7 +49013,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/maintenance/department/medical/ghetto)
+/area/station/maintenance/department/security/ghetto/aft)
 "lTt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49179,7 +49181,7 @@
 	color = "#6e6e6e"
 	},
 /turf/open/openspace,
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "lVn" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/disks{
@@ -49224,7 +49226,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "lVF" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -49235,9 +49237,8 @@
 /area/station/maintenance/port/fore)
 "lVL" = (
 /obj/structure/chair/sofa/corp/left,
-/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/carpet/neon/simple/violet,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "lVR" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -49261,7 +49262,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/red,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "lWa" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -49447,7 +49448,7 @@
 /obj/item/clothing/head/costume/rice_hat,
 /obj/item/melee/flyswatter,
 /turf/open/floor/stone,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "lYf" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -49539,7 +49540,7 @@
 	color = "#777777"
 	},
 /turf/open/floor/grass,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "lZi" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -49579,16 +49580,6 @@
 /obj/machinery/computer/libraryconsole/bookmanagement,
 /turf/open/floor/wood,
 /area/station/security/prison)
-"lZF" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/table,
-/obj/effect/spawner/random/medical/minor_healing,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto/aft)
 "lZI" = (
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron,
@@ -49773,7 +49764,7 @@
 	},
 /obj/machinery/light/floor,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "mcc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -49816,7 +49807,7 @@
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "mcK" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/maintenance,
@@ -49885,7 +49876,7 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/stone,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "mdi" = (
 /obj/structure/chair/sofa/corp,
 /turf/open/floor/iron,
@@ -50014,7 +50005,7 @@
 	color = "#777777"
 	},
 /turf/open/floor/grass,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "mfC" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/structure/cable/layer1,
@@ -50292,8 +50283,9 @@
 	pixel_x = 6;
 	pixel_y = 12
 	},
+/obj/machinery/light/small/blacklight/directional/east,
 /turf/open/floor/carpet/green,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "miV" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 4
@@ -50366,9 +50358,6 @@
 /area/station/maintenance/port/aft)
 "mjV" = (
 /mob/living/carbon/human/species/monkey/punpun,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "mka" = (
@@ -50623,6 +50612,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
 "mnR" = (
@@ -50662,12 +50652,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "moO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "mpa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50739,10 +50726,11 @@
 	dir = 1
 	},
 /obj/machinery/food_cart,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "mpY" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -50773,7 +50761,7 @@
 	pixel_x = 4
 	},
 /turf/open/floor/iron/cafeteria,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "mqd" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/disposal/bin,
@@ -50863,9 +50851,7 @@
 /obj/effect/turf_decal/tile/dark{
 	dir = 1
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/corner{
 	dir = 1
 	},
@@ -51072,9 +51058,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "mtM" = (
@@ -51195,7 +51178,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "mvm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51271,6 +51254,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/common/cryopods)
+"mvZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
 "mwf" = (
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
@@ -51842,8 +51832,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
 	},
 /turf/open/floor/iron/stairs/right{
 	dir = 1
@@ -51906,7 +51896,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "mEq" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -52022,6 +52012,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "mFv" = (
@@ -52035,7 +52027,7 @@
 	color = "#AAAAB1"
 	},
 /turf/open/openspace,
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "mFz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -52095,6 +52087,7 @@
 /area/station/maintenance/ghetto/port/aft)
 "mFZ" = (
 /obj/structure/closet/secure_closet/freezer/empty/open,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "mGh" = (
@@ -52682,7 +52675,7 @@
 /obj/structure/chair/sofa/corner/maroon,
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "mMF" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -52738,15 +52731,12 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "mNq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "mNs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /obj/structure/platform{
 	dir = 4;
 	color = "#AAAAB1"
@@ -52757,7 +52747,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "mNz" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -52804,6 +52794,7 @@
 	},
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "mOm" = (
@@ -53163,7 +53154,7 @@
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/grass,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "mTa" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -53407,7 +53398,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "mWk" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -53508,11 +53499,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
-"mXG" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/marker_beacon/indigo,
-/turf/open/space/basic,
-/area/space/nearstation)
 "mXH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/book/bible,
@@ -53610,10 +53596,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
+"mYD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "mYF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
 "mYH" = (
 /obj/machinery/component_printer,
@@ -53762,7 +53757,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "nay" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -53820,6 +53815,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/small,
 /area/station/security/interrogation/ghetto)
+"naS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/crate,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/iron,
+/area/station/maintenance/department/security/ghetto/aft)
 "naU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -53839,7 +53840,7 @@
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/small/blacklight/directional/south,
 /turf/open/floor/carpet/red,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "nbo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/xeno/larva,
@@ -53901,17 +53902,16 @@
 	pixel_y = 8
 	},
 /turf/open/floor/iron/checker,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "nbV" = (
-/obj/machinery/door/airlock/hydroponics/glass{
-	name = "Apiary"
-	},
+/obj/machinery/door/airlock/hydroponics,
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/iron,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "nbX" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -54194,7 +54194,7 @@
 "ngz" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "ngA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54219,7 +54219,7 @@
 /turf/open/floor/iron/corner{
 	dir = 8
 	},
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "ngQ" = (
 /obj/effect/spawner/random/structure/table,
 /turf/open/floor/iron,
@@ -54341,7 +54341,7 @@
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "niy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -54412,7 +54412,7 @@
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light/warm/directional/east,
 /turf/open/floor/grass,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "njr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -54723,7 +54723,7 @@
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "nmW" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/red{
@@ -55259,7 +55259,9 @@
 /obj/item/holosign_creator/robot_seat/bar{
 	pixel_y = -4
 	},
-/obj/machinery/camera/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Bar - North"
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "nsP" = (
@@ -56033,26 +56035,7 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
 "nCO" = (
-/obj/item/radio/intercom/directional/west{
-	pixel_y = -5
-	},
-/obj/machinery/button/door/directional/west{
-	id = "viplounge_bolt1";
-	name = "ViP Bolt Control - West";
-	normaldoorcontrol = 1;
-	specialfunctions = 4;
-	pixel_y = 7
-	},
-/obj/machinery/button/door/directional/west{
-	id = "viplounge_bolt2";
-	name = "ViP Bolt Control - East";
-	normaldoorcontrol = 1;
-	specialfunctions = 4;
-	pixel_y = 17
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "nCR" = (
@@ -56084,7 +56067,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "nCX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/dark_green{
@@ -56804,10 +56786,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
-"nMK" = (
-/obj/structure/girder,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "nMM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -57268,24 +57246,24 @@
 /obj/machinery/airalarm/directional/west{
 	pixel_y = 3
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "nSz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/platform{
-	dir = 2;
 	color = "#AAAAB1"
 	},
 /obj/structure/railing{
-	dir = 2;
 	color = "#6e6e6e"
 	},
 /obj/machinery/duct,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "nSN" = (
 /turf/closed/wall,
 /area/station/service/chapel)
@@ -57333,7 +57311,7 @@
 "nTj" = (
 /obj/structure/chair/sofa/left/maroon,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "nTm" = (
 /obj/machinery/recharge_station,
 /obj/machinery/firealarm/directional/east,
@@ -57865,6 +57843,10 @@
 "nZT" = (
 /turf/closed/wall,
 /area/station/service/bar)
+"nZU" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space)
 "nZZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 9
@@ -57950,7 +57932,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "obg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -57997,7 +57979,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/service,
 /turf/open/floor/wood/parquet,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "obA" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/timer{
@@ -58036,9 +58018,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
 "obP" = (
 /obj/machinery/holopad,
@@ -58055,8 +58037,6 @@
 /area/station/maintenance/ghetto/port)
 "obW" = (
 /obj/machinery/disposal/bin,
-/obj/structure/sign/poster/official/fruit_bowl/directional/north,
-/obj/machinery/duct,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
@@ -58113,7 +58093,7 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "ocB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -58481,13 +58461,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
-"ohn" = (
-/obj/effect/turf_decal/tile/dark_green,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
 "oht" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/generic/style_random,
@@ -58496,7 +58469,7 @@
 	color = "#777777"
 	},
 /turf/open/floor/grass,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "ohv" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/disposalpipe/segment,
@@ -58571,10 +58544,11 @@
 /obj/effect/turf_decal/trimline/tram/line{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 4
 	},
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "oiw" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -58588,8 +58562,10 @@
 /obj/effect/turf_decal/trimline/tram/line{
 	dir = 1
 	},
+/obj/machinery/duct,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark/textured_edge,
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "oiB" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -58869,7 +58845,7 @@
 	},
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "omE" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -58966,7 +58942,10 @@
 /area/station/security/mechbay)
 "onP" = (
 /obj/machinery/light/small/directional/west,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door/window/right/directional/north{
+	req_access = list("bar");
+	name = "Bar Deliverys"
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "onQ" = (
@@ -59027,10 +59006,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "ooh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/wood/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "ooo" = (
@@ -59112,14 +59091,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/directional/north{
-	c_tag = "Lower Service Hall";
+	c_tag = "Kitchen - Backroom Lower Floor West";
 	dir = 9
 	},
 /obj/machinery/duct,
 /obj/structure/cable,
 /obj/machinery/icecream_vat,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white/corner,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "ooM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -59237,9 +59217,8 @@
 	dir = 8;
 	color = "#6e6e6e"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/carpet/red,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "oqa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -59308,7 +59287,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "oqP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59319,7 +59298,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "oqQ" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/circuit,
@@ -59523,6 +59502,9 @@
 /obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/ghetto)
+"otf" = (
+/turf/closed/wall,
+/area/station/service/bar/backroom/ghetto)
 "oth" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59942,6 +59924,7 @@
 "oyq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "oys" = (
@@ -60125,7 +60108,7 @@
 /obj/item/reagent_containers/cup/watering_can,
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "oBo" = (
 /turf/open/floor/iron,
 /area/station/cargo/storage/ghetto)
@@ -60259,7 +60242,7 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
 	},
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "oDc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -60443,7 +60426,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_edge,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "oFe" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 10
@@ -60665,7 +60648,7 @@
 "oIg" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/area/station/service/kitchen/coldroom/ghetto)
 "oIi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -60723,11 +60706,10 @@
 	dir = 8;
 	color = "#6e6e6e"
 	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small/blacklight/directional/east,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "oIN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -61059,7 +61041,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "oMH" = (
 /turf/closed/wall/r_wall,
 /area/station/commons/storage/primary)
@@ -61205,12 +61187,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "oOG" = (
-/obj/machinery/duct,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/small,
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "oOI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -61278,6 +61259,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "oPS" = (
@@ -61341,7 +61323,7 @@
 	},
 /obj/structure/sign/departments/botany/directional/north,
 /turf/open/floor/stone,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "oQL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -61373,6 +61355,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"oRl" = (
+/obj/effect/spawner/structure/window,
+/obj/effect/mapping_helpers/damaged_window,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "oRn" = (
 /obj/effect/turf_decal/stripes/box,
 /obj/structure/ladder,
@@ -61385,7 +61372,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/glass,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "oRy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -61627,7 +61614,7 @@
 /obj/structure/flora/bush/jungle/a/style_random,
 /obj/structure/flora/bush/jungle/b/style_random,
 /turf/open/misc/dirt/dark/station,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "oUd" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -61651,6 +61638,7 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/clothing/gloves,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical/ghetto/morgue)
 "oUZ" = (
@@ -61972,7 +61960,6 @@
 "oYP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/xmastree,
 /obj/structure/platform{
 	dir = 8
 	},
@@ -61980,6 +61967,7 @@
 	dir = 8;
 	color = "#6e6e6e"
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/black,
 /area/station/commons/lounge)
 "oYV" = (
@@ -62141,7 +62129,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/checker,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "paX" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -62374,7 +62362,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "ped" = (
 /obj/structure/railing{
 	dir = 1
@@ -62880,8 +62868,9 @@
 /area/station/medical/surgery/theatre)
 "pkk" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/holopad,
 /turf/open/floor/wood/parquet,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "pkn" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -63004,21 +62993,13 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
-/area/station/service/bar/backroom)
-"plj" = (
-/turf/open/floor/iron,
-/area/station/maintenance/department/medical/ghetto)
+/area/station/service/bar/backroom/ghetto)
 "plq" = (
-/obj/machinery/button/door/directional/east{
-	id = "botany_apiary";
-	name = "Bee Protection Shutters";
-	pixel_y = -25
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "plw" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /obj/effect/turf_decal/tile/yellow{
@@ -63545,8 +63526,9 @@
 "psp" = (
 /obj/structure/table/reinforced/plasmarglass,
 /obj/effect/spawner/random/entertainment/deck,
+/obj/machinery/light/small/blacklight/directional/east,
 /turf/open/floor/carpet/neon/simple/violet,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "psq" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters{
@@ -64112,7 +64094,7 @@
 	},
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/wood/parquet,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "pyz" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/airalarm/directional/north,
@@ -64409,12 +64391,13 @@
 /obj/item/kirbyplants/organic/plant24{
 	pixel_y = 6
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/camera/directional/north{
-	c_tag = "Lower Bar - North"
+	c_tag = "Bar - Lower Floor North"
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/carpet/red,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "pCc" = (
 /obj/structure/chair{
 	dir = 4
@@ -64488,7 +64471,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "pCC" = (
 /obj/effect/spawner/random/structure/barricade,
 /turf/open/floor/plating,
@@ -64583,7 +64566,7 @@
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 8
 	},
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "pDI" = (
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/iron,
@@ -64994,7 +64977,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "pIx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65176,7 +65159,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "pKQ" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -65192,11 +65175,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
-"pLn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet/black,
-/area/station/commons/lounge)
 "pLp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -65233,7 +65211,7 @@
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "pLC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -65519,7 +65497,7 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "pOQ" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -65691,7 +65669,6 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "pRz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 8
 	},
@@ -66301,7 +66278,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "pYX" = (
 /obj/structure/water_source/puddle,
 /turf/open/misc/grass,
@@ -66436,7 +66413,7 @@
 "qaE" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/area/station/service/kitchen/coldroom/ghetto)
 "qaG" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
 	color = "#ff0000";
@@ -66475,6 +66452,7 @@
 "qbt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "qbF" = (
@@ -66498,6 +66476,7 @@
 /area/station/maintenance/ghetto/fore/starboard)
 "qbN" = (
 /obj/effect/spawner/random/structure/crate,
+/obj/structure/sign/directions/medical/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "qbQ" = (
@@ -66508,14 +66487,13 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/small,
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "qbV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "qca" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/chair/sofa/corp/right{
 	dir = 8
 	},
@@ -66529,12 +66507,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/abandoned_gambling_den)
 "qcp" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
 /turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "qcu" = (
 /obj/structure/tank_dispenser,
 /turf/open/floor/iron/dark/smooth_large,
@@ -66958,9 +66935,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage/ghetto/depot)
-"qiU" = (
-/turf/open/floor/iron/dark,
-/area/station/service/bar)
 "qiV" = (
 /obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/stripes/corner{
@@ -67005,7 +66979,7 @@
 	name = "Hydroponics Shutter"
 	},
 /turf/open/floor/plating,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "qjw" = (
 /obj/machinery/mining_weather_monitor/directional/north,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -67091,6 +67065,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/explab)
+"qkz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/medical/ghetto/morgue)
 "qkC" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -67236,10 +67217,14 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
+"qmf" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
 "qmk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -67313,9 +67298,6 @@
 /area/station/engineering/supermatter/room)
 "qnd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
@@ -67335,7 +67317,7 @@
 	},
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "qnH" = (
 /obj/machinery/door/airlock/public/glass{
 	autoclose = 0;
@@ -67915,10 +67897,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/corner,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "qwS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -68193,14 +68175,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/railing{
-	dir = 2;
 	color = "#6e6e6e"
 	},
 /obj/effect/turf_decal/siding/dark,
 /obj/machinery/duct,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "qzJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -68298,11 +68282,16 @@
 "qAE" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "qAG" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
+"qAJ" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood/parquet,
+/area/station/hallway/secondary/service)
 "qAN" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red{
@@ -68412,9 +68401,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "qCq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/dark_green/fourcorners,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "qCv" = (
@@ -68867,11 +68858,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"qIN" = (
-/obj/structure/sign/warning/vacuum/directional/north,
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central/fore)
 "qIR" = (
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
@@ -69090,6 +69076,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
+"qLD" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "qLI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/barricade/wooden,
@@ -69189,7 +69179,7 @@
 	color = "#AAAAB1"
 	},
 /turf/open/openspace,
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "qMY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -69372,10 +69362,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "qPh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/dark_green/anticorner,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/maint,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "qPl" = (
@@ -69390,8 +69380,9 @@
 /obj/effect/turf_decal/trimline/white/end{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark/textured,
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "qPm" = (
 /obj/structure/table/wood,
 /obj/item/stack/sheet/cloth,
@@ -69616,7 +69607,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "qSz" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow,
@@ -69661,7 +69652,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "qSY" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/dark/half{
@@ -69705,7 +69696,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/green,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "qTo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/loading_area,
@@ -69721,10 +69712,8 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/airlock,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
+/area/station/maintenance/department/security/ghetto/aft)
 "qTy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/electric_shock/directional/south,
@@ -69741,7 +69730,7 @@
 "qTE" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "qTM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -69988,7 +69977,7 @@
 /obj/structure/sink/directional/west,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/stone,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "qWG" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
@@ -70285,7 +70274,7 @@
 /area/station/maintenance/ghetto/sorting)
 "raA" = (
 /turf/closed/wall,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "raF" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -70405,7 +70394,7 @@
 	amount = 5
 	},
 /turf/open/floor/iron/white/corner,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "rbJ" = (
 /obj/structure/railing,
 /turf/open/floor/iron/stairs/right{
@@ -70726,11 +70715,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/warm/directional/east,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "rfO" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/light/cold/directional/south,
@@ -70767,10 +70758,11 @@
 /obj/item/clothing/gloves/color/green,
 /obj/item/mop,
 /obj/machinery/light/small/blacklight/directional/east,
+/obj/structure/table,
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 1
 	},
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "rgA" = (
 /obj/structure/reagent_dispensers/plumbed{
 	dir = 8
@@ -70945,10 +70937,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "riH" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "riU" = (
@@ -71081,7 +71070,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/crate,
-/obj/structure/cable,
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
@@ -71101,7 +71089,7 @@
 	color = "#555559"
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "rku" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/dark_green/fourcorners,
@@ -71298,10 +71286,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"rmN" = (
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/iron,
-/area/station/maintenance/department/medical/ghetto)
 "rmQ" = (
 /obj/machinery/requests_console/directional/west{
 	department = "Cargo";
@@ -71849,9 +71833,6 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
-"rtl" = (
-/turf/closed/wall/r_wall,
-/area/station/service/bar/atrium)
 "rtm" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow{
@@ -72293,10 +72274,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"rzS" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/station/maintenance/ghetto/central)
 "rAh" = (
 /obj/machinery/light/directional/north,
 /obj/effect/landmark/navigate_destination/chemfactory,
@@ -72339,12 +72316,7 @@
 	},
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
-"rAv" = (
-/obj/effect/spawner/random/structure/crate,
-/obj/machinery/light/small/blacklight/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central/fore)
+/area/station/service/bar/atrium/ghetto)
 "rAB" = (
 /obj/structure/cable/multilayer/connected,
 /turf/open/floor/plating,
@@ -72375,7 +72347,7 @@
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "rBg" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -72408,7 +72380,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/parquet,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "rBy" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/spawner/random/trash/garbage,
@@ -72459,7 +72431,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/stone,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "rCa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72815,10 +72787,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
-"rHD" = (
-/obj/structure/closet/l3closet/virology,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
 "rHU" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
@@ -73085,7 +73053,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/corner,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "rKS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -73312,7 +73280,7 @@
 /turf/open/floor/iron/corner{
 	dir = 4
 	},
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "rNk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -73372,9 +73340,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/ghetto)
 "rNV" = (
-/obj/structure/closet/secure_closet/medical1,
 /obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/maintenance/four,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "rOa" = (
@@ -73499,7 +73465,7 @@
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "rPI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
@@ -73707,6 +73673,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
+"rST" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto/central)
 "rTb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -73782,7 +73754,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/parquet,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "rTJ" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -73932,8 +73904,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "rVd" = (
-/obj/effect/spawner/random/structure/crate,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "rVq" = (
@@ -74066,7 +74039,7 @@
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/biogenerator,
 /turf/open/floor/stone,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "rWN" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -74231,11 +74204,9 @@
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "rYf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table/wood,
@@ -74440,7 +74411,6 @@
 /turf/open/floor/wood,
 /area/station/service/kitchen/abandoned)
 "sba" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 1
 	},
@@ -74605,10 +74575,6 @@
 "scv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ants,
-/obj/item/ammo_casing/rebar/paperball{
-	pixel_x = 11;
-	pixel_y = -9
-	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "scy" = (
@@ -74651,7 +74617,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
+/area/station/maintenance/department/security/ghetto/aft)
 "sdh" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 4
@@ -74736,7 +74702,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/curtain/cloth/fancy/mechanical/start_closed,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "sdE" = (
 /obj/machinery/dna_infuser,
 /obj/machinery/camera/directional/south{
@@ -74793,7 +74759,7 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/door/window/right/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "seo" = (
 /turf/closed/wall,
 /area/station/security/processing)
@@ -75547,7 +75513,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "snG" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -75685,7 +75651,7 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/structure/cable,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "spq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -75782,7 +75748,7 @@
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "sqy" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8
@@ -75888,7 +75854,7 @@
 /turf/open/floor/iron/corner{
 	dir = 1
 	},
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "srG" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
@@ -75914,7 +75880,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "ssc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -76033,7 +75999,7 @@
 "stF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "stV" = (
 /obj/structure/table/wood,
 /obj/machinery/light/directional/south,
@@ -76056,7 +76022,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "sub" = (
 /obj/structure/broken_flooring/corner/directional/east,
 /turf/open/floor/plating,
@@ -76512,7 +76478,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/dark/smooth_edge,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "sAo" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood,
@@ -76768,7 +76734,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/freezer,
 /turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/area/station/service/kitchen/coldroom/ghetto)
 "sDN" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Vacant Store"
@@ -77001,7 +76967,7 @@
 	pixel_x = -3
 	},
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "sFx" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -77320,8 +77286,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "sKd" = (
@@ -77566,7 +77530,7 @@
 /obj/structure/closet/crate/freezer,
 /obj/item/food/cheese/wheel,
 /turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/area/station/service/kitchen/coldroom/ghetto)
 "sOi" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/wood{
@@ -77582,7 +77546,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/parquet,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "sOC" = (
 /obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -77594,12 +77558,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "sOT" = (
-/obj/structure/mirror/directional/north{
-	pixel_y = 34
-	},
+/obj/structure/mirror/directional/north,
 /obj/structure/sink/kitchen/directional/south{
 	pixel_y = 11
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "sOW" = (
@@ -77619,8 +77582,10 @@
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 8
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/white/corner,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "sPk" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 1";
@@ -77673,6 +77638,7 @@
 "sPz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto/central)
 "sPC" = (
@@ -77791,7 +77757,7 @@
 	color = "#777777"
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "sRs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -77869,7 +77835,7 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "sSO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -77960,6 +77926,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"sTZ" = (
+/turf/closed/wall,
+/area/station/service/kitchen/kitchen_backroom)
 "sUh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -77995,6 +77964,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"sUA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/chair/wood,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
 "sUF" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/department/engine/ghetto)
@@ -78010,7 +77985,7 @@
 	pixel_y = 11
 	},
 /turf/open/floor/carpet/red,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "sUL" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -78037,13 +78012,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood/corner,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "sVg" = (
 /obj/structure/broken_flooring/side/directional/south,
 /turf/open/floor/plating,
@@ -78139,7 +78113,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/area/station/service/kitchen/coldroom/ghetto)
 "sWy" = (
 /obj/machinery/door/airlock/security,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -78206,7 +78180,7 @@
 "sXk" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/area/station/service/kitchen/coldroom/ghetto)
 "sXl" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/grille/broken,
@@ -78247,7 +78221,7 @@
 "sXK" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/area/station/service/kitchen/coldroom/ghetto)
 "sXO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -78629,9 +78603,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "tex" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
@@ -78684,7 +78655,7 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "tfm" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/plating,
@@ -78693,7 +78664,6 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/ghetto)
 "tfC" = (
@@ -79038,7 +79008,7 @@
 /obj/structure/sink/directional/west,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "tkE" = (
 /obj/effect/turf_decal/tile/dark/half{
 	dir = 4
@@ -79447,7 +79417,7 @@
 /obj/structure/chair/sofa/corp/right,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/green,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "tot" = (
 /obj/structure/transit_tube/station/dispenser/reverse{
 	dir = 4
@@ -79474,7 +79444,7 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "toF" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -79527,6 +79497,14 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/commons/toilet/restrooms)
+"tpa" = (
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "tpk" = (
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
@@ -79704,7 +79682,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "tqM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -79788,6 +79766,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
@@ -80115,13 +80096,11 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
 "tvm" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/service/bar,
-/obj/machinery/door/airlock/service,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/duct,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "tvt" = (
@@ -80131,6 +80110,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/wood/parquet,
 /area/station/hallway/secondary/service)
 "tvz" = (
@@ -80577,15 +80557,13 @@
 	},
 /obj/structure/table/wood/fancy/red,
 /obj/item/flashlight/lamp/green{
-	pixel_x = 0;
 	pixel_y = 14
 	},
 /obj/item/stack/spacecash/c100{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "tCo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office{
@@ -81239,6 +81217,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/sign/poster/official/fruit_bowl/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "tKl" = (
@@ -81248,7 +81227,6 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "tKo" = (
 /obj/structure/rack,
-/obj/item/book/manual/chef_recipes,
 /obj/item/holosign_creator/robot_seat/restaurant,
 /obj/effect/turf_decal/trimline/tram/line{
 	dir = 4
@@ -81256,7 +81234,7 @@
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "tKq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -81424,7 +81402,7 @@
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "tMa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -81511,9 +81489,9 @@
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/carpet/red,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "tNr" = (
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
@@ -81559,7 +81537,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/neon/simple/violet,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "tOc" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -82228,7 +82206,7 @@
 	pixel_y = 15
 	},
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "tWW" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck,
@@ -82265,12 +82243,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
-"tXm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
 "tXr" = (
 /obj/item/kirbyplants/random,
 /obj/structure/cable,
@@ -82286,7 +82258,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/stone,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "tXD" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/belt/utility{
@@ -82426,7 +82398,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "tYQ" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Central Hallway East"
@@ -82470,6 +82442,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto/fore)
+"tZC" = (
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "tZM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -82548,7 +82528,6 @@
 /turf/open/floor/wood/parquet,
 /area/station/hallway/secondary/service)
 "uaA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/crate,
@@ -82575,7 +82554,7 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
 /turf/open/floor/iron/dark,
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "uaJ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/holosign/barrier/engineering,
@@ -82726,8 +82705,11 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "uco" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/mess,
 /obj/machinery/light/small/dim/directional/east,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
 "ucp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -82888,7 +82870,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "ueM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -83055,7 +83037,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "ugz" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/pod,
@@ -83089,7 +83071,7 @@
 /obj/item/food/grown/onion,
 /obj/structure/closet/crate/freezer/food,
 /turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/area/station/service/kitchen/coldroom/ghetto)
 "ugS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -83251,7 +83233,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_edge,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "uiL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
@@ -83261,7 +83243,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
 "uiN" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
@@ -83434,7 +83419,7 @@
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "ulr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -83508,10 +83493,10 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/effect/spawner/random/trash/graffiti{
 	spawn_loot_chance = 50
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "umm" = (
@@ -83547,7 +83532,7 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/flora/bush/pointy/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "unm" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -83571,11 +83556,6 @@
 /obj/structure/sign/poster/official/there_is_no_gas_giant/directional/east,
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/atmos/project)
-"unE" = (
-/obj/structure/lattice,
-/obj/structure/marker_beacon/indigo,
-/turf/open/space/basic,
-/area/space/nearstation)
 "unJ" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -83956,7 +83936,7 @@
 "uuc" = (
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/carpet/green,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "uue" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -84094,7 +84074,7 @@
 "uwz" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/red,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "uwD" = (
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 8
@@ -84205,13 +84185,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
 "uxx" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/duct,
 /turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "uxD" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/command/storage/eva)
@@ -84397,6 +84373,9 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "uAy" = (
@@ -84458,7 +84437,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "uBb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -84556,6 +84535,15 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/genetics,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
+"uCF" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/commons/lounge)
 "uCH" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral,
@@ -84570,7 +84558,7 @@
 "uCO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "uCS" = (
 /obj/structure/table/reinforced,
 /obj/item/instrument/bikehorn{
@@ -84587,7 +84575,7 @@
 	name = "Hydroponics Shutter"
 	},
 /turf/open/floor/plating,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "uCW" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/machinery/status_display/evac/directional/south,
@@ -84614,7 +84602,7 @@
 "uDi" = (
 /obj/effect/turf_decal/tile/green/half,
 /turf/open/floor/iron/edge,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "uDk" = (
 /obj/effect/turf_decal/siding/white,
 /turf/open/water/alternative/muddy/no_fishing,
@@ -84629,7 +84617,7 @@
 "uDD" = (
 /obj/structure/chair/sofa/right/maroon,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "uDH" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -84758,7 +84746,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/glass,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "uFW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -84779,7 +84767,7 @@
 /obj/structure/cable,
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/area/station/service/kitchen/coldroom/ghetto)
 "uGu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
@@ -84818,7 +84806,7 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "uGN" = (
 /obj/structure/table/reinforced/rglass,
 /obj/item/food/grown/banana,
@@ -84846,7 +84834,6 @@
 "uGP" = (
 /obj/machinery/griddle,
 /obj/effect/turf_decal/delivery/white,
-/obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
@@ -84882,7 +84869,7 @@
 /obj/structure/flora/bush/leavy/style_random,
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "uHq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -84960,7 +84947,7 @@
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "uIo" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/trimline/dark_blue/corner{
@@ -85010,6 +84997,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "uIZ" = (
@@ -85064,6 +85052,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"uJB" = (
+/obj/effect/spawner/random/structure/crate,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "uJC" = (
 /obj/structure/cable,
 /obj/structure/closet/secure_closet/brig,
@@ -85451,7 +85444,7 @@
 	name = "SapMaster XP"
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "uOa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -85548,7 +85541,7 @@
 	pixel_y = -5
 	},
 /turf/open/floor/iron/white/corner,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "uOX" = (
 /turf/closed/wall,
 /area/station/hallway/primary/central/aft)
@@ -85558,11 +85551,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "uPq" = (
-/obj/effect/turf_decal/tile/dark_green{
-	dir = 1
-	},
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "uPs" = (
@@ -85649,7 +85640,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "uRh" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/computer/slot_machine,
@@ -85821,7 +85812,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/checker,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "uTn" = (
 /obj/structure/table/wood,
 /obj/item/folder,
@@ -86071,12 +86062,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
-"uXd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
 "uXq" = (
 /obj/effect/turf_decal/arrows{
 	dir = 1
@@ -86278,7 +86263,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/iron/white/corner,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "uZW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
@@ -86480,11 +86465,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/ghetto)
 "vcM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/small/directional/west,
+/obj/structure/table,
+/obj/effect/spawner/random/medical/minor_healing,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
+/area/station/maintenance/department/security/ghetto/aft)
 "vcR" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/door/poddoor/preopen{
@@ -86775,12 +86760,9 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "vhi" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/structure/closet/crate/silvercrate,
@@ -87252,7 +87234,7 @@
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "vmg" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
@@ -87270,7 +87252,7 @@
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/grass,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "vmy" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -87319,7 +87301,7 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "vnc" = (
 /obj/structure/chair,
 /obj/effect/mapping_helpers/broken_floor,
@@ -87470,7 +87452,7 @@
 /obj/structure/table/reinforced,
 /obj/item/sharpener,
 /turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/area/station/service/kitchen/coldroom/ghetto)
 "voG" = (
 /obj/structure/chair{
 	dir = 8
@@ -87483,7 +87465,7 @@
 "voK" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "voM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/cable,
@@ -87517,6 +87499,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
+"voZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/xmastree,
+/turf/open/floor/carpet,
+/area/station/service/chapel)
 "vpb" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
@@ -88083,7 +88070,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "vug" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -88247,7 +88234,7 @@
 /obj/structure/flora/bush/sunny/style_random,
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "vwC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -88392,7 +88379,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/parquet,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "vyE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/chair_flipped{
@@ -88481,13 +88468,13 @@
 	pixel_x = -4
 	},
 /obj/machinery/camera/directional/east{
-	c_tag = "Bar - Backroom"
+	c_tag = "Bar - Backroom Lower Floor"
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /turf/open/floor/wood/parquet,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "vzF" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -88537,7 +88524,7 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "vAe" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -88611,7 +88598,7 @@
 "vAP" = (
 /obj/structure/chair/sofa/corp/right,
 /turf/open/floor/carpet/neon/simple/violet,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "vBb" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/decal/cleanable/dirt,
@@ -88667,7 +88654,7 @@
 	pixel_y = 2
 	},
 /turf/open/misc/dirt/dark/station,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "vBQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/corner/end/flip{
@@ -88691,7 +88678,7 @@
 	color = "#777777"
 	},
 /turf/open/misc/sandy_dirt,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "vBZ" = (
 /turf/closed/wall,
 /area/station/service/chapel/office)
@@ -88738,7 +88725,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "vCB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -88842,7 +88829,7 @@
 /area/station/ai_monitored/security/armory)
 "vDW" = (
 /turf/open/floor/carpet/red,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "vDX" = (
 /turf/open/floor/iron/stairs,
 /area/station/commons/dorms)
@@ -88958,6 +88945,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "vFH" = (
@@ -89456,7 +89444,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "vLT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -89485,10 +89473,6 @@
 /obj/item/paint_palette,
 /turf/open/floor/carpet/blue,
 /area/station/service/library/ghetto)
-"vMn" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/station/maintenance/ghetto/fore/starboard)
 "vMr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -89559,6 +89543,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/wood/parquet,
 /area/station/hallway/secondary/service)
 "vNo" = (
@@ -89656,9 +89641,6 @@
 	location = "Bar"
 	},
 /obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/bar)
 "vPo" = (
@@ -89693,7 +89675,7 @@
 /obj/effect/turf_decal/trimline/dark/corner,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/checker,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "vPN" = (
 /obj/machinery/telecomms/bus/preset_three,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
@@ -90025,7 +90007,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/iron/white/corner,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "vUI" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/item/book/manual/wiki/grenades,
@@ -90146,7 +90128,7 @@
 	},
 /obj/structure/closet/emcloset,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "vWn" = (
 /obj/structure/table/reinforced,
 /obj/structure/railing{
@@ -90379,7 +90361,7 @@
 	color = "#6e6e6e"
 	},
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "vZa" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -91213,7 +91195,7 @@
 	},
 /obj/machinery/light/floor,
 /turf/open/floor/iron/checker,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "wje" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -91341,9 +91323,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/fore)
-"wkX" = (
-/turf/closed/wall,
-/area/station/service/bar/backroom)
 "wlt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
@@ -91723,6 +91702,9 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "wrB" = (
@@ -91775,10 +91757,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/break_room)
-"wsk" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
 "wsn" = (
 /turf/open/floor/iron/stairs/right{
 	dir = 1
@@ -92348,7 +92326,7 @@
 	},
 /obj/structure/sign/poster/official/moth_meth/directional/east,
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "wzL" = (
 /obj/item/trash/pistachios,
 /obj/effect/decal/cleanable/dirt,
@@ -92608,12 +92586,14 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/stone,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "wCk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "wCs" = (
@@ -92660,7 +92640,7 @@
 	},
 /obj/machinery/light/warm/directional/north,
 /turf/open/floor/iron/white/corner,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "wCJ" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -92916,7 +92896,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "wFi" = (
 /obj/item/toy/basketball,
 /obj/effect/decal/cleanable/dirt,
@@ -93051,6 +93031,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
+"wGr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "wGV" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port/fore)
@@ -93393,10 +93381,6 @@
 /obj/structure/cable,
 /turf/open/space/openspace,
 /area/station/solars/port/aft)
-"wLE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
 "wLH" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/generic,
@@ -93607,7 +93591,7 @@
 	pixel_y = -4
 	},
 /turf/open/misc/dirt/dark/station,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "wOW" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -93695,7 +93679,7 @@
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/structure/flora/bush/lavendergrass/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "wQa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -93870,10 +93854,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chemistry/ghetto)
-"wRT" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/station/service/bar/atrium)
 "wRV" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 4;
@@ -93901,7 +93881,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood/large,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/ghetto)
 "wSm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -94068,6 +94048,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
+"wUq" = (
+/turf/open/openspace,
+/area/station/service/bar)
 "wUu" = (
 /obj/effect/turf_decal/tile/dark{
 	dir = 8
@@ -94120,13 +94103,12 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/wood/large,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "wVe" = (
 /obj/effect/turf_decal/tile/dark/half{
 	dir = 1
@@ -94173,7 +94155,7 @@
 /area/station/science/lobby)
 "wWh" = (
 /turf/closed/wall,
-/area/station/service/kitchen/coldroom)
+/area/station/service/kitchen/coldroom/ghetto)
 "wWj" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -94229,14 +94211,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
 "wWT" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
-/area/station/commons/lounge)
+/area/station/service/bar)
 "wWV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -94338,7 +94319,7 @@
 "wYg" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "wYk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -94496,7 +94477,7 @@
 /obj/structure/cable,
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "xaW" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
@@ -94584,7 +94565,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/iron/white/corner,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "xbG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -94851,7 +94832,6 @@
 "xeB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
@@ -94922,12 +94902,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/storage)
 "xfj" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/frame/computer,
 /turf/open/floor/iron,
-/area/station/maintenance/department/medical/ghetto)
+/area/station/maintenance/department/security/ghetto/aft)
 "xfm" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
@@ -95128,7 +95106,7 @@
 /obj/item/radio/intercom/directional/north,
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron/dark/smooth_edge,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "xgU" = (
 /obj/structure/cable,
 /obj/machinery/camera/directional/south{
@@ -95157,7 +95135,7 @@
 /obj/machinery/light/small/directional/south,
 /obj/structure/closet/secure_closet/bar,
 /turf/open/floor/wood,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "xhf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -95236,9 +95214,6 @@
 "xiF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/bartender,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "xiG" = (
@@ -95445,20 +95420,16 @@
 	},
 /obj/structure/table,
 /obj/item/storage/box/drinkingglasses{
-	pixel_y = 9;
-	pixel_x = 0
+	pixel_y = 9
 	},
 /obj/item/storage/box/dishdrive{
 	pixel_y = 23;
 	pixel_x = 3
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "xkR" = (
 /obj/structure/closet/emcloset,
 /obj/effect/spawner/random/maintenance,
@@ -95647,7 +95618,9 @@
 "xnD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
@@ -96033,6 +96006,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "xto" = (
@@ -96155,7 +96129,7 @@
 	dir = 2
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "xun" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 5
@@ -96329,7 +96303,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/kitchen,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "xwI" = (
 /obj/item/kirbyplants/random/dead,
 /turf/open/floor/wood,
@@ -96369,7 +96343,7 @@
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 4
 	},
-/area/station/service/kitchen)
+/area/station/service/kitchen/kitchen_backroom)
 "xxv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -96427,7 +96401,6 @@
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical/ghetto/morgue)
 "xyi" = (
@@ -96747,7 +96720,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/checker,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "xCJ" = (
 /obj/effect/spawner/random/glass_shards,
 /obj/machinery/light/small/directional/east,
@@ -96832,7 +96805,7 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "xEg" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -97170,7 +97143,7 @@
 /obj/item/stack/cable_coil,
 /obj/item/wrench,
 /turf/open/floor/wood/parquet,
-/area/station/service/bar/backroom)
+/area/station/service/bar/backroom/ghetto)
 "xIr" = (
 /obj/structure/railing{
 	dir = 10
@@ -97273,7 +97246,7 @@
 	pixel_y = 12
 	},
 /turf/open/floor/iron/checker,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "xKc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -97682,7 +97655,7 @@
 	},
 /obj/structure/aquarium,
 /turf/open/floor/iron/white/corner,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "xOv" = (
 /turf/closed/wall,
 /area/station/science/robotics/mechbay)
@@ -98009,6 +97982,9 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"xSN" = (
+/turf/closed/wall,
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "xTa" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable,
@@ -98044,11 +98020,9 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "xTr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "xTs" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /turf/open/floor/iron/dark,
@@ -98221,11 +98195,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
-"xVw" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/light/directional/west,
-/turf/open/floor/wood/parquet,
-/area/station/hallway/secondary/service)
 "xVM" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock,
@@ -98279,7 +98248,7 @@
 /obj/structure/curtain/cloth/fancy,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/cafeteria,
-/area/station/service/bar/atrium)
+/area/station/service/bar/atrium/ghetto)
 "xWE" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/machinery/door/airlock/atmos,
@@ -98363,9 +98332,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/structure/reagent_dispensers/water_cooler{
-	pixel_y = 10
-	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "xXQ" = (
@@ -98402,7 +98369,7 @@
 	color = "#777777"
 	},
 /turf/open/misc/sandy_dirt,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "xYj" = (
 /obj/machinery/door/airlock,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -98460,6 +98427,11 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"xYQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron,
+/area/station/maintenance/department/security/ghetto/aft)
 "xYR" = (
 /obj/machinery/recharger{
 	pixel_y = 4
@@ -98874,14 +98846,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"yeH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
 "yeI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -99007,7 +98971,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen/kitchen_backroom/ghetto)
 "ygA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -99037,7 +99001,7 @@
 /obj/item/reagent_containers/spray/plantbgone,
 /obj/item/watertank,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "ygZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/binary/valve/on{
@@ -99247,7 +99211,6 @@
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/port/aft)
 "yjN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -99427,7 +99390,7 @@
 	pixel_y = 9
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/area/station/service/hydroponics)
 "ylO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/effect/turf_decal/tile/blue{
@@ -128883,7 +128846,7 @@ jxu
 qGg
 gtv
 nPy
-lCL
+rST
 iTk
 svn
 sMd
@@ -129419,14 +129382,14 @@ txs
 guN
 bsv
 guN
-guN
-guN
-guN
-guN
-guN
-guN
-guN
-guN
+nZU
+doz
+doz
+doz
+doz
+doz
+hUE
+doz
 phd
 qBZ
 tZW
@@ -129676,14 +129639,14 @@ doz
 guN
 skM
 guN
-bsv
-liU
-bsv
-bsv
-bsv
-svx
-rAv
-kJJ
+nZU
+doz
+doz
+doz
+doz
+doz
+hUE
+doz
 phd
 phd
 phd
@@ -129933,15 +129896,15 @@ doz
 guN
 bsv
 guN
-bsv
 guN
 guN
-guN
-bsv
-bsv
-bsv
-bsv
-guN
+doz
+doz
+doz
+doz
+hUE
+ceC
+doz
 doz
 doz
 job
@@ -130170,7 +130133,7 @@ wMc
 fqZ
 iCy
 lCL
-sPz
+lCL
 joZ
 bWy
 nzc
@@ -130189,16 +130152,16 @@ doz
 doz
 guN
 bsv
-cfA
-bsv
+tRT
+kwx
 guN
 doz
-guN
-guN
-guN
-guN
-skM
-guN
+doz
+doz
+doz
+hUE
+hUE
+hUE
 hUE
 hUE
 hUE
@@ -130445,17 +130408,17 @@ doz
 ceC
 ceC
 guN
-kJJ
 hLM
-hLM
+svx
+kwx
 guN
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
 doz
-doz
-doz
-doz
-guN
-bsv
-guN
 doz
 isY
 isY
@@ -130702,17 +130665,17 @@ vbK
 vbK
 doz
 guN
+kJJ
+hLM
+kwx
 guN
-guN
-qIN
-guN
+doz
+doz
 ceC
+doz
+doz
 ceC
-ceC
-ceC
-guN
-bsv
-guN
+doz
 doz
 doz
 ceC
@@ -130959,19 +130922,19 @@ hpP
 vbK
 txs
 guN
-kJJ
 guN
-hLM
 guN
-doz
-doz
-doz
-doz
-guN
-skM
+dZS
 guN
 doz
 doz
+ceC
+doz
+doz
+ceC
+ceC
+ceC
+ceC
 ceC
 doz
 ceC
@@ -131203,13 +131166,13 @@ bqY
 fQm
 bqY
 nSR
-lBq
+jZk
 uIU
 hpP
 uIU
-lBq
+jZk
 nSR
-aaN
+tpa
 cHe
 pRz
 hpP
@@ -131218,15 +131181,15 @@ jUu
 sVY
 hLM
 lsH
-hLM
+kwx
 guN
 ceC
 ceC
 ceC
 ceC
-guN
-bsv
-guN
+ceC
+ceC
+doz
 doz
 doz
 ceC
@@ -131460,7 +131423,7 @@ tfC
 wih
 piL
 jZk
-dpr
+aaN
 xtm
 aaN
 xtm
@@ -131471,18 +131434,18 @@ oEt
 drD
 hpP
 hpP
-jZk
-nSR
-nSR
-nSR
-nSR
 hpP
+hpP
+hpP
+hpP
+kwx
+guN
 doz
 doz
-doz
+ceC
 guN
 guN
-bsv
+guN
 guN
 guN
 guN
@@ -131725,27 +131688,27 @@ yjl
 rnx
 rOp
 qCq
-drD
+tZC
 hpP
 rNV
-yeH
 nyd
-rmN
 uFx
 kEv
-nSR
-doz
-doz
-doz
+hpP
+kwx
 guN
+doz
+doz
+ceC
+guN
+kwx
 bsv
 bsv
-bsv
-skM
+aNR
 liU
 bsv
-kkI
-dlM
+rqb
+bCC
 mOI
 mOI
 mOI
@@ -131981,32 +131944,32 @@ qbt
 mIr
 hpP
 vFz
-oEt
+fZq
 gLw
 wjz
 cjh
-pri
+wGr
 wCk
-fkt
-uXd
 vrw
-nSR
-guN
-guN
-guN
-guN
-bsv
-guN
+hpP
+kwx
 guN
 guN
 guN
 guN
 guN
-dlM
-gxo
+kwx
+guN
+guN
+guN
+guN
+guN
+guN
+gJQ
+bBe
 dEJ
 bBe
-bBe
+gxo
 rqb
 dlM
 dlM
@@ -132231,28 +132194,28 @@ yaz
 jxf
 uXV
 nSR
-hpP
+nSR
 jZk
 upw
 jZk
-hpP
-hpP
+nSR
+nSR
 umj
 kMk
 oyq
 xBh
 brd
-knZ
 sZz
 hZY
-hZY
-kaz
-nSR
-hvU
-wNH
-bsv
-bsv
-bsv
+eCv
+hpP
+kwx
+kwx
+kwx
+kwx
+kwx
+kwx
+kwx
 guN
 doz
 ceC
@@ -132484,7 +132447,7 @@ uXV
 bJR
 bMl
 xye
-ijC
+nYm
 bup
 gOu
 nSR
@@ -132493,21 +132456,21 @@ tdP
 nnb
 ksT
 keX
-hpP
+nSR
 rki
 uvJ
-oyq
+uvJ
 wjz
 knT
 gfU
-uvJ
-ioy
-ohn
+hYm
 kuW
-nSR
+hpP
+hpP
+hpP
 mFZ
 wNH
-svx
+ccS
 guN
 guN
 guN
@@ -132750,18 +132713,18 @@ lgp
 dJh
 plA
 ukM
-hpP
+nSR
 sJU
 kpI
 uaA
 hpP
 hds
 iCg
-oEt
-rHD
-plj
+cvk
 rtu
-nSR
+hpP
+bgA
+hpP
 xws
 wNH
 bdK
@@ -133002,27 +132965,27 @@ dXW
 lqn
 toF
 nSR
-hpP
-hpP
-hpP
-hpP
-hpP
-hpP
+nSR
+nSR
+nSR
+nSR
+nSR
+nSR
 amI
 uvJ
-cgz
-nSR
-nSR
-nSR
-nSR
-nSR
-rtl
-rtl
-rtl
-raA
+ioy
+hpP
+hpP
+hpP
+hpP
+hpP
+hpP
+hpP
+hpP
+guN
 snB
-raA
-raA
+guN
+guN
 raA
 raA
 raA
@@ -133038,7 +133001,7 @@ doz
 mOI
 fAb
 uco
-iEa
+mOI
 dvk
 mOI
 mOI
@@ -133255,25 +133218,25 @@ yaz
 qFY
 okD
 bUU
-nYm
+qkz
 ixJ
 vgn
-hpP
-yjl
-yjl
-yjl
+aLe
+cfl
+cfl
+lNw
 qTw
-tXm
-amI
+uvJ
+uvJ
 dgR
-amI
-dJh
+uvJ
+uvJ
 hIl
 jVO
 wvJ
 dGM
 iET
-raA
+hpP
 vuf
 vuf
 cRr
@@ -133295,7 +133258,7 @@ doz
 mOI
 mOI
 mOI
-rzS
+mOI
 dGY
 nPs
 pOC
@@ -133515,22 +133478,22 @@ uXV
 yaz
 faT
 uXV
-nSR
-yjl
-hpP
-hpP
-hpP
+aLe
+qzS
+aLe
+aLe
+aLe
 bqM
-bBM
+kGB
 fuM
-wLE
+pri
 cgz
 xYj
 rFF
 pAB
 amI
 amI
-raA
+hpP
 aWb
 aWb
 spi
@@ -133547,11 +133510,11 @@ hzy
 wFf
 mca
 iZA
-vbK
+doz
 doz
 ceC
 ceC
-doz
+ceC
 mOI
 eXr
 pCC
@@ -133766,28 +133729,28 @@ aLe
 hOR
 qGg
 xeB
-qGg
+sdc
 qmk
-qGg
+sdc
 xeB
-qGg
-qGg
-qGg
-yjl
+sdc
+sdc
+sdc
+sdc
 kHI
 sdc
+aLe
 hpP
-wkX
-wkX
-wkX
-wkX
-wkX
-wkX
-wkX
-wkX
-wkX
-raA
-raA
+hpP
+hpP
+hpP
+hpP
+hpP
+hpP
+hpP
+hpP
+hpP
+hpP
 wOV
 oTV
 gNt
@@ -134029,12 +133992,12 @@ aLe
 aLe
 aLe
 hvE
-wYp
-hpP
-hpP
+aLe
+aLe
+aLe
 lSU
 gSq
-wkX
+otf
 dwb
 xEa
 gTC
@@ -134043,14 +134006,14 @@ oEZ
 lEK
 pyx
 lqt
-raA
+otf
 lVT
 eDc
 opZ
 kvQ
 eHI
 aQX
-dJX
+vYT
 vYT
 cvB
 raA
@@ -134285,22 +134248,22 @@ vbK
 vbK
 ceC
 aLe
-qzS
-lZF
+kKp
+xmh
 vcM
 azG
 sdc
-oEt
-wkX
+xYQ
+otf
 gga
 stF
 uiH
-wkX
+otf
 xgM
 kGA
 jDu
 bWQ
-raA
+otf
 eyg
 hcs
 vDW
@@ -134319,14 +134282,14 @@ kTA
 kTA
 uDD
 iZA
-doz
-ceC
-doz
-doz
 ceC
 ceC
 doz
-doz
+ceC
+ceC
+ceC
+ceC
+ceC
 mOI
 jKW
 mOI
@@ -134542,12 +134505,12 @@ doz
 doz
 ceC
 aLe
-qzS
-hWY
+kKp
+xmh
 xfj
-oEt
-plj
-fkt
+cQc
+feU
+qzS
 dQW
 oCT
 uCO
@@ -134557,7 +134520,7 @@ hwz
 abq
 hlb
 xIq
-raA
+otf
 bFy
 gHN
 uwz
@@ -134576,12 +134539,12 @@ kTA
 eZs
 nTj
 iZA
-vbK
-vbK
-vbK
-vbK
 ceC
-ceC
+vbK
+vbK
+vbK
+vbK
+vbK
 mOI
 mOI
 mOI
@@ -134800,12 +134763,12 @@ ceC
 ceC
 aLe
 lKu
-fBU
-rXX
+xmh
+naS
 rVd
 rXX
 feU
-wkX
+otf
 pDH
 ple
 rgy
@@ -134814,7 +134777,7 @@ sAk
 vyz
 pkk
 bYq
-raA
+otf
 pCa
 iMh
 tNq
@@ -135058,20 +135021,20 @@ ceC
 aLe
 aLe
 aLe
-aLe
-aLe
-aLe
-aLe
-wkX
-wkX
-wkX
-wkX
+pNZ
+eHU
+pNZ
+pNZ
+pNZ
+pNZ
+pNZ
+pNZ
 aCd
 dry
 rBw
 rTy
 xgZ
-raA
+otf
 wOV
 iex
 fqU
@@ -135090,12 +135053,12 @@ iOg
 kDA
 iZA
 iZA
-vbK
-mXG
-vbK
-vbK
-vbK
 ceC
+vbK
+vbK
+vbK
+vbK
+vbK
 mOI
 mOI
 mOI
@@ -135315,20 +135278,20 @@ ceC
 doz
 doz
 doz
-doz
-doz
-doz
-doz
-doz
-doz
-vbK
-wkX
+pNZ
+aEx
+pNZ
+aPK
+aPK
+aPK
+aPK
+pNZ
 cIu
 fBH
 lQG
 sOm
 vzA
-raA
+otf
 sVf
 oIJ
 rYe
@@ -135346,15 +135309,15 @@ mMv
 gsW
 eIx
 iZA
-vbK
-doz
-ceC
-doz
 doz
 doz
 ceC
-doz
-doz
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
 mOI
 jKW
 mOI
@@ -135572,20 +135535,20 @@ ceC
 vbK
 vbK
 vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-wkX
-wkX
-wkX
-wkX
+pNZ
+mvZ
+pNZ
+pNZ
+oRl
+rYX
+pNZ
+pNZ
+pNZ
+otf
+otf
 obz
-wkX
-raA
+otf
+otf
 xwG
 raA
 raA
@@ -135603,13 +135566,13 @@ rAt
 iZA
 iZA
 iZA
-vbK
-doz
-ceC
-doz
 doz
 doz
 ceC
+doz
+doz
+doz
+doz
 doz
 doz
 mOI
@@ -135829,16 +135792,16 @@ ceC
 doz
 doz
 doz
-doz
-doz
-doz
-ceC
-doz
-doz
-vbK
 pNZ
-hXp
-pNZ
+ggA
+jld
+raL
+sUA
+mYD
+bFX
+yaI
+yaI
+xSN
 ooL
 xbr
 vUG
@@ -135862,7 +135825,7 @@ doz
 doz
 doz
 doz
-unE
+ceC
 doz
 doz
 doz
@@ -136086,14 +136049,14 @@ ceC
 doz
 doz
 doz
-doz
-doz
-ceC
-doz
-doz
-doz
-vbK
 pNZ
+tOS
+aEx
+jrB
+aEx
+bjm
+tOS
+aEx
 hFL
 lVy
 qwC
@@ -136109,7 +136072,7 @@ raA
 vAP
 jtX
 fxH
-wRT
+raA
 doz
 ceC
 doz
@@ -136343,16 +136306,16 @@ ceC
 vbK
 vbK
 vbK
-vbK
-vbK
-ceC
-vbK
-vbK
-vbK
-vbK
 pNZ
+pNZ
+pNZ
+pNZ
+pNZ
+pNZ
+pNZ
+eRj
 ylo
-pNZ
+xSN
 uZU
 xTr
 nSz
@@ -136368,7 +136331,7 @@ psp
 tOb
 raA
 ceC
-vbK
+ceC
 ceC
 ceC
 ceC
@@ -136606,12 +136569,12 @@ ceC
 doz
 uXq
 doz
-vbK
 pNZ
+vpn
 iYF
-pNZ
+xSN
 rbH
-xTr
+gUN
 qzI
 rko
 iQW
@@ -136863,12 +136826,12 @@ vbK
 vbK
 mqq
 vbK
-vbK
 pNZ
-eQX
-pNZ
+yaI
+aTe
+xSN
 xOr
-xTr
+ieg
 gNr
 fTH
 bQn
@@ -136879,11 +136842,11 @@ ldb
 sXK
 sOd
 wWh
-doz
-doz
-job
-vbK
-vbK
+ceC
+ceC
+ceC
+ceC
+ceC
 ceC
 ceC
 ceC
@@ -137120,12 +137083,12 @@ doz
 doz
 doz
 doz
-vbK
 qqz
+uJB
 iYF
-pNZ
+xSN
 iNr
-xTr
+gUN
 hke
 qcp
 mpX
@@ -137139,8 +137102,8 @@ wWh
 doz
 doz
 doz
-vbK
-doz
+ceC
+ceC
 doz
 doz
 doz
@@ -137377,12 +137340,12 @@ doz
 doz
 doz
 doz
-vbK
 qqz
-cof
-pNZ
+foT
+ylo
+xSN
 wCH
-xTr
+edE
 epA
 iYW
 hky
@@ -137396,8 +137359,8 @@ wWh
 doz
 doz
 doz
-jEk
-doz
+ceC
+ceC
 doz
 doz
 doz
@@ -137634,10 +137597,10 @@ doz
 doz
 doz
 vbK
-vbK
 pNZ
+yaI
 eQX
-pNZ
+xSN
 uOO
 uxx
 fFe
@@ -137652,7 +137615,7 @@ cXX
 wWh
 ceC
 ceC
-cOR
+vbK
 ceC
 vbK
 doz
@@ -137891,10 +137854,10 @@ doz
 doz
 doz
 vbK
-vMn
 pNZ
+raL
 iYF
-pNZ
+xSN
 tqK
 xkQ
 rfN
@@ -137909,7 +137872,7 @@ cXX
 wWh
 doz
 doz
-lqh
+vbK
 ceC
 vbK
 vbK
@@ -138148,26 +138111,26 @@ vbK
 vbK
 vbK
 vbK
-vMn
 pNZ
+loN
 kKA
 pNZ
-nrH
+iBi
 jJb
 jJb
 nbV
-nrH
-nrH
-nrH
-wWh
-wWh
-wWh
-wWh
-wWh
+iBi
+iBi
+iBi
+iBi
+iBi
+iBi
+iBi
+iBi
 ceC
 ceC
-hUE
-ceC
+vbK
+jEk
 vbK
 doz
 doz
@@ -138405,17 +138368,17 @@ doz
 uXq
 doz
 vbK
-vMn
 pNZ
+yaI
 cof
 jfa
-nrH
+iBi
 gHM
 ayw
 cki
 qnC
 tXs
-nrH
+iBi
 lXK
 mfx
 iym
@@ -138662,8 +138625,8 @@ vbK
 vbK
 vbK
 vbK
-vMn
 pNZ
+yaI
 iYF
 ygA
 lrM
@@ -138672,7 +138635,7 @@ kPl
 ueJ
 ckj
 eKl
-bti
+dVO
 rBf
 lZb
 wPU
@@ -138919,11 +138882,11 @@ doz
 doz
 doz
 vbK
-vMn
 pNZ
+vpn
 eQX
 scv
-nrH
+iBi
 vmY
 oMD
 hHb
@@ -138937,7 +138900,7 @@ vwk
 bti
 doz
 doz
-nMK
+vbK
 ceC
 vbK
 vbK
@@ -139176,17 +139139,17 @@ doz
 doz
 doz
 vbK
-vMn
 pNZ
+evs
 iYF
 uSZ
-nrH
+iBi
 fED
 hEM
 wSl
 aTN
 plq
-bti
+dVO
 fME
 oht
 pON
@@ -139434,16 +139397,16 @@ pNZ
 pNZ
 pNZ
 pNZ
-pNZ
+vpn
 eVl
 xOl
-nrH
+iBi
 oQI
 iZg
 aDd
 wzK
 eGb
-nrH
+iBi
 luS
 mfx
 njp
@@ -139691,24 +139654,24 @@ aTb
 jFO
 tOk
 pNZ
-pNZ
+loN
 prv
 pNZ
-nrH
-nrH
-nrH
+iBi
+iBi
+iBi
 jJb
-nrH
-nrH
-nrH
-nrH
+iBi
+iBi
+iBi
+iBi
 jJb
 jJb
-nrH
-nrH
+iBi
+iBi
 doz
 doz
-hUE
+vbK
 ceC
 vbK
 siJ
@@ -139948,7 +139911,7 @@ aTb
 vkd
 sHi
 pNZ
-pNZ
+aCq
 eVl
 pNZ
 koq
@@ -139965,8 +139928,8 @@ doz
 doz
 doz
 doz
-lqh
-jEk
+vbK
+ceC
 vbK
 siJ
 gEm
@@ -140205,7 +140168,7 @@ tbe
 aCq
 hku
 pNZ
-pNZ
+aCq
 nOr
 pNZ
 eOa
@@ -140462,7 +140425,7 @@ jmc
 ugK
 odU
 pNZ
-wsk
+vpn
 gMj
 dGC
 yaI
@@ -140480,7 +140443,7 @@ doz
 ipz
 oFI
 ipz
-vbK
+ceC
 vbK
 siJ
 dyq
@@ -141495,7 +141458,7 @@ rOQ
 qbN
 wXK
 aTF
-gZc
+qmf
 vpn
 vpn
 vpn
@@ -147156,7 +147119,7 @@ qen
 wjB
 ltk
 tdQ
-tdQ
+voZ
 vrX
 tdQ
 tdQ
@@ -199316,7 +199279,7 @@ kFR
 nEu
 fzc
 pld
-fqC
+pld
 pld
 oSL
 pld
@@ -199324,13 +199287,13 @@ vss
 kOB
 aae
 tsi
-wFA
+uCF
 xXO
 iAR
 tPg
 qtS
 vZV
-wFA
+eAV
 hjI
 peZ
 iEr
@@ -200087,8 +200050,8 @@ oAt
 oAt
 hlF
 nZT
-qiU
-qiU
+nZT
+nZT
 nZT
 xKI
 mjV
@@ -200342,10 +200305,10 @@ fgy
 fgy
 jCm
 nEu
-lEU
+fFk
+hLk
 nZT
-nZT
-nZT
+wUq
 nZT
 yce
 mtA
@@ -200355,7 +200318,7 @@ uAx
 acF
 fnW
 hfy
-iAM
+ygq
 hfy
 hfy
 aQk
@@ -200599,10 +200562,10 @@ mzS
 fgy
 fgy
 gBt
-fFk
+iMZ
 riH
 nZT
-jnj
+wUq
 nZT
 dcd
 xiF
@@ -200612,7 +200575,7 @@ uAx
 vjb
 hfy
 hfy
-pLn
+ygq
 hfy
 hfy
 qDi
@@ -200867,9 +200830,9 @@ aAf
 aPq
 uAx
 ygq
-aJw
+qca
 cJj
-pLn
+ygq
 qca
 jVn
 ygq
@@ -201376,7 +201339,7 @@ nZT
 sOT
 nZT
 nsJ
-dog
+qnd
 fvT
 wWT
 xnD
@@ -201628,16 +201591,16 @@ kNp
 kNp
 mIQ
 iMZ
-nEu
+jmO
 kru
 mFl
 aAk
 kAm
 bMH
-pHh
-pHh
-pHh
-pHh
+sTZ
+sTZ
+sTZ
+sTZ
 pHh
 tvf
 rVW
@@ -201885,16 +201848,16 @@ kNp
 phQ
 nEu
 iMZ
-kNp
+qLD
 nZT
 tvm
 nZT
 itk
 cXG
-pHh
+sTZ
 mFx
 gjY
-pHh
+sTZ
 nGu
 dKr
 dKr
@@ -202143,15 +202106,15 @@ eEF
 nEu
 caW
 vix
-xVw
-cTS
 vix
-pHh
-pHh
-pHh
+fgU
+vix
+sTZ
+sTZ
+sTZ
 qMX
 lVc
-pHh
+sTZ
 hRN
 dKr
 uVD
@@ -202400,15 +202363,15 @@ szl
 wzH
 iSs
 vix
-rOn
+qAJ
 vNk
 ran
-pHh
+sTZ
 mEo
 oim
 xxt
 qPl
-pHh
+sTZ
 ayU
 feW
 uGP
@@ -202660,7 +202623,7 @@ hMB
 eeN
 tvt
 cTS
-pHh
+sTZ
 oiA
 bNo
 bNo
@@ -202922,7 +202885,7 @@ jJL
 oOG
 fxV
 fgR
-hKc
+sTZ
 obW
 lya
 jWz
@@ -203174,12 +203137,12 @@ vix
 rlr
 xFd
 tli
-pHh
+sTZ
 kAC
 eMv
 qbT
 lNm
-pHh
+sTZ
 rUZ
 lya
 gVV
@@ -203431,12 +203394,12 @@ vix
 mdy
 wyD
 uxp
-pHh
+sTZ
 nar
 tKo
 dmh
 fPT
-pHh
+sTZ
 tKk
 lya
 dKr
@@ -203688,12 +203651,12 @@ vix
 mfF
 rzJ
 dRD
-pHh
-pHh
-pHh
-pHh
+sTZ
+sTZ
+sTZ
+sTZ
 fSS
-pHh
+sTZ
 uqu
 lya
 dKr
@@ -203702,7 +203665,7 @@ pLB
 uHo
 jBk
 ibV
-dWX
+nrH
 dXc
 nke
 ckR
@@ -203945,7 +203908,7 @@ vix
 fZQ
 klS
 dle
-yjq
+tli
 rOn
 dbs
 rOn
@@ -204459,7 +204422,7 @@ vix
 jtn
 tli
 dRD
-rOn
+yjq
 gtl
 uyt
 jZY
@@ -204473,7 +204436,7 @@ qWE
 rWM
 xYd
 ome
-dWX
+nrH
 fHn
 nke
 ckR
@@ -204717,20 +204680,20 @@ sjU
 rFc
 dRD
 pRT
-dWX
-dWX
-dWX
-dWX
+nrH
+nrH
+nrH
+nrH
 pHh
 eUf
 tJk
 pHh
-dWX
-dWX
-dWX
+nrH
+nrH
+nrH
 sRo
-dWX
-dWX
+nrH
+nrH
 nYw
 nke
 ckR
@@ -204973,11 +204936,11 @@ vix
 vix
 iii
 dRD
-dWX
-dWX
+nrH
+nrH
 teP
 jWd
-dWX
+nrH
 ctG
 byC
 uGI
@@ -205234,7 +205197,7 @@ ean
 sdY
 dlg
 mvc
-dWX
+nrH
 mNp
 rKR
 aAe
@@ -205491,7 +205454,7 @@ stY
 ocv
 xaT
 ygU
-dWX
+nrH
 toE
 vAa
 uIn
@@ -205744,7 +205707,7 @@ gnf
 gnf
 gnf
 gAA
-dWX
+nrH
 dND
 isp
 isp
@@ -206001,11 +205964,11 @@ fAH
 qIS
 fAH
 wRN
-dWX
+nrH
 nih
 frW
 lRd
-dWX
+nrH
 fDQ
 uDi
 iuM
@@ -206258,11 +206221,11 @@ jrF
 jrF
 jrF
 wRN
-dWX
+nrH
 jgw
 jki
 lnG
-dWX
+nrH
 aNY
 fxO
 chW
@@ -206515,11 +206478,11 @@ jrF
 iPQ
 jyv
 nPl
-dWX
+nrH
 qSe
 aqw
 uNV
-dWX
+nrH
 jtO
 ngN
 rPH
@@ -206772,11 +206735,11 @@ iPQ
 tAH
 gnf
 uWh
-dWX
+nrH
 ngz
 wYg
 ylA
-dWX
+nrH
 oBh
 hEZ
 lAG
@@ -207029,21 +206992,21 @@ iPQ
 jyv
 oiL
 uWh
-dWX
-dWX
-dWX
-dWX
-dWX
-dWX
-dWX
-dWX
-dWX
-dWX
-dWX
-dWX
-dWX
-dWX
-dWX
+nrH
+nrH
+nrH
+nrH
+nrH
+nrH
+nrH
+nrH
+nrH
+nrH
+nrH
+nrH
+nrH
+nrH
+nrH
 lGE
 rWB
 lGE

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -3638,6 +3638,7 @@
 	},
 /obj/machinery/duct,
 /obj/effect/decal/cleanable/plastic,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "aTg" = (
@@ -11924,7 +11925,6 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
-/obj/machinery/light/floor,
 /turf/open/floor/wood/large,
 /area/station/service/bar/atrium/ghetto)
 "cRA" = (
@@ -11978,7 +11978,7 @@
 "cSk" = (
 /obj/structure/chair/sofa/right/maroon,
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/glass,
+/turf/open/floor/wood/large,
 /area/station/service/bar/atrium/ghetto)
 "cSo" = (
 /obj/effect/turf_decal/stripes/red/line{
@@ -12876,7 +12876,6 @@
 "dbs" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/costume/tv_head,
-/obj/machinery/light/warm/directional/west,
 /turf/open/floor/wood/parquet,
 /area/station/hallway/secondary/service)
 "dbt" = (
@@ -19398,7 +19397,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/obj/machinery/light/floor,
 /turf/open/floor/wood/large,
 /area/station/service/bar/atrium/ghetto)
 "eIA" = (
@@ -20151,7 +20149,6 @@
 /area/station/maintenance/starboard/fore)
 "eTo" = (
 /obj/effect/turf_decal/siding/wood/corner,
-/obj/machinery/light/floor,
 /turf/open/floor/wood/large,
 /area/station/service/bar/atrium/ghetto)
 "eTt" = (
@@ -25087,8 +25084,7 @@
 	},
 /obj/machinery/button/door/directional/north{
 	name = "ViP Hall Shutters Control";
-	id = "viphall";
-	pixel_y = 27
+	id = "viphall"
 	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -32992,10 +32988,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
-"hXB" = (
-/obj/structure/chair/sofa/left/maroon,
-/turf/open/floor/glass,
-/area/station/service/bar/atrium/ghetto)
 "hXF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36269,7 +36261,7 @@
 /obj/effect/spawner/random/food_or_drink/dinner{
 	pixel_y = 5
 	},
-/turf/open/floor/glass,
+/turf/open/floor/wood/large,
 /area/station/service/bar/atrium/ghetto)
 "iOh" = (
 /obj/structure/cable,
@@ -38453,6 +38445,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/glass_debris,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "jrC" = (
@@ -43240,7 +43233,7 @@
 /obj/effect/turf_decal/trimline/tram/line{
 	dir = 1
 	},
-/obj/machinery/light/directional/north,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark/textured_edge,
 /area/station/service/kitchen/kitchen_backroom)
 "kAD" = (
@@ -43510,6 +43503,7 @@
 /area/station/engineering/atmos/project)
 "kDA" = (
 /obj/effect/turf_decal/siding/wood,
+/obj/machinery/light/floor,
 /turf/open/floor/wood/large,
 /area/station/service/bar/atrium/ghetto)
 "kDD" = (
@@ -44568,7 +44562,7 @@
 /area/station/service/chapel/office)
 "kOU" = (
 /obj/structure/chair/sofa/middle/maroon,
-/turf/open/floor/glass,
+/turf/open/floor/wood/large,
 /area/station/service/bar/atrium/ghetto)
 "kOV" = (
 /obj/effect/turf_decal/box,
@@ -47545,12 +47539,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
-"lAs" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Bar - West"
-	},
-/turf/open/openspace,
-/area/station/commons/lounge)
 "lAv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan{
 	dir = 4
@@ -48194,7 +48182,7 @@
 "lJm" = (
 /obj/structure/chair/sofa/middle/maroon,
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/glass,
+/turf/open/floor/wood/large,
 /area/station/service/bar/atrium/ghetto)
 "lJp" = (
 /obj/structure/cable,
@@ -48563,7 +48551,7 @@
 /area/station/engineering/lobby)
 "lNm" = (
 /obj/effect/turf_decal/trimline/tram/line,
-/obj/machinery/light/directional/south,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 1
 	},
@@ -48733,7 +48721,7 @@
 	pixel_x = 4;
 	pixel_y = 5
 	},
-/turf/open/floor/glass,
+/turf/open/floor/wood/large,
 /area/station/service/bar/atrium/ghetto)
 "lPb" = (
 /obj/machinery/door/window/brigdoor/right/directional/east{
@@ -49762,7 +49750,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/obj/machinery/light/floor,
 /turf/open/floor/wood/large,
 /area/station/service/bar/atrium/ghetto)
 "mcc" = (
@@ -50283,7 +50270,6 @@
 	pixel_x = 6;
 	pixel_y = 12
 	},
-/obj/machinery/light/small/blacklight/directional/east,
 /turf/open/floor/carpet/green,
 /area/station/service/bar/atrium/ghetto)
 "miV" = (
@@ -50756,7 +50742,7 @@
 	pixel_y = 7;
 	pixel_x = -12
 	},
-/obj/item/kirbyplants/potty{
+/obj/item/kirbyplants/organic/plant19{
 	pixel_y = 15;
 	pixel_x = 4
 	},
@@ -61367,7 +61353,7 @@
 	pixel_x = -3;
 	pixel_y = 6
 	},
-/turf/open/floor/glass,
+/turf/open/floor/wood/large,
 /area/station/service/bar/atrium/ghetto)
 "oRy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -63522,7 +63508,6 @@
 "psp" = (
 /obj/structure/table/reinforced/plasmarglass,
 /obj/effect/spawner/random/entertainment/deck,
-/obj/machinery/light/small/blacklight/directional/east,
 /turf/open/floor/carpet/neon/simple/violet,
 /area/station/service/bar/atrium/ghetto)
 "psq" = (
@@ -65700,6 +65685,16 @@
 /obj/structure/sign/warning/vacuum/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
+"pRX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "pSd" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -68283,11 +68278,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
-"qAJ" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/light/directional/west,
-/turf/open/floor/wood/parquet,
-/area/station/hallway/secondary/service)
 "qAN" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red{
@@ -74571,6 +74561,7 @@
 "scv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ants,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "scy" = (
@@ -84239,6 +84230,7 @@
 /obj/structure/chair/sofa/middle/brown{
 	dir = 8
 	},
+/obj/machinery/light/warm/directional/east,
 /turf/open/floor/wood/parquet,
 /area/station/hallway/secondary/service)
 "uyA" = (
@@ -84741,7 +84733,7 @@
 	pixel_x = 8;
 	pixel_y = 8
 	},
-/turf/open/floor/glass,
+/turf/open/floor/wood/large,
 /area/station/service/bar/atrium/ghetto)
 "uFW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -134016,7 +134008,7 @@ raA
 gbO
 dAy
 qST
-hXB
+nTj
 lPa
 cRy
 sFs
@@ -143505,7 +143497,7 @@ tzu
 pNZ
 pNZ
 pNZ
-gGK
+pRX
 xjE
 xjE
 cjH
@@ -198772,7 +198764,7 @@ wFA
 dfB
 rKe
 mgs
-lAs
+mgs
 mgs
 rKe
 xME
@@ -202359,7 +202351,7 @@ szl
 wzH
 iSs
 vix
-qAJ
+rOn
 vNk
 ran
 sTZ

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -13751,7 +13751,6 @@
 /area/space/nearstation)
 "dmh" = (
 /obj/structure/table,
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/turf_decal/trimline/tram/line{
 	dir = 4
 	},
@@ -24307,7 +24306,7 @@
 	location = "Kitchen"
 	},
 /turf/open/floor/plating,
-/area/station/hallway/secondary/service)
+/area/station/service/kitchen)
 "fSY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -33698,6 +33697,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"iii" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/wood/parquet,
+/area/station/hallway/secondary/service)
 "iik" = (
 /obj/structure/cable,
 /obj/machinery/holopad/secure,
@@ -203684,10 +203688,10 @@ vix
 mfF
 rzJ
 dRD
-vix
-vix
-vix
-vix
+pHh
+pHh
+pHh
+pHh
 fSS
 pHh
 uqu
@@ -204710,13 +204714,13 @@ gKm
 jkH
 vix
 sjU
-tli
+rFc
 dRD
 pRT
-vix
-vix
-vix
-vix
+dWX
+dWX
+dWX
+dWX
 pHh
 eUf
 tJk
@@ -204967,7 +204971,7 @@ mdo
 wdZ
 vix
 vix
-rFc
+iii
 dRD
 dWX
 dWX

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -95,6 +95,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/backroom/ghetto)
 "abw" = (
@@ -1856,10 +1858,10 @@
 "ayw" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/food_or_drink/seed,
-/obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics/ghetto)
 "ayF" = (
@@ -3714,6 +3716,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics/ghetto)
 "aTP" = (
@@ -3886,7 +3889,9 @@
 /turf/open/floor/iron/stairs/medium,
 /area/station/hallway/primary/aft)
 "aWb" = (
-/obj/structure/fake_stairs/wood/directional/north,
+/obj/structure/stairs/wood{
+	dir = 1
+	},
 /obj/structure/railing{
 	dir = 4
 	},
@@ -8755,13 +8760,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"cfX" = (
-/obj/structure/fake_stairs/wood/directional/south,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/wood/large,
-/area/station/service/bar/atrium/ghetto)
 "cfY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9189,6 +9187,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics/ghetto)
 "ckk" = (
@@ -14626,6 +14625,7 @@
 	dir = 8
 	},
 /obj/machinery/vending/wardrobe/bar_wardrobe,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/service/bar/backroom/ghetto)
 "dwg" = (
@@ -19117,6 +19117,7 @@
 	id = "botany_apiary";
 	name = "Bee Protection Shutters"
 	},
+/obj/structure/sign/poster/official/moth_meth/directional/east,
 /turf/open/floor/stone,
 /area/station/service/hydroponics/ghetto)
 "eGj" = (
@@ -19562,6 +19563,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics/ghetto)
 "eKq" = (
@@ -25431,7 +25433,6 @@
 /obj/effect/turf_decal/trimline/tram/mid_joiner{
 	dir = 1
 	},
-/obj/machinery/status_display/evac/directional/north,
 /obj/structure/rack,
 /obj/item/chair/plastic{
 	pixel_y = 8
@@ -25442,6 +25443,7 @@
 /obj/item/chair/plastic{
 	pixel_y = 19
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
 	},
@@ -27916,6 +27918,8 @@
 /obj/effect/turf_decal/trimline/tram/warning,
 /obj/effect/turf_decal/trimline/tram/mid_joiner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/service/bar/backroom/ghetto)
 "gNf" = (
@@ -28509,6 +28513,8 @@
 /obj/effect/turf_decal/trimline/tram/mid_joiner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 4
 	},
@@ -36881,6 +36887,8 @@
 /obj/structure/curtain/bounty,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
 	},
@@ -43853,6 +43861,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/backroom/ghetto)
 "kGB" = (
@@ -44589,6 +44599,7 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics/ghetto)
 "kPp" = (
@@ -47821,6 +47832,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/backroom/ghetto)
 "lEP" = (
@@ -48898,6 +48911,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/backroom/ghetto)
 "lQJ" = (
@@ -49161,9 +49176,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "lVc" = (
-/obj/structure/fake_stairs/directional/east{
-	color = "#555559"
-	},
 /obj/structure/railing{
 	dir = 1;
 	color = "#6e6e6e"
@@ -60407,6 +60419,8 @@
 "oEZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/service/bar/backroom/ghetto)
 "oFe" = (
@@ -62972,6 +62986,7 @@
 	dir = 4
 	},
 /obj/structure/sink/kitchen/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
@@ -62980,6 +62995,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics/ghetto)
 "plw" = (
@@ -64544,6 +64560,8 @@
 	dir = 1
 	},
 /obj/structure/reagent_dispensers/beerkeg,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 8
 	},
@@ -66263,13 +66281,6 @@
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/asphalt,
 /area/station/maintenance/ghetto/garden)
-"pYQ" = (
-/obj/structure/fake_stairs/wood/directional/south,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/wood/large,
-/area/station/service/bar/atrium/ghetto)
 "pYX" = (
 /obj/structure/water_source/puddle,
 /turf/open/misc/grass,
@@ -67307,6 +67318,7 @@
 	dir = 10
 	},
 /obj/structure/reagent_dispensers/watertank,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics/ghetto)
 "qnH" = (
@@ -70745,6 +70757,8 @@
 /obj/item/mop,
 /obj/machinery/light/small/blacklight/directional/east,
 /obj/structure/table,
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 1
 	},
@@ -72365,6 +72379,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/backroom/ghetto)
 "rBy" = (
@@ -77532,6 +77548,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/backroom/ghetto)
 "sOC" = (
@@ -82384,6 +82402,7 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics/ghetto)
 "tYQ" = (
@@ -82856,6 +82875,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics/ghetto)
 "ueM" = (
@@ -83219,6 +83239,8 @@
 /obj/effect/turf_decal/trimline/tram/mid_joiner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/service/bar/backroom/ghetto)
 "uiL" = (
@@ -87286,8 +87308,8 @@
 	},
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/duct,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics/ghetto)
 "vnc" = (
@@ -88053,7 +88075,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "vuf" = (
-/obj/structure/fake_stairs/wood/directional/north,
+/obj/structure/stairs/wood{
+	dir = 1
+	},
 /obj/structure/railing{
 	dir = 8
 	},
@@ -88366,6 +88390,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/backroom/ghetto)
 "vyE" = (
@@ -92312,7 +92338,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/obj/structure/sign/poster/official/moth_meth/directional/east,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics/ghetto)
 "wzL" = (
@@ -133230,7 +133257,7 @@ vuf
 cRr
 mWh
 cRr
-pYQ
+srW
 srW
 raA
 lnU
@@ -133487,7 +133514,7 @@ aWb
 spi
 ugs
 col
-cfX
+pec
 pec
 raA
 nbO

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -2064,6 +2064,9 @@
 "aAk" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/curtain/bounty,
+/obj/machinery/door/airlock/service,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "aAp" = (
@@ -12841,6 +12844,7 @@
 "dbs" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/costume/tv_head,
+/obj/machinery/light/warm/directional/west,
 /turf/open/floor/wood/parquet,
 /area/station/hallway/secondary/service)
 "dbt" = (
@@ -58034,6 +58038,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "obY" = (

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -16217,7 +16217,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/firedoor,
 /obj/machinery/duct,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /turf/open/floor/iron/dark,
 /area/station/service/bar/backroom)
@@ -44865,12 +44864,15 @@
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "kSN" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 1;
-	color = "#777777"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/misc/sandy_dirt,
-/area/station/service/hydroponics/upper)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/bar)
 "kSS" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -52726,6 +52728,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"mNp" = (
+/obj/structure/sink/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics/upper)
 "mNq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -61545,13 +61554,6 @@
 /obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
-"oTk" = (
-/obj/structure/sink/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
 "oTm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -67310,9 +67312,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "qnk" = (
@@ -84947,16 +84947,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "uIn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/green/half{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
+/area/station/service/hydroponics/upper)
 "uIo" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/trimline/dark_blue/corner{
@@ -98393,15 +98393,11 @@
 /turf/open/floor/carpet/black,
 /area/station/command/meeting_room)
 "xYd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/green/half{
-	dir = 4
+/obj/effect/turf_decal/siding/dark{
+	dir = 1;
+	color = "#777777"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron/edge{
-	dir = 4
-	},
+/turf/open/misc/sandy_dirt,
 /area/station/service/hydroponics/upper)
 "xYj" = (
 /obj/machinery/door/airlock,
@@ -99394,13 +99390,16 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "ylo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/service/bar)
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
 "ylp" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -136348,7 +136347,7 @@ vbK
 vbK
 vbK
 pNZ
-uIn
+ylo
 pNZ
 uZU
 xTr
@@ -200859,7 +200858,7 @@ nZT
 bEo
 nZT
 mID
-qnd
+kSN
 aAf
 aPq
 uAx
@@ -201116,7 +201115,7 @@ nZT
 eGV
 nZT
 mam
-ylo
+qnd
 jdL
 cIN
 wrA
@@ -204211,7 +204210,7 @@ fxv
 mdc
 wCj
 fot
-kSN
+xYd
 voK
 obc
 ckR
@@ -204468,7 +204467,7 @@ dKY
 eDH
 qWE
 rWM
-kSN
+xYd
 ome
 dWX
 fHn
@@ -205232,7 +205231,7 @@ sdY
 dlg
 mvc
 dWX
-oTk
+mNp
 rKR
 aAe
 keB
@@ -205491,7 +205490,7 @@ ygU
 dWX
 toE
 vAa
-xYd
+uIn
 mcF
 eJS
 mcF

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -88,6 +88,15 @@
 /obj/effect/turf_decal/tile/dark_red/diagonal_edge,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
+"abq" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1;
+	color = "#4e4e4e"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
+/area/station/service/bar/backroom)
 "abw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -166,6 +175,7 @@
 /area/station/service/chapel/monastery)
 "acF" = (
 /obj/structure/chair/sofa/corp/right,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/black,
 /area/station/commons/lounge)
 "acG" = (
@@ -1259,7 +1269,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "aqx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
@@ -1270,10 +1280,13 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "aqF" = (
-/obj/structure/railing{
-	dir = 10
+/obj/structure/platform/corner{
+	dir = 8
 	},
-/turf/open/floor/glass,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/openspace,
 /area/station/commons/lounge)
 "aqJ" = (
 /obj/machinery/light/directional/north,
@@ -1841,10 +1854,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "ayw" = (
-/obj/structure/closet/firecloset,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/structure/rack,
+/obj/effect/spawner/random/food_or_drink/seed,
+/obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/wood/large,
+/area/station/service/hydroponics)
 "ayF" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/dark,
@@ -1877,6 +1894,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"ayP" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/structure/curtain/cloth/fancy/mechanical/start_closed{
+	name = "ViP Curtains"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "ayQ" = (
 /obj/structure/flora/tree/jungle{
 	pixel_y = -14
@@ -1897,6 +1925,12 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
+"ayU" = (
+/obj/structure/sink/kitchen/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "ayW" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -1970,9 +2004,9 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "azG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/maint,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
 /area/station/maintenance/department/medical/ghetto)
 "azO" = (
 /obj/structure/closet/l3closet/scientist,
@@ -2007,6 +2041,17 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"aAe" = (
+/obj/effect/turf_decal/tile/green/half{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
+/area/station/service/hydroponics/upper)
 "aAf" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -2018,11 +2063,8 @@
 /area/station/service/bar)
 "aAk" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/service/bar,
-/turf/open/floor/plating,
+/obj/structure/curtain/bounty,
+/turf/open/floor/iron/dark,
 /area/station/service/bar)
 "aAp" = (
 /obj/structure/cable,
@@ -2129,18 +2171,21 @@
 /turf/open/floor/engine/cult,
 /area/station/service/chapel/office)
 "aCd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
+/obj/structure/railing{
+	dir = 2;
+	color = "#6e6e6e"
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto/aft)
+/obj/structure/railing/corner/end/flip{
+	dir = 4;
+	color = "#6e6e6e"
+	},
+/obj/machinery/light_switch/directional/north,
+/obj/structure/railing/corner/end{
+	dir = 8;
+	color = "#6e6e6e"
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/bar/backroom)
 "aCe" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 1
@@ -2245,6 +2290,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"aDd" = (
+/obj/structure/ladder,
+/obj/effect/turf_decal/stripes/box,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plating,
+/area/station/service/hydroponics)
 "aDs" = (
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 8
@@ -2779,6 +2830,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/black,
 /area/station/commons/lounge)
 "aJA" = (
@@ -2874,7 +2926,7 @@
 	name = "Hydroponics Shutter Control"
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "aKY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3118,7 +3170,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "aOe" = (
 /obj/effect/landmark/start/shaft_miner,
 /obj/effect/landmark/start/shaft_miner,
@@ -3172,6 +3224,11 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /turf/open/floor/iron/telecomms,
 /area/station/tcommsat/server)
+"aOR" = (
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/beebox,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "aOV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3203,6 +3260,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
+"aPq" = (
+/obj/structure/chair/stool/bar/directional/north,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet/black,
+/area/station/commons/lounge)
 "aPt" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/garden)
@@ -3221,12 +3283,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "aPM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/checker,
+/area/station/service/bar/atrium)
 "aPQ" = (
 /turf/closed/wall/r_wall,
 /area/station/science/xenobiology)
@@ -3269,6 +3329,7 @@
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
 	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/black,
 /area/station/commons/lounge)
 "aQq" = (
@@ -3332,6 +3393,25 @@
 "aQU" = (
 /turf/closed/wall/r_wall,
 /area/station/security/checkpoint/customs)
+"aQX" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/structure/railing/corner{
+	dir = 8;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "aQY" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 8
@@ -3445,8 +3525,8 @@
 /mob/living/basic/chicken{
 	name = "Коммандор Клакки"
 	},
-/turf/open/misc/beach/sand,
-/area/station/service/hydroponics)
+/turf/open/misc/sandy_dirt,
+/area/station/service/hydroponics/upper)
 "aSg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -3612,17 +3692,13 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/captain)
 "aTN" = (
-/obj/item/taperecorder{
-	pixel_x = -6;
-	pixel_y = 4
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
 	},
-/obj/structure/table/reinforced/rglass,
-/turf/open/floor/light{
-	icon_state = "light_on-7";
-	state = 7;
-	light_color = "#a659ff"
-	},
-/area/station/commons/lounge)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/large,
+/area/station/service/hydroponics)
 "aTP" = (
 /obj/structure/spider/stickyweb,
 /obj/machinery/vending/autodrobe,
@@ -3792,6 +3868,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/stairs/medium,
 /area/station/hallway/primary/aft)
+"aWb" = (
+/obj/structure/fake_stairs/wood/directional/north,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "aWp" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /obj/effect/turf_decal/stripes/line{
@@ -3944,6 +4027,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
+"aXJ" = (
+/obj/effect/turf_decal/trimline/white/arrow_cw{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/white/corner,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/secondary/service)
 "aXQ" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating,
@@ -4368,7 +4458,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "bdK" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/closet/l3closet/virology,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "bdV" = (
@@ -4891,6 +4981,12 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/wood,
 /area/station/service/kitchen/abandoned)
+"bka" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "bkf" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow{
@@ -5349,8 +5445,11 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Bar - East"
+	},
 /turf/open/floor/wood/large,
-/area/station/service/bar)
+/area/station/commons/lounge)
 "bqt" = (
 /obj/structure/table/reinforced,
 /obj/item/pipe_dispenser,
@@ -5630,10 +5729,13 @@
 	},
 /area/station/holodeck/rec_center)
 "bti" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "botany_apiary";
+	name = "Apiary Shutters"
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/area/station/service/hydroponics)
 "bto" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden/crude,
@@ -5815,6 +5917,16 @@
 /obj/structure/sign/warning/secure_area/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
+"bvY" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/kirbyplants{
+	pixel_y = 15
+	},
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "bwa" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 8
@@ -6076,7 +6188,7 @@
 /area/station/maintenance/ghetto/auxiliary)
 "byC" = (
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "byD" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -6244,9 +6356,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "bBM" = (
-/obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "bBN" = (
 /obj/effect/spawner/random/trash/bin,
@@ -6338,6 +6454,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/central)
+"bCG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/service/bar/atrium)
 "bCJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red{
@@ -6467,6 +6589,17 @@
 "bEn" = (
 /turf/closed/wall,
 /area/station/command/heads_quarters/hop)
+"bEo" = (
+/obj/structure/railing{
+	dir = 1;
+	color = "#6e6e6e"
+	},
+/obj/structure/railing{
+	dir = 2;
+	color = "#6e6e6e"
+	},
+/turf/open/openspace,
+/area/station/service/bar)
 "bEq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6488,6 +6621,14 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
+"bEz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/platform/corner{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/station/commons/lounge)
 "bEA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6554,17 +6695,10 @@
 /turf/closed/wall,
 /area/station/commons/fitness)
 "bFy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/random/maintenance,
-/obj/structure/closet,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/wood/parquet,
-/area/station/hallway/secondary/service)
+/obj/structure/chair/sofa/left/maroon,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/carpet/red,
+/area/station/service/bar/atrium)
 "bFB" = (
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
@@ -7090,11 +7224,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
 "bMH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "bML" = (
@@ -7156,12 +7288,9 @@
 "bNo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/airalarm/directional/west,
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/station/service/bar/backroom)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/small,
+/area/station/service/kitchen)
 "bNv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -7381,6 +7510,13 @@
 /obj/effect/turf_decal/tile/purple/anticorner,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
+"bQn" = (
+/obj/structure/railing/corner/end{
+	dir = 8;
+	color = "#6e6e6e"
+	},
+/turf/closed/wall,
+/area/station/hallway/secondary/service)
 "bQo" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -7597,10 +7733,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "bSG" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/ghetto/central)
+/obj/machinery/airalarm/directional/north,
+/obj/structure/closet/secure_closet/freezer,
+/obj/item/food/meat/slab/pig,
+/obj/item/food/meat/slab/pig,
+/obj/item/food/meat/slab/pig,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "bSX" = (
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 1
@@ -7824,6 +7963,24 @@
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
+"bWQ" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass{
+	pixel_x = -13;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/rag{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/effect/spawner/random/entertainment/cigarette_pack{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood,
+/area/station/service/bar/backroom)
 "bWR" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/atmospherics/pipe/smart/simple/general{
@@ -7965,6 +8122,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
+"bYq" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/closet,
+/obj/item/circuitboard/computer/arcade/orion_trail,
+/obj/item/circuitboard/computer/arcade/battle,
+/obj/item/circuitboard/computer/slot_machine,
+/obj/item/circuitboard/computer/slot_machine,
+/obj/item/vending_refill/cigarette,
+/obj/item/vending_refill/coffee,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/wood/parquet,
+/area/station/service/bar/backroom)
 "bYr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -8267,6 +8436,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
+"cbv" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/ghetto/central)
 "cbw" = (
 /obj/machinery/door/poddoor/shutters/window{
 	id = "chemistry_access_shutters"
@@ -8299,7 +8474,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "cbR" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -8522,13 +8697,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "cfm" = (
-/obj/structure/chair/comfy/brown{
-	color = "#514E58";
-	dir = 8
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/carpet/black,
-/area/station/commons/lounge)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/floor,
+/turf/open/floor/iron/checker,
+/area/station/service/bar/atrium)
 "cfp" = (
 /obj/effect/turf_decal/tile/green/half{
 	dir = 1
@@ -8536,12 +8709,15 @@
 /turf/open/floor/iron/edge{
 	dir = 1
 	},
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "cfA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/dark_green/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/west,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "cfF" = (
 /obj/structure/closet/secure_closet/security/med,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8556,6 +8732,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"cfX" = (
+/obj/structure/fake_stairs/wood/directional/south,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "cfY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8732,7 +8915,7 @@
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "chY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/bar/fourcorners,
@@ -8965,12 +9148,27 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "cki" = (
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/south,
-/obj/effect/spawner/random/medical/minor_healing,
-/turf/open/floor/iron,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/station/service/hydroponics)
+"ckj" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/large,
+/area/station/service/hydroponics)
 "ckk" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
@@ -9062,6 +9260,12 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/commons/storage/primary)
+"ckY" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "cla" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9174,6 +9378,17 @@
 	},
 /turf/open/floor/wood,
 /area/station/security/prison)
+"cmt" = (
+/obj/structure/railing{
+	dir = 2;
+	color = "#6e6e6e"
+	},
+/obj/structure/railing{
+	dir = 1;
+	color = "#6e6e6e"
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/bar/backroom)
 "cmE" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
@@ -9292,13 +9507,28 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "cof" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
+"col" = (
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/structure/railing/corner{
+	dir = 2;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "cop" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9707,7 +9937,7 @@
 	},
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "ctJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -9837,6 +10067,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"cvB" = (
+/obj/effect/turf_decal/siding/wood/end,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "cvE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9904,6 +10142,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/trash)
+"cwa" = (
+/obj/effect/turf_decal/trimline/white/line,
+/obj/machinery/camera/directional/south{
+	dir = 5;
+	c_tag = "Lower Service Hall Alt"
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/station/hallway/secondary/service)
 "cwd" = (
 /turf/open/floor/iron/stairs/right{
 	dir = 8
@@ -10191,6 +10439,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/processing)
+"czW" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/kirbyplants{
+	pixel_y = 15
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "czX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
@@ -10691,13 +10952,13 @@
 /turf/open/floor/wood,
 /area/station/service/library/ghetto)
 "cGB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/obj/structure/table/wood/fancy/green,
+/obj/effect/spawner/random/entertainment/deck{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/turf/open/floor/carpet/green,
+/area/station/service/bar/atrium)
 "cGC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -10757,6 +11018,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
+"cHj" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/computer/slot_machine,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "cHo" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -10860,11 +11131,19 @@
 /turf/open/floor/carpet/black,
 /area/station/command/meeting_room)
 "cIu" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/cell_charger,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/structure/railing{
+	dir = 2;
+	color = "#6e6e6e"
+	},
+/obj/structure/railing{
+	dir = 1;
+	color = "#6e6e6e"
+	},
+/obj/structure/stairs/east{
+	color = "#555559"
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/bar/backroom)
 "cIx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10896,7 +11175,7 @@
 "cIN" = (
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/carpet/black,
-/area/station/service/bar)
+/area/station/commons/lounge)
 "cIS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -10911,6 +11190,7 @@
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet/black,
 /area/station/commons/lounge)
 "cJk" = (
@@ -11006,7 +11286,7 @@
 	slogan_delay = 700
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "cJZ" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -11576,12 +11856,25 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
+"cRk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "cRo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
+"cRr" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/light/small/blacklight/directional/west,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "cRx" = (
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 4
@@ -11592,6 +11885,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"cRy" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "cRA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -11640,6 +11940,11 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"cSk" = (
+/obj/structure/chair/sofa/right/maroon,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/glass,
+/area/station/service/bar/atrium)
 "cSo" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
@@ -11699,11 +12004,15 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "cTa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/effect/spawner/random/trash/mess,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
 "cTb" = (
 /obj/structure/reagent_dispensers/wall/peppertank/directional/north,
@@ -12128,14 +12437,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay/ghetto)
 "cXG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/disposal/bin,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/machinery/duct,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "cXQ" = (
@@ -12227,10 +12533,8 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "cYq" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
+/obj/effect/turf_decal/tile/dark/anticorner/contrasted,
+/turf/open/floor/iron,
 /area/station/commons/lounge)
 "cYu" = (
 /obj/effect/spawner/random/trash/graffiti,
@@ -12535,13 +12839,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "dbs" = (
-/obj/machinery/icecream_vat,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/effect/landmark/generic_maintenance_landmark,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/obj/structure/table/wood,
+/obj/item/clothing/head/costume/tv_head,
+/turf/open/floor/wood/parquet,
+/area/station/hallway/secondary/service)
 "dbt" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector{
 	dir = 1
@@ -12586,12 +12887,23 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
+"dbU" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/obj/structure/curtain/bounty,
+/obj/machinery/door/airlock/service,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/station/service/bar)
 "dcd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/drinks{
 	pixel_y = 8
 	},
-/obj/machinery/status_display/evac/directional/north,
+/obj/structure/sign/picture_frame/portrait/bar{
+	pixel_y = 28
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "dch" = (
@@ -12606,6 +12918,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"dcl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "dcn" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -12778,11 +13095,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "dfB" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
 /obj/machinery/light_switch/directional/west,
-/turf/open/floor/wood/large,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/openspace,
 /area/station/commons/lounge)
 "dfE" = (
 /obj/machinery/holopad,
@@ -13330,20 +13650,17 @@
 "dle" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/duct,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/item/kirbyplants/random,
-/obj/machinery/light_switch/directional/south,
-/obj/machinery/duct,
 /turf/open/floor/wood/parquet,
 /area/station/hallway/secondary/service)
 "dlg" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "dlm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/trash/mess,
@@ -13425,6 +13742,16 @@
 /obj/structure/marker_beacon/burgundy,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"dmh" = (
+/obj/structure/table,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/turf_decal/trimline/tram/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/station/service/kitchen)
 "dmj" = (
 /obj/machinery/status_display/ai/directional/north,
 /obj/effect/turf_decal/bot_white/right,
@@ -13573,9 +13900,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
 "dog" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
@@ -13620,6 +13946,15 @@
 /obj/structure/lattice,
 /turf/open/space/openspace,
 /area/space/nearstation)
+"doJ" = (
+/obj/structure/railing{
+	dir = 4;
+	color = "#6e6e6e"
+	},
+/turf/open/floor/iron/stairs/right{
+	color = "#9a9a9a"
+	},
+/area/station/commons/lounge)
 "doM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13836,6 +14171,15 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"dry" = (
+/obj/structure/platform{
+	dir = 1
+	},
+/obj/item/kirbyplants/random{
+	pixel_y = 2
+	},
+/turf/open/floor/iron/dark/smooth_edge,
+/area/station/service/bar/backroom)
 "drA" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/glass{
@@ -14254,10 +14598,21 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "dwb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/tram/warning{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/tram/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/tram/mid_joiner{
+	dir = 8
+	},
+/obj/machinery/vending/wardrobe/bar_wardrobe{
+	layer = 2.91
+	},
+/turf/open/floor/iron/dark/smooth_corner,
+/area/station/service/bar/backroom)
 "dwg" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
@@ -14586,6 +14941,26 @@
 	},
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
+"dAy" = (
+/obj/structure/chair/stool/bar,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 4;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/trimline/dark/warning,
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/checker,
+/area/station/service/bar/atrium)
 "dAB" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -15061,11 +15436,9 @@
 /turf/open/floor/carpet,
 /area/station/service/library)
 "dGC" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/effect/spawner/random/structure/barricade,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "dGF" = (
@@ -15329,6 +15702,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay/ghetto)
+"dJX" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8;
+	color = "#6e6e6e"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "dKd" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/bodycontainer/morgue{
@@ -15428,8 +15817,19 @@
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "dKY" = (
-/obj/machinery/smartfridge/drying,
-/obj/machinery/light/small/directional/east,
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/donkpockets{
+	pixel_y = 6;
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/cup/beaker{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/machinery/light/directional/north,
+/obj/item/reagent_containers/condiment/enzyme{
+	pixel_y = 5
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "dKZ" = (
@@ -15606,8 +16006,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "dNF" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/white,
@@ -15804,6 +16205,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"dQW" = (
+/obj/machinery/door/airlock/service,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/obj/machinery/duct,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/service/bar/backroom)
 "dRl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
 	dir = 10
@@ -15834,11 +16245,17 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "dRC" = (
-/obj/effect/spawner/random/structure/table_or_rack,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/effect/turf_decal/delivery,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/door/window/right/directional/south{
+	name = "Bar Deliverys";
+	req_access = list("bar")
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/service/bar)
 "dRD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15886,8 +16303,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "dSp" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood/large,
+/obj/structure/chair/comfy/brown{
+	color = "#514E58";
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/large,
 /area/station/commons/lounge)
 "dSr" = (
 /obj/structure/cable,
@@ -16213,12 +16634,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/garden)
 "dWX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/small,
-/area/station/maintenance/ghetto/central)
+/turf/closed/wall,
+/area/station/service/hydroponics/upper)
 "dWZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 5
@@ -16400,10 +16817,18 @@
 /turf/open/floor/iron/stairs/medium,
 /area/station/hallway/secondary/exit/departure_lounge)
 "dZX" = (
-/obj/structure/table/reinforced,
-/obj/item/wallframe/apc,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/item/ammo_casing/rebar/paperball{
+	pixel_x = 11;
+	pixel_y = -9
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/service/hydroponics)
 "dZZ" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -16454,7 +16879,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "eao" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16765,22 +17190,15 @@
 /turf/open/floor/sepia,
 /area/station/security/prison/ghetto)
 "eef" = (
-/obj/structure/table/wood,
-/obj/item/stack/cable_coil,
-/obj/item/gun/ballistic/shotgun/doublebarrel{
-	pixel_y = 12
-	},
-/obj/item/stack/cable_coil{
-	pixel_y = -4
-	},
-/obj/item/reagent_containers/dropper{
-	pixel_y = -8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/item/toy/figure/bartender,
-/turf/open/floor/wood,
-/area/station/service/bar/backroom)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/tram/warning,
+/obj/machinery/duct,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
+	},
+/area/station/service/kitchen)
 "eeh" = (
 /obj/effect/spawner/random/engineering/tank,
 /turf/open/floor/plating,
@@ -17161,6 +17579,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/sorting)
+"ejp" = (
+/obj/structure/frame/computer,
+/obj/item/stack/cable_coil,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "ejr" = (
 /obj/structure/chair/sofa/bench/right,
 /obj/effect/turf_decal/tile/blue{
@@ -17173,6 +17596,15 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
+"ejC" = (
+/obj/item/kirbyplants/random{
+	pixel_y = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/checker,
+/area/station/service/bar/atrium)
 "ejI" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /mob/living/basic/mouse,
@@ -17603,6 +18035,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"epA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/holopad,
+/obj/machinery/duct,
+/turf/open/floor/iron/kitchen/small,
+/area/station/hallway/secondary/service)
 "epC" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/signaler{
@@ -17933,6 +18372,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"euV" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "euX" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine,
@@ -18089,6 +18540,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/fore/starboard)
+"eyg" = (
+/obj/structure/chair/sofa/middle/maroon,
+/obj/machinery/light/small/blacklight/directional/north,
+/turf/open/floor/carpet/red,
+/area/station/service/bar/atrium)
 "eyu" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -18152,6 +18608,14 @@
 "ezv" = (
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
+"ezz" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "ezB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -18420,6 +18884,19 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
+"eDc" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8;
+	color = "#6e6e6e"
+	},
+/obj/structure/chair/sofa/right/maroon{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/station/service/bar/atrium)
 "eDr" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 6
@@ -18453,9 +18930,6 @@
 /area/station/maintenance/port/aft)
 "eDH" = (
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/item/reagent_containers/cup/bucket{
 	pixel_x = -6;
@@ -18469,8 +18943,8 @@
 	pixel_y = -20;
 	c_tag = "Hydroponics - Pasture"
 	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
+/turf/open/floor/stone,
+/area/station/service/hydroponics/upper)
 "eDR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -18602,10 +19076,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "eGb" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/structure/table,
+/obj/effect/spawner/random/entertainment/lighter,
+/obj/item/kitchen/spoon{
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/structure/sign/poster/official/moth_meth/directional/east{
+	pixel_y = 16;
+	pixel_x = 30
+	},
+/turf/open/floor/stone,
+/area/station/service/hydroponics)
 "eGj" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/directional/north,
@@ -18644,6 +19126,25 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
+"eGy" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/structure/railing/corner{
+	dir = 1;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/trimline/dark/warning,
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/checker,
+/area/station/service/bar/atrium)
 "eGA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18675,10 +19176,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "eGV" = (
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/machinery/light/small/blacklight/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/service/bar)
 "eHe" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -18742,6 +19242,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
+"eHI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "eHP" = (
 /obj/structure/table,
 /obj/machinery/light/small/directional/north,
@@ -18813,6 +19323,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"eIo" = (
+/obj/item/kirbyplants/random{
+	pixel_y = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/bar/atrium)
 "eIq" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -18825,6 +19343,13 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"eIx" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "eIA" = (
 /turf/closed/wall,
 /area/station/maintenance/department/engine/ghetto)
@@ -18959,10 +19484,11 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "eJY" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/plating,
@@ -18981,6 +19507,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"eKl" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/large,
+/area/station/service/hydroponics)
 "eKq" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/port/fore)
@@ -19069,16 +19603,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard/west)
 "eLX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/effect/spawner/random/structure/barricade,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/structure/chair/sofa/left/maroon,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet/red,
+/area/station/service/bar/atrium)
 "eLY" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Pure to Mix";
@@ -19130,10 +19658,9 @@
 /turf/open/floor/iron,
 /area/station/security/range)
 "eMv" = (
-/obj/machinery/vending/wardrobe/bar_wardrobe,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/wood,
-/area/station/service/bar/backroom)
+/obj/effect/landmark/start/cook,
+/turf/open/floor/iron/dark/small,
+/area/station/service/kitchen)
 "eME" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
@@ -19233,9 +19760,8 @@
 /turf/open/floor/carpet/black,
 /area/station/command/meeting_room)
 "eOa" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
+/obj/structure/frame/computer,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "eOd" = (
 /obj/structure/table/wood,
@@ -19405,9 +19931,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "eQX" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "eRa" = (
@@ -19564,11 +20095,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "eTo" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/machinery/light/floor,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "eTt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -19687,6 +20217,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "eUY" = (
@@ -19698,11 +20229,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "eVl" = (
-/obj/structure/cable,
-/obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "eVn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19856,7 +20390,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "eXh" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -20019,6 +20553,10 @@
 /obj/structure/closet/crate/internals,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"eZs" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/glass,
+/area/station/service/bar/atrium)
 "eZv" = (
 /obj/structure/rack,
 /obj/item/storage/fancy/candle_box{
@@ -20398,18 +20936,23 @@
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
+"feU" = (
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/iron,
+/area/station/maintenance/department/security/ghetto/aft)
 "feV" = (
 /turf/open/floor/carpet/black,
 /area/station/command/heads_quarters/magistrate)
 "feW" = (
-/obj/structure/sink/kitchen/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "feX" = (
-/obj/structure/railing/corner{
-	dir = 1
+/obj/structure/platform{
+	dir = 4
 	},
-/turf/open/floor/carpet/black,
+/turf/open/openspace,
 /area/station/commons/lounge)
 "ffg" = (
 /obj/structure/table,
@@ -20560,10 +21103,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "fgR" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/open/floor/wood,
-/area/station/service/bar/backroom)
+/obj/machinery/duct,
+/obj/effect/turf_decal/trimline/tram/line,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
+	},
+/area/station/service/kitchen)
 "fgW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20755,7 +21300,7 @@
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "fiV" = (
 /obj/structure/railing{
 	dir = 1
@@ -20818,6 +21363,16 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/ghetto)
+"fjz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/central)
 "fjA" = (
 /obj/structure/firelock_frame{
 	anchored = 1
@@ -20855,6 +21410,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "fjQ" = (
@@ -20894,6 +21450,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"fkt" = (
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "fkv" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 8
@@ -20901,6 +21460,16 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/small,
 /area/station/maintenance/ghetto/central)
+"fkw" = (
+/obj/structure/railing{
+	dir = 8;
+	color = "#6e6e6e"
+	},
+/turf/open/floor/iron/stairs/right{
+	dir = 1;
+	color = "#9a9a9a"
+	},
+/area/station/commons/lounge)
 "fkB" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 4
@@ -21218,6 +21787,12 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"fot" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/stone,
+/area/station/service/hydroponics/upper)
 "foN" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -21314,12 +21889,14 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
 "fqC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "fqE" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/airalarm/directional/west,
@@ -21343,6 +21920,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"fqU" = (
+/obj/structure/railing{
+	dir = 1;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "fqZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/stasis{
@@ -21445,7 +22036,7 @@
 "frW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "fse" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21679,12 +22270,12 @@
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "fuM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/dark_green{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "fuT" = (
 /obj/machinery/door/airlock/external,
@@ -21702,6 +22293,10 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"fvf" = (
+/obj/machinery/holopad,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/bar/atrium)
 "fvi" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -21784,13 +22379,15 @@
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "fwa" = (
-/obj/item/clothing/mask/breath,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/radio,
-/obj/item/clothing/suit/hazardvest,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/structure/railing{
+	dir = 4;
+	color = "#6e6e6e"
+	},
+/turf/open/floor/iron/stairs/left{
+	color = "#9a9a9a";
+	dir = 1
+	},
+/area/station/commons/lounge)
 "fwd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -21898,10 +22495,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "fxv" = (
-/obj/structure/rack,
-/obj/item/book/manual/chef_recipes,
-/obj/item/holosign_creator/robot_seat/restaurant,
+/obj/structure/closet/crate/freezer/food,
+/obj/item/reagent_containers/condiment/flour,
+/obj/item/reagent_containers/condiment/rice,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
@@ -21932,20 +22530,25 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
+"fxH" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 1
+	},
+/turf/open/floor/carpet/neon/simple/violet,
+/area/station/service/bar/atrium)
 "fxO" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "fxV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/duct,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/effect/landmark/event_spawn,
-/obj/effect/landmark/start/bartender,
-/turf/open/floor/wood,
-/area/station/service/bar/backroom)
+/turf/open/floor/iron/dark/small,
+/area/station/service/kitchen)
 "fyb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22216,14 +22819,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "fBH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/public{
-	id_tag = "viplounge_bolt"
+/obj/structure/platform{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/wood/large,
-/area/station/service/bar)
+/turf/open/floor/iron/dark/smooth_edge,
+/area/station/service/bar/backroom)
 "fBN" = (
 /obj/machinery/door/airlock{
 	id_tag = "AuxToilet2"
@@ -22238,11 +22838,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "fBU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/railing{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/area/station/maintenance/department/security/ghetto/aft)
 "fBV" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -22278,7 +22879,7 @@
 	},
 /obj/machinery/restaurant_portal/bar,
 /turf/open/floor/wood/large,
-/area/station/service/bar)
+/area/station/commons/lounge)
 "fCl" = (
 /obj/structure/cable,
 /obj/machinery/camera/directional/west{
@@ -22359,16 +22960,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "fDi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/directions/medical/directional/west{
-	pixel_y = -4
+/obj/structure/railing{
+	dir = 9;
+	color = "#6e6e6e"
 	},
-/obj/structure/sign/directions/security/directional/west{
-	pixel_y = 4
+/obj/structure/railing/corner{
+	dir = 2;
+	color = "#6e6e6e"
 	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/turf/open/floor/iron/dark,
+/area/station/service/bar/backroom)
 "fDn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22416,7 +23017,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "fDS" = (
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
@@ -22475,6 +23076,24 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
+"fED" = (
+/obj/item/ammo_casing/rebar/paperball{
+	pixel_x = 4
+	},
+/obj/item/ammo_casing/rebar/paperball{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/ammo_casing/rebar/paperball{
+	pixel_x = 11;
+	pixel_y = -9
+	},
+/obj/structure/sink/kitchen/directional/south,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/wood/large,
+/area/station/service/hydroponics)
 "fEG" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/bot,
@@ -22540,11 +23159,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "fFe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/iron,
-/area/station/maintenance/department/medical/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/iron/kitchen/small,
+/area/station/hallway/secondary/service)
 "fFk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23171,13 +23790,14 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/locker)
 "fME" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/dark_green,
-/obj/machinery/light/small/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/stone,
+/area/station/service/hydroponics)
 "fMF" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres{
@@ -23454,10 +24074,11 @@
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/blueshield)
 "fPT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/right/directional/west,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/station/service/kitchen)
 "fPZ" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
@@ -23675,6 +24296,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/abandoned)
+"fSS" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery";
+	location = "Kitchen"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/service)
 "fSY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -23726,6 +24356,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"fTH" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/end{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/secondary/service)
 "fTI" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -24336,8 +24973,12 @@
 /area/station/command/heads_quarters/hos)
 "gbn" = (
 /obj/machinery/holopad,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet/black,
+/obj/effect/turf_decal/tile/dark/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/edge{
+	dir = 8
+	},
 /area/station/commons/lounge)
 "gbq" = (
 /obj/structure/chair/comfy/teal{
@@ -24380,9 +25021,29 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "gbO" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/structure/chair/stool/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark/warning{
+	dir = 5
+	},
+/obj/machinery/button/door/directional/north{
+	name = "ViP Hall Shutters Control";
+	id = "viphall";
+	pixel_y = 27
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/checker,
+/area/station/service/bar/atrium)
 "gbT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/south,
@@ -24703,6 +25364,44 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"gfU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
+"gga" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/tram/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/tram/mid_joiner{
+	dir = 1
+	},
+/obj/machinery/status_display/evac/directional/north,
+/obj/structure/rack,
+/obj/item/chair/plastic{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/obj/item/chair/plastic{
+	pixel_x = 0;
+	pixel_y = 14
+	},
+/obj/item/chair/plastic{
+	pixel_x = 0;
+	pixel_y = 19
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
+/area/station/service/bar/backroom)
 "ggc" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -24998,16 +25697,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
 "gjY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/purple/corner{
-	dir = 1
+/obj/structure/railing/corner/end/flip{
+	dir = 4;
+	color = "#6e6e6e"
 	},
-/obj/effect/turf_decal/siding/purple/corner{
-	dir = 8
-	},
-/turf/open/floor/carpet/purple,
-/area/station/service/bar)
+/turf/open/openspace,
+/area/station/service/kitchen)
 "gkn" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
@@ -25298,6 +25993,14 @@
 	},
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
+"gnI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "ViP Hall Shutters";
+	id = "viphall"
+	},
+/turf/open/floor/plating,
+/area/station/service/bar/atrium)
 "gnK" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -25624,6 +26327,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
+"gsW" = (
+/obj/structure/chair/sofa/left/maroon{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "gsZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -25639,12 +26352,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/prison)
 "gtl" = (
-/obj/structure/sink/kitchen/directional/south,
-/obj/machinery/camera/directional/north{
-	c_tag = "Kitchen - Freezer"
+/obj/structure/chair/sofa/right/brown{
+	dir = 8
 	},
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/turf/open/floor/wood/parquet,
+/area/station/hallway/secondary/service)
 "gto" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -25906,6 +26618,13 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/locker)
+"gxo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/meter,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/station/maintenance/ghetto/central)
 "gxu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance,
@@ -25952,11 +26671,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
 "gyK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/duct,
-/obj/structure/cable,
+/obj/machinery/light/warm/directional/east,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "gyL" = (
@@ -26500,6 +27215,20 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/misc/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
+"gGl" = (
+/obj/structure/platform/corner{
+	color = "#AAAAB1"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing/corner{
+	dir = 2;
+	color = "#6e6e6e"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
+/turf/open/floor/iron/kitchen/small,
+/area/station/hallway/secondary/service)
 "gGp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26668,6 +27397,31 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
+"gHM" = (
+/obj/structure/closet/crate{
+	name = "Le Caisee D'abeille"
+	},
+/obj/machinery/status_display/evac/directional/north,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/clothing/suit/hooded/bee_costume,
+/obj/item/queen_bee/bought,
+/obj/item/seeds/sunflower,
+/obj/machinery/camera/directional/north{
+	dir = 9;
+	c_tag = "Apiary"
+	},
+/turf/open/floor/stone,
+/area/station/service/hydroponics)
+"gHN" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/flashlight/flare/candle{
+	pixel_y = 11
+	},
+/obj/item/storage/wallet,
+/turf/open/floor/carpet/red,
+/area/station/service/bar/atrium)
 "gHR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -27020,6 +27774,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage/gas)
+"gMj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
 "gMm" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/table,
@@ -27085,13 +27848,15 @@
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
 "gNa" = (
-/obj/structure/ladder,
-/obj/effect/turf_decal/stripes/box,
-/obj/structure/sign/directions/security/directional/north{
-	pixel_y = 39
+/obj/structure/platform,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto/aft)
+/obj/effect/turf_decal/trimline/tram/warning,
+/obj/effect/turf_decal/trimline/tram/mid_joiner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_edge,
+/area/station/service/bar/backroom)
 "gNf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27105,6 +27870,30 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
+"gNr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/railing/corner/end/flip{
+	dir = 8;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/siding/dark,
+/obj/machinery/duct,
+/turf/open/floor/iron/kitchen/small,
+/area/station/hallway/secondary/service)
+"gNt" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "gNu" = (
 /turf/closed/wall/r_wall,
 /area/station/science/server)
@@ -27119,6 +27908,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
+"gNJ" = (
+/obj/effect/turf_decal/trimline/dark/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/checker,
+/area/station/service/bar/atrium)
 "gNN" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/machinery/computer/atmos_control/oxygen_tank{
@@ -27573,10 +28371,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "gSq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office,
-/turf/open/floor/iron,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "gSs" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
@@ -27641,11 +28437,19 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "gTC" = (
+/obj/effect/turf_decal/trimline/tram/mid_joiner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/tram/warning{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/tram/mid_joiner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
+/area/station/service/bar/backroom)
 "gTQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
@@ -27712,6 +28516,12 @@
 "gUL" = (
 /turf/closed/wall,
 /area/station/service/library/artgallery)
+"gUN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen/small,
+/area/station/hallway/secondary/service)
 "gUR" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -27788,9 +28598,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "gVV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/table,
 /obj/item/knife/kitchen{
 	pixel_x = -8;
 	pixel_y = 10
@@ -27799,7 +28606,7 @@
 	pixel_x = 4;
 	pixel_y = 6
 	},
-/obj/machinery/duct,
+/obj/structure/table,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "gVW" = (
@@ -27808,6 +28615,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
+"gWh" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "gWj" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -27928,6 +28746,21 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
+"gXA" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/hangover,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "gXC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -28279,6 +29112,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/detective,
 /turf/open/floor/iron,
 /area/station/security/detectives_office)
+"hcs" = (
+/obj/structure/table/wood/fancy/red,
+/turf/open/floor/carpet/red,
+/area/station/service/bar/atrium)
 "hcA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -28296,17 +29133,16 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "hcY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/sorting/mail{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/mail_sorting/service/bar,
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/service/bar)
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "hdb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -28360,6 +29196,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/service)
+"hds" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/iron,
+/area/station/maintenance/department/medical/ghetto)
 "hdu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -28717,6 +29559,16 @@
 /obj/item/defibrillator/loaded,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
+"hiq" = (
+/obj/effect/turf_decal/trimline/dark/warning{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/checker,
+/area/station/service/bar/atrium)
 "hir" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/effect/spawner/random/trash,
@@ -28853,6 +29705,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"hjI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/commons/lounge)
 "hjP" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/machinery/door/airlock/maintenance,
@@ -28875,6 +29734,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"hke" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/effect/landmark/event_spawn,
+/obj/machinery/duct,
+/turf/open/floor/iron/kitchen/small,
+/area/station/hallway/secondary/service)
 "hki" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -28885,6 +29754,15 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
+"hky" = (
+/obj/effect/turf_decal/trimline/white/warning,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/station/hallway/secondary/service)
 "hkz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -28911,6 +29789,12 @@
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"hlb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/bar/backroom)
 "hlc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -29059,6 +29943,22 @@
 /obj/effect/turf_decal/trimline/yellow/warning,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
+"hmM" = (
+/obj/structure/closet/crate/freezer/food,
+/obj/item/food/grown/tomato{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/food/grown/tomato{
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/item/food/grown/tomato{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "hmV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -29073,6 +29973,15 @@
 /obj/machinery/duct,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/engine/atmos)
+"hnc" = (
+/obj/effect/turf_decal/trimline/white/warning{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/service)
 "hne" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -29811,10 +30720,19 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "hwz" = (
-/obj/structure/table/glass,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/iron,
-/area/station/maintenance/department/medical/ghetto)
+/obj/structure/railing{
+	dir = 4;
+	color = "#6e6e6e"
+	},
+/obj/structure/railing{
+	dir = 8;
+	color = "#6e6e6e"
+	},
+/obj/structure/fake_stairs/directional/north{
+	color = "#555559"
+	},
+/turf/open/floor/iron/dark/smooth_edge,
+/area/station/service/bar/backroom)
 "hwC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29850,6 +30768,14 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"hwN" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/wood/large,
+/area/station/service/hydroponics)
 "hwT" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -29963,11 +30889,19 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "hxX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/ghetto/central)
+/obj/effect/turf_decal/trimline/dark/warning{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/trimline/dark/corner,
+/turf/open/floor/iron/checker,
+/area/station/service/bar/atrium)
 "hyi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 6
@@ -30067,6 +31001,15 @@
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/station/science/lab)
+"hzy" = (
+/obj/structure/chair/sofa/corner/maroon{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "hzz" = (
 /obj/effect/turf_decal/tile/purple/half,
 /turf/open/floor/iron,
@@ -30250,12 +31193,12 @@
 "hCo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/duct,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/mail_sorting/service/kitchen,
-/obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/wood/parquet,
 /area/station/hallway/secondary/service)
 "hCq" = (
@@ -30512,18 +31455,18 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "hEM" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
+/obj/structure/chair/plastic{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/turf/open/floor/wood/large,
+/area/station/service/hydroponics)
 "hEO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30532,10 +31475,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "hER" = (
-/obj/effect/landmark/start/hangover,
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/obj/structure/table/wood,
+/obj/item/plate,
+/obj/item/reagent_containers/cup/glass/bottle/beer{
+	pixel_x = -10;
+	pixel_y = 9
+	},
+/obj/item/kitchen/fork{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/turf/open/floor/wood/parquet,
+/area/station/hallway/secondary/service)
 "hES" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30557,7 +31509,7 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/item/reagent_containers/cup/watering_can,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "hFa" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -30573,6 +31525,15 @@
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
+"hFc" = (
+/mob/living/basic/goat/pete{
+	name = "Боря"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "hFm" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -30605,11 +31566,15 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/aft)
 "hFL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/ghetto/central)
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
 "hFO" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -30733,10 +31698,10 @@
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
 "hHb" = (
-/obj/structure/closet/crate/internals,
-/obj/item/clothing/mask/breath,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/machinery/holopad,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/stone,
+/area/station/service/hydroponics)
 "hHe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30815,6 +31780,10 @@
 /obj/machinery/computer/records/medical/laptop,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
+"hIl" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "hIp" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern/on{
@@ -30842,6 +31811,13 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
+"hIx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/iron/checker,
+/area/station/service/bar/atrium)
 "hIA" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/structure/cable,
@@ -30934,6 +31910,12 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
+"hJN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "hJP" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/two,
@@ -30968,12 +31950,9 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
 "hKc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/machinery/duct,
+/turf/closed/wall,
+/area/station/service/kitchen)
 "hKf" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
@@ -31435,6 +32414,15 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto/central)
+"hQL" = (
+/obj/structure/flora/grass/jungle/a/style_random,
+/obj/structure/flora/bush/jungle/b/style_2,
+/obj/machinery/light_switch/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Lower Bar - South"
+	},
+/turf/open/misc/dirt/dark/station,
+/area/station/service/bar/atrium)
 "hQN" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -31506,6 +32494,15 @@
 "hRA" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/ghetto/starboard)
+"hRN" = (
+/obj/machinery/status_display/evac/directional/north,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/machinery/camera{
+	c_tag = "Kitchen";
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "hRP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -31917,17 +32914,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "hWY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/event_spawn,
-/mob/living/basic/goat/pete{
-	name = "Боря"
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/obj/structure/frame/computer,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "hXl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31936,7 +32928,11 @@
 "hXp" = (
 /obj/structure/sink/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
+"hXB" = (
+/obj/structure/chair/sofa/left/maroon,
+/turf/open/floor/glass,
+/area/station/service/bar/atrium)
 "hXF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32184,6 +33180,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"iaz" = (
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1;
+	color = "#777777"
+	},
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "iaC" = (
 /obj/machinery/computer/accounting{
 	dir = 8
@@ -32252,8 +33257,8 @@
 /area/station/science/xenobiology)
 "ibH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/shieldgen,
-/turf/open/floor/iron,
+/obj/effect/spawner/random/trash/hobo_squat,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "ibI" = (
 /obj/machinery/computer/security{
@@ -32272,7 +33277,7 @@
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/grass,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "icg" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted,
@@ -32405,12 +33410,21 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"iex" = (
+/obj/structure/flora/bush/jungle/a/style_random,
+/obj/structure/flora/rock/style_2{
+	pixel_y = 2
+	},
+/turf/open/misc/dirt/dark/station,
+/area/station/service/bar/atrium)
 "ieH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/wood/parquet,
 /area/station/hallway/secondary/service)
 "ieN" = (
@@ -33077,6 +34091,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
+"imX" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/wood/parquet,
+/area/station/hallway/secondary/service)
 "ine" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron,
@@ -33169,11 +34189,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "ioy" = (
-/obj/machinery/food_cart,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/obj/effect/turf_decal/tile/dark_green,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "ioz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -33474,8 +34493,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "isq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/plasma_output{
 	dir = 1
@@ -33555,11 +34575,11 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "itk" = (
-/obj/structure/sink/kitchen/directional/south,
-/obj/structure/mirror/directional/north{
-	pixel_y = 36
+/obj/machinery/chem_master/condimaster{
+	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
+	name = "HoochMaster Deluxe"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "itp" = (
@@ -33678,7 +34698,7 @@
 "iuM" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "iuP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33895,6 +34915,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto/morgue)
+"iym" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/machinery/hydroponics/soil,
+/obj/machinery/light/warm/directional/west,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "iyn" = (
 /obj/machinery/door/poddoor/massdriver_chapel,
 /obj/structure/fans/tiny,
@@ -34032,6 +35058,12 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/chemistry/ghetto)
+"iAM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/carpet/black,
+/area/station/commons/lounge)
 "iAQ" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -34040,9 +35072,13 @@
 /area/station/maintenance/port)
 "iAR" = (
 /obj/structure/railing{
-	dir = 4
+	dir = 9;
+	color = "#6e6e6e"
 	},
-/turf/open/floor/glass,
+/obj/effect/turf_decal/tile/dark/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/station/commons/lounge)
 "iAT" = (
 /obj/machinery/door/airlock/maintenance,
@@ -34120,11 +35156,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "iCg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/small,
-/area/station/maintenance/ghetto/central)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "iCi" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/openspace,
@@ -34285,17 +35325,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "iEj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/freezer,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/obj/machinery/door/airlock/service,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "iEl" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
@@ -34973,6 +36009,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"iMh" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4;
+	color = "#6e6e6e"
+	},
+/turf/open/floor/carpet/red,
+/area/station/service/bar/atrium)
 "iMm" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -35012,6 +36058,11 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/engineering/gravity_generator)
+"iML" = (
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "iMQ" = (
 /obj/machinery/vending/boozeomat{
 	req_access = list(1)
@@ -35071,6 +36122,20 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
+"iNr" = (
+/obj/structure/rack,
+/obj/item/mop{
+	pixel_x = 2
+	},
+/obj/item/mop{
+	pixel_x = 10
+	},
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/service)
 "iNx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35133,11 +36198,16 @@
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/nanotrasen_representative)
 "iOg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/glass,
-/obj/item/modular_computer/laptop,
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
+/obj/structure/table/wood/fancy/red,
+/obj/item/flashlight/flare/candle{
+	pixel_y = 14
+	},
+/obj/effect/spawner/random/food_or_drink/dinner{
+	pixel_x = 0;
+	pixel_y = 5
+	},
+/turf/open/floor/glass,
+/area/station/service/bar/atrium)
 "iOh" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -35321,11 +36391,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "iQW" = (
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/stairs{
-	dir = 1
+/obj/structure/stairs/east{
+	color = "#555559"
 	},
-/area/station/commons/lounge)
+/obj/structure/railing{
+	dir = 1;
+	color = "#6e6e6e"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/secondary/service)
 "iRa" = (
 /obj/machinery/power/smes,
 /obj/structure/cable,
@@ -35483,16 +36557,8 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs)
 "iSS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/service,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/machinery/duct,
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/wood/parquet,
 /area/station/hallway/secondary/service)
 "iSW" = (
 /obj/structure/table,
@@ -35756,11 +36822,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "iWD" = (
+/obj/structure/curtain/bounty,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/random/dead,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
+/area/station/service/bar/backroom)
 "iWF" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -35945,10 +37013,25 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
+"iYD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "iYF" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "iYM" = (
@@ -35968,6 +37051,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
+"iYW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/kitchen/small,
+/area/station/hallway/secondary/service)
 "iYX" = (
 /obj/structure/sink/directional/west,
 /obj/machinery/camera/directional/north{
@@ -35979,6 +37068,25 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"iZg" = (
+/obj/structure/table,
+/obj/item/paper{
+	pixel_x = 4;
+	pixel_y = 7
+	},
+/obj/item/paper{
+	pixel_x = -4
+	},
+/obj/item/paper{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/wood/large,
+/area/station/service/hydroponics)
 "iZh" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/engine/hull/reinforced,
@@ -35996,11 +37104,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
 "iZA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/meter,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/small,
-/area/station/maintenance/ghetto/central)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "ViP Hall Shutters";
+	id = "viphall"
+	},
+/turf/open/floor/plating/airless,
+/area/station/service/bar/atrium)
 "iZB" = (
 /obj/structure/rack,
 /obj/item/electronics/airlock,
@@ -36299,6 +37409,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/arrivals)
+"jdE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/floor,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/bar/atrium)
 "jdK" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/cafeteria,
@@ -36415,10 +37531,11 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/dronefabricator)
 "jfa" = (
+/obj/structure/chair/plastic{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/girder,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "jfc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36517,6 +37634,16 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"jgg" = (
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/machinery/door/airlock/hydroponics/glass{
+	name = "Apiary"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/stone,
+/area/station/service/hydroponics)
 "jgi" = (
 /obj/structure/table/reinforced,
 /obj/item/tape/random{
@@ -36539,7 +37666,7 @@
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "jgy" = (
 /obj/effect/spawner/random/maintenance,
 /obj/item/reagent_containers/syringe,
@@ -36852,7 +37979,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "jkB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
@@ -37004,9 +38131,17 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "jnj" = (
-/obj/machinery/gibber,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/obj/structure/railing/corner/end/flip{
+	dir = 4;
+	color = "#6e6e6e"
+	},
+/obj/structure/railing/corner/end{
+	dir = 4;
+	color = "#6e6e6e"
+	},
+/obj/machinery/light/small/blacklight/directional/west,
+/turf/open/openspace,
+/area/station/service/bar)
 "jnm" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -37172,12 +38307,20 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/aft)
 "jqE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/sign/warning/vacuum/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/sign/poster/random/directional/east,
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/light/small/blacklight/directional/east,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "jqG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
@@ -37256,6 +38399,22 @@
 	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/ce)
+"jrE" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small/blacklight/directional/east,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "jrF" = (
 /obj/machinery/duct,
 /turf/open/floor/plating,
@@ -37443,7 +38602,7 @@
 /obj/effect/mapping_helpers/requests_console/assistance,
 /obj/effect/mapping_helpers/requests_console/information,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "jtQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37462,6 +38621,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"jtX" = (
+/obj/structure/table/reinforced/plasmarglass,
+/obj/effect/spawner/random/entertainment/cigarette_pack{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/turf/open/floor/carpet/neon/simple/violet,
+/area/station/service/bar/atrium)
 "jua" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -37791,6 +38958,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"jyV" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/kirbyplants/organic/plant10{
+	pixel_y = 15;
+	pixel_x = -4
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/service/bar/atrium)
 "jyX" = (
 /obj/machinery/light/broken/directional/north,
 /turf/open/floor/plating,
@@ -37955,7 +39130,7 @@
 /obj/structure/flora/bush/pointy/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "jBn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38052,10 +39227,11 @@
 /turf/open/floor/carpet/black,
 /area/station/security/courtroom)
 "jDu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/structure/chair/comfy/black{
+	dir = 2
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/bar/backroom)
 "jDE" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 5
@@ -38597,10 +39773,8 @@
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "jJb" = (
-/obj/structure/closet,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/turf/closed/wall/rust,
+/area/station/service/hydroponics)
 "jJh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/chair/wood,
@@ -38666,15 +39840,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "jJL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/service/bar/backroom)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/tram/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_edge,
+/area/station/service/kitchen)
 "jJM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -38713,7 +39887,7 @@
 "jKd" = (
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "jKe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/camera/directional/north{
@@ -38733,6 +39907,19 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
+"jKr" = (
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/railing{
+	dir = 2;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "jKt" = (
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hop)
@@ -39522,11 +40709,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
 "jVn" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
 	},
 /turf/open/floor/carpet/black,
 /area/station/commons/lounge)
@@ -39602,6 +40789,11 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
+"jWd" = (
+/obj/effect/turf_decal/stripes/box,
+/obj/structure/ladder,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics/upper)
 "jWg" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance/two,
@@ -39634,6 +40826,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"jWt" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "jWy" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -39642,11 +40844,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "jWz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/oven/range,
 /obj/effect/turf_decal/delivery/white,
-/obj/machinery/duct,
+/obj/machinery/oven/range,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "jWF" = (
@@ -39766,6 +40965,14 @@
 /obj/item/storage/toolbox/electrical,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
+"jYu" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "jYA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -39921,9 +41128,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "jZY" = (
-/obj/effect/landmark/start/cook,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/obj/structure/chair/sofa/left/brown{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
+/area/station/hallway/secondary/service)
 "kac" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40258,7 +41467,7 @@
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "keD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40661,6 +41870,21 @@
 /obj/structure/sign/directions/engineering/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
+"kkG" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "kkH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/grille/broken,
@@ -40669,6 +41893,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"kkI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/ghetto/central/fore)
 "kkK" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -40723,9 +41961,17 @@
 /turf/open/floor/asphalt,
 /area/station/maintenance/ghetto/garden)
 "klF" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 6
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/station/hallway/secondary/service)
 "klO" = (
 /obj/machinery/seed_extractor,
 /obj/machinery/status_display/evac/directional/north,
@@ -40914,13 +42160,9 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "knI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/duct,
-/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "knL" = (
@@ -40943,9 +42185,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage/ghetto)
 "knZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/ghetto/central)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "kob" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -40989,8 +42233,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/trash)
 "koq" = (
-/obj/machinery/light/cold/directional/north,
-/obj/item/kirbyplants/random,
+/obj/structure/frame/machine/secured,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "kos" = (
@@ -41156,9 +42399,8 @@
 /turf/open/floor/iron,
 /area/station/security/range)
 "kpI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "kpJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -41226,6 +42468,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
+"kru" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/obj/machinery/door/airlock/service,
+/turf/open/floor/iron/dark,
+/area/station/service/bar)
 "krH" = (
 /obj/structure/closet/secure_closet/detective,
 /obj/machinery/status_display/evac/directional/north,
@@ -41620,6 +42869,28 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
+"kvQ" = (
+/obj/structure/railing/corner{
+	dir = 1;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "kvS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41637,8 +42908,8 @@
 /mob/living/basic/chicken{
 	name = "Галя"
 	},
-/turf/open/misc/beach/sand,
-/area/station/service/hydroponics)
+/turf/open/misc/sandy_dirt,
+/area/station/service/hydroponics/upper)
 "kwf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/bag/trash,
@@ -41694,6 +42965,18 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"kwS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/duct,
+/obj/structure/cable,
+/obj/machinery/door/airlock/freezer,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen)
 "kxa" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -41891,6 +43174,7 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/theater)
 "kAm" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
@@ -41920,14 +43204,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "kAC" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/door/window/right/directional/west{
-	name = "Bar Deliverys";
-	req_access = list("bar")
+/obj/effect/turf_decal/trimline/tram/line{
+	dir = 1
 	},
-/turf/open/floor/wood,
-/area/station/service/bar/backroom)
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/textured_edge,
+/area/station/service/kitchen)
 "kAD" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -41982,15 +43264,21 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
 "kBu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/dark/warning{
+	dir = 1
 	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/service/general,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/service)
+/obj/effect/turf_decal/trimline/dark/warning,
+/obj/machinery/light/small/blacklight/directional/north,
+/obj/item/storage/box/drinkingglasses{
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/cup/glass/shaker{
+	pixel_x = -3;
+	pixel_y = -10
+	},
+/turf/open/floor/iron/checker,
+/area/station/service/bar/atrium)
 "kBw" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
@@ -42188,13 +43476,9 @@
 /turf/open/floor/iron/half,
 /area/station/engineering/atmos/project)
 "kDA" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/glasses/welding,
-/obj/item/wrench,
-/obj/item/crowbar,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "kDD" = (
 /turf/open/floor/carpet,
 /area/station/service/library/ghetto)
@@ -42490,6 +43774,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/theater)
+"kFW" = (
+/obj/structure/chair/sofa/right/maroon,
+/turf/open/floor/carpet/red,
+/area/station/service/bar/atrium)
 "kFX" = (
 /obj/structure/railing{
 	dir = 4
@@ -42528,6 +43816,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"kGA" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating/corner{
+	color = "#4e4e4e";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
+/area/station/service/bar/backroom)
 "kGB" = (
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
@@ -42621,9 +43921,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "kHI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/random/dead,
-/turf/open/floor/iron/white,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "kHR" = (
 /obj/machinery/duct,
@@ -42638,12 +43942,6 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "kIg" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
 /obj/machinery/door/window/right/directional/north{
 	name = "Garden";
 	req_access = list("kitchen")
@@ -42651,8 +43949,11 @@
 /mob/living/basic/pig{
 	name = "Саня"
 	},
-/turf/open/misc/beach/sand,
-/area/station/service/hydroponics)
+/obj/effect/turf_decal/siding/white/end{
+	dir = 1
+	},
+/turf/open/misc/sandy_dirt,
+/area/station/service/hydroponics/upper)
 "kIk" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/ambrosia,
@@ -42896,12 +44197,15 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "kKA" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "kKF" = (
 /obj/structure/disposalpipe/segment,
@@ -42987,6 +44291,12 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/stone,
 /area/station/maintenance/ghetto/port/aft)
+"kLD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
 "kLF" = (
 /turf/closed/wall,
 /area/station/medical/surgery/aft)
@@ -43220,6 +44530,10 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
+"kOU" = (
+/obj/structure/chair/sofa/middle/maroon,
+/turf/open/floor/glass,
+/area/station/service/bar/atrium)
 "kOV" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
@@ -43238,6 +44552,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/kitchen)
+"kPl" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/large,
+/area/station/service/hydroponics)
 "kPp" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -43388,10 +44711,10 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
 "kRc" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 8
+/obj/effect/turf_decal/tile/dark/anticorner/contrasted{
+	dir = 4
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/iron,
 /area/station/commons/lounge)
 "kRe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -43437,6 +44760,14 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
+"kRI" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "kRJ" = (
 /obj/structure/broken_flooring/pile/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -43521,6 +44852,12 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
+"kSN" = (
+/obj/effect/turf_decal/siding/white/end{
+	dir = 4
+	},
+/turf/open/misc/sandy_dirt,
+/area/station/service/hydroponics/upper)
 "kSS" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -43583,17 +44920,8 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/fore)
 "kTA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/item/kirbyplants/random,
-/obj/machinery/duct,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/wood/parquet,
-/area/station/hallway/secondary/service)
+/turf/open/floor/glass,
+/area/station/service/bar/atrium)
 "kTN" = (
 /obj/structure/table,
 /obj/effect/spawner/random/decoration/material,
@@ -44323,6 +45651,18 @@
 "lcZ" = (
 /turf/closed/wall,
 /area/station/medical/treatment_center)
+"ldb" = (
+/obj/structure/table/reinforced,
+/obj/item/knife/butcher{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/cup/rag{
+	pixel_x = 15;
+	pixel_y = 4
+	},
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "ldi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44339,12 +45679,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "ldD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/structure/chair/sofa/corp/left{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/station/service/bar/atrium)
 "ldU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 1
@@ -44469,6 +45808,14 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
+"lgl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/platform/corner{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/station/commons/lounge)
 "lgn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44678,6 +46025,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
+"liU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/light/small/blacklight/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "liY" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
@@ -45044,7 +46398,7 @@
 	},
 /obj/item/toy/figure/botanist,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "lnI" = (
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/eighties,
@@ -45053,6 +46407,14 @@
 /obj/structure/frame/machine,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"lnU" = (
+/obj/item/storage/cans/sixbeer,
+/obj/item/reagent_containers/cup/glass/bottle/beer,
+/obj/item/reagent_containers/cup/glass/bottle/beer,
+/obj/item/reagent_containers/cup/glass/bottle/beer,
+/obj/structure/closet/secure_closet/freezer/empty,
+/turf/open/floor/iron/checker,
+/area/station/service/bar/atrium)
 "lnZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -45203,6 +46565,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
+"lpC" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/holopad,
+/turf/open/floor/wood/large,
+/area/station/commons/lounge)
 "lpG" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/item/vending_refill/boozeomat,
@@ -45244,6 +46613,17 @@
 /obj/effect/landmark/start/psychologist,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
+"lpU" = (
+/obj/effect/turf_decal/trimline/white/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/station/hallway/secondary/service)
 "lqb" = (
 /obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
 /obj/effect/turf_decal/siding/thinplating_new/light/end{
@@ -45284,6 +46664,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical/ghetto/morgue)
+"lqt" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp{
+	pixel_y = 5
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/bar/backroom)
 "lqy" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
@@ -45369,6 +46759,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/detectives_office)
+"lre" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "lrf" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
@@ -45437,6 +46831,21 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
+"lrM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "lrR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -45523,6 +46932,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"lsH" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "lsJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/decal/cleanable/dirt,
@@ -45611,6 +47029,15 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
+"ltI" = (
+/obj/structure/railing{
+	dir = 8;
+	color = "#6e6e6e"
+	},
+/turf/open/floor/iron/stairs/left{
+	color = "#9a9a9a"
+	},
+/area/station/commons/lounge)
 "ltX" = (
 /obj/structure/frame/computer,
 /obj/effect/decal/cleanable/dirt,
@@ -45699,6 +47126,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"luS" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/food/monkeycube/bee,
+/turf/open/floor/stone,
+/area/station/service/hydroponics)
 "luY" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -45756,7 +47190,13 @@
 "lvA" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood/large,
+/obj/structure/table/reinforced/rglass,
+/obj/item/clothing/head/utility/hardhat/cakehat,
+/turf/open/floor/light{
+	icon_state = "light_on-7";
+	state = 7;
+	light_color = "#a659ff"
+	},
 /area/station/commons/lounge)
 "lvF" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -45885,9 +47325,7 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/service)
 "lya" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "lyd" = (
@@ -45915,14 +47353,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "lyJ" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	location = "Bar"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plating,
-/area/station/service/bar/backroom)
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "lyK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -46079,11 +47513,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "lAs" = (
-/obj/structure/musician/piano,
 /obj/machinery/camera/directional/west{
 	c_tag = "Bar - West"
 	},
-/turf/open/floor/carpet/black,
+/turf/open/openspace,
 /area/station/commons/lounge)
 "lAv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan{
@@ -46115,7 +47548,7 @@
 /obj/structure/reagent_dispensers/plumbed,
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "lAJ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -46366,15 +47799,14 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "lEK" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 1
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
 	},
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/siding/purple{
-	dir = 6
-	},
-/turf/open/floor/carpet/purple,
-/area/station/service/bar)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
+/area/station/service/bar/backroom)
 "lEP" = (
 /obj/item/kirbyplants/random,
 /obj/structure/cable,
@@ -46745,18 +48177,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/sorting)
 "lJm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/random/structure/table_or_rack,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/wood/parquet,
-/area/station/hallway/secondary/service)
+/obj/structure/chair/sofa/middle/maroon,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/glass,
+/area/station/service/bar/atrium)
 "lJp" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
@@ -47006,7 +48430,7 @@
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "lLH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
 	dir = 9
@@ -47121,24 +48545,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "lNm" = (
-/obj/structure/table/wood,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass{
-	amount = 50;
-	pixel_x = 3;
-	pixel_y = 3
+/obj/effect/turf_decal/trimline/tram/line,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 1
 	},
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/candle_box{
-	pixel_y = 2;
-	pixel_x = -2
-	},
-/obj/item/storage/fancy/candle_box{
-	pixel_y = 4;
-	pixel_x = -4
-	},
-/turf/open/floor/wood,
-/area/station/service/bar/backroom)
+/area/station/service/kitchen)
 "lNn" = (
 /obj/item/stack/rods{
 	amount = 10
@@ -47239,6 +48651,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
+"lOA" = (
+/obj/structure/chair/sofa/right/maroon{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/station/service/bar/atrium)
 "lOC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47281,6 +48699,20 @@
 /obj/item/toy/figure/borg,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"lPa" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/reagent_containers/cup/glass/bottle/whiskey{
+	pixel_y = 11;
+	pixel_x = -9;
+	name = "Просторы Вселенной";
+	desc = "Особое виски для особых гостей."
+	},
+/obj/effect/spawner/random/entertainment/cigarette_pack{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/turf/open/floor/glass,
+/area/station/service/bar/atrium)
 "lPb" = (
 /obj/machinery/door/window/brigdoor/right/directional/east{
 	name = "Forensic Laboratory";
@@ -47450,6 +48882,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"lQG" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
+/area/station/service/bar/backroom)
 "lQJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -47464,7 +48904,7 @@
 "lRd" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "lRk" = (
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -47548,8 +48988,8 @@
 /area/station/commons/dorms)
 "lSU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/dark_green/fourcorners,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/ghetto)
 "lTt" = (
@@ -47711,29 +49151,15 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "lVc" = (
-/obj/machinery/button/door/directional/east{
-	id = "viplounge_bolt";
-	name = "ViP Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_y = -6;
-	specialfunctions = 4
+/obj/structure/fake_stairs/directional/east{
+	color = "#555559"
 	},
-/obj/structure/table/reinforced/rglass,
-/obj/effect/landmark/event_spawn,
-/obj/item/cigarette/cigar/havana,
-/obj/machinery/button/door/directional/east{
-	id = "viplounge";
-	pixel_y = 6
+/obj/structure/railing{
+	dir = 1;
+	color = "#6e6e6e"
 	},
-/obj/effect/turf_decal/siding/purple{
-	dir = 4
-	},
-/turf/open/floor/light{
-	icon_state = "light_on-7";
-	state = 7;
-	light_color = "#a659ff"
-	},
-/area/station/service/bar)
+/turf/open/openspace,
+/area/station/service/kitchen)
 "lVn" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/disks{
@@ -47767,6 +49193,18 @@
 "lVu" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/break_room)
+"lVy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/airlock/service,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
 "lVF" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -47775,6 +49213,11 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"lVL" = (
+/obj/structure/chair/sofa/corp/left,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/carpet/neon/simple/violet,
+/area/station/service/bar/atrium)
 "lVR" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -47789,6 +49232,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"lVT" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/structure/chair/sofa/corner/maroon{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet/red,
+/area/station/service/bar/atrium)
 "lWa" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -47968,6 +49421,13 @@
 /obj/effect/spawner/random/trash/bin,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"lXK" = (
+/obj/structure/railing,
+/obj/structure/table,
+/obj/item/clothing/head/costume/rice_hat,
+/obj/item/melee/flyswatter,
+/turf/open/floor/stone,
+/area/station/service/hydroponics)
 "lYf" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -48051,6 +49511,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
+"lZb" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/style_random,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1;
+	color = "#777777"
+	},
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "lZi" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -48090,6 +49559,16 @@
 /obj/machinery/computer/libraryconsole/bookmanagement,
 /turf/open/floor/wood,
 /area/station/security/prison)
+"lZF" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table,
+/obj/effect/spawner/random/medical/minor_healing,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "lZI" = (
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron,
@@ -48141,25 +49620,8 @@
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/service/chapel/monastery)
 "mam" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light/directional/north,
-/obj/machinery/requests_console/directional/north{
-	name = "Bar Requests Console";
-	department = "Bar"
-	},
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/effect/mapping_helpers/requests_console/supplies,
-/obj/effect/mapping_helpers/requests_console/announcement,
-/obj/machinery/reagentgrinder{
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/cup/glass/shaker{
-	pixel_x = -9;
-	pixel_y = 6
-	},
-/obj/item/holosign_creator/robot_seat/bar{
-	pixel_y = -4
-	},
+/obj/machinery/vending/cigarette,
+/obj/structure/sign/poster/official/high_class_martini/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "maq" = (
@@ -48286,12 +49748,12 @@
 /turf/closed/wall,
 /area/station/security/prison/visit)
 "mca" = (
-/obj/machinery/atmospherics/components/tank/air/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
 	},
-/turf/open/floor/iron/dark/small,
-/area/station/maintenance/ghetto/central)
+/obj/machinery/light/floor,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "mcc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -48330,13 +49792,14 @@
 /obj/effect/turf_decal/tile/green/half{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "mcK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/structure/table/wood,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "mcM" = (
@@ -48390,9 +49853,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
 "mdc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table,
 /obj/item/hatchet,
 /obj/item/shovel/spade,
@@ -48400,8 +49861,11 @@
 /obj/item/toy/figure/chef{
 	pixel_x = -8
 	},
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/stone,
+/area/station/service/hydroponics/upper)
 "mdi" = (
 /obj/structure/chair/sofa/corp,
 /turf/open/floor/iron,
@@ -48522,6 +49986,15 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
+"mfx" = (
+/obj/structure/flora/bush/sunny/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1;
+	color = "#777777"
+	},
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "mfC" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/structure/cable/layer1,
@@ -48635,6 +50108,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
+"mgs" = (
+/turf/open/openspace,
+/area/station/commons/lounge)
 "mgu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48782,14 +50258,22 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "miT" = (
-/obj/item/storage/dice,
-/obj/structure/table/reinforced/rglass,
-/turf/open/floor/light{
-	icon_state = "light_on-7";
-	state = 7;
-	light_color = "#a659ff"
+/obj/structure/table/wood/fancy/green,
+/obj/item/reagent_containers/cup/glass/bottle/whiskey{
+	pixel_y = 11;
+	pixel_x = -9;
+	name = "Просторы Вселенной";
+	desc = "Особое виски для особых гостей."
 	},
-/area/station/commons/lounge)
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/turf/open/floor/carpet/green,
+/area/station/service/bar/atrium)
 "miV" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 4
@@ -48862,6 +50346,9 @@
 /area/station/maintenance/port/aft)
 "mjV" = (
 /mob/living/carbon/human/species/monkey/punpun,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "mka" = (
@@ -49154,6 +50641,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
+"moO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen/small,
+/area/station/hallway/secondary/service)
 "mpa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49220,16 +50714,48 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "mpX" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/obj/effect/turf_decal/trimline/white/line,
+/obj/item/kirbyplants/random{
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/station/hallway/secondary/service)
 "mpY" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"mqb" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/plate/small{
+	color = "#454545";
+	pixel_y = 4;
+	pixel_x = -17
+	},
+/obj/item/flashlight/flare/candle{
+	pixel_y = 11;
+	pixel_x = -16
+	},
+/obj/item/flashlight/flare/candle{
+	pixel_y = 7;
+	pixel_x = -20
+	},
+/obj/item/flashlight/flare/candle{
+	pixel_y = 7;
+	pixel_x = -12
+	},
+/obj/item/kirbyplants/potty{
+	pixel_y = 15;
+	pixel_x = 4
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/service/bar/atrium)
 "mqd" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/disposal/bin,
@@ -49316,8 +50842,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/dark{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
 	dir = 1
 	},
 /turf/open/floor/iron/corner{
@@ -49526,6 +51054,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "mtM" = (
@@ -49646,7 +51177,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "mvm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50352,19 +51883,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "mEo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/closet/chefcloset,
+/obj/effect/turf_decal/trimline/tram/line{
+	dir = 9
 	},
-/obj/machinery/door/airlock/wood,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/service/bar,
-/obj/machinery/door/firedoor,
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/service/bar)
+/turf/open/floor/iron/dark/textured,
+/area/station/service/kitchen)
 "mEq" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -50480,9 +52004,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/turf/open/floor/iron/dark,
+/area/station/service/bar)
 "mFv" = (
 /obj/item/exodrone,
 /obj/machinery/exodrone_launcher,
@@ -50490,14 +52013,11 @@
 /turf/open/floor/plating/reinforced,
 /area/station/cargo/storage)
 "mFx" = (
-/obj/structure/chair/sofa/corp/right,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/siding/purple{
-	dir = 9
+/obj/structure/platform/corner{
+	color = "#AAAAB1"
 	},
-/turf/open/floor/carpet/purple,
-/area/station/service/bar)
+/turf/open/openspace,
+/area/station/service/kitchen)
 "mFz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -50555,6 +52075,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port/aft)
+"mFZ" = (
+/obj/structure/closet/secure_closet/freezer/empty/open,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "mGh" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/bot,
@@ -50827,11 +52351,9 @@
 /turf/closed/wall,
 /area/station/engineering/atmos/mix/ghetto)
 "mID" = (
-/obj/machinery/vending/cigarette,
-/obj/machinery/camera/directional/north{
-	c_tag = "Bar - North"
-	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/obj/machinery/vending/boozeomat,
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "mII" = (
@@ -51138,6 +52660,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"mMv" = (
+/obj/structure/chair/sofa/corner/maroon,
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "mMF" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -51191,6 +52718,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
+"mNs" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/platform{
+	dir = 4;
+	color = "#AAAAB1"
+	},
+/obj/structure/railing{
+	dir = 4;
+	color = "#6e6e6e"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/kitchen/small,
+/area/station/hallway/secondary/service)
 "mNz" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -51438,11 +52980,10 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "mQv" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/obj/item/radio/intercom/directional/north,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "mQx" = (
@@ -51592,6 +53133,12 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"mSO" = (
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "mTa" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -51825,13 +53372,17 @@
 /turf/open/floor/circuit/green,
 /area/station/science/xenobiology)
 "mWh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/dark_green,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "mWk" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -51932,6 +53483,11 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"mXG" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/indigo,
+/turf/open/space/basic,
+/area/space/nearstation)
 "mXH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/book/bible,
@@ -52175,6 +53731,13 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/starboard)
+"nar" = (
+/obj/machinery/vending/wardrobe/chef_wardrobe,
+/obj/effect/turf_decal/trimline/tram/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/service/kitchen)
 "nay" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -52233,22 +53796,25 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/interrogation/ghetto)
 "naU" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+	dir = 8
 	},
-/obj/effect/turf_decal/siding/purple{
-	dir = 10
-	},
-/turf/open/floor/carpet/purple,
-/area/station/service/bar)
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/ghetto/central)
 "nbf" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/electrical)
+"nbl" = (
+/obj/structure/chair/sofa/left/maroon{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
+/obj/machinery/light/small/blacklight/directional/south,
+/turf/open/floor/carpet/red,
+/area/station/service/bar/atrium)
 "nbo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/xeno/larva,
@@ -52305,11 +53871,22 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
 "nbO" = (
-/obj/structure/railing/corner{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks{
+	pixel_y = 8
 	},
-/turf/open/floor/carpet/black,
-/area/station/commons/lounge)
+/turf/open/floor/iron/checker,
+/area/station/service/bar/atrium)
+"nbV" = (
+/obj/machinery/door/airlock/hydroponics/glass{
+	name = "Apiary"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "nbX" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -52592,7 +54169,7 @@
 "ngz" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "ngA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -52617,7 +54194,7 @@
 /turf/open/floor/iron/corner{
 	dir = 8
 	},
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "ngQ" = (
 /obj/effect/spawner/random/structure/table,
 /turf/open/floor/iron,
@@ -52739,7 +54316,7 @@
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "niy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -52804,6 +54381,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/diagonal,
 /area/station/maintenance/ghetto/starboard/aft)
+"njp" = (
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/machinery/hydroponics/soil,
+/obj/machinery/light/warm/directional/east,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "njr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -53098,6 +54682,23 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"nmO" = (
+/obj/structure/platform{
+	dir = 4;
+	color = "#AAAAB1"
+	},
+/obj/effect/turf_decal/trimline/white/line,
+/obj/structure/railing{
+	dir = 4;
+	color = "#6e6e6e"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/station/hallway/secondary/service)
 "nmW" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/red{
@@ -53614,12 +55215,26 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/ghetto/starboard/aft)
 "nsJ" = (
-/obj/machinery/newscaster/directional/north,
-/obj/machinery/chem_master/condimaster{
-	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
-	name = "HoochMaster Deluxe"
+/obj/structure/table/reinforced,
+/obj/machinery/light/directional/north,
+/obj/machinery/requests_console/directional/north{
+	name = "Bar Requests Console";
+	department = "Bar"
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/machinery/reagentgrinder{
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/cup/glass/shaker{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/obj/item/holosign_creator/robot_seat/bar{
+	pixel_y = -4
+	},
+/obj/machinery/camera/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "nsP" = (
@@ -54055,12 +55670,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "nyd" = (
-/obj/machinery/light/small/directional/south,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/table/glass,
-/obj/machinery/airalarm/directional/south,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron,
 /area/station/maintenance/department/medical/ghetto)
 "nyv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -54397,7 +56008,26 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
 "nCO" = (
-/obj/item/radio/intercom/directional/west,
+/obj/item/radio/intercom/directional/west{
+	pixel_y = -5
+	},
+/obj/machinery/button/door/directional/west{
+	id = "viplounge_bolt1";
+	name = "ViP Bolt Control - West";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_y = 7
+	},
+/obj/machinery/button/door/directional/west{
+	id = "viplounge_bolt2";
+	name = "ViP Bolt Control - East";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_y = 17
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "nCR" = (
@@ -55609,38 +57239,26 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "nSw" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door/directional/west{
-	id = "viplounge_bolt";
-	name = "ViP Bolt Control";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
+/obj/machinery/airalarm/directional/west{
+	pixel_y = 3
 	},
-/obj/item/lighter{
-	pixel_x = 10
-	},
-/obj/item/lighter{
-	pixel_x = 6
-	},
-/obj/item/storage/box/matches{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/book/manual/wiki/barman_recipes{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/cup/glass/shaker{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/cup/glass/flask{
-	pixel_x = 6;
-	pixel_y = 2
-	},
-/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
+"nSz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/platform{
+	dir = 2;
+	color = "#AAAAB1"
+	},
+/obj/structure/railing{
+	dir = 2;
+	color = "#6e6e6e"
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/kitchen/small,
+/area/station/hallway/secondary/service)
 "nSN" = (
 /turf/closed/wall,
 /area/station/service/chapel)
@@ -55686,12 +57304,9 @@
 /turf/open/floor/plating,
 /area/station/medical/medbay/lobby)
 "nTj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/sign/warning/vacuum/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/structure/chair/sofa/left/maroon,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "nTm" = (
 /obj/machinery/recharge_station,
 /obj/machinery/firealarm/directional/east,
@@ -56216,7 +57831,7 @@
 /area/station/maintenance/ghetto/fore/starboard)
 "nZS" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
@@ -56308,7 +57923,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "obg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -56345,6 +57960,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
+"obz" = (
+/obj/machinery/door/airlock/service,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/obj/machinery/duct,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood/parquet,
+/area/station/service/bar/backroom)
 "obA" = (
 /obj/structure/table/reinforced,
 /obj/item/assembly/timer{
@@ -56401,12 +58028,11 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
 "obW" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/disposal/bin,
+/obj/structure/sign/poster/official/fruit_bowl/directional/north,
+/obj/machinery/duct,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
-	},
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/machinery/camera/directional/north{
-	c_tag = "Kitchen"
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
@@ -56458,8 +58084,9 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "ocB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -56827,11 +58454,22 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"ohn" = (
+/obj/effect/turf_decal/tile/dark_green,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "oht" = (
-/obj/structure/girder,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1;
+	color = "#777777"
+	},
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "ohv" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/disposalpipe/segment,
@@ -56897,6 +58535,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
+"oim" = (
+/obj/structure/closet/chefcloset,
+/obj/structure/railing/corner{
+	dir = 8;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/trimline/tram/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/station/service/kitchen)
 "oiw" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -56904,16 +58555,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "oiA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light_switch/directional/north,
-/obj/machinery/duct,
 /obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/service/bar/backroom)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/tram/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_edge,
+/area/station/service/kitchen)
 "oiB" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -57193,7 +58842,7 @@
 	},
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/grass,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "omE" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -57289,12 +58938,10 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/mechbay)
 "onP" = (
-/obj/item/lighter/skull{
-	pixel_x = 8;
-	pixel_y = -2
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/machinery/light/small/directional/west,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/station/service/bar)
 "onQ" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
@@ -57353,13 +59000,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "ooh" = (
-/obj/structure/chair/comfy/brown{
-	color = "#514E58";
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "ooo" = (
@@ -57435,14 +59079,21 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "ooL" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery";
-	location = "Kitchen"
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 9
 	},
-/turf/open/floor/plating,
-/area/station/service/kitchen/coldroom)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/kirbyplants/random{
+	pixel_y = 2
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Lower Service Hall";
+	dir = 9
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/service)
 "ooM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -57552,6 +59203,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"opZ" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8;
+	color = "#6e6e6e"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/carpet/red,
+/area/station/service/bar/atrium)
 "oqa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -57613,11 +59275,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "oqM" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/door/window/right/directional/east,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "oqP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57626,8 +59291,9 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /obj/machinery/door/firedoor,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "oqQ" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/circuit,
@@ -58433,7 +60099,7 @@
 /obj/item/reagent_containers/cup/watering_can,
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "oBo" = (
 /turf/open/floor/iron,
 /area/station/cargo/storage/ghetto)
@@ -58556,6 +60222,18 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/carpet/red,
 /area/station/maintenance/department/security/ghetto)
+"oCT" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/tram/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/tram/mid_joiner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
+/area/station/service/bar/backroom)
 "oDc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58583,6 +60261,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"oDo" = (
+/obj/structure/railing/corner{
+	dir = 8;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/tile/dark/half/contrasted,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/station/commons/lounge)
 "oDq" = (
 /obj/machinery/door/airlock{
 	id_tag = "secmaintdorm2"
@@ -58725,6 +60413,11 @@
 /obj/structure/sign/warning/radiation/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"oEZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_edge,
+/area/station/service/bar/backroom)
 "oFe" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 10
@@ -58943,6 +60636,10 @@
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
+"oIg" = (
+/obj/structure/reagent_dispensers/cooking_oil,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "oIi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58989,6 +60686,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/diagonal,
 /area/station/maintenance/ghetto/starboard/aft)
+"oIJ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8;
+	color = "#6e6e6e"
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small/blacklight/directional/east,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "oIN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -59311,10 +61024,16 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "oMD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/shieldgen,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/item/ammo_casing/rebar/paperball{
+	pixel_x = 11;
+	pixel_y = -9
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/service/hydroponics)
 "oMH" = (
 /turf/closed/wall/r_wall,
 /area/station/commons/storage/primary)
@@ -59460,11 +61179,12 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "oOG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/duct,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/wood,
-/area/station/service/bar/backroom)
+/turf/open/floor/iron/dark/small,
+/area/station/service/kitchen)
 "oOI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -59526,6 +61246,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/maintenance/starboard/aft)
+"oPO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "oPS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -59571,6 +61299,23 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/engine,
 /area/station/science/explab)
+"oQI" = (
+/obj/structure/table,
+/obj/item/paper{
+	pixel_x = 8;
+	pixel_y = -7
+	},
+/obj/item/clothing/head/costume/paper_hat{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/item/food/pizzaslice/dank{
+	pixel_y = 11;
+	pixel_x = 2
+	},
+/obj/structure/sign/departments/botany/directional/north,
+/turf/open/floor/stone,
+/area/station/service/hydroponics)
 "oQL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -59607,6 +61352,14 @@
 /obj/structure/ladder,
 /turf/open/floor/plating,
 /area/station/commons/storage/emergency)
+"oRu" = (
+/obj/structure/table/wood/fancy/red,
+/obj/effect/spawner/random/entertainment/cigarette_pack{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/turf/open/floor/glass,
+/area/station/service/bar/atrium)
 "oRy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59844,6 +61597,11 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/fore)
+"oTV" = (
+/obj/structure/flora/bush/jungle/a/style_random,
+/obj/structure/flora/bush/jungle/b/style_random,
+/turf/open/misc/dirt/dark/station,
+/area/station/service/bar/atrium)
 "oUd" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -60189,6 +61947,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/xmastree,
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8;
+	color = "#6e6e6e"
+	},
 /turf/open/floor/carpet/black,
 /area/station/commons/lounge)
 "oYV" = (
@@ -60251,6 +62016,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
+"oZM" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/openspace,
+/area/station/commons/lounge)
 "oZN" = (
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
@@ -60331,6 +62102,20 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"paU" = (
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark/warning{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/checker,
+/area/station/service/bar/atrium)
 "paX" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -60557,6 +62342,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"pec" = (
+/obj/structure/stairs/wood,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "ped" = (
 /obj/structure/railing{
 	dir = 1
@@ -60654,6 +62446,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/atmos)
+"peZ" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair/comfy/brown{
+	color = "#514E58";
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood/large,
+/area/station/commons/lounge)
 "pfh" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
@@ -60809,6 +62610,13 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
+"phh" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/station/commons/lounge)
 "phm" = (
 /obj/structure/table,
 /obj/item/multitool/circuit{
@@ -61044,6 +62852,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
+"pkk" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/wood/parquet,
+/area/station/service/bar/backroom)
 "pkn" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -61053,11 +62865,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "pkq" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "ghetto_medical_storage"
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/tank/air/layer4,
+/turf/open/floor/iron/dark/small,
 /area/station/maintenance/ghetto/central)
 "pkv" = (
 /obj/machinery/light/small/directional/south,
@@ -61149,15 +62965,34 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "ple" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/sign/directions/medical/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto/aft)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/tram/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/tram/mid_joiner{
+	dir = 4
+	},
+/obj/structure/sink/kitchen/directional/west,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
+/area/station/service/bar/backroom)
 "plj" = (
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/ghetto)
+"plq" = (
+/obj/machinery/button/door/directional/east{
+	id = "botany_apiary";
+	name = "Bee Protection Shutters";
+	pixel_y = -25
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/wood/large,
+/area/station/service/hydroponics)
 "plw" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /obj/effect/turf_decal/tile/yellow{
@@ -61602,18 +63437,24 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "pri" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/dark_green/fourcorners,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "prr" = (
 /obj/machinery/newscaster/directional/east,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
+"prv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
 "pry" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -61675,6 +63516,11 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"psp" = (
+/obj/structure/table/reinforced/plasmarglass,
+/obj/effect/spawner/random/entertainment/deck,
+/turf/open/floor/carpet/neon/simple/violet,
+/area/station/service/bar/atrium)
 "psq" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters{
@@ -62231,13 +64077,16 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/atmos/hfr_room)
 "pyx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/central)
+/obj/item/kirbyplants/random{
+	pixel_y = 2
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/wood/parquet,
+/area/station/service/bar/backroom)
 "pyz" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/airalarm/directional/north,
@@ -62378,12 +64227,9 @@
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "pAB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/dark_green{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "pAM" = (
@@ -62526,6 +64372,23 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
+"pCa" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4;
+	color = "#6e6e6e"
+	},
+/obj/item/kirbyplants/organic/plant24{
+	pixel_y = 6
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Lower Bar - North"
+	},
+/turf/open/floor/carpet/red,
+/area/station/service/bar/atrium)
 "pCc" = (
 /obj/structure/chair{
 	dir = 4
@@ -62591,6 +64454,15 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
+"pCA" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "pCC" = (
 /obj/effect/spawner/random/structure/barricade,
 /turf/open/floor/plating,
@@ -62671,6 +64543,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
+"pDH" = (
+/obj/effect/turf_decal/trimline/tram/warning{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/tram/mid_joiner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/tram/mid_joiner{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
+/area/station/service/bar/backroom)
 "pDI" = (
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/iron,
@@ -63076,10 +64963,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "pIw" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "pIx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -63250,16 +65139,18 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "pKP" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/obj/structure/sign/poster/official/high_class_martini/directional/north,
-/obj/machinery/light/small/directional/north{
-	name = "maintenance light";
-	nightshift_allowed = 0;
-	nightshift_enabled = 1
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/service/bar)
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "pKQ" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -63316,7 +65207,7 @@
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "pLC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63598,6 +65489,11 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"pON" = (
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "pOQ" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -63796,6 +65692,11 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/port/fore)
+"pRT" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/wood/parquet,
+/area/station/hallway/secondary/service)
 "pRW" = (
 /obj/structure/sign/warning/vacuum/directional/west,
 /turf/open/floor/plating,
@@ -64368,6 +66269,13 @@
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/asphalt,
 /area/station/maintenance/ghetto/garden)
+"pYQ" = (
+/obj/structure/fake_stairs/wood/directional/south,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "pYX" = (
 /obj/structure/water_source/puddle,
 /turf/open/misc/grass,
@@ -64499,6 +66407,10 @@
 /obj/machinery/photocopier,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
+"qaE" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "qaG" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
 	color = "#ff0000";
@@ -64566,13 +66478,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "qbT" = (
-/obj/structure/closet/secure_closet/bar,
-/obj/structure/sign/poster/random/directional/east,
-/obj/machinery/camera/directional/east{
-	c_tag = "Bar - Backroom"
+/obj/structure/chair/stool{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/station/service/bar/backroom)
+/turf/open/floor/iron/dark/small,
+/area/station/service/kitchen)
 "qbV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/machinery/light/small/directional/south,
@@ -64583,7 +66493,7 @@
 /obj/structure/chair/sofa/corp/right{
 	dir = 8
 	},
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/black,
 /area/station/commons/lounge)
 "qcf" = (
@@ -64593,9 +66503,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/abandoned_gambling_den)
 "qcp" = (
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen/small,
+/area/station/hallway/secondary/service)
 "qcu" = (
 /obj/structure/tank_dispenser,
 /turf/open/floor/iron/dark/smooth_large,
@@ -65020,10 +66933,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage/ghetto/depot)
 "qiU" = (
-/obj/structure/ladder,
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/turf/open/floor/iron/dark,
+/area/station/service/bar)
 "qiV" = (
 /obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/stripes/corner{
@@ -65068,7 +66979,7 @@
 	name = "Hydroponics Shutter"
 	},
 /turf/open/floor/plating,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "qjw" = (
 /obj/machinery/mining_weather_monitor/directional/north,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -65376,6 +67287,9 @@
 /area/station/engineering/supermatter/room)
 "qnd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "qnk" = (
@@ -65388,6 +67302,13 @@
 	},
 /turf/open/floor/iron/herringbone,
 /area/station/maintenance/aft)
+"qnC" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/wood/large,
+/area/station/service/hydroponics)
 "qnH" = (
 /obj/machinery/door/airlock/public/glass{
 	autoclose = 0;
@@ -65802,6 +67723,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
+"qtS" = (
+/obj/structure/railing{
+	dir = 10;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/tile/dark/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/commons/lounge)
 "qtV" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/light/directional/south,
@@ -65950,6 +67881,17 @@
 /obj/effect/spawner/random/trash/box,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
+"qwC" = (
+/obj/effect/turf_decal/trimline/white/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/service)
 "qwS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -66216,6 +68158,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"qzI" = (
+/obj/structure/platform/corner{
+	dir = 1;
+	color = "#AAAAB1"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing{
+	dir = 2;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/siding/dark,
+/obj/machinery/duct,
+/turf/open/floor/iron/kitchen/small,
+/area/station/hallway/secondary/service)
 "qzJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66313,7 +68270,7 @@
 "qAE" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "qAG" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -66484,7 +68441,6 @@
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
 	},
-/obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet/black,
 /area/station/commons/lounge)
 "qDk" = (
@@ -66820,14 +68776,11 @@
 "qHX" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/directional/east,
-/obj/machinery/camera/directional/east{
-	c_tag = "Bar - East"
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/wood/large,
-/area/station/service/bar)
+/area/station/commons/lounge)
 "qIa" = (
 /obj/structure/showcase/cyborg/old{
 	dir = 4;
@@ -66886,6 +68839,11 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"qIN" = (
+/obj/structure/sign/warning/vacuum/directional/north,
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "qIR" = (
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
@@ -67198,12 +69156,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/lower)
 "qMX" = (
-/obj/structure/chair/sofa/corp/left,
-/obj/effect/turf_decal/siding/purple{
-	dir = 5
+/obj/structure/platform{
+	dir = 6;
+	color = "#AAAAB1"
 	},
-/turf/open/floor/carpet/purple,
-/area/station/service/bar)
+/turf/open/openspace,
+/area/station/service/kitchen)
 "qMY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -67393,11 +69351,19 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "qPl" = (
-/obj/effect/turf_decal/siding/white/corner{
+/obj/structure/railing/corner{
+	dir = 1;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/trimline/tram/warning,
+/obj/effect/turf_decal/trimline/tram/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/end{
 	dir = 4
 	},
-/turf/closed/wall,
-/area/station/service/bar)
+/turf/open/floor/iron/dark/textured,
+/area/station/service/kitchen)
 "qPm" = (
 /obj/structure/table/wood,
 /obj/item/stack/sheet/cloth,
@@ -67622,7 +69588,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "qSz" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow,
@@ -67659,6 +69625,15 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
+"qST" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "qSY" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/dark/half{
@@ -67696,6 +69671,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
+"qTl" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet/green,
+/area/station/service/bar/atrium)
 "qTo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/loading_area,
@@ -67708,10 +69690,13 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/upper)
 "qTw" = (
-/obj/machinery/vending/wardrobe/chef_wardrobe,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/door/airlock,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "qTy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/electric_shock/directional/south,
@@ -67728,7 +69713,7 @@
 "qTE" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "qTM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -67778,12 +69763,13 @@
 /area/station/hallway/primary/central/aft)
 "qUG" = (
 /obj/structure/chair/comfy/black{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "qUM" = (
@@ -67973,8 +69959,8 @@
 /obj/machinery/airalarm/directional/east,
 /obj/structure/sink/directional/west,
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
+/turf/open/floor/stone,
+/area/station/service/hydroponics/upper)
 "qWG" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
@@ -68072,6 +70058,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison)
+"qXM" = (
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central)
 "qXN" = (
 /obj/machinery/mecha_part_fabricator/maint,
 /turf/open/floor/plating,
@@ -68243,6 +70233,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/security/range)
+"ran" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/wood/parquet,
+/area/station/hallway/secondary/service)
 "raq" = (
 /obj/machinery/door/window/left/directional/north{
 	name = "AI Core Door";
@@ -68259,9 +70256,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/sorting)
 "raA" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/closed/wall,
+/area/station/service/bar/atrium)
 "raF" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -68371,6 +70367,15 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"rbH" = (
+/obj/machinery/food_cart,
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/service)
 "rbJ" = (
 /obj/structure/railing,
 /turf/open/floor/iron/stairs/right{
@@ -68684,6 +70689,18 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/ghetto/central/fore)
+"rfN" = (
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/warm/directional/east,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/station/hallway/secondary/service)
 "rfO" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/light/cold/directional/south,
@@ -68704,6 +70721,26 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
+"rgy" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/tram/warning{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/tram/mid_joiner,
+/obj/effect/turf_decal/trimline/tram/mid_joiner{
+	dir = 4
+	},
+/obj/structure/mop_bucket,
+/obj/structure/platform,
+/obj/item/clothing/gloves/color/green,
+/obj/item/mop,
+/obj/machinery/light/small/blacklight/directional/east,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 1
+	},
+/area/station/service/bar/backroom)
 "rgA" = (
 /obj/structure/reagent_dispensers/plumbed{
 	dir = 8
@@ -69014,8 +71051,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/crate,
-/obj/effect/spawner/random/maintenance/two,
 /obj/structure/cable,
+/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "rkj" = (
@@ -69029,6 +71066,12 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
+"rko" = (
+/obj/structure/fake_stairs/directional/west{
+	color = "#555559"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/secondary/service)
 "rku" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/dark_green/fourcorners,
@@ -69225,6 +71268,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"rmN" = (
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/iron,
+/area/station/maintenance/department/medical/ghetto)
 "rmQ" = (
 /obj/machinery/requests_console/directional/west{
 	department = "Cargo";
@@ -69773,12 +71820,8 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "rtl" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron,
-/area/station/maintenance/department/medical/ghetto)
+/turf/closed/wall/r_wall,
+/area/station/service/bar/atrium)
 "rtm" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow{
@@ -70221,11 +72264,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "rzS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
 /area/station/maintenance/ghetto/central)
 "rAh" = (
 /obj/machinery/light/directional/north,
@@ -70263,6 +72303,18 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"rAt" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
+"rAv" = (
+/obj/effect/spawner/random/structure/crate,
+/obj/machinery/light/small/blacklight/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "rAB" = (
 /obj/structure/cable/multilayer/connected,
 /turf/open/floor/plating,
@@ -70285,6 +72337,15 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"rBf" = (
+/obj/structure/railing/corner/end/flip{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/stone,
+/area/station/service/hydroponics)
 "rBg" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -70310,6 +72371,14 @@
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
+"rBw" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
+/area/station/service/bar/backroom)
 "rBy" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/spawner/random/trash/garbage,
@@ -70356,12 +72425,11 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/upper)
 "rBZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/glass,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/stone,
+/area/station/service/hydroponics)
 "rCa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -70613,6 +72681,12 @@
 /obj/structure/cable,
 /turf/open/floor/sepia,
 /area/station/security/prison/ghetto)
+"rFF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "rFH" = (
 /obj/structure/transport/linear/public,
 /obj/effect/abstract/elevator_music_zone{
@@ -70712,14 +72786,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "rHD" = (
-/obj/item/clothing/head/utility/hardhat/cakehat,
-/obj/structure/table/reinforced/rglass,
-/turf/open/floor/light{
-	icon_state = "light_on-7";
-	state = 7;
-	light_color = "#a659ff"
-	},
-/area/station/commons/lounge)
+/obj/structure/closet/l3closet/virology,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "rHU" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
@@ -70921,7 +72990,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "rKe" = (
-/turf/open/floor/iron/stairs,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/openspace,
 /area/station/commons/lounge)
 "rKf" = (
 /obj/structure/table,
@@ -70982,8 +73054,9 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/corner,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "rKS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -71210,7 +73283,7 @@
 /turf/open/floor/iron/corner{
 	dir = 4
 	},
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "rNk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -71230,11 +73303,17 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
 "rNp" = (
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/door/airlock,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/platform{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8;
+	color = "#6e6e6e"
+	},
+/turf/open/floor/carpet/black,
+/area/station/commons/lounge)
 "rNr" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/sink/kitchen/directional/south,
@@ -71294,7 +73373,7 @@
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/department/security/ghetto)
 "rOn" = (
-/obj/structure/closet/emcloset,
+/obj/item/kirbyplants/random,
 /turf/open/floor/wood/parquet,
 /area/station/hallway/secondary/service)
 "rOp" = (
@@ -71337,6 +73416,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"rOQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "rOZ" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -71385,7 +73470,7 @@
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "rPI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
@@ -71664,10 +73749,11 @@
 /turf/open/floor/eighties/red,
 /area/station/maintenance/port/aft)
 "rTy" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/bar/backroom)
 "rTJ" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -71797,22 +73883,13 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/fore/starboard)
 "rUZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/grill{
+	pixel_y = 8
 	},
 /obj/structure/table,
-/obj/structure/sign/poster/official/fruit_bowl/directional/north,
-/obj/effect/spawner/random/food_or_drink/donkpockets{
-	pixel_y = 6;
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/cup/beaker{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/machinery/light/directional/north,
-/obj/item/reagent_containers/condiment/enzyme{
-	pixel_y = 5
+/obj/machinery/airalarm/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
@@ -71826,11 +73903,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "rVd" = (
-/obj/machinery/chem_master/condimaster{
-	name = "CondiMaster Neo"
-	},
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/obj/effect/spawner/random/structure/crate,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "rVq" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/bottle/beer{
@@ -71960,8 +74036,8 @@
 /obj/machinery/light/small/directional/east,
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/biogenerator,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
+/turf/open/floor/stone,
+/area/station/service/hydroponics/upper)
 "rWN" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -72104,16 +74180,8 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
 "rXX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
 /area/station/maintenance/department/security/ghetto/aft)
 "rYb" = (
 /obj/machinery/ai_slipper{
@@ -72124,9 +74192,21 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "rYe" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/wood/parquet,
-/area/station/hallway/secondary/service)
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 1;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "rYf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table/wood,
@@ -72493,6 +74573,15 @@
 /obj/structure/broken_flooring/corner/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
+"scv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ants,
+/obj/item/ammo_casing/rebar/paperball{
+	pixel_x = 11;
+	pixel_y = -9
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "scy" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -72530,12 +74619,9 @@
 /turf/closed/wall,
 /area/station/commons/vacant_room/commissary)
 "sdc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "sdh" = (
 /obj/machinery/computer/mech_bay_power_console{
@@ -72614,6 +74700,16 @@
 "sdA" = (
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"sdD" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/curtain/cloth/fancy/mechanical/start_closed{
+	name = "ViP Curtains"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "sdE" = (
 /obj/machinery/dna_infuser,
 /obj/machinery/camera/directional/south{
@@ -72670,7 +74766,7 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/door/window/right/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "seo" = (
 /turf/closed/wall,
 /area/station/security/processing)
@@ -73187,12 +75283,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "skM" = (
-/obj/machinery/atmospherics/components/tank/air/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/maintenance/ghetto/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "skQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -73415,6 +75511,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
+"snB" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/service/bar/atrium)
 "snG" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -73541,6 +75645,18 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
+"spi" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 4;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "spq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -73637,7 +75753,7 @@
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "sqy" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8
@@ -73743,7 +75859,7 @@
 /turf/open/floor/iron/corner{
 	dir = 1
 	},
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "srG" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
@@ -73763,6 +75879,13 @@
 "srK" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/fore)
+"srW" = (
+/obj/structure/stairs/wood,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "ssc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -73878,6 +76001,10 @@
 /obj/structure/chair,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
+"stF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/service/bar/backroom)
 "stV" = (
 /obj/structure/table/wood,
 /obj/machinery/light/directional/south,
@@ -73898,8 +76025,9 @@
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
-/area/station/hallway/secondary/service)
+/area/station/service/hydroponics/upper)
 "sub" = (
 /obj/structure/broken_flooring/corner/directional/east,
 /turf/open/floor/plating,
@@ -74010,6 +76138,10 @@
 /obj/structure/flora/rock/pile/jungle/style_random,
 /turf/open/misc/grass,
 /area/station/security/prison/garden)
+"svx" = (
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "svz" = (
 /obj/structure/table/wood,
 /obj/item/pizzabox/margherita,
@@ -74346,6 +76478,12 @@
 /obj/machinery/telecomms/broadcaster/preset_left,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
+"sAk" = (
+/obj/structure/platform{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/smooth_edge,
+/area/station/service/bar/backroom)
 "sAo" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood,
@@ -74590,6 +76728,20 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
+"sDM" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/freezer,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/duct,
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "sDN" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Vacant Store"
@@ -74807,6 +76959,20 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/processing)
+"sFs" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/table/wood/fancy/red,
+/obj/item/plate/small{
+	color = "#454545"
+	},
+/obj/item/cigbutt/cigarbutt{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "sFx" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -74832,6 +76998,13 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
+"sFZ" = (
+/obj/effect/spawner/random/trash,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "sGh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -75360,6 +77533,11 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
+"sOd" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/food/cheese/wheel,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "sOi" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/wood{
@@ -75367,6 +77545,15 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
+"sOm" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
+/area/station/service/bar/backroom)
 "sOC" = (
 /obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -75377,6 +77564,13 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"sOT" = (
+/obj/structure/mirror/directional/north,
+/obj/structure/sink/kitchen/directional/south{
+	pixel_y = 11
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/bar)
 "sOW" = (
 /obj/structure/table,
 /obj/effect/spawner/random/mod/maint,
@@ -75390,6 +77584,12 @@
 /obj/machinery/door/window/right/directional/south,
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
+"sPh" = (
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/service)
 "sPk" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 1";
@@ -75551,12 +77751,12 @@
 /turf/open/floor/wood/parquet,
 /area/station/security/courtroom)
 "sRo" = (
-/obj/machinery/door/airlock/hydroponics,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/hydroponics,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "sRs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -75634,7 +77834,7 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "sSO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -75769,6 +77969,13 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/kitchen/abandoned)
+"sUK" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/flashlight/flare/candle{
+	pixel_y = 11
+	},
+/turf/open/floor/carpet/red,
+/area/station/service/bar/atrium)
 "sUL" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -75783,6 +77990,25 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"sVf" = (
+/obj/structure/railing{
+	dir = 8;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "sVg" = (
 /obj/structure/broken_flooring/side/directional/south,
 /turf/open/floor/plating,
@@ -75873,6 +78099,12 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
+"sWx" = (
+/obj/structure/chair/stool{
+	dir = 1
+	},
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "sWy" = (
 /obj/machinery/door/airlock/security,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -75936,6 +78168,10 @@
 	},
 /turf/open/floor/carpet,
 /area/station/service/library)
+"sXk" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "sXl" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/grille/broken,
@@ -75973,6 +78209,10 @@
 	dir = 4
 	},
 /area/station/engineering/hallway/west)
+"sXK" = (
+/obj/machinery/light/warm/directional/west,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "sXO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -76065,9 +78305,7 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/bitrunning/den)
 "sZz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "sZA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -76356,14 +78594,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "tex" = (
-/obj/structure/chair/comfy/brown{
-	color = "#514E58";
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "tey" = (
@@ -76409,6 +78645,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
+"teP" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics/upper)
 "tfm" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/plating,
@@ -76762,7 +79003,7 @@
 /obj/structure/sink/directional/west,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "tkE" = (
 /obj/effect/turf_decal/tile/dark/half{
 	dir = 4
@@ -77167,6 +79408,11 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/station/command/heads_quarters/nanotrasen_representative)
+"tor" = (
+/obj/structure/chair/sofa/corp/right,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet/green,
+/area/station/service/bar/atrium)
 "tot" = (
 /obj/structure/transit_tube/station/dispenser/reverse{
 	dir = 4
@@ -77191,7 +79437,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "toF" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -77413,9 +79659,15 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "tqK" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/service)
 "tqM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -77497,6 +79749,9 @@
 /area/station/engineering/main)
 "tsi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "tsk" = (
@@ -77823,11 +80078,15 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
 "tvm" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/obj/machinery/door/airlock/service,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/turf/open/floor/iron/dark,
+/area/station/service/bar)
 "tvt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -78275,13 +80534,27 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"tCm" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/structure/table/wood/fancy/red,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 0;
+	pixel_y = 14
+	},
+/obj/item/stack/spacecash/c100{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "tCo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "tCp" = (
 /obj/structure/rack,
@@ -78672,6 +80945,9 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/service)
+"tHv" = (
+/turf/open/floor/wood/large,
+/area/station/commons/lounge)
 "tHw" = (
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
@@ -78754,14 +81030,11 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/tcommsat/server)
 "tIt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/duct,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "tIw" = (
@@ -78853,6 +81126,9 @@
 	name = "Kitchen";
 	req_access = list("kitchen")
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/service/kitchen)
 "tJl" = (
@@ -78922,13 +81198,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/aft)
 "tKk" = (
+/obj/machinery/smartfridge/drying,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/item/reagent_containers/condiment/rice,
-/obj/item/reagent_containers/condiment/flour,
-/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "tKl" = (
@@ -78936,6 +81209,17 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"tKo" = (
+/obj/structure/rack,
+/obj/item/book/manual/chef_recipes,
+/obj/item/holosign_creator/robot_seat/restaurant,
+/obj/effect/turf_decal/trimline/tram/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/station/service/kitchen)
 "tKq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -79099,10 +81383,11 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "tMa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -79181,6 +81466,17 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/theater)
+"tNq" = (
+/obj/structure/railing/corner{
+	dir = 4;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/carpet/red,
+/area/station/service/bar/atrium)
 "tNr" = (
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
@@ -79220,6 +81516,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/aft)
+"tOb" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet/neon/simple/violet,
+/area/station/service/bar/atrium)
 "tOc" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -79319,12 +81622,16 @@
 /turf/open/floor/carpet,
 /area/station/hallway/secondary/entry)
 "tPg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/musician/piano,
+/obj/structure/railing{
+	dir = 8;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/tile/dark/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
+/turf/open/floor/iron,
+/area/station/commons/lounge)
 "tPj" = (
 /obj/structure/closet/secure_closet/magistrate,
 /obj/effect/turf_decal/siding/wood{
@@ -79872,6 +82179,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"tWV" = (
+/obj/structure/table/wood/fancy/black,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/item/kirbyplants/potty{
+	pixel_y = 15
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "tWW" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck,
@@ -79909,15 +82229,28 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "tXm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/area/station/maintenance/department/medical/ghetto)
 "tXr" = (
 /obj/item/kirbyplants/random,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/magistrate)
+"tXs" = (
+/obj/item/reagent_containers/cup/bucket{
+	pixel_x = 8;
+	pixel_y = -5
+	},
+/obj/machinery/smartfridge/drying/rack{
+	pixel_y = 9;
+	layer = 2.91
+	},
+/turf/open/floor/stone,
+/area/station/service/hydroponics)
 "tXD" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/belt/utility{
@@ -79948,6 +82281,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
+"tXJ" = (
+/obj/effect/turf_decal/stripes/end,
+/obj/machinery/atmospherics/components/tank/air/layer4,
+/turf/open/floor/iron/dark/small,
+/area/station/maintenance/ghetto/central)
 "tXL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
@@ -80044,6 +82382,15 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"tYO" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/large,
+/area/station/service/hydroponics)
 "tYQ" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Central Hallway East"
@@ -80168,6 +82515,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "uaB" = (
@@ -80183,17 +82531,15 @@
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "uaE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/service,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/machinery/duct,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/service/bar,
-/turf/open/floor/wood/parquet,
-/area/station/hallway/secondary/service)
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/turf/open/floor/iron/dark,
+/area/station/service/kitchen)
 "uaJ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/holosign/barrier/engineering,
@@ -80495,6 +82841,18 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
+"ueJ" = (
+/obj/item/ammo_casing/rebar/paperball{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/large,
+/area/station/service/hydroponics)
 "ueM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -80640,10 +82998,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "ugf" = (
+/obj/structure/platform/corner,
 /obj/structure/railing{
-	dir = 9
+	dir = 4
 	},
-/turf/open/floor/glass,
+/turf/open/openspace,
 /area/station/commons/lounge)
 "ugh" = (
 /turf/closed/wall,
@@ -80652,6 +83011,15 @@
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/security/ghetto/fore)
+"ugs" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "ugz" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/pod,
@@ -80679,6 +83047,13 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
+"ugR" = (
+/obj/item/food/grown/cabbage,
+/obj/item/food/grown/onion,
+/obj/item/food/grown/onion,
+/obj/structure/closet/crate/freezer/food,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "ugS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -80737,17 +83112,12 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
 "uhA" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/air{
-	anchored = 1
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/small,
-/area/station/maintenance/ghetto/central)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/wood/large,
+/area/station/commons/lounge)
 "uhG" = (
 /obj/item/kirbyplants/random/dead,
 /turf/open/floor/plating,
@@ -80836,8 +83206,16 @@
 /turf/open/floor/iron,
 /area/station/science/lobby)
 "uiH" = (
-/turf/closed/wall/r_wall/rust,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/platform/corner,
+/obj/effect/turf_decal/trimline/tram/warning,
+/obj/effect/turf_decal/trimline/tram/mid_joiner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_edge,
+/area/station/service/bar/backroom)
 "uiL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
@@ -81020,7 +83398,7 @@
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "ulr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -81133,7 +83511,7 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/flora/bush/pointy/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "unm" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -81157,6 +83535,11 @@
 /obj/structure/sign/poster/official/there_is_no_gas_giant/directional/east,
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/atmos/project)
+"unE" = (
+/obj/structure/lattice,
+/obj/structure/marker_beacon/indigo,
+/turf/open/space/basic,
+/area/space/nearstation)
 "unJ" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -81341,14 +83724,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "uqu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/grill{
 	pixel_y = 8
 	},
 /obj/structure/table,
-/obj/machinery/airalarm/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "uqw" = (
@@ -81536,11 +83918,9 @@
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/ghetto/bar)
 "uuc" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/structure/chair/sofa/corp/left,
+/turf/open/floor/carpet/green,
+/area/station/service/bar/atrium)
 "uue" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -81675,6 +84055,10 @@
 /obj/machinery/atmospherics/components/binary/valve/on,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"uwz" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet/red,
+/area/station/service/bar/atrium)
 "uwD" = (
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 8
@@ -81784,6 +84168,14 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
+"uxx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/kitchen/small,
+/area/station/hallway/secondary/service)
 "uxD" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/command/storage/eva)
@@ -81836,12 +84228,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard/west)
 "uyt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/structure/chair/sofa/middle/brown{
 	dir = 8
 	},
-/obj/machinery/duct,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/turf/open/floor/wood/parquet,
+/area/station/hallway/secondary/service)
 "uyA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -82021,6 +84412,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"uAP" = (
+/obj/structure/table/wood/fancy/black,
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 1
+	},
+/obj/item/kirbyplants/organic/applebush{
+	pixel_y = 15
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "uBb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -82130,14 +84532,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "uCO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/service/bar/backroom)
 "uCS" = (
 /obj/structure/table/reinforced,
 /obj/item/instrument/bikehorn{
@@ -82154,7 +84551,7 @@
 	name = "Hydroponics Shutter"
 	},
 /turf/open/floor/plating,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "uCW" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/machinery/status_display/evac/directional/south,
@@ -82181,7 +84578,7 @@
 "uDi" = (
 /obj/effect/turf_decal/tile/green/half,
 /turf/open/floor/iron/edge,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "uDk" = (
 /obj/effect/turf_decal/siding/white,
 /turf/open/water/alternative/muddy/no_fishing,
@@ -82193,6 +84590,10 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
+"uDD" = (
+/obj/structure/chair/sofa/right/maroon,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "uDH" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -82307,6 +84708,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
+"uFT" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/turf/open/floor/glass,
+/area/station/service/bar/atrium)
 "uFW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -82322,6 +84738,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"uGq" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "uGu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
@@ -82356,8 +84778,11 @@
 "uGI" = (
 /obj/effect/landmark/start/botanist,
 /obj/structure/chair/stool/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "uGN" = (
 /obj/structure/table/reinforced/rglass,
 /obj/item/food/grown/banana,
@@ -82386,6 +84811,7 @@
 /obj/machinery/griddle,
 /obj/effect/turf_decal/delivery/white,
 /obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "uGR" = (
@@ -82420,7 +84846,7 @@
 /obj/structure/flora/bush/leavy/style_random,
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "uHq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -82488,6 +84914,13 @@
 /obj/effect/landmark/navigate_destination/eva,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"uIn" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen/small,
+/area/station/hallway/secondary/service)
 "uIo" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/trimline/dark_blue/corner{
@@ -82978,7 +85411,7 @@
 	name = "SapMaster XP"
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "uOa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -83061,6 +85494,13 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
+"uOO" = (
+/obj/structure/sink/kitchen/directional/south,
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/service)
 "uOX" = (
 /turf/closed/wall,
 /area/station/hallway/primary/central/aft)
@@ -83159,8 +85599,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "uRh" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/computer/slot_machine,
@@ -83315,9 +85756,24 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "uSZ" = (
-/obj/item/kirbyplants/random,
+/obj/structure/reagent_dispensers/plumbed{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
+	},
 /turf/open/floor/iron,
-/area/station/commons/dorms)
+/area/station/maintenance/ghetto/fore/starboard)
+"uTl" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/trimline/dark/warning,
+/obj/effect/turf_decal/trimline/dark/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/checker,
+/area/station/service/bar/atrium)
 "uTn" = (
 /obj/structure/table/wood,
 /obj/item/folder,
@@ -83488,6 +85944,11 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
+"uVU" = (
+/obj/effect/landmark/start/cook,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "uVZ" = (
 /obj/structure/railing{
 	dir = 8
@@ -83562,6 +86023,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
+"uXd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "uXq" = (
 /obj/effect/turf_decal/arrows{
 	dir = 1
@@ -83754,6 +86221,15 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"uZU" = (
+/obj/machinery/icecream_vat,
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/light/warm/directional/north,
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/service)
 "uZW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
@@ -83954,6 +86430,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/ghetto)
+"vcM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "vcR" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/door/poddoor/preopen{
@@ -84238,10 +86720,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "vgO" = (
-/obj/structure/reagent_dispensers/cooking_oil,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/freezer,
-/area/station/service/kitchen/coldroom)
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "vhi" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/structure/closet/crate/silvercrate,
@@ -84713,7 +87203,7 @@
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "vmg" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
@@ -84726,6 +87216,12 @@
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/grimy,
 /area/station/hallway/secondary/entry)
+"vmn" = (
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "vmy" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -84766,11 +87262,15 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/port)
 "vmY" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil,
-/obj/item/clothing/suit/hazardvest,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/wood/large,
+/area/station/service/hydroponics)
 "vnc" = (
 /obj/structure/chair,
 /obj/effect/mapping_helpers/broken_floor,
@@ -84918,9 +87418,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay/ghetto)
 "vox" = (
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/ghetto/central)
+/obj/structure/table/reinforced,
+/obj/item/sharpener,
+/turf/open/floor/iron/freezer,
+/area/station/service/kitchen/coldroom)
 "voG" = (
 /obj/structure/chair{
 	dir = 8
@@ -84933,7 +87434,7 @@
 "voK" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/floor/grass,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "voM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/cable,
@@ -85527,6 +88028,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"vuf" = (
+/obj/structure/fake_stairs/wood/directional/north,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "vug" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -85687,11 +88195,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "vwk" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/turf/open/floor/wood/large,
-/area/station/commons/lounge)
+/obj/structure/flora/bush/sunny/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "vwC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -85824,6 +88331,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
+"vyz" = (
+/obj/effect/landmark/start/bartender,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating/corner{
+	color = "#4e4e4e";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
+/area/station/service/bar/backroom)
 "vyE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/chair_flipped{
@@ -85846,7 +88366,10 @@
 /turf/open/misc/grass,
 /area/station/security/prison/garden)
 "vyQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "vzj" = (
@@ -85891,6 +88414,31 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/ghetto/fore/starboard)
+"vzA" = (
+/obj/structure/table/wood,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass{
+	amount = 50;
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box{
+	pixel_y = 2;
+	pixel_x = -2
+	},
+/obj/item/storage/fancy/candle_box{
+	pixel_y = 4;
+	pixel_x = -4
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Bar - Backroom"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/wood/parquet,
+/area/station/service/bar/backroom)
 "vzF" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -85937,8 +88485,10 @@
 "vAa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "vAe" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -86009,6 +88559,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
+"vAP" = (
+/obj/structure/chair/sofa/corp/right,
+/turf/open/floor/carpet/neon/simple/violet,
+/area/station/service/bar/atrium)
 "vBb" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/decal/cleanable/dirt,
@@ -86058,6 +88612,13 @@
 /obj/effect/turf_decal/tile/purple/anticorner,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
+"vBP" = (
+/obj/structure/flora/grass/jungle/a/style_random,
+/obj/structure/flora/bush/large/style_2{
+	pixel_y = 3
+	},
+/turf/open/misc/dirt/dark/station,
+/area/station/service/bar/atrium)
 "vBQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/corner/end/flip{
@@ -86082,8 +88643,8 @@
 /mob/living/basic/cow{
 	name = "Бетси"
 	},
-/turf/open/misc/beach/sand,
-/area/station/service/hydroponics)
+/turf/open/misc/sandy_dirt,
+/area/station/service/hydroponics/upper)
 "vBZ" = (
 /turf/closed/wall,
 /area/station/service/chapel/office)
@@ -86119,6 +88680,18 @@
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"vCA" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "vCB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -86220,6 +88793,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"vDW" = (
+/turf/open/floor/carpet/red,
+/area/station/service/bar/atrium)
 "vDX" = (
 /turf/open/floor/iron/stairs,
 /area/station/commons/dorms)
@@ -86833,7 +89409,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "vLT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -86863,11 +89439,9 @@
 /turf/open/floor/carpet/blue,
 /area/station/service/library/ghetto)
 "vMn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron/cafeteria,
-/area/station/service/kitchen)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/station/maintenance/ghetto/fore/starboard)
 "vMr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -86934,6 +89508,12 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"vNk" = (
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
+/area/station/hallway/secondary/service)
 "vNo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -87022,6 +89602,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/station/maintenance/aft)
+"vPg" = (
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	location = "Bar"
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/service/bar)
 "vPo" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -87044,6 +89636,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/department/security/ghetto)
+"vPK" = (
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark/warning{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/dark/corner,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/checker,
+/area/station/service/bar/atrium)
 "vPN" = (
 /obj/machinery/telecomms/bus/preset_three,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
@@ -87366,9 +89969,15 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "vUG" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/warm/directional/west,
+/obj/machinery/duct,
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/service)
 "vUI" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/item/book/manual/wiki/grenades,
@@ -87483,6 +90092,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"vWm" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "vWn" = (
 /obj/structure/table/reinforced,
 /obj/structure/railing{
@@ -87703,6 +90319,19 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
+"vYT" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8;
+	color = "#6e6e6e"
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "vZa" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -87749,10 +90378,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "vZV" = (
-/obj/structure/railing{
-	dir = 6
+/obj/structure/platform{
+	dir = 1
 	},
-/turf/open/floor/glass,
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "wab" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -87870,8 +90503,8 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance/office)
 "wbL" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/structure/disposalpipe/junction,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "wbM" = (
@@ -87906,6 +90539,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
+"wcb" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
 "wcf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -88444,6 +91083,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
+"wiG" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/commons/lounge)
 "wiJ" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -88502,14 +91150,22 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "wjd" = (
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/effect/turf_decal/trimline/dark/warning,
+/obj/effect/turf_decal/trimline/dark/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/railing{
+	dir = 1;
+	color = "#6e6e6e"
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/iron/checker,
+/area/station/service/bar/atrium)
 "wje" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -89452,6 +92108,17 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
+"wxw" = (
+/obj/structure/railing/corner{
+	dir = 1;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/tile/dark/half/contrasted{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/edge,
+/area/station/commons/lounge)
 "wxD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -89624,10 +92291,15 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "wzK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/structure/rack,
+/obj/item/clothing/suit/utility/beekeeper_suit,
+/obj/item/clothing/head/utility/beekeeper_head,
+/obj/item/melee/flyswatter,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/wood/large,
+/area/station/service/hydroponics)
 "wzL" = (
 /obj/item/trash/pistachios,
 /obj/effect/decal/cleanable/dirt,
@@ -89881,18 +92553,20 @@
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "wCj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/service/hydroponics)
-"wCk" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	name = "Privacy Shutters";
-	id = "viplounge"
+/obj/machinery/duct,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/service/bar)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/stone,
+/area/station/service/hydroponics/upper)
+"wCk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "wCs" = (
 /obj/structure/chair/sofa/right/brown{
 	dir = 4
@@ -89929,9 +92603,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "wCH" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/machinery/chem_master/condimaster{
+	name = "CondiMaster Neo"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1
+	},
+/obj/machinery/light/warm/directional/north,
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/service)
 "wCJ" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -90179,6 +92859,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/kitchen)
+"wFf" = (
+/obj/structure/chair/sofa/right/maroon{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "wFi" = (
 /obj/item/toy/basketball,
 /obj/effect/decal/cleanable/dirt,
@@ -90656,10 +93345,7 @@
 /turf/open/space/openspace,
 /area/station/solars/port/aft)
 "wLE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "wLH" = (
@@ -90796,6 +93482,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"wNH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "wOb" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -90861,10 +93553,13 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
 "wOV" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/ghetto/central)
+/obj/structure/flora/bush/large/style_random{
+	pixel_y = 0;
+	layer = 5.2
+	},
+/obj/structure/flora/bush/jungle/a/style_random,
+/turf/open/misc/dirt/dark/station,
+/area/station/service/bar/atrium)
 "wOW" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -90946,6 +93641,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white/textured_large,
 /area/station/maintenance/ghetto/starboard/aft)
+"wPU" = (
+/obj/structure/flora/bush/generic/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "wQa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -91120,6 +93822,10 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chemistry/ghetto)
+"wRT" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/station/service/bar/atrium)
 "wRV" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 4;
@@ -91137,6 +93843,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"wSl" = (
+/obj/item/ammo_casing/rebar/paperball{
+	pixel_x = -8;
+	pixel_y = -8
+	},
+/obj/item/ammo_casing/rebar/paperball,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/service/hydroponics)
 "wSm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -91351,9 +94068,17 @@
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/department/security/ghetto)
 "wUZ" = (
-/obj/effect/turf_decal/arrows,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium)
 "wVe" = (
 /obj/effect/turf_decal/tile/dark/half{
 	dir = 1
@@ -91461,7 +94186,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood/large,
-/area/station/service/bar)
+/area/station/commons/lounge)
 "wWV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -91563,7 +94288,7 @@
 "wYg" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "wYk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -91721,7 +94446,7 @@
 /obj/structure/cable,
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "xaW" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
@@ -91800,6 +94525,15 @@
 /obj/effect/mapping_helpers/requests_console/information,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
+"xbr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/white/warning{
+	dir = 8
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/service)
 "xbG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -92136,6 +94870,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/storage)
+"xfj" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/medical/ghetto)
 "xfm" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
@@ -92329,6 +95070,14 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/security/courtroom)
+"xgM" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/north,
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/iron/dark/smooth_edge,
+/area/station/service/bar/backroom)
 "xgU" = (
 /obj/structure/cable,
 /obj/machinery/camera/directional/south{
@@ -92351,6 +95100,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"xgZ" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/closet/secure_closet/bar{
+	layer = 2.91
+	},
+/obj/item/gun/ballistic/shotgun/doublebarrel,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood,
+/area/station/service/bar/backroom)
 "xhf" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -92429,6 +95187,9 @@
 "xiF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/bartender,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "xiG" = (
@@ -92630,11 +95391,25 @@
 /turf/closed/wall,
 /area/station/engineering/atmos/project)
 "xkQ" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/storage/box/drinkingglasses{
+	pixel_y = 9;
+	pixel_x = 0
+	},
+/obj/item/storage/box/dishdrive{
+	pixel_y = 23;
+	pixel_x = 3
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/station/hallway/secondary/service)
 "xkR" = (
 /obj/structure/closet/emcloset,
 /obj/effect/spawner/random/maintenance,
@@ -92824,15 +95599,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/siding/wood/corner,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/wood/large,
-/area/station/service/bar)
+/area/station/commons/lounge)
 "xnG" = (
 /obj/effect/landmark/start/shaft_miner,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -93332,7 +96106,7 @@
 	dir = 2
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "xun" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 5
@@ -93455,6 +96229,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
+"xws" = (
+/obj/item/storage/cans/sixbeer,
+/obj/structure/closet/secure_closet/freezer/empty,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "xww" = (
 /obj/effect/spawner/structure/electrified_grille,
 /turf/open/floor/plating,
@@ -93492,6 +96271,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"xwG" = (
+/obj/machinery/door/airlock/service,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/service/general,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen,
+/area/station/service/bar/atrium)
 "xwI" = (
 /obj/item/kirbyplants/random/dead,
 /turf/open/floor/wood,
@@ -93519,6 +96308,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"xxt" = (
+/obj/item/kirbyplants/random,
+/obj/structure/railing{
+	dir = 8;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/trimline/tram/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/station/service/kitchen)
 "xxv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -93826,11 +96628,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "xBP" = (
-/obj/item/clothing/mask/breath,
-/obj/structure/rack,
-/obj/item/radio,
-/obj/item/clothing/suit/hazardvest,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "xBU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -93885,6 +96685,20 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
+"xCG" = (
+/obj/effect/turf_decal/trimline/dark/warning{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/checker,
+/area/station/service/bar/atrium)
 "xCJ" = (
 /obj/effect/spawner/random/glass_shards,
 /obj/machinery/light/small/directional/east,
@@ -93957,6 +96771,19 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"xEa" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/tram/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/tram/mid_joiner{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/station/service/bar/backroom)
 "xEg" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -94285,6 +97112,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"xIq" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/siding/wood,
+/obj/item/stack/cable_coil{
+	pixel_y = -4
+	},
+/obj/item/stack/cable_coil,
+/obj/item/wrench,
+/turf/open/floor/wood/parquet,
+/area/station/service/bar/backroom)
 "xIr" = (
 /obj/structure/railing{
 	dir = 10
@@ -94366,10 +97203,28 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
+"xJQ" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
 "xJU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard/west)
+"xJX" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/dark/warning,
+/obj/effect/turf_decal/trimline/dark/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/reagent_containers/cup/rag{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/turf/open/floor/iron/checker,
+/area/station/service/bar/atrium)
 "xKc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -94428,8 +97283,30 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "xKI" = (
-/obj/machinery/vending/boozeomat,
-/obj/machinery/light/directional/north,
+/obj/structure/table/reinforced,
+/obj/item/lighter{
+	pixel_x = 10
+	},
+/obj/item/lighter{
+	pixel_x = 6
+	},
+/obj/item/storage/box/matches{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/book/manual/wiki/barman_recipes{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/cup/glass/shaker{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/cup/glass/flask{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "xKS" = (
@@ -94567,11 +97444,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "xME" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/wood/large,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/openspace,
 /area/station/commons/lounge)
 "xMI" = (
 /obj/structure/rack,
@@ -94738,20 +97615,11 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "xOl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/closet,
-/obj/item/wrench,
-/obj/item/circuitboard/computer/arcade/orion_trail,
-/obj/item/circuitboard/computer/arcade/battle,
-/obj/item/circuitboard/computer/slot_machine,
-/obj/item/circuitboard/computer/slot_machine,
-/obj/item/vending_refill/cigarette,
-/obj/item/vending_refill/coffee,
-/obj/machinery/firealarm/directional/west,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/station/service/bar/backroom)
+/obj/effect/spawner/random/maintenance,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "xOp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -94759,6 +97627,21 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"xOr" = (
+/obj/item/reagent_containers/cup/bucket{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/cup/bucket{
+	pixel_x = 15;
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/service)
 "xOv" = (
 /turf/closed/wall,
 /area/station/science/robotics/mechbay)
@@ -95120,9 +98003,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "xTr" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen/small,
+/area/station/hallway/secondary/service)
 "xTs" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /turf/open/floor/iron/dark,
@@ -95295,6 +98180,11 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
+"xVw" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood/parquet,
+/area/station/hallway/secondary/service)
 "xVM" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock,
@@ -95328,9 +98218,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "xWm" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_y = 3
+	},
+/turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "xWn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -95340,6 +98232,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"xWy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/bar/atrium)
 "xWE" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/machinery/door/airlock/atmos,
@@ -95418,10 +98317,15 @@
 /turf/open/floor/iron/white/herringbone,
 /area/station/maintenance/ghetto/starboard/aft)
 "xXO" = (
-/obj/structure/railing{
-	dir = 5
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/platform,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/turf/open/floor/glass,
+/obj/structure/reagent_dispensers/water_cooler{
+	pixel_y = 10
+	},
+/turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "xXQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -95456,8 +98360,8 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/turf/open/misc/beach/sand,
-/area/station/service/hydroponics)
+/turf/open/misc/sandy_dirt,
+/area/station/service/hydroponics/upper)
 "xYj" = (
 /obj/machinery/door/airlock,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -95613,9 +98517,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
 "yam" = (
-/obj/structure/chair/comfy/brown{
-	color = "#514E58"
-	},
 /obj/machinery/light/directional/west,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -95749,9 +98650,7 @@
 /obj/machinery/chem_dispenser/drinks/beer{
 	pixel_y = 8
 	},
-/obj/structure/sign/picture_frame/portrait/bar{
-	pixel_y = 28
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "ycf" = (
@@ -96055,6 +98954,26 @@
 "ygq" = (
 /turf/open/floor/carpet/black,
 /area/station/commons/lounge)
+"ygv" = (
+/obj/structure/railing/corner/end/flip{
+	dir = 4;
+	color = "#6e6e6e"
+	},
+/obj/effect/turf_decal/trimline/white/arrow_cw{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/white/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/secondary/service)
+"ygA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "ygO" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -96077,7 +98996,7 @@
 /obj/item/reagent_containers/spray/plantbgone,
 /obj/item/watertank,
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "ygZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/binary/valve/on{
@@ -96267,6 +99186,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
+"yjq" = (
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/wood/parquet,
+/area/station/hallway/secondary/service)
 "yjy" = (
 /obj/structure/table/optable,
 /turf/open/floor/iron/dark,
@@ -96428,6 +99352,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"ylo" = (
+/obj/effect/turf_decal/tile/green/half,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/edge,
+/area/station/service/hydroponics/upper)
 "ylp" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -96451,7 +99381,7 @@
 	pixel_y = 9
 	},
 /turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
+/area/station/service/hydroponics/upper)
 "ylO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/effect/turf_decal/tile/blue{
@@ -126443,14 +129373,14 @@ txs
 guN
 bsv
 guN
-vbK
-doz
-doz
-doz
-doz
-doz
-hUE
-doz
+guN
+guN
+guN
+guN
+guN
+guN
+guN
+guN
 phd
 qBZ
 tZW
@@ -126698,16 +129628,16 @@ ceC
 ceC
 doz
 guN
-bsv
+skM
 guN
-vbK
-doz
-doz
-doz
-doz
-doz
-hUE
-doz
+bsv
+liU
+bsv
+bsv
+bsv
+svx
+rAv
+kJJ
 phd
 phd
 phd
@@ -126957,15 +129887,15 @@ doz
 guN
 bsv
 guN
-vbK
-doz
-doz
-doz
-doz
-doz
-hUE
-ceC
-doz
+bsv
+guN
+guN
+guN
+bsv
+bsv
+bsv
+bsv
+guN
 doz
 doz
 job
@@ -127213,16 +130143,16 @@ doz
 doz
 guN
 bsv
+cfA
+bsv
 guN
-vbK
 doz
-doz
-doz
-doz
-doz
-hUE
-hUE
-hUE
+guN
+guN
+guN
+guN
+skM
+guN
 hUE
 hUE
 hUE
@@ -127469,17 +130399,17 @@ doz
 ceC
 ceC
 guN
-ldD
+kJJ
+hLM
+hLM
 guN
-vbK
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
 doz
+doz
+doz
+doz
+guN
+bsv
+guN
 doz
 isY
 isY
@@ -127726,17 +130656,17 @@ vbK
 vbK
 doz
 guN
+guN
+guN
+qIN
+guN
+ceC
+ceC
+ceC
+ceC
+guN
 bsv
 guN
-vbK
-doz
-doz
-doz
-ceC
-doz
-doz
-ceC
-doz
 doz
 doz
 ceC
@@ -127983,17 +130913,17 @@ hpP
 vbK
 txs
 guN
-bsv
+kJJ
 guN
-vbK
+hLM
+guN
 doz
 doz
 doz
-ceC
 doz
-doz
-ceC
-doz
+guN
+skM
+guN
 doz
 doz
 ceC
@@ -128239,18 +131169,18 @@ pRz
 hpP
 vbK
 jUu
+sVY
+hLM
+lsH
+hLM
+guN
+ceC
+ceC
+ceC
+ceC
 guN
 bsv
 guN
-guN
-guN
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-doz
 doz
 doz
 ceC
@@ -128493,27 +131423,27 @@ hpP
 uPq
 oEt
 drD
+hpP
+hpP
 jZk
-vbK
+nSR
+nSR
+nSR
+nSR
+hpP
 doz
+doz
+doz
+guN
 guN
 bsv
-tRT
-aPM
 guN
-doz
-doz
-ceC
-doz
-doz
-ceC
-doz
-doz
-doz
-ceC
-ceC
-ceC
-doz
+guN
+guN
+guN
+guN
+mOI
+mOI
 doz
 doz
 ceC
@@ -128750,34 +131680,34 @@ rnx
 rOp
 qCq
 drD
-jZk
-vbK
+hpP
+rNV
+yeH
+nyd
+rmN
+uFx
+kEv
+nSR
+doz
+doz
 doz
 guN
-kJJ
-hLM
 bsv
-guN
-doz
-doz
-ceC
-doz
-doz
-ceC
-doz
-doz
-doz
-ceC
-doz
-ceC
-doz
-doz
-doz
-ceC
-doz
-doz
-doz
-doz
+bsv
+bsv
+skM
+liU
+bsv
+kkI
+dlM
+mOI
+mOI
+mOI
+mOI
+mOI
+mOI
+mOI
+mOI
 ceC
 vbK
 jEk
@@ -129007,34 +131937,34 @@ hpP
 vFz
 oEt
 gLw
-jZk
-vbK
-vbK
+wjz
+cjh
+pri
+wCk
+fkt
+uXd
+vrw
+nSR
 guN
 guN
 guN
-jqE
+guN
+bsv
 guN
 guN
 guN
 guN
 guN
 guN
-vbK
-doz
-doz
-doz
-ceC
-doz
-ceC
-doz
-doz
-doz
-ceC
-doz
-doz
-doz
-doz
+dlM
+gxo
+dEJ
+bBe
+bBe
+rqb
+dlM
+dlM
+mOI
 doz
 mOI
 jGX
@@ -129264,34 +132194,34 @@ hpP
 umj
 kMk
 oyq
-hpP
-vbK
-jEk
-sVY
-hLM
-iyE
-bsv
-bsv
-bsv
+xBh
+brd
+knZ
+sZz
+hZY
+hZY
+kaz
+nSR
+hvU
+wNH
 bsv
 bsv
 bsv
 guN
+doz
 ceC
-vbK
-vbK
-vbK
-vbK
-ceC
-vbK
-ceC
-ceC
-vbK
-vbK
-vbK
-ceC
-vbK
-vbK
+doz
+doz
+guN
+mOI
+pkq
+tXJ
+cbv
+naU
+mOI
+mOI
+dlM
+mOI
 doz
 mOI
 dGY
@@ -129521,33 +132451,33 @@ hpP
 rki
 uvJ
 oyq
-hpP
-hpP
-jZk
+wjz
+knT
+gfU
+uvJ
+ioy
+ohn
+kuW
 nSR
-nSR
-nSR
-nSR
+mFZ
+wNH
+svx
 guN
 guN
 guN
-hvU
-bsv
-guN
-guN
-guN
-guN
-guN
-guN
-guN
+ceC
+ceC
+ceC
+ceC
+ceC
 mOI
 mOI
 mOI
 mOI
 mOI
 mOI
-mOI
-mOI
+hzl
+tZn
 mOI
 mOI
 mOI
@@ -129776,36 +132706,36 @@ plA
 ukM
 hpP
 sJU
-kMk
+kpI
 uaA
 hpP
-rNV
-yeH
-uvJ
-uFx
-kEv
+hds
+iCg
+oEt
+rHD
+plj
+rtu
 nSR
+xws
+wNH
+bdK
+guN
+doz
+doz
+doz
 ceC
 doz
-guN
-bdK
-bsv
-bsv
-nTj
-bsv
-bsv
-bsv
-eDw
-bsv
-rqb
-bBe
-dEJ
-bBe
-bBe
-rqb
-dlM
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+mOI
+qXM
 cTa
-dlM
+fjz
 dlM
 dlM
 dlM
@@ -130035,34 +132965,34 @@ hpP
 amI
 uvJ
 cgz
-wjz
-cjh
-amI
-tPg
-vrw
-rtl
 nSR
-ceC
+nSR
+nSR
+nSR
+nSR
+rtl
+rtl
+rtl
+raA
+snB
+raA
+raA
+raA
+raA
+raA
+raA
+raA
+raA
+iZA
+iZA
 doz
-guN
-guN
-tHN
-tHN
-guN
-uVw
-guN
-guN
-guN
-guN
+doz
+doz
+doz
 mOI
-uhA
-dWX
-bSG
-knZ
-mOI
-mOI
-mOI
-pkq
+fAb
+uco
+iEa
 dvk
 mOI
 mOI
@@ -130282,43 +133212,43 @@ bUU
 nYm
 ixJ
 vgn
-nSR
 hpP
+yjl
+yjl
+yjl
+qTw
+tXm
+amI
+dgR
+amI
+dJh
+hIl
 jVO
 wvJ
 dGM
 iET
-hpP
-amI
-dgR
-dJh
-xBh
-brd
-kpI
-cfA
-kaz
-fFe
-nSR
-ceC
-doz
-doz
-doz
-ceC
-vbK
-guN
-hLM
-guN
-ceC
-doz
-doz
-mOI
+raA
+vuf
+vuf
+cRr
+mWh
+cRr
+pYQ
+srW
+raA
+lnU
+bvY
+cHj
+tWV
+vWm
+gnI
 iZA
-iCg
-vox
-hxX
+iZA
+doz
+doz
 mOI
-hzl
-pyx
+mOI
+mOI
 rzS
 dGY
 nPs
@@ -130540,43 +133470,43 @@ yaz
 faT
 uXV
 nSR
-nSR
-hZY
-rTy
-amI
-amI
+yjl
+hpP
+hpP
+hpP
+bqM
 bBM
 fuM
 wLE
 cgz
-wjz
-knT
+xYj
+rFF
 pAB
-mWh
-kuW
-cki
-nSR
-ceC
-ceC
-ceC
-ceC
-ceC
-vbK
-guN
-cFS
-guN
-ceC
+amI
+amI
+raA
+aWb
+aWb
+spi
+ugs
+col
+cfX
+pec
+raA
+nbO
+vPK
+paU
+oqM
+hzy
+wFf
+mca
+iZA
 vbK
 doz
+ceC
+ceC
+doz
 mOI
-mca
-skM
-wOV
-hFL
-mOI
-fAb
-uco
-iEa
 eXr
 pCC
 rMh
@@ -130797,42 +133727,42 @@ xeB
 qGg
 qGg
 qGg
-nSR
+yjl
 kHI
 sdc
-pri
-pIw
-xYj
-kGB
-kMk
-fME
 hpP
-sZz
-uCO
-plj
-rtu
-hwz
-nSR
+wkX
+wkX
+wkX
+wkX
+wkX
+wkX
+wkX
+wkX
+wkX
+raA
+raA
+wOV
+oTV
+gNt
+eZs
+jKr
+oTV
+wOV
+raA
+raA
+kBu
+xJX
+ckY
+lJm
+uFT
+kDA
+iZA
+iZA
+ceC
 ceC
 doz
-doz
-doz
 ceC
-vbK
-ceC
-jEk
-ceC
-ceC
-vbK
-doz
-mOI
-mOI
-mOI
-mOI
-mOI
-mOI
-mOI
-mOI
 mOI
 mOI
 mOI
@@ -131053,41 +133983,41 @@ aLe
 aLe
 aLe
 hvE
-qGg
-uiH
-uvJ
+wYp
+hpP
+hpP
 lSU
 gSq
-rBZ
+wkX
 dwb
-bqM
+xEa
 gTC
 iWD
-nSR
-nSR
-jZk
-nSR
-nSR
-nSR
-nSR
+oEZ
+lEK
+pyx
+lqt
+raA
+lVT
+eDc
+opZ
+kvQ
+eHI
+aQX
+dJX
+vYT
+cvB
+raA
+gbO
+dAy
+qST
+hXB
+lPa
+cRy
+sFs
+iZA
+doz
 ceC
-doz
-doz
-doz
-ceC
-vbK
-doz
-ceC
-doz
-jEk
-vbK
-doz
-doz
-doz
-doz
-doz
-doz
-doz
 doz
 ceC
 doz
@@ -131310,41 +134240,41 @@ vbK
 ceC
 aLe
 qzS
-qGg
-uiH
+lZF
+vcM
 azG
-fPT
-iOg
-nyd
-hpP
-nSR
+sdc
+oEt
+wkX
+gga
+stF
 uiH
-rNp
-nSR
+wkX
+xgM
+kGA
+jDu
+bWQ
+raA
+eyg
+hcs
+vDW
+ezz
+jyV
+pCA
+kFW
+sUK
+nbl
+raA
+vBP
+wjd
+pIw
+kTA
+kTA
+kTA
+uDD
+iZA
+doz
 ceC
-vbK
-doz
-doz
-doz
-doz
-ceC
-doz
-doz
-doz
-ceC
-vbK
-doz
-ceC
-doz
-vbK
-vbK
-doz
-doz
-doz
-doz
-doz
-doz
-doz
 doz
 doz
 ceC
@@ -131567,39 +134497,39 @@ doz
 ceC
 aLe
 qzS
-qGg
-nSR
-nSR
-nSR
-nSR
-nSR
-nSR
-nSR
+hWY
+xfj
+oEt
+plj
+fkt
+dQW
+oCT
+uCO
 gNa
-qzS
-wYp
-ceC
-vbK
-vbK
-vbK
-vbK
-vbK
-ceC
-vbK
-vbK
-vbK
-vbK
-jEk
-doz
+fDi
+hwz
+abq
+hlb
+xIq
 raA
-nMK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
+bFy
+gHN
+uwz
+ezz
+mqb
+pCA
+eLX
+sUK
+lOA
+raA
+hQL
+wjd
+ckY
+kTA
+kTA
+eZs
+nTj
+iZA
 vbK
 vbK
 vbK
@@ -131824,42 +134754,42 @@ ceC
 ceC
 aLe
 lKu
-qGg
-xeB
-qGg
+fBU
 rXX
-qGg
-xeB
-qGg
+rVd
+rXX
+feU
+wkX
+pDH
 ple
-qGg
-tTo
-aLe
-ceC
-vbK
+rgy
+cmt
+sAk
+vyz
+pkk
+bYq
+raA
+pCa
+iMh
+tNq
 wUZ
-doz
-doz
-uXq
-ceC
-wUZ
-doz
-doz
-wUZ
-vbK
-doz
-ceC
-lqh
-vbK
-doz
+jWt
+kkG
+hcY
+hcY
+gWh
+sdD
+hxX
+eGy
+oqM
+cSk
+oRu
+eTo
+tCm
+iZA
 doz
 job
 doz
-doz
-job
-doz
-doz
-job
 doz
 doz
 jEk
@@ -132086,36 +135016,36 @@ aLe
 aLe
 aLe
 aLe
-aLe
-aLe
-aLe
-aLe
+wkX
+wkX
+wkX
+wkX
 aCd
-aLe
-ceC
+dry
+rBw
+rTy
+xgZ
+raA
+wOV
+iex
+fqU
+kRI
+fvf
+pCA
+kTA
+kTA
+jYu
+iYD
+gNJ
+uTl
+ckY
+kOU
+iOg
+kDA
+iZA
+iZA
 vbK
-vbK
-vbK
-vbK
-vbK
-ceC
-vbK
-vbK
-vbK
-vbK
-vbK
-doz
-cfT
-lqh
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
+mXG
 vbK
 vbK
 vbK
@@ -132346,33 +135276,33 @@ doz
 doz
 doz
 vbK
-pNZ
-vfq
-pNZ
-ceC
-vbK
-doz
-doz
-doz
-ceC
-ceC
-doz
-doz
-doz
-ceC
-vbK
-nMK
+wkX
+cIu
+fBH
+lQG
+sOm
+vzA
 raA
-lqh
+sVf
+oIJ
+rYe
+gXA
+euV
+jrE
+vgO
+pKP
+vCA
+ayP
+hiq
+xCG
+qST
+mMv
+gsW
+eIx
+iZA
+vbK
+doz
 ceC
-doz
-doz
-doz
-doz
-doz
-ceC
-doz
-doz
 doz
 doz
 doz
@@ -132603,32 +135533,32 @@ vbK
 vbK
 vbK
 vbK
-pNZ
-vfq
-pNZ
-ceC
+wkX
+wkX
+wkX
+wkX
+obz
+wkX
+raA
+xwG
+raA
+raA
+xWy
+raA
+raA
+raA
+hIx
+raA
+raA
+uAP
+jqE
+czW
+rAt
+iZA
+iZA
+iZA
 vbK
 doz
-doz
-ceC
-doz
-ceC
-doz
-doz
-doz
-ceC
-vbK
-doz
-ceC
-cOR
-ceC
-doz
-doz
-doz
-doz
-doz
-ceC
-ceC
 ceC
 doz
 doz
@@ -132859,34 +135789,34 @@ doz
 ceC
 doz
 doz
-job
-qqz
-vfq
-qqz
-ceC
 vbK
-ceC
-ceC
+pNZ
+eJq
+pNZ
+ooL
+xbr
+vUG
+sPh
+hnc
+raA
+eIo
+jdE
+bCG
+raA
+aPM
+cfm
+ejC
+raA
+raA
+raA
+raA
+iZA
+iZA
 doz
 doz
-ceC
 doz
 doz
-doz
-ceC
-vbK
-doz
-ceC
-hUE
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-doz
-ceC
+unE
 doz
 doz
 doz
@@ -133118,31 +136048,31 @@ doz
 doz
 vbK
 pNZ
-vfq
-pNZ
-ceC
-vbK
-doz
-doz
-doz
-doz
-ceC
-doz
-doz
-doz
-ceC
-vbK
-lqh
-job
-doz
-vbK
-doz
-doz
+hFL
+lVy
+qwC
+moO
+gGl
+mNs
+nmO
+raA
+tor
+cGB
+ldD
+raA
+vAP
+jtX
+fxH
+wRT
 doz
 ceC
 doz
-ceC
-vbK
+doz
+doz
+doz
+doz
+doz
+doz
 ceC
 doz
 doz
@@ -133375,31 +136305,31 @@ vbK
 vbK
 vbK
 pNZ
-vfq
+cof
 pNZ
-ceC
-vbK
-vbK
-vbK
-vbK
-vbK
-ceC
-vbK
-vbK
-vbK
-vbK
-vbK
-lqh
+uZU
+xTr
+nSz
+aXJ
+ygv
 raA
-doz
-vbK
-vbK
-doz
-doz
-doz
-doz
+uuc
+miT
+qTl
+raA
+lVL
+psp
+tOb
+raA
 ceC
 vbK
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
 vbK
 vbK
 vbK
@@ -133632,35 +136562,35 @@ uXq
 doz
 vbK
 pNZ
-vfq
+iYF
 pNZ
-ceC
-vbK
-wUZ
-doz
-doz
-job
-ceC
-wUZ
-doz
-doz
-wUZ
-vbK
-nMK
-ceC
-doz
-jEk
-vbK
-doz
-doz
-doz
+rbH
+xTr
+qzI
+rko
+iQW
+raA
+raA
+raA
+raA
+raA
+raA
+raA
+raA
+raA
 doz
 ceC
-vbK
+doz
+doz
+doz
+doz
 doz
 ceC
+doz
+doz
+doz
 ceC
-ceC
+doz
 doz
 doz
 doz
@@ -133888,24 +136818,24 @@ vbK
 mqq
 vbK
 vbK
-qqz
-vfq
-qqz
-jEk
-vbK
-vbK
-vbK
-vbK
-vbK
-ceC
-vbK
-vbK
-vbK
-vbK
-vbK
-nMK
+pNZ
+eQX
+pNZ
+xOr
+uIn
+gNr
+fTH
+bQn
+wWh
+oIg
+qaE
+ldb
+sXK
+sOd
+wWh
+doz
+doz
 job
-hUE
 vbK
 vbK
 ceC
@@ -133913,7 +136843,7 @@ ceC
 ceC
 ceC
 ceC
-ceC
+doz
 doz
 doz
 ceC
@@ -134145,25 +137075,25 @@ doz
 doz
 doz
 vbK
+qqz
+iYF
 pNZ
-vfq
-pNZ
-doz
+iNr
 xTr
+hke
+qcp
+mpX
+wWh
+uGq
+hFc
+vox
+sXk
+hmM
+wWh
 doz
-hUE
 doz
 doz
-ceC
-doz
-doz
-doz
-ceC
 vbK
-cOR
-job
-doz
-vbK
 doz
 doz
 doz
@@ -134171,7 +137101,7 @@ doz
 doz
 ceC
 doz
-ceC
+doz
 doz
 ceC
 doz
@@ -134402,23 +137332,23 @@ doz
 doz
 doz
 vbK
+qqz
+cof
 pNZ
-vfq
-pNZ
+wCH
+xTr
+epA
+iYW
+hky
+sDM
+cRk
+dcl
+lyW
+lyW
+sWx
+wWh
 doz
-job
 doz
-hUE
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-vbK
-hUE
-raA
 doz
 jEk
 doz
@@ -134660,22 +137590,22 @@ doz
 vbK
 vbK
 pNZ
-vfq
+eQX
 pNZ
-doz
-job
-doz
-hUE
-doz
-doz
+uOO
+uxx
+fFe
+gUN
+cwa
+wWh
+bSG
+bka
+lyW
+lre
+cXX
+wWh
 ceC
-doz
-doz
-doz
 ceC
-vbK
-doz
-job
 cOR
 ceC
 vbK
@@ -134915,24 +137845,24 @@ doz
 doz
 doz
 vbK
+vMn
 pNZ
+iYF
 pNZ
-hEM
-asK
 tqK
 xkQ
-asK
-pNZ
+rfN
+lpU
+klF
+wWh
+ugR
+lyW
+lyW
+gyK
+cXX
+wWh
 doz
 doz
-ceC
-doz
-doz
-doz
-ceC
-jEk
-doz
-ceC
 lqh
 ceC
 vbK
@@ -135172,23 +138102,23 @@ vbK
 vbK
 vbK
 vbK
+vMn
 pNZ
-vpn
 kKA
-fDi
-vpn
-yaI
+pNZ
+nrH
 jJb
-qqz
-job
-doz
+jJb
+nbV
+nrH
+nrH
+nrH
+wWh
+wWh
+wWh
+wWh
+wWh
 ceC
-doz
-doz
-doz
-ceC
-vbK
-doz
 ceC
 hUE
 ceC
@@ -135429,24 +138359,24 @@ doz
 uXq
 doz
 vbK
+vMn
 pNZ
-klF
 cof
 jfa
-vpn
-jPb
+nrH
+gHM
 ayw
-qqz
-job
-job
-vbK
-vbK
-ceC
-ceC
-ceC
-vbK
-hUE
-txs
+cki
+qnC
+tXs
+nrH
+lXK
+mfx
+iym
+mSO
+jJb
+doz
+doz
 doz
 ceC
 vbK
@@ -135686,24 +138616,24 @@ vbK
 vbK
 vbK
 vbK
+vMn
 pNZ
-yaI
 iYF
-kvl
-kvl
-kvl
-asK
-asK
-asK
-asK
-asK
-vbK
+ygA
+lrM
+hwN
+kPl
+ueJ
+ckj
+eKl
+bti
+rBf
+lZb
+wPU
+lyJ
+bti
 doz
 doz
-ceC
-vbK
-cOR
-raA
 doz
 ceC
 vbK
@@ -135943,24 +138873,24 @@ doz
 doz
 doz
 vbK
+vMn
 pNZ
-aCq
 eQX
-kvl
-eOa
+scv
+nrH
 vmY
 oMD
 hHb
 dZX
-eOa
-asK
-vbK
+tYO
+jgg
+rBZ
+iaz
+aOR
+vwk
+bti
 doz
 doz
-ceC
-vbK
-lqh
-ceC
 nMK
 ceC
 vbK
@@ -136200,24 +139130,24 @@ doz
 doz
 doz
 vbK
+vMn
 pNZ
-yaI
 iYF
-qqz
-uuc
-yaI
-yaI
-aCq
-yaI
-yaI
+uSZ
+nrH
+fED
+hEM
+wSl
+aTN
+plq
 bti
-vbK
+fME
+oht
+pON
+iML
+bti
 doz
 doz
-ceC
-vbK
-hUE
-job
 doz
 ceC
 txs
@@ -136458,23 +139388,23 @@ pNZ
 pNZ
 pNZ
 pNZ
-oht
-iYF
-wXK
-yaI
-yaI
-yaI
-yaI
+pNZ
+eVl
+xOl
+nrH
+oQI
+iZg
+aDd
 wzK
 eGb
-bti
-vbK
+nrH
+luS
+mfx
+njp
+vmn
+jJb
 doz
 doz
-ceC
-vbK
-doz
-ceC
 doz
 ceC
 vbK
@@ -136715,23 +139645,23 @@ aTb
 jFO
 tOk
 pNZ
-wZR
-eQX
-wXK
-yaI
-aCq
-yaI
-yaI
-wzK
-gbO
-asK
-vbK
+pNZ
+prv
+pNZ
+nrH
+nrH
+nrH
+jJb
+nrH
+nrH
+nrH
+nrH
+jJb
+jJb
+nrH
+nrH
 doz
 doz
-ceC
-vbK
-nMK
-ceC
 hUE
 ceC
 vbK
@@ -136971,24 +139901,24 @@ jql
 aTb
 vkd
 sHi
-tzu
-vpn
+pNZ
+pNZ
 eVl
-asK
+pNZ
 koq
-vpn
+xJQ
 xBP
-fwa
-wCH
 asK
-asK
-vbK
-vbK
-vbK
-vbK
-vbK
 doz
-raA
+ceC
+doz
+doz
+doz
+ceC
+doz
+doz
+doz
+doz
 lqh
 jEk
 vbK
@@ -137229,23 +140159,23 @@ tbe
 aCq
 hku
 pNZ
-tbQ
-tbQ
-eLX
-hKc
+pNZ
+nOr
+pNZ
+eOa
 tCo
 mcK
-jDu
-mcK
-jfD
 asK
-vbK
-doz
-wUZ
-doz
+ceC
 vbK
 ceC
-jEk
+ceC
+ceC
+vbK
+ceC
+ceC
+ceC
+ceC
 ceC
 ceC
 vbK
@@ -137486,21 +140416,21 @@ jmc
 ugK
 odU
 pNZ
-tfN
-wZR
+wsk
+gMj
 dGC
 yaI
 yaI
 xWm
-aCq
-fBU
-wsk
-bti
-vbK
-vbK
-vbK
+asK
+doz
 ceC
-job
+doz
+doz
+doz
+ceC
+doz
+doz
 ipz
 oFI
 ipz
@@ -137742,22 +140672,22 @@ wip
 wip
 qKz
 oOk
-tzu
-fqC
-wZR
-qqz
-vpn
-yaI
-yaI
-vpn
-tXm
-yaI
-bti
-vbK
-doz
+pNZ
+tbQ
+oPO
+pNZ
+ejp
+wcb
+gZc
+asK
 ceC
-doz
 vbK
+ceC
+ceC
+ceC
+vbK
+ceC
+ceC
 ipz
 qTP
 ipz
@@ -137999,20 +140929,20 @@ swT
 ygh
 eBA
 cox
-tzu
-pcX
-vpn
-asK
+pNZ
+tbQ
+rOQ
+pNZ
 eOa
-kDA
+wZR
 ibH
-hHb
-cIu
-eTo
 asK
-vbK
+doz
+ceC
 doz
 doz
+doz
+ceC
 doz
 ipz
 ipz
@@ -138258,11 +141188,11 @@ qZo
 qow
 tzu
 tbQ
-wZR
-asK
-asK
-asK
-asK
+kLD
+pNZ
+pNZ
+pNZ
+pNZ
 kvl
 kvl
 kvl
@@ -138515,7 +141445,7 @@ qZo
 uMY
 pNZ
 tbQ
-vpn
+rOQ
 qbN
 wXK
 aTF
@@ -138772,7 +141702,7 @@ uaD
 feE
 pNZ
 iUi
-vpn
+rOQ
 vpn
 aCq
 yaI
@@ -139029,7 +141959,7 @@ sLy
 pNZ
 pNZ
 tbQ
-wCV
+sFZ
 pNZ
 pNZ
 pNZ
@@ -139286,7 +142216,7 @@ xxv
 sRR
 pNZ
 tbQ
-wCV
+sFZ
 lKn
 pNZ
 nDT
@@ -195833,15 +198763,15 @@ xZM
 fmN
 kNp
 yam
-aTN
+wFA
 dfB
-iQW
-ygq
+rKe
+mgs
 lAs
-ygq
+mgs
 rKe
 xME
-rHD
+wFA
 qUG
 vOa
 ckR
@@ -196091,13 +199021,13 @@ mDh
 bZl
 cTV
 ooh
-wzM
+oZM
 ugf
 feX
-cfm
-nbO
+feX
+feX
 aqF
-aae
+oZM
 tex
 lvA
 vOa
@@ -196340,7 +199270,7 @@ kFR
 nEu
 fzc
 pld
-pld
+fqC
 pld
 oSL
 pld
@@ -196348,15 +199278,15 @@ vss
 kOB
 aae
 tsi
-wzM
+wFA
 xXO
 iAR
-iAR
-iAR
+tPg
+qtS
 vZV
-aae
-nUa
-wzM
+wFA
+hjI
+peZ
 iEr
 ckR
 nke
@@ -196596,22 +199526,22 @@ oVh
 kFR
 nEu
 iMZ
-gnf
-gnf
-wjd
-gnf
+nZT
+vPg
+nZT
+nZT
 nZT
 nZT
 nZT
 fCk
 fPr
-wzM
-hfy
-hfy
+tHv
+fkw
+wxw
 dSp
-hfy
-hfy
-aae
+oDo
+ltI
+tHv
 nUa
 hcl
 vOa
@@ -196853,22 +199783,22 @@ fgy
 fgy
 ltg
 dtY
-gnf
+nZT
 dRC
 onP
-gnf
+dbU
 nSw
 nCO
 dTC
 cIN
 cqq
 nZS
-cYq
+fwa
 kRc
 gbn
 cYq
-kRc
-vwk
+doJ
+nZS
 lsl
 jKI
 vOa
@@ -197110,21 +200040,21 @@ kcP
 oAt
 oAt
 hlF
-gnf
+nZT
 qiU
-iPQ
-gnf
+qiU
+nZT
 xKI
 mjV
 aAf
-cIN
+aPq
 uAx
 bSs
-bSs
-bSs
+lgl
+rNp
 oYP
-bSs
-bSs
+rNp
+bEz
 bSs
 diW
 wzM
@@ -197367,10 +200297,10 @@ fgy
 jCm
 nEu
 lEU
-gnf
-gnf
-vUG
-gnf
+nZT
+nZT
+nZT
+nZT
 yce
 mtA
 aAf
@@ -197379,7 +200309,7 @@ uAx
 acF
 fnW
 hfy
-pLn
+iAM
 hfy
 hfy
 aQk
@@ -197625,9 +200555,9 @@ fgy
 gBt
 fFk
 riH
-gnf
-iPQ
-gnf
+nZT
+jnj
+nZT
 dcd
 xiF
 aAf
@@ -197637,7 +200567,7 @@ vjb
 hfy
 hfy
 pLn
-miT
+hfy
 hfy
 qDi
 diW
@@ -197882,13 +200812,13 @@ hVT
 oAt
 iMZ
 qoW
-gnf
-iPQ
-gnf
+nZT
+bEo
+nZT
 mID
 qnd
 aAf
-cIN
+aPq
 uAx
 ygq
 aJw
@@ -197897,7 +200827,7 @@ pLn
 qca
 jVn
 ygq
-aae
+phh
 wzM
 iEr
 ckR
@@ -198139,21 +201069,21 @@ kNp
 cNI
 iMZ
 ixF
-gnf
+nZT
 eGV
-gnf
+nZT
 mam
 qnd
 jdL
 cIN
 wrA
+wiG
 wFA
 wFA
+lpC
 wFA
 wFA
-wFA
-wFA
-wFA
+uhA
 eUM
 bOe
 vOa
@@ -198396,9 +201326,9 @@ nvx
 oAt
 iMZ
 qNp
-gnf
-iPQ
-gnf
+nZT
+sOT
+nZT
 nsJ
 dog
 fvT
@@ -198652,17 +201582,17 @@ kNp
 kNp
 mIQ
 iMZ
-uSZ
-gnf
+nEu
+kru
 mFl
 aAk
 kAm
 bMH
-nZT
-wCk
-fBH
-wCk
-nZT
+pHh
+pHh
+pHh
+pHh
+pHh
 tvf
 rVW
 rVW
@@ -198909,18 +201839,18 @@ kNp
 phQ
 nEu
 iMZ
-nEu
-gnf
+kNp
+nZT
 tvm
-gnf
+nZT
 itk
 cXG
-nZT
+pHh
 mFx
 gjY
-naU
-nZT
+pHh
 nGu
+dKr
 dKr
 dKr
 dKr
@@ -199167,17 +202097,17 @@ eEF
 nEu
 caW
 vix
+xVw
+cTS
 vix
-kBu
-vix
-pKP
-hcY
-nZT
+pHh
+pHh
+pHh
 qMX
 lVc
-lEK
-nZT
-qcp
+pHh
+hRN
+dKr
 uVD
 gry
 dOW
@@ -199425,18 +202355,18 @@ wzH
 iSs
 vix
 rOn
-cTS
-vix
-nZT
+vNk
+ran
+pHh
 mEo
-nZT
-nZT
+oim
+xxt
 qPl
-nZT
-nZT
+pHh
+ayU
 feW
 uGP
-mcM
+uVU
 pwo
 dKr
 qio
@@ -199683,16 +202613,16 @@ fsn
 hMB
 eeN
 tvt
-rYe
-wkX
+cTS
+pHh
 oiA
-xOl
+bNo
 bNo
 eef
-wkX
+kwS
 mQv
 vyQ
-vMn
+dKr
 jGO
 moM
 qjB
@@ -199946,9 +202876,9 @@ jJL
 oOG
 fxV
 fgR
-wkX
+hKc
 obW
-dKr
+lya
 jWz
 mcM
 pak
@@ -200198,14 +203128,14 @@ vix
 rlr
 xFd
 tli
-lyJ
+pHh
 kAC
 eMv
 qbT
 lNm
-wkX
+pHh
 rUZ
-dKr
+lya
 gVV
 gry
 lWz
@@ -200455,15 +203385,15 @@ vix
 mdy
 wyD
 uxp
-wkX
-wkX
-wkX
-wkX
-wkX
-wkX
+pHh
+nar
+tKo
+dmh
+fPT
+pHh
 tKk
+lya
 dKr
-vMn
 dKr
 dKr
 dKr
@@ -200712,21 +203642,21 @@ vix
 mfF
 rzJ
 dRD
-ooL
-oqM
-vgO
-lyW
-cXX
+vix
+vix
+vix
+vix
+fSS
 pHh
 uqu
+lya
 dKr
-vMn
 unf
 pLB
 uHo
 jBk
 ibV
-nrH
+dWX
 dXc
 nke
 ckR
@@ -200969,15 +203899,15 @@ vix
 fZQ
 klS
 dle
-wWh
-ioy
+yjq
+rOn
 dbs
-lyW
-jnj
+rOn
+tli
 pHh
 tIt
 lya
-lya
+dKr
 kIg
 kvX
 aSb
@@ -201227,17 +204157,17 @@ uax
 bsy
 hCo
 iSS
-cGB
-hWY
-gyK
-gyK
+iSS
+iSS
+iSS
+iSS
 iEj
 knI
-dKr
+hJN
 fxv
 mdc
 wCj
-wCj
+fot
 xYd
 voK
 obc
@@ -201482,22 +204412,22 @@ pzY
 vix
 jtn
 tli
-kTA
-wWh
+dRD
+rOn
 gtl
 uyt
 jZY
 hER
 pHh
 dKr
-dKr
+hJN
 dKY
 eDH
 qWE
 rWM
-xYd
+kSN
 ome
-nrH
+dWX
 fHn
 nke
 ckR
@@ -201739,22 +204669,22 @@ jkH
 vix
 sjU
 tli
-lJm
-wWh
-rVd
-mpX
-qTw
-cXX
+dRD
+pRT
+vix
+vix
+vix
+vix
 pHh
 eUf
 tJk
 pHh
-nrH
-nrH
-nrH
+dWX
+dWX
+dWX
 sRo
-nrH
-nrH
+dWX
+dWX
 nYw
 nke
 ckR
@@ -201996,13 +204926,13 @@ wdZ
 vix
 vix
 rFc
-bFy
-nrH
-nrH
-nrH
-nrH
-nrH
-nrH
+dRD
+dWX
+dWX
+teP
+jWd
+dWX
+dWX
 hXp
 uGI
 vLR
@@ -202258,10 +205188,10 @@ ean
 sdY
 dlg
 mvc
-nrH
+dWX
 ctG
 rKR
-chW
+aAe
 keB
 chW
 keB
@@ -202509,13 +205439,13 @@ jKe
 wdZ
 acm
 vix
-tli
+imX
 koD
 stY
 ocv
 xaT
 ygU
-nrH
+dWX
 toE
 vAa
 mcF
@@ -202768,13 +205698,13 @@ gnf
 gnf
 gnf
 gAA
-gnf
+dWX
 dND
 isp
 isp
 oqP
 uRd
-uDi
+ylo
 cJY
 qTE
 qTE
@@ -203025,11 +205955,11 @@ fAH
 qIS
 fAH
 wRN
-gnf
+dWX
 nih
 frW
 lRd
-nrH
+dWX
 fDQ
 uDi
 iuM
@@ -203282,11 +206212,11 @@ jrF
 jrF
 jrF
 wRN
-gnf
+dWX
 jgw
 jki
 lnG
-nrH
+dWX
 aNY
 fxO
 chW
@@ -203539,11 +206469,11 @@ jrF
 iPQ
 jyv
 nPl
-gnf
+dWX
 qSe
 aqw
 uNV
-nrH
+dWX
 jtO
 ngN
 rPH
@@ -203796,11 +206726,11 @@ iPQ
 tAH
 gnf
 uWh
-gnf
+dWX
 ngz
 wYg
 ylA
-nrH
+dWX
 oBh
 hEZ
 lAG
@@ -204053,21 +206983,21 @@ iPQ
 jyv
 oiL
 uWh
-gnf
-gnf
-gnf
-gnf
-gnf
-gnf
-gnf
-gnf
-gnf
-gnf
-gnf
-nrH
-nrH
-nrH
-nrH
+dWX
+dWX
+dWX
+dWX
+dWX
+dWX
+dWX
+dWX
+dWX
+dWX
+dWX
+dWX
+dWX
+dWX
+dWX
 lGE
 rWB
 lGE

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -10825,6 +10825,13 @@
 /obj/structure/sign/warning/electric_shock/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"cEN" = (
+/obj/structure/flora/bush/jungle/a/style_random,
+/obj/structure/flora/bush/large/style_random{
+	pixel_y = -8
+	},
+/turf/open/misc/dirt/dark/station,
+/area/station/service/bar/atrium)
 "cEP" = (
 /obj/effect/turf_decal/tile/red,
 /obj/item/kirbyplants/random/dead,
@@ -78761,13 +78768,6 @@
 /obj/effect/turf_decal/tile/dark_red/diagonal_edge,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
-"thr" = (
-/obj/structure/flora/bush/jungle/a/style_random,
-/obj/structure/flora/bush/large/style_random{
-	pixel_y = -4
-	},
-/turf/open/misc/dirt/dark/station,
-/area/station/service/bar/atrium)
 "thw" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
@@ -88613,7 +88613,7 @@
 "vBP" = (
 /obj/structure/flora/grass/jungle/a/style_random,
 /obj/structure/flora/bush/large/style_2{
-	pixel_y = 3
+	pixel_y = 2
 	},
 /turf/open/misc/dirt/dark/station,
 /area/station/service/bar/atrium)
@@ -93552,11 +93552,10 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
 "wOV" = (
-/obj/structure/flora/bush/large/style_random{
-	pixel_y = 0;
-	layer = 5.2
-	},
 /obj/structure/flora/bush/jungle/a/style_random,
+/obj/structure/flora/bush/large/style_random{
+	pixel_y = -4
+	},
 /turf/open/misc/dirt/dark/station,
 /area/station/service/bar/atrium)
 "wOW" = (
@@ -133739,13 +133738,13 @@ wkX
 wkX
 raA
 raA
-thr
+wOV
 oTV
 gNt
 eZs
 jKr
 oTV
-wOV
+cEN
 raA
 raA
 kBu
@@ -135023,7 +135022,7 @@ rBw
 rTy
 xgZ
 raA
-thr
+wOV
 iex
 fqU
 kRI

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -32695,13 +32695,6 @@
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/theater)
-"hUi" = (
-/obj/structure/flora/bush/jungle/a/style_random,
-/obj/structure/flora/bush/large/style_random{
-	pixel_y = -4
-	},
-/turf/open/misc/dirt/dark/station,
-/area/station/service/bar/atrium)
 "hUy" = (
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
@@ -78768,6 +78761,13 @@
 /obj/effect/turf_decal/tile/dark_red/diagonal_edge,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
+"thr" = (
+/obj/structure/flora/bush/jungle/a/style_random,
+/obj/structure/flora/bush/large/style_random{
+	pixel_y = -4
+	},
+/turf/open/misc/dirt/dark/station,
+/area/station/service/bar/atrium)
 "thw" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
@@ -133739,7 +133739,7 @@ wkX
 wkX
 raA
 raA
-wOV
+thr
 oTV
 gNt
 eZs
@@ -135023,7 +135023,7 @@ rBw
 rTy
 xgZ
 raA
-hUi
+thr
 iex
 fqU
 kRI

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -49199,10 +49199,10 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/service,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
+/obj/effect/mapping_helpers/airlock/access/all/service/general,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "lVF" = (
@@ -75517,6 +75517,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/service/general,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/station/service/bar/atrium)
 "snG" = (
@@ -82537,7 +82539,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/service,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/effect/mapping_helpers/airlock/access/all/service/general,
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
 "uaJ" = (

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -14610,9 +14610,7 @@
 /obj/effect/turf_decal/trimline/tram/mid_joiner{
 	dir = 8
 	},
-/obj/machinery/vending/wardrobe/bar_wardrobe{
-	layer = 2.91
-	},
+/obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/service/bar/backroom)
 "dwg" = (
@@ -16214,7 +16212,6 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/service/bar,
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/service/bar/backroom)
 "dRl" = (
@@ -19083,10 +19080,6 @@
 /obj/item/kitchen/spoon{
 	pixel_x = -8;
 	pixel_y = 7
-	},
-/obj/structure/sign/poster/official/moth_meth/directional/east{
-	pixel_y = 16;
-	pixel_x = 30
 	},
 /turf/open/floor/stone,
 /area/station/service/hydroponics)
@@ -32702,6 +32695,13 @@
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/theater)
+"hUi" = (
+/obj/structure/flora/bush/jungle/a/style_random,
+/obj/structure/flora/bush/large/style_random{
+	pixel_y = -4
+	},
+/turf/open/misc/dirt/dark/station,
+/area/station/service/bar/atrium)
 "hUy" = (
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
@@ -37637,13 +37637,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "jgg" = (
-/obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /obj/machinery/door/airlock/hydroponics/glass{
 	name = "Apiary"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/stone,
 /area/station/service/hydroponics)
 "jgi" = (
@@ -43925,10 +43925,10 @@
 "kHI" = (
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "kHR" = (
@@ -46843,7 +46843,6 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/iron,
@@ -49201,10 +49200,10 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/service,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "lVF" = (
@@ -57963,7 +57962,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "obz" = (
-/obj/machinery/door/airlock/service,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/firedoor,
 /obj/machinery/duct,
@@ -57971,7 +57969,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/service,
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/backroom)
 "obA" = (
@@ -76735,14 +76733,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/freezer,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/duct,
 /obj/structure/cable,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/freezer,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "sDN" = (
@@ -82249,8 +82245,7 @@
 	pixel_y = -5
 	},
 /obj/machinery/smartfridge/drying/rack{
-	pixel_y = 9;
-	layer = 2.91
+	pixel_y = 7
 	},
 /turf/open/floor/stone,
 /area/station/service/hydroponics)
@@ -92301,6 +92296,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
+/obj/structure/sign/poster/official/moth_meth/directional/east,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics)
 "wzL" = (
@@ -95105,11 +95101,9 @@
 /area/station/engineering/atmos)
 "xgZ" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/closet/secure_closet/bar{
-	layer = 2.91
-	},
 /obj/item/gun/ballistic/shotgun/doublebarrel,
 /obj/machinery/light/small/directional/south,
+/obj/structure/closet/secure_closet/bar,
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "xhf" = (
@@ -98238,8 +98232,8 @@
 "xWy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
 /obj/structure/curtain/cloth/fancy,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/bar/atrium)
 "xWE" = (
@@ -135029,7 +135023,7 @@ rBw
 rTy
 xgZ
 raA
-wOV
+hUi
 iex
 fqU
 kRI

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -2044,8 +2044,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -3517,14 +3517,12 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
 "aSb" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
 /mob/living/basic/chicken{
 	name = "Коммандор Клакки"
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4;
+	color = "#777777"
 	},
 /turf/open/misc/sandy_dirt,
 /area/station/service/hydroponics/upper)
@@ -13912,6 +13910,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "dok" = (
@@ -22365,6 +22365,8 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/service/bar,
 /obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "fvV" = (
@@ -24359,7 +24361,6 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "fTH" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/white/end{
 	dir = 4
 	},
@@ -27229,6 +27230,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen/small,
 /area/station/hallway/secondary/service)
 "gGp" = (
@@ -29116,6 +29118,9 @@
 /area/station/security/detectives_office)
 "hcs" = (
 /obj/structure/table/wood/fancy/red,
+/obj/effect/spawner/random/trash/crushed_can{
+	pixel_y = 8
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/bar/atrium)
 "hcA" = (
@@ -29744,6 +29749,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen/small,
 /area/station/hallway/secondary/service)
 "hki" = (
@@ -30776,6 +30782,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/duct,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics)
 "hwT" = (
@@ -31575,6 +31584,7 @@
 	dir = 6
 	},
 /obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "hFO" = (
@@ -32928,9 +32938,9 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
 "hXp" = (
-/obj/structure/sink/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics/upper)
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
 "hXB" = (
 /obj/structure/chair/sofa/left/maroon,
 /turf/open/floor/glass,
@@ -42236,6 +42246,7 @@
 /area/station/maintenance/disposal/trash)
 "koq" = (
 /obj/structure/frame/machine/secured,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "kos" = (
@@ -42901,14 +42912,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
 "kvX" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
 /mob/living/basic/chicken{
 	name = "Галя"
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4;
+	color = "#777777"
 	},
 /turf/open/misc/sandy_dirt,
 /area/station/service/hydroponics/upper)
@@ -43951,8 +43960,9 @@
 /mob/living/basic/pig{
 	name = "Саня"
 	},
-/obj/effect/turf_decal/siding/white/end{
-	dir = 1
+/obj/effect/turf_decal/siding/dark{
+	dir = 5;
+	color = "#777777"
 	},
 /turf/open/misc/sandy_dirt,
 /area/station/service/hydroponics/upper)
@@ -44855,8 +44865,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "kSN" = (
-/obj/effect/turf_decal/siding/white/end{
-	dir = 4
+/obj/effect/turf_decal/siding/dark{
+	dir = 1;
+	color = "#777777"
 	},
 /turf/open/misc/sandy_dirt,
 /area/station/service/hydroponics/upper)
@@ -46415,6 +46426,7 @@
 /obj/item/reagent_containers/cup/glass/bottle/beer,
 /obj/item/reagent_containers/cup/glass/bottle/beer,
 /obj/structure/closet/secure_closet/freezer/empty,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/checker,
 /area/station/service/bar/atrium)
 "lnZ" = (
@@ -47132,6 +47144,7 @@
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/food/monkeycube/bee,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/stone,
 /area/station/service/hydroponics)
 "luY" = (
@@ -50716,12 +50729,10 @@
 /area/station/maintenance/port/aft)
 "mpX" = (
 /obj/effect/turf_decal/trimline/white/line,
-/obj/item/kirbyplants/random{
-	pixel_y = 2
-	},
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 1
 	},
+/obj/machinery/food_cart,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -56346,6 +56357,7 @@
 /obj/effect/mapping_helpers/requests_console/assistance,
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/effect/mapping_helpers/requests_console/announcement,
+/obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "nGx" = (
@@ -57258,6 +57270,7 @@
 	color = "#6e6e6e"
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen/small,
 /area/station/hallway/secondary/service)
 "nSN" = (
@@ -59085,14 +59098,13 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/kirbyplants/random{
-	pixel_y = 2
-	},
 /obj/machinery/camera/directional/north{
 	c_tag = "Lower Service Hall";
 	dir = 9
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
+/obj/machinery/icecream_vat,
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/service)
 "ooM" = (
@@ -61533,6 +61545,13 @@
 /obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
+"oTk" = (
+/obj/structure/sink/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics/upper)
 "oTm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -67291,6 +67310,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "qnk" = (
@@ -68172,6 +68194,7 @@
 	},
 /obj/effect/turf_decal/siding/dark,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen/small,
 /area/station/hallway/secondary/service)
 "qzJ" = (
@@ -70369,12 +70392,14 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "rbH" = (
-/obj/machinery/food_cart,
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
+/obj/structure/table,
+/obj/item/stack/sheet/cardboard{
+	amount = 5
+	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/service)
 "rbJ" = (
@@ -73055,7 +73080,6 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 1
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron/corner,
 /area/station/service/hydroponics/upper)
 "rKS" = (
@@ -76964,11 +76988,13 @@
 	},
 /obj/structure/table/wood/fancy/red,
 /obj/item/plate/small{
-	color = "#454545"
+	color = "#454545";
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/item/cigbutt/cigarbutt{
-	pixel_x = 2;
-	pixel_y = 4
+/obj/item/cigarette/cigar{
+	pixel_y = 10;
+	pixel_x = -3
 	},
 /turf/open/floor/wood/large,
 /area/station/service/bar/atrium)
@@ -77564,7 +77590,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "sOT" = (
-/obj/structure/mirror/directional/north,
+/obj/structure/mirror/directional/north{
+	pixel_y = 34
+	},
 /obj/structure/sink/kitchen/directional/south{
 	pixel_y = 11
 	},
@@ -77754,6 +77782,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hydroponics,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1;
+	color = "#777777"
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/upper)
 "sRs" = (
@@ -79435,6 +79467,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/upper)
 "toF" = (
@@ -84913,12 +84947,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "uIn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/kitchen/small,
-/area/station/hallway/secondary/service)
+/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
 "uIo" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/trimline/dark_blue/corner{
@@ -85496,6 +85534,14 @@
 /obj/structure/sink/kitchen/directional/south,
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 1
+	},
+/obj/item/reagent_containers/cup/bucket{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/cup/bucket{
+	pixel_x = 15;
+	pixel_y = -5
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/service)
@@ -86220,12 +86266,13 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "uZU" = (
-/obj/machinery/icecream_vat,
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/light/warm/directional/north,
+/obj/item/kirbyplants/random{
+	pixel_y = 2
+	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/service)
 "uZW" = (
@@ -88632,14 +88679,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay/ghetto)
 "vBW" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 4
-	},
 /mob/living/basic/cow{
 	name = "Бетси"
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4;
+	color = "#777777"
 	},
 /turf/open/misc/sandy_dirt,
 /area/station/service/hydroponics/upper)
@@ -89974,6 +90019,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/warm/directional/west,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/service)
 "vUI" = (
@@ -94183,6 +94229,8 @@
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "wWV" = (
@@ -94530,6 +94578,7 @@
 	dir = 8
 	},
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/service)
 "xbG" = (
@@ -97624,18 +97673,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "xOr" = (
-/obj/item/reagent_containers/cup/bucket{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/cup/bucket{
-	pixel_x = 15;
-	pixel_y = -5
-	},
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 1
 	},
-/obj/structure/cable,
+/obj/structure/aquarium,
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/service)
 "xOv" = (
@@ -98352,11 +98393,15 @@
 /turf/open/floor/carpet/black,
 /area/station/command/meeting_room)
 "xYd" = (
-/obj/effect/turf_decal/siding/white,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/green/half{
+	dir = 4
 	},
-/turf/open/misc/sandy_dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron/edge{
+	dir = 4
+	},
 /area/station/service/hydroponics/upper)
 "xYj" = (
 /obj/machinery/door/airlock,
@@ -99349,11 +99394,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "ylo" = (
-/obj/effect/turf_decal/tile/green/half,
-/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/edge,
-/area/station/service/hydroponics/upper)
+/turf/open/floor/iron/dark,
+/area/station/service/bar)
 "ylp" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -135787,7 +135834,7 @@ doz
 doz
 vbK
 pNZ
-eJq
+hXp
 pNZ
 ooL
 xbr
@@ -136301,7 +136348,7 @@ vbK
 vbK
 vbK
 pNZ
-cof
+uIn
 pNZ
 uZU
 xTr
@@ -136818,7 +136865,7 @@ pNZ
 eQX
 pNZ
 xOr
-uIn
+xTr
 gNr
 fTH
 bQn
@@ -201069,7 +201116,7 @@ nZT
 eGV
 nZT
 mam
-qnd
+ylo
 jdL
 cIN
 wrA
@@ -204164,7 +204211,7 @@ fxv
 mdc
 wCj
 fot
-xYd
+kSN
 voK
 obc
 ckR
@@ -204928,8 +204975,8 @@ dWX
 teP
 jWd
 dWX
-dWX
-hXp
+ctG
+byC
 uGI
 vLR
 lLF
@@ -205185,7 +205232,7 @@ sdY
 dlg
 mvc
 dWX
-ctG
+oTk
 rKR
 aAe
 keB
@@ -205444,7 +205491,7 @@ ygU
 dWX
 toE
 vAa
-mcF
+xYd
 mcF
 eJS
 mcF
@@ -205700,7 +205747,7 @@ isp
 isp
 oqP
 uRd
-ylo
+uDi
 cJY
 qTE
 qTE

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -1898,11 +1898,9 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/obj/structure/curtain/cloth/fancy/mechanical/start_closed{
-	name = "ViP Curtains"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/structure/curtain/cloth/fancy/mechanical/start_closed,
 /turf/open/floor/wood/large,
 /area/station/service/bar/atrium)
 "ayQ" = (
@@ -26675,7 +26673,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
 "gyK" = (
-/obj/machinery/light/warm/directional/east,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "gyL" = (
@@ -74709,10 +74707,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/obj/structure/curtain/cloth/fancy/mechanical/start_closed{
-	name = "ViP Curtains"
-	},
 /obj/machinery/door/firedoor,
+/obj/structure/curtain/cloth/fancy/mechanical/start_closed,
 /turf/open/floor/wood/large,
 /area/station/service/bar/atrium)
 "sdE" = (
@@ -78217,7 +78213,7 @@
 	},
 /area/station/engineering/hallway/west)
 "sXK" = (
-/obj/machinery/light/warm/directional/west,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "sXO" = (

--- a/modular_bandastation/mapping/code/areas/station.dm
+++ b/modular_bandastation/mapping/code/areas/station.dm
@@ -26,6 +26,21 @@
 /area/station/service/library/ghetto
 	name = "Library Lower Floor"
 
+/area/station/service/hydroponics/ghetto
+	name = "Hydroponics Lower Floor"
+
+/area/station/service/bar/atrium/ghetto
+	name = "Bar Atrium Lower Floor"
+
+/area/station/service/bar/backroom/ghetto
+	name = "Bar Backroom Lower Floor"
+
+/area/station/service/kitchen/coldroom/ghetto
+	name = "Kitchen Cold Room Lower Floor"
+
+/area/station/service/kitchen/kitchen_backroom/ghetto
+	name = "Kitchen Backroom Lower Floor"
+
 /area/station/medical/chemistry/ghetto
 	name = "Chemistry Lower Floor"
 


### PR DESCRIPTION
## Что этот PR делает

Добавляет просторный атриум с приватными комнатами на нижнем этаже бара. Переносит вниз комнату бармена и холодильную комнату. Добавляет снизу большой холл для хранения оборудования и всякого барахлища

## Почему это хорошо для игры

Нижнему уровню Кибериады не хватает жизни, а в баре и на кухне чутка тесновато

## Изображения изменений

![image](https://github.com/user-attachments/assets/d0e2e1fb-cf30-42b8-9e36-13c995cae1b1)
![image](https://github.com/user-attachments/assets/4f34f7aa-dfb7-41c1-b1d9-54ecba59f4c7)

![image](https://github.com/user-attachments/assets/7e2115da-95c5-448a-9031-c7507c6a116c)
![image](https://github.com/user-attachments/assets/f5fbe0d9-1dad-465e-8618-02578cd11c40)
![image](https://github.com/user-attachments/assets/1f430570-a36f-466f-968d-0a2773a3fa76)

![image](https://github.com/user-attachments/assets/c9c02a8e-53bc-4e83-950f-182f812ccf87)
![image](https://github.com/user-attachments/assets/5b267abd-d975-4f93-a315-caad6e7b7708)

## Тестирование

Видно из скриншотов + побегал по карте

## Changelog

:cl:
add: Кибериада: Добавлен атриум бара на нижнем этаже, туда же перенесены морозильная камера и комната бармена
/:cl:

## Summary by Sourcery

Add a lower bar atrium, relocate the cold room and barmen's room to the lower floor, and add a storage hall on the lower floor.

New Features:
- Add a lower bar atrium with private rooms.
- Relocate the barman's room and cold room to the lower floor.
- Add a large hall on the lower floor for equipment storage