### PR TITLE
Feat: VV and PP now on admin-ghost hotkeys

### DIFF
--- a/modular_bandastation/admin/_admin.dm
+++ b/modular_bandastation/admin/_admin.dm
@@ -1,4 +1,4 @@
 /datum/modpack/admin
 	name = "Административные удобства"
 	desc = "Всякие вещи для удобства администрации и дебага."
-	author = "Aylong"
+	author = "Aylong, Ez-Briz"

--- a/modular_bandastation/admin/_admin.dme
+++ b/modular_bandastation/admin/_admin.dme
@@ -1,3 +1,4 @@
 #include "_admin.dm"
 
 #include "code/admin_verbs.dm"
+#include "code/admin_hotkeys.dm"

--- a/modular_bandastation/admin/code/admin_hotkeys.dm
+++ b/modular_bandastation/admin/code/admin_hotkeys.dm
@@ -1,0 +1,9 @@
+// Open "View Variables" menu for target
+/mob/dead/observer/CtrlShiftClickOn(atom/target)
+	if (check_rights(R_DEBUG))
+		SSadmin_verbs.dynamic_invoke_verb(client, /datum/admin_verb/debug_variables, target)
+
+// Open "Show Player Panel" menu for target mob
+/mob/dead/observer/CtrlClickOn(atom/target)
+	if (check_rights(R_ADMIN) && ismob(target))
+		SSadmin_verbs.dynamic_invoke_verb(client, /datum/admin_verb/show_player_panel, target)


### PR DESCRIPTION

## Что этот PR делает
Добавляет гостам-админам хоткей для PP (Ctrl + LMB) и переопределяет функцию хоткея для VV (Ctrl + Shift + LMB). Дополняет модуль @AyIong.
Fixes #38 
## Почему это хорошо для игры
Админам не нужно искать кнопки в контекстном меню, быстрое взаимодействие.
## Изображения изменений
## Тестирование
Зашёл на локалку, протыкал VV-шки объектов, проверил, чтобы не открывалась PP-шка для чего-то, кроме мобов.
## Changelog

:cl: Ez-Briz
admin: У админов появилась возможность открыть PP через Ctrl+LMB и VV через Ctrl+Shift+LMB из гостов.
/:cl:
