### PR TITLE
Cyberiad: remap RND (and Med) [2/2]

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -49,12 +49,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
-"aaC" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
 "aaH" = (
 /turf/open/floor/sepia,
 /area/station/security/prison/ghetto)
@@ -88,15 +82,6 @@
 /obj/effect/turf_decal/tile/dark_red/diagonal_edge,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
-"abw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
 "abz" = (
 /obj/structure/flora/bush/jungle/b/style_random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -260,6 +245,7 @@
 "adQ" = (
 /obj/structure/sign/poster/contraband/random/directional/east,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/starboard)
 "aec" = (
@@ -278,10 +264,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
-"aey" = (
-/obj/effect/turf_decal/stripes/red/line,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/science/xenobiology)
 "aeL" = (
 /obj/structure/table/wood,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -313,16 +295,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/trash)
-"afy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno4";
-	name = "Creature Cell #4"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "afI" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Garden"
@@ -369,15 +341,16 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "afW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "afX" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/photobooth,
@@ -467,18 +440,15 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/fore/starboard)
 "ahc" = (
-/obj/machinery/door/window/brigdoor/left/directional/north{
-	name = "Creature Pen";
-	req_access = list("research")
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno1";
-	name = "Creature Cell #1"
-	},
 /obj/structure/cable,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobiomain";
+	name = "Containment Blast Door"
+	},
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "ahg" = (
 /obj/effect/decal/cleanable/dirt,
@@ -489,14 +459,9 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
 "ahi" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/light_switch/directional/south,
-/obj/effect/turf_decal/tile/purple/anticorner,
-/turf/open/floor/iron/white,
-/area/station/science/explab)
+/obj/machinery/light/directional/east,
+/turf/open/openspace,
+/area/station/science/xenobiology)
 "ahj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -554,10 +519,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "ahK" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
-/area/station/science/research)
+/area/station/science/xenobiology)
 "ahO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -736,12 +703,9 @@
 /turf/open/floor/carpet/black,
 /area/station/command/meeting_room)
 "akg" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/table/glass,
-/obj/effect/turf_decal/stripes/line,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/effect/spawner/random/trash/box,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "akm" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron/dark,
@@ -860,13 +824,8 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
 "alp" = (
-/obj/structure/table,
-/obj/item/storage/crayons,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
-"alr" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/seeds/berry,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/upper)
 "aly" = (
@@ -938,18 +897,22 @@
 /turf/open/floor/iron/kitchen/small,
 /area/station/maintenance/starboard/fore)
 "amm" = (
-/obj/structure/table,
-/obj/item/hand_labeler,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
-"amp" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/seeds/cannabis,
+/obj/item/food/grown/ambrosia/vulgaris,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/area/station/maintenance/starboard/aft)
+"amp" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/obj/item/flatpack{
+	board = /obj/item/circuitboard/machine/flatpacker
+	},
+/obj/item/multitool,
+/turf/open/floor/iron,
+/area/station/science/lab)
 "amF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -1072,13 +1035,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/atmos)
-"aoa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/aft)
 "aod" = (
 /mob/living/basic/parrot/poly,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -1119,9 +1075,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "aoT" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/open/floor/iron/herringbone,
+/area/station/maintenance/starboard/aft)
 "aoW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/general{
 	dir = 1
@@ -1141,18 +1104,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "apb" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/maintenance/two,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
-"ape" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/obj/structure/table_frame/wood,
+/obj/item/stack/spacecash/c10,
+/turf/open/floor/iron/grimy,
+/area/station/service/abandoned_gambling_den)
 "apg" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/decal/cleanable/dirt,
@@ -1178,12 +1133,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/bar)
 "apA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "apE" = (
 /obj/machinery/porta_turret/ai{
@@ -1299,13 +1251,9 @@
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/blueshield)
 "arb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/garden)
 "are" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/spawner/random/trash/cigbutt,
@@ -1356,14 +1304,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/mechbay)
 "arT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/white,
-/area/station/maintenance/starboard/aft)
+/area/station/science/explab)
 "arW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
 /turf/open/floor/iron,
@@ -1377,10 +1323,15 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
 "asx" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/atmos,
+/obj/effect/mapping_helpers/airlock/access/all/engineering,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "asz" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
 	dir = 4
@@ -1499,12 +1450,6 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
-"atR" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/station/science/xenobiology)
 "atS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -1537,8 +1482,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "aut" = (
-/obj/structure/grille,
-/turf/open/floor/engine/hull/reinforced,
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "auD" = (
 /obj/machinery/door/airlock/maintenance,
@@ -1588,17 +1534,11 @@
 /area/station/engineering/atmos/project)
 "avs" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/table,
+/obj/item/soap/deluxe,
+/obj/item/clothing/neck/stethoscope,
+/turf/open/floor/iron/white,
+/area/station/maintenance/aft)
 "avu" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -1642,8 +1582,10 @@
 /turf/open/floor/carpet/black,
 /area/station/maintenance/starboard/fore)
 "awe" = (
-/obj/machinery/atmospherics/components/binary/valve/on,
 /obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/simple{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "awk" = (
@@ -1781,40 +1723,33 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "axO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/genetics,
-/obj/machinery/duct,
-/obj/machinery/door/poddoor/preopen{
-	id = "research_lockdown";
-	name = "Research Lockdown Blast Doors"
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/turf/open/floor/iron/dark/textured_large,
+/area/station/science/xenobiology)
 "axW" = (
 /obj/structure/holosign/barrier/engineering,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "axX" = (
-/obj/effect/spawner/random/trash/grille_or_waste,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor/iron,
-/area/station/maintenance/aft)
+/obj/structure/flora/grass/jungle/b/style_random,
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "axZ" = (
-/turf/closed/wall,
-/area/station/science/genetics)
-"aye" = (
-/obj/structure/chair/wood{
+/obj/structure/microscope,
+/obj/structure/table/glass,
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/purple/half{
 	dir = 1
 	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
+"aye" = (
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/area/station/service/abandoned_gambling_den)
 "ayg" = (
 /turf/open/floor/iron/stairs{
 	dir = 4
@@ -1828,10 +1763,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "ayp" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/aft)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/mechbay)
 "ays" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plating,
@@ -1867,10 +1803,8 @@
 "ayM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 2
-	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "ayQ" = (
@@ -1968,17 +1902,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "azO" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/effect/turf_decal/bot,
-/obj/machinery/door_buttons/airlock_controller{
-	idExterior = "xeno_airlock_exterior";
-	idInterior = "xeno_airlock_interior";
-	idSelf = "xeno_airlock_control";
-	name = "Xeno Access Console";
-	req_access = list("xenobiology");
-	pixel_x = 24
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/left/directional/east{
+	name = "Containment Pen 5";
+	req_access = list("xenobiology")
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/iron,
 /area/station/science/xenobiology)
 "azU" = (
 /obj/machinery/camera/directional/west{
@@ -2178,24 +2111,14 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "aCH" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/monkeycubes,
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 4
 	},
-/obj/machinery/button/door{
-	id = "testlab";
-	name = "Test Chamber Blast Doors";
-	req_access = list("xenobiology");
-	pixel_y = -24;
-	pixel_x = -4
-	},
-/obj/machinery/button/ignition{
-	id = "testigniter_exp";
-	pixel_y = -24;
-	pixel_x = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron/white,
-/area/station/science/explab)
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "aCK" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -2307,11 +2230,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "aEf" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/openspace,
-/area/station/science/xenobiology)
+/obj/structure/flora/bush/fullgrass/style_random,
+/mob/living/basic/butterfly,
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "aEk" = (
 /turf/closed/wall/rust,
 /area/station/security/prison)
@@ -2338,10 +2260,10 @@
 /area/station/maintenance/ghetto/garden)
 "aEt" = (
 /obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 1
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
 	},
-/obj/machinery/light_switch/directional/north,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "aEu" = (
@@ -2378,38 +2300,32 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aEP" = (
-/obj/machinery/shower/directional/south,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/turf_decal/trimline/blue/end,
-/obj/structure/fluff/shower_drain,
-/obj/machinery/door/window/right/directional/south,
-/obj/structure/curtain,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/textured_large,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/smartfridge/petri/preloaded,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "aEU" = (
-/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/north,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/aft)
 "aFj" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/textured,
+/area/station/science/xenobiology)
 "aFl" = (
 /obj/structure/fluff/paper/stack{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
-"aFr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
 "aFs" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/textured,
@@ -2528,13 +2444,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
-"aGV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "aGW" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
@@ -2569,10 +2478,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "aHl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/science/server)
+/obj/effect/turf_decal/tile/purple/half,
+/obj/machinery/keycard_auth/wall_mounted/directional/south,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "aHn" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -2596,9 +2505,8 @@
 /turf/open/floor/iron/half,
 /area/station/commons/dorms)
 "aHB" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "aHD" = (
 /obj/machinery/light/small/directional/north,
@@ -2685,10 +2593,11 @@
 /turf/open/space/openspace,
 /area/station/solars/port/fore)
 "aIw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/south,
+/obj/structure/rack,
+/obj/machinery/light/small/directional/east,
+/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/area/station/maintenance/starboard/upper)
 "aIE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2869,9 +2778,9 @@
 /turf/closed/wall,
 /area/station/maintenance/department/security/ghetto/aft)
 "aLi" = (
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/wood,
-/area/station/maintenance/aft)
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "aLu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2936,12 +2845,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/dronefabricator)
-"aLZ" = (
-/obj/structure/railing,
-/obj/structure/chair,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
 "aMl" = (
 /obj/machinery/light/broken/directional/north,
 /obj/effect/turf_decal/trimline/yellow/filled/warning/corner{
@@ -2999,18 +2902,17 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "aMR" = (
 /turf/open/floor/iron/stairs/medium,
 /area/station/security/courtroom)
 "aNd" = (
-/obj/effect/turf_decal/box/white/corners,
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/white/warning{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/area/station/service/abandoned_gambling_den)
 "aNe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3689,16 +3591,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "aVh" = (
-/obj/structure/table/glass,
-/obj/item/taperecorder{
-	pixel_y = 7
-	},
-/obj/item/pai_card,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
+/turf/closed/wall,
+/area/station/science/circuits)
 "aVl" = (
 /obj/structure/table/reinforced,
 /obj/effect/landmark/event_spawn,
@@ -3898,12 +3792,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "aXx" = (
-/obj/structure/sink/directional/south,
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
-	dir = 1
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
@@ -3983,10 +3878,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
-"aYv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
 "aYy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -4016,12 +3907,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"aYP" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
 "aYR" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/large,
@@ -4067,11 +3952,11 @@
 	},
 /area/station/security/courtroom)
 "aZA" = (
-/obj/structure/stairs/east{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/machinery/light/small/directional/east,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "aZB" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -4144,14 +4029,14 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "baH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/destructive_scanner,
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/science/lobby)
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio6";
+	name = "Xenobio Pen 6 Blast Door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "baK" = (
 /obj/structure/reflector/single,
 /obj/effect/decal/cleanable/dirt,
@@ -4232,11 +4117,17 @@
 /turf/open/floor/wood,
 /area/station/service/kitchen/abandoned)
 "bbR" = (
-/obj/machinery/sparker/directional/west{
-	id = "testigniter_exp"
+/obj/machinery/door/window/left/directional/east{
+	name = "Containment Pen 1";
+	req_access = list("xenobiology")
 	},
-/turf/open/floor/engine,
-/area/station/science/explab)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light/floor,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "bbY" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
@@ -4396,16 +4287,6 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
-"bev" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/button/door{
-	id = "xeno4";
-	name = "Containment Control";
-	req_access = list("xenobiology")
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "beH" = (
 /turf/closed/wall,
 /area/station/cargo/warehouse)
@@ -4513,7 +4394,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "bfZ" = (
@@ -4706,8 +4587,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "biJ" = (
-/turf/open/openspace,
-/area/station/maintenance/aft)
+/obj/structure/spacevine{
+	can_spread = 0;
+	pixel_y = -32
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "biL" = (
 /obj/machinery/light/directional/north,
 /obj/structure/railing/corner/end{
@@ -4801,18 +4692,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "bjo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
+/obj/structure/flora/bush/jungle/b/style_random,
+/obj/structure/chair/pew/right{
+	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "bjq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4936,10 +4821,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "bli" = (
-/obj/effect/spawner/random/structure/closet_empty,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
+/obj/machinery/camera/directional/east{
+	c_tag = "Xenobiology Pens - Starboard Aft";
+	network = list("ss13","rd","xeno")
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "bll" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5002,12 +4889,10 @@
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hos)
 "blE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/structure/girder,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/area/station/maintenance/starboard/aft)
 "blI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -5023,15 +4908,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "blM" = (
+/obj/structure/flora/rock/pile,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wideplating_new{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/iron/herringbone,
-/area/station/maintenance/aft)
+/obj/structure/railing,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "blT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5072,9 +4954,9 @@
 /turf/open/floor/carpet,
 /area/station/maintenance/port/fore)
 "bmr" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
+/obj/effect/spawner/random/trash/box,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard/aft)
 "bmx" = (
 /obj/effect/spawner/random/structure/furniture_parts,
 /turf/open/floor/plating,
@@ -5107,13 +4989,11 @@
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/ghetto/bar)
 "bnr" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "testlab";
-	name = "Test Chamber Blast Door"
-	},
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/engine,
-/area/station/science/explab)
+/obj/machinery/processor/slime,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "bnt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -5162,10 +5042,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
 "boy" = (
-/obj/effect/spawner/random/structure/crate,
-/obj/effect/spawner/random/maintenance/two,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/area/station/maintenance/starboard/upper)
 "boI" = (
 /obj/structure/chair/stool/bar{
 	dir = 4
@@ -5173,11 +5052,13 @@
 /turf/open/misc/beach/sand,
 /area/station/hallway/secondary/exit/departure_lounge)
 "boK" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
+/obj/machinery/newscaster/directional/west,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/turf/open/floor/iron/freezer,
+/area/station/science/robotics/lab)
 "boM" = (
 /obj/structure/chair,
 /turf/open/floor/iron/dark,
@@ -5269,10 +5150,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
+/turf/open/floor/iron/white,
+/area/station/science/circuits)
 "bpJ" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/tile,
@@ -5394,12 +5273,6 @@
 "bqY" = (
 /turf/closed/wall,
 /area/station/maintenance/department/medical/ghetto/central)
-"brb" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/random/maintenance,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
 "brd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5409,7 +5282,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/ghetto)
 "bri" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/window/right/directional/north{
 	name = "Body Disposal"
 	},
@@ -5422,11 +5294,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "brm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "brn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -5439,18 +5316,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/dronefabricator)
-"brs" = (
-/obj/machinery/door/window/brigdoor/left/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
 "brv" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/science/research)
+/obj/structure/chair/stool/bar/directional/east,
+/turf/open/floor/iron/grimy,
+/area/station/service/abandoned_gambling_den)
 "bry" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark/smooth_edge{
@@ -5467,10 +5336,12 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "brG" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/structure/sign/warning/gas_mask/directional/west,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/area/station/maintenance/starboard/upper)
 "brH" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Aft Primary Hallway North"
@@ -5632,8 +5503,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "btA" = (
-/obj/structure/table,
-/obj/item/hatchet,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "btJ" = (
@@ -5676,12 +5549,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto/morgue)
-"but" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/ordnance/office)
 "buv" = (
 /obj/machinery/light/cold/directional/north,
 /obj/machinery/airalarm/directional/north,
@@ -5691,14 +5558,6 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
-"buy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
 "buC" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/engineering_guide{
@@ -5759,9 +5618,15 @@
 /turf/open/floor/plating,
 /area/station/security/interrogation/ghetto)
 "bvA" = (
-/obj/effect/spawner/random/vending/snackvend,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance,
+/turf/open/floor/plating,
+/area/station/medical/cryo)
 "bvF" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/trimline/dark_blue/line{
@@ -5776,8 +5641,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bvP" = (
-/turf/open/floor/iron/white,
-/area/station/science/lower)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "bvW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5831,15 +5702,20 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "bwl" = (
-/obj/structure/disposaloutlet{
-	dir = 1
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/box/white/corners{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/obj/machinery/camera/directional/south{
+	c_tag = "Xenobiology Pens Hall - Aft";
+	network = list("ss13","rd","xeno_pens")
+	},
+/turf/open/floor/iron,
 /area/station/science/xenobiology)
 "bwo" = (
 /obj/structure/barricade/wooden,
@@ -5848,19 +5724,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
-"bwq" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/table/glass,
-/obj/item/extinguisher,
-/obj/item/extinguisher{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "bwr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -5981,10 +5844,15 @@
 /turf/open/floor/plating,
 /area/station/security/checkpoint/science)
 "bxT" = (
-/obj/structure/bed/maint,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/structure/flora/bush/jungle/b/style_random,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "bxU" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "Incinerator Output Pump";
@@ -6029,15 +5897,18 @@
 	},
 /area/station/hallway/secondary/entry)
 "byg" = (
-/obj/structure/closet/crate/freezer,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/directional/west,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "byv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "byw" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -6055,12 +5926,9 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "byD" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/effect/spawner/random/maintenance,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/obj/machinery/power/floodlight,
+/turf/open/floor/iron/dark,
+/area/station/service/abandoned_gambling_den)
 "byL" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
@@ -6176,7 +6044,6 @@
 /area/station/science/ordnance/bomb)
 "bAH" = (
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/structure/sign/warning/electric_shock/directional/south,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
@@ -6197,21 +6064,22 @@
 /turf/open/floor/iron/grimy,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "bAW" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/open/floor/iron/herringbone,
+/area/station/maintenance/starboard/aft)
 "bAZ" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/hallway/west)
 "bBc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "bBd" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -6337,15 +6205,8 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "bCK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "bCN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6374,13 +6235,16 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "bDa" = (
+/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "bDk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6388,13 +6252,16 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "bDp" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/sign/warning/no_smoking/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "bDu" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -6473,9 +6340,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/storage)
 "bEw" = (
-/obj/effect/spawner/random/trash/garbage,
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/area/station/maintenance/starboard/upper)
 "bEA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6591,24 +6458,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/trash)
 "bGb" = (
-/obj/structure/railing{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/command/rd,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/jungle/b/style_random,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
-"bGf" = (
-/obj/structure/chair/stool{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood,
-/area/station/maintenance/aft)
+/obj/effect/landmark/navigate_destination,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "bGg" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -6698,8 +6560,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "bIa" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
@@ -6717,13 +6580,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/engineering/atmos)
-"bIg" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "bIn" = (
 /obj/structure/rack,
 /obj/item/storage/fancy/donut_box{
@@ -6732,16 +6588,24 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "bIq" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/item/clothing/mask/gas{
+	pixel_x = 6;
+	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 8
+/obj/item/clothing/mask/gas{
+	pixel_x = -8;
+	pixel_y = 4
 	},
+/obj/machinery/door_buttons/access_button,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
+/obj/machinery/camera/directional/east{
+	c_tag = "Xenobiology Test Chamber Access";
+	network = list("ss13","test","rd","xeno")
+	},
+/turf/open/floor/iron,
 /area/station/science/xenobiology)
 "bIw" = (
 /obj/structure/disposalpipe/segment,
@@ -6753,11 +6617,6 @@
 /obj/effect/decal/cleanable/vomit,
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/ghetto/fore/starboard)
-"bIL" = (
-/obj/machinery/light/small/directional/east,
-/obj/structure/sign/warning/vacuum/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
 "bIQ" = (
 /obj/structure/safe/vault,
 /obj/item/clothing/neck/stethoscope,
@@ -6831,11 +6690,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bJM" = (
-/obj/structure/table/wood,
-/obj/structure/mirror/directional/north,
-/obj/effect/spawner/random/entertainment/cigarette_pack,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/machinery/light/directional/west,
+/turf/open/openspace,
+/area/station/science/xenobiology)
 "bJQ" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 2";
@@ -6871,12 +6728,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "bKc" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/machinery/camera/directional/west{
+	c_tag = "Xenobiology Pens - Port Aft";
+	network = list("ss13","rd","xeno")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/turf/open/floor/iron,
+/obj/structure/sign/warning/docking/directional/west,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "bKj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6927,13 +6784,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/station/security/courtroom)
-"bLb" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
 "bLc" = (
 /obj/structure/table,
 /obj/structure/microscope,
@@ -6953,12 +6803,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/aft)
-"bLz" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/breakroom)
 "bLC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -7198,11 +7042,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "bOi" = (
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder,
 /obj/machinery/light/directional/east,
 /turf/open/floor/engine,
-/area/station/science/lower)
+/area/station/science/explab)
 "bOl" = (
 /obj/structure/table,
 /turf/open/floor/iron,
@@ -7269,21 +7111,29 @@
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "bOW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sink/kitchen/directional/south,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio3";
+	name = "Xenobio Pen 3 Blast Door"
+	},
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "bPa" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto)
 "bPl" = (
-/obj/structure/table_frame/wood,
-/obj/item/stack/spacecash/c10,
-/turf/open/floor/iron/grimy,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/disposaloutlet,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "bPm" = (
 /obj/effect/spawner/random/engineering/canister,
 /turf/open/floor/iron/dark,
@@ -7298,18 +7148,15 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "bPr" = (
-/obj/effect/turf_decal/tile/neutral/half{
+/obj/structure/sign/warning/biohazard/directional/north,
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
-	},
-/obj/machinery/processor/slime,
-/obj/effect/turf_decal/bot_red,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron,
 /area/station/science/xenobiology)
 "bPs" = (
 /obj/structure/disposalpipe/segment,
@@ -7424,19 +7271,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/misc/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
-"bQI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
-"bQQ" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/engine/hull/reinforced,
-/area/space/nearstation)
 "bQU" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
@@ -7608,10 +7442,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bTl" = (
-/obj/structure/closet/emcloset,
-/obj/structure/sign/warning/vacuum/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "bTH" = (
 /turf/closed/wall,
 /area/station/maintenance/starboard/aft)
@@ -7642,17 +7478,29 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
 "bTY" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
-"bUe" = (
-/obj/structure/cable,
-/obj/machinery/light/directional/north,
-/obj/machinery/door/window/left/directional/west,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
+"bUe" = (
+/obj/structure/rack,
+/obj/item/integrated_circuit/loaded/hello_world{
+	pixel_x = 7
+	},
+/obj/item/integrated_circuit/loaded/speech_relay{
+	pixel_x = 7
+	},
+/obj/item/controller{
+	pixel_x = -7
+	},
+/obj/item/compact_remote{
+	pixel_x = -7
+	},
+/obj/item/compact_remote{
+	pixel_x = -7
+	},
+/obj/effect/turf_decal/tile/purple/half,
+/turf/open/floor/iron/white,
+/area/station/science/circuits)
 "bUj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -7743,14 +7591,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "bVL" = (
-/obj/machinery/washing_machine,
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 8
+/obj/machinery/camera/directional/east{
+	c_tag = "Xenobiology Test Chamber Access";
+	network = list("ss13","test","rd","xeno")
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/iron/cafeteria,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/structure/table/glass,
+/obj/item/storage/box/monkeycubes,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "bVS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -7819,13 +7668,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"bWX" = (
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/white,
-/area/station/science/explab)
 "bXe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8000,8 +7842,8 @@
 /turf/open/floor/wood/large,
 /area/station/commons/dorms)
 "bZr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/turf/closed/wall/r_wall,
+/mob/living/basic/slime,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "bZs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8015,22 +7857,11 @@
 	},
 /area/station/hallway/secondary/entry)
 "bZw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/science/server)
-"bZx" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/science/general,
-/obj/machinery/door/poddoor/preopen{
-	id = "research_lockdown";
-	name = "Research Lockdown Blast Doors"
-	},
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "bZF" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -8116,16 +7947,10 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/magistrate)
-"caw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
 "cax" = (
-/obj/machinery/airalarm/directional/north,
+/obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/engine,
-/area/station/science/lower)
+/area/station/science/explab)
 "cay" = (
 /obj/structure/cable/layer1,
 /turf/open/floor/engine,
@@ -8141,27 +7966,12 @@
 /turf/open/openspace,
 /area/station/cargo/storage)
 "caH" = (
-/obj/structure/table,
-/obj/item/storage/medkit/regular{
-	empty = 1;
-	name = "First-Aid (empty)"
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 6
 	},
-/obj/item/storage/medkit/regular{
-	empty = 1;
-	name = "First-Aid (empty)"
-	},
-/obj/item/storage/medkit/regular{
-	empty = 1;
-	name = "First-Aid (empty)"
-	},
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
-/obj/item/reagent_containers/cup/beaker/large,
-/obj/machinery/status_display/ai/directional/east,
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "caJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
@@ -8299,10 +8109,11 @@
 /turf/open/floor/plating,
 /area/station/service/hydroponics/garden)
 "cbS" = (
-/obj/item/stack/sheet/cardboard,
-/obj/effect/spawner/random/trash/janitor_supplies,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/structure/table/wood,
+/obj/item/clothing/gloves/color/fyellow,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/iron/dark,
+/area/station/service/abandoned_gambling_den)
 "cbU" = (
 /obj/effect/turf_decal/trimline/blue/end{
 	dir = 4
@@ -8463,9 +8274,6 @@
 "ces" = (
 /obj/machinery/door/window/right/directional/east{
 	name = "Coroner"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark/small,
@@ -8720,13 +8528,6 @@
 	dir = 8
 	},
 /area/station/service/hydroponics)
-"chY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/bar/fourcorners,
-/obj/effect/spawner/random/trash/mess,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
 "cic" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8811,13 +8612,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "ciR" = (
-/obj/machinery/bci_implanter,
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/xenobiology)
 "ciU" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue,
@@ -8932,20 +8729,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"cjR" = (
-/obj/machinery/door/window/brigdoor/left/directional/south{
-	name = "Creature Pen";
-	req_access = list("research")
-	},
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno7";
-	name = "Creature Cell #7"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "cjU" = (
 /obj/structure/closet/wardrobe/mixed,
 /obj/item/clothing/shoes/jackboots,
@@ -9132,20 +8915,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "clW" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/machinery/camera/directional/south{
-	c_tag = "Research - E.X.P.E.R.I-MENTOR Lab";
-	network = list("ss13","rd")
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple/half,
-/turf/open/floor/iron/white,
-/area/station/science/explab)
-"clY" = (
-/obj/structure/sink/directional/south,
-/obj/structure/mirror/directional/north,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "cmg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9228,14 +9004,15 @@
 /turf/open/floor/wood,
 /area/station/service/library/ghetto)
 "cnx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/herringbone,
-/area/station/maintenance/aft)
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/hallway/primary/starboard)
 "cnG" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -9326,11 +9103,13 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port/aft)
 "coB" = (
-/obj/structure/table/reinforced,
-/obj/item/trash/tray,
-/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/area/station/science/xenobiology)
 "coR" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor2-old"
@@ -9358,13 +9137,11 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/fore)
 "cpi" = (
-/obj/structure/rack,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/item/aicard,
-/obj/item/circuitboard/aicore,
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/tile/purple/anticorner,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 1
+	},
+/obj/machinery/pdapainter/research,
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "cpk" = (
 /obj/effect/mapping_helpers/burnt_floor,
@@ -9542,8 +9319,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "crJ" = (
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den)
 "crY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1,
@@ -9621,11 +9402,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"csD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
 "csF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9825,13 +9601,17 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "cvE" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio8";
+	name = "Xenobio Pen 8 Blast Door"
+	},
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/maintenance/aft)
+/area/station/science/xenobiology)
 "cvG" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -9915,9 +9695,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "cwk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "cwl" = (
@@ -10038,10 +9822,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"cys" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/kitchen)
 "cyw" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -10283,12 +10063,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "cBA" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/effect/turf_decal/tile/neutral/anticorner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/science/genetics)
+/obj/effect/turf_decal/stripes/box,
+/obj/structure/ladder,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "cBD" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -10358,10 +10136,9 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/maintenance/department/security/ghetto/fore)
 "cCx" = (
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/engine,
-/area/station/science/explab)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "cCA" = (
 /obj/machinery/exodrone_launcher,
 /obj/item/fuel_pellet,
@@ -10382,16 +10159,15 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "cCI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/sign/warning/secure_area/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple/half{
+/turf/open/floor/iron/dark/textured_corner{
 	dir = 8
 	},
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/area/station/science/xenobiology)
 "cCP" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/office)
@@ -10399,12 +10175,6 @@
 /obj/machinery/smartfridge/organ,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
-"cDj" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/science/genetics)
 "cDm" = (
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
@@ -10418,10 +10188,11 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "cDt" = (
-/obj/machinery/light/small/directional/north,
-/obj/machinery/door/firedoor,
+/obj/structure/table,
+/obj/item/reagent_containers/spray/plantbgone,
+/obj/item/cultivator/rake,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/area/station/maintenance/starboard/aft)
 "cDv" = (
 /turf/open/floor/iron/stairs/right{
 	dir = 8
@@ -10478,15 +10249,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "cEn" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "cEs" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 4
@@ -10508,11 +10273,14 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "cEB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/holopad,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/dark,
-/area/station/science/server)
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/purple/half,
+/obj/machinery/light/directional/south,
+/obj/item/radio/intercom/directional/south,
+/obj/item/aicard,
+/obj/item/circuitboard/aicore,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "cEE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -10535,10 +10303,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
-"cEJ" = (
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/engine,
-/area/station/science/lower)
 "cEL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -10580,9 +10344,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "cFo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/effect/decal/cleanable/vomit,
+/obj/item/crowbar/red,
+/turf/open/floor/iron/dark,
+/area/station/service/abandoned_gambling_den)
 "cFr" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -10628,18 +10393,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
-"cFX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "cGg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10744,12 +10497,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
-"cHo" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/lower)
 "cHq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -10778,23 +10525,9 @@
 /turf/open/floor/cult,
 /area/station/maintenance/starboard/fore)
 "cHV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
-	},
-/obj/structure/table/optable,
-/obj/effect/spawner/random/medical/surgery_tool,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/turf/closed/wall/r_wall,
+/area/space,
+/area/station/maintenance/starboard/upper)
 "cHW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10959,13 +10692,9 @@
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "cJy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/aft)
 "cJE" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/siding/wood{
@@ -11041,10 +10770,22 @@
 /turf/open/floor/iron/kitchen,
 /area/station/maintenance/ghetto/bar)
 "cKJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/sink/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
+/obj/structure/table/glass,
+/obj/machinery/airalarm/directional/north,
+/obj/item/book/manual/wiki/cytology{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/biopsy_tool{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/storage/box/monkeycubes,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "cKW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -11151,11 +10892,6 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/storage/ghetto)
-"cMg" = (
-/obj/structure/disposalpipe/junction/yjunction,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "cMi" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -11186,10 +10922,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/disposal)
-"cMA" = (
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "cMB" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8
@@ -11292,12 +11024,8 @@
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "cNP" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "cNQ" = (
 /obj/structure/bodycontainer/morgue{
@@ -11390,11 +11118,9 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "cOZ" = (
-/obj/machinery/computer/operating{
-	dir = 1
-	},
-/turf/open/floor/iron/freezer,
-/area/station/science/robotics/lab)
+/obj/effect/turf_decal/tile/purple/half,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "cPd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11411,9 +11137,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "cPo" = (
-/obj/effect/spawner/structure/electrified_grille,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/door/window/right/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/service/abandoned_gambling_den)
 "cPq" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -11443,19 +11171,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "cPM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/right/directional/east{
-	name = "Genetics Desk";
-	req_access = list("genetics")
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/science/genetics)
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "cPP" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -11487,11 +11208,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "cQk" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "cQm" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
 	dir = 1
@@ -11511,6 +11232,7 @@
 "cQE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/light/small/directional/north,
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "cQG" = (
@@ -11519,15 +11241,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
-"cQI" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "cQO" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -11685,24 +11398,25 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
 "cTb" = (
-/obj/structure/reagent_dispensers/wall/peppertank/directional/north,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/purple/half{
 	dir = 1
 	},
-/obj/effect/landmark/start/depsec/science,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
+/turf/open/floor/iron/white,
+/area/station/science/circuits)
 "cTu" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/ghetto)
 "cTB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/mail_sorting/science/rd_office,
+/obj/structure/disposalpipe/sorting/mail,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "cTF" = (
 /obj/structure/sign/warning/vacuum/directional/east,
 /turf/open/floor/catwalk_floor/iron_smooth,
@@ -11767,7 +11481,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "cUa" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/steam_vent,
 /turf/open/floor/plating,
@@ -11923,13 +11636,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
-"cVl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "cVq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11991,13 +11697,23 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "cVU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/structure/table,
+/obj/machinery/camera{
+	c_tag = "Research Lobby";
+	network = list("Research","SS13");
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_switch/directional/north,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/obj/item/folder,
+/obj/item/pen,
 /turf/open/floor/iron,
-/area/station/maintenance/aft)
+/area/station/science/lobby)
 "cVV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -12063,9 +11779,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "cXa" = (
-/obj/structure/sign/warning/vacuum/directional/south,
+/obj/structure/chair/wood,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/area/station/service/abandoned_gambling_den)
 "cXd" = (
 /obj/machinery/light/directional/north,
 /obj/effect/spawner/random/vending/colavend,
@@ -12212,9 +11928,10 @@
 /turf/open/floor/carpet/black,
 /area/station/commons/lounge)
 "cYu" = (
-/obj/effect/spawner/random/trash/graffiti,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/freezer,
+/area/station/science/robotics/lab)
 "cYv" = (
 /obj/structure/cable,
 /turf/open/floor/wood/tile,
@@ -12238,10 +11955,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/ghetto)
-"cYE" = (
-/obj/item/storage/box,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
 "cYF" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/light/small/directional/south,
@@ -12263,10 +11976,15 @@
 /turf/open/floor/carpet/black,
 /area/station/maintenance/starboard/fore)
 "cYY" = (
-/obj/structure/railing/corner,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/item/cautery{
+	pixel_x = 4
+	},
+/obj/item/hemostat,
+/obj/item/retractor,
+/obj/structure/table,
+/turf/open/floor/iron/freezer,
+/area/station/science/robotics/lab)
 "cYZ" = (
 /obj/structure/easel,
 /obj/item/canvas/nineteen_nineteen,
@@ -12300,15 +12018,14 @@
 /turf/open/floor/iron,
 /area/station/security/lockers)
 "cZo" = (
-/obj/structure/chair/office{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron/white,
-/area/station/science/explab)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "cZt" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
@@ -12526,15 +12243,16 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/station/science/lower)
+/area/station/science/explab)
 "dbD" = (
-/obj/structure/closet/secure_closet/security/science,
 /obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder,
+/obj/effect/turf_decal/tile/purple/anticorner{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
+/turf/open/floor/iron/white,
+/area/station/science/circuits)
 "dbH" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4
@@ -12551,20 +12269,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/storage)
-"dbP" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
 "dbS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/structure/closet/secure_closet/cytology,
+/obj/effect/turf_decal/tile/purple/half{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "dcd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/drinks{
@@ -12612,10 +12323,9 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "dcV" = (
-/obj/structure/barricade/wooden/crude,
-/obj/structure/barricade/wooden,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/mechbay)
 "dcX" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/structure/closet/emcloset,
@@ -12716,18 +12426,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "deZ" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 8
-	},
-/obj/machinery/monkey_recycler,
-/obj/effect/turf_decal/bot_red,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/structure/closet/l3closet/scientist,
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
+	dir = 8
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron,
 /area/station/science/xenobiology)
 "dfe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12969,12 +12672,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/security/ghetto)
 "dic" = (
-/obj/machinery/washing_machine,
-/obj/machinery/light/small/directional/north,
-/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "dii" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13112,11 +12817,11 @@
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "djt" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "djA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13132,7 +12837,7 @@
 "djK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/area/station/maintenance/ghetto/aft)
 "djL" = (
 /obj/structure/transit_tube/crossing,
 /obj/structure/lattice/catwalk,
@@ -13509,12 +13214,13 @@
 /area/station/cargo/office)
 "dnt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/area/station/service/abandoned_gambling_den)
 "dny" = (
-/obj/structure/table/wood,
-/obj/item/storage/fancy/rollingpapers,
-/turf/open/floor/plating,
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
 "dnz" = (
 /obj/effect/turf_decal/tile/blue/full,
@@ -13720,12 +13426,9 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "dpz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
+/obj/structure/stairs/east,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "dpE" = (
 /obj/machinery/light/small/directional/south{
 	name = "maintenance light";
@@ -13785,18 +13488,12 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "dqW" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/radio/off,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/machinery/component_printer,
+/obj/effect/turf_decal/tile/purple/half{
 	dir = 8
 	},
-/obj/item/screwdriver{
-	pixel_y = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
+/turf/open/floor/iron/white,
+/area/station/science/circuits)
 "drc" = (
 /turf/closed/wall,
 /area/station/command/heads_quarters/hos)
@@ -13880,13 +13577,32 @@
 	},
 /area/station/hallway/secondary/entry)
 "drZ" = (
-/obj/machinery/light/directional/east,
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/science/lab)
+/obj/structure/table,
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/item/radio/headset/headset_medsci{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 4
+	},
+/obj/machinery/button/door/directional/east{
+	id = "genetics_shutters";
+	name = "Genetics Shutters";
+	req_access = list("science")
+	},
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "dsa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13926,11 +13642,6 @@
 /turf/open/floor/carpet/green,
 /area/station/commons/dorms/apartment1)
 "dsq" = (
-/obj/structure/sign/warning/deathsposal/directional/north,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -14187,16 +13898,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/ghetto/central)
 "dvv" = (
-/obj/machinery/door/window/brigdoor/left/directional/east{
-	name = "Secure Creature Pen";
-	req_access = list("research")
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "dvy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -14260,13 +13965,6 @@
 /obj/structure/frame,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
-"dwn" = (
-/obj/structure/table,
-/obj/item/storage/bag/plants/portaseeder,
-/obj/item/plant_analyzer,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "dwo" = (
 /obj/structure/reflector/box,
 /turf/open/floor/plating,
@@ -14429,20 +14127,26 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/bar)
 "dyr" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner/directional/north{
+	pixel_y = 2
+	},
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "dys" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "dyy" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -14467,12 +14171,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "dyW" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/obj/structure/flora/rock/pile/style_2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/bush/fullgrass/style_random,
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "dza" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -14508,12 +14211,38 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
 "dzy" = (
-/obj/structure/railing{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/openspace,
-/area/station/science/xenobiology)
+/obj/structure/table/glass,
+/obj/machinery/camera/directional/south{
+	c_tag = "Medbay - Cryogenics";
+	network = list("ss13","medbay")
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/pill_bottle/mannitol,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/machinery/requests_console/directional/south{
+	department = "Medbay";
+	name = "Medbay Requests Console"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "dzH" = (
 /obj/structure/sign/departments/cargo/directional/west,
 /obj/structure/table,
@@ -14538,17 +14267,12 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "dzT" = (
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/structure/rack,
 /obj/effect/turf_decal/tile/purple/anticorner{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/science/lab)
+/obj/machinery/dna_scannernew,
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "dzZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
@@ -14767,7 +14491,6 @@
 /turf/closed/wall,
 /area/station/security/checkpoint/engineering)
 "dCQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/floor,
 /obj/effect/mapping_helpers/dead_body_placer,
@@ -14892,14 +14615,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/kitchen)
-"dEy" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 10
-	},
-/turf/open/floor/iron/dark/textured_corner{
-	dir = 8
-	},
-/area/station/science/xenobiology)
 "dEB" = (
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
@@ -15071,9 +14786,24 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "dGH" = (
-/obj/structure/railing/corner,
-/turf/open/floor/engine/hull/reinforced,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/storage/box/disks{
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/storage/box/syringes{
+	pixel_y = 9
+	},
+/obj/item/toy/figure/geneticist,
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "dGK" = (
 /obj/structure/railing{
 	dir = 1
@@ -15123,6 +14853,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
+	},
+/obj/structure/reagent_dispensers/plumbed,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "dHl" = (
@@ -15136,16 +14870,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/airless,
 /area/station/science/ordnance/bomb)
-"dHo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "dHq" = (
 /obj/effect/turf_decal/tile/dark_green/anticorner{
 	dir = 1
@@ -15181,16 +14905,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "dIb" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/barricade/wooden/crude,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/dna_infuser,
+/obj/item/infuser_book,
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "dId" = (
 /obj/structure/closet/emcloset{
 	contents_initialized = 1;
@@ -15216,13 +14937,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "dIw" = (
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 10
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio8";
+	name = "Xenobio Pen 8 Blast Door"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/caution_sign,
-/turf/open/floor/iron/white/herringbone,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "dIJ" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/effect/decal/cleanable/dirt,
@@ -15327,6 +15049,7 @@
 /obj/structure/bodycontainer/morgue{
 	dir = 1
 	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "dKj" = (
@@ -15375,15 +15098,6 @@
 /obj/effect/turf_decal/tile/red/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/checkpoint/medical)
-"dKD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
 "dKE" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/maintenance,
@@ -15454,9 +15168,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
 "dLh" = (
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/light/small/directional/south,
+/obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/area/station/maintenance/ghetto/aft)
 "dLn" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/bottle/morphine{
@@ -15743,9 +15458,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "dQm" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron/grimy,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/trimline/white/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/abandoned_gambling_den)
 "dQs" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron/dark,
@@ -15948,11 +15666,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "dTr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/machinery/oven/range,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "dTt" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -15975,13 +15692,6 @@
 	},
 /turf/open/water/alternative/muddy/no_fishing,
 /area/station/service/kitchen/abandoned)
-"dTP" = (
-/obj/machinery/light/small/directional/east,
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 8
-	},
-/turf/open/floor/iron/grimy,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
 "dTS" = (
 /obj/effect/landmark/start/shaft_miner,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -16080,14 +15790,10 @@
 /turf/closed/wall,
 /area/station/medical/medbay/aft)
 "dVk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rd_office_shutters";
-	name = "Privacy Shutters";
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/rd)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space,
+/area/space/nearstation)
 "dVq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan{
 	dir = 1
@@ -16123,15 +15829,17 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "dWc" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/button/door{
-	id = "xeno1";
-	name = "Containment Control";
-	req_access = list("xenobiology")
+/obj/machinery/light/directional/east,
+/obj/machinery/camera/directional/north{
+	c_tag = "Robotics Lab - North";
+	network = list("ss13","rd");
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/science/robotics/lab)
 "dWf" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -16147,12 +15855,18 @@
 /turf/open/floor/carpet,
 /area/station/maintenance/starboard/aft)
 "dWl" = (
-/obj/structure/table,
-/obj/item/reagent_containers/cup/glass/bottle/vodka/badminka,
-/obj/machinery/light/small/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/station/maintenance/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard/aft)
 "dWp" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/structure/crate,
@@ -16160,23 +15874,27 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/storage)
 "dWz" = (
-/obj/structure/chair/sofa/right/brown{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/aft)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "dWD" = (
 /obj/item/soap,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/station/maintenance/fore)
 "dWG" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/railing{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/open/floor/iron/herringbone,
+/area/station/maintenance/starboard/aft)
 "dWL" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/effect/turf_decal/tile/neutral/anticorner{
@@ -16308,10 +16026,15 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical/ghetto/morgue)
 "dXY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/structure/rack,
+/obj/item/wirecutters,
+/obj/item/screwdriver,
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "dYm" = (
 /obj/structure/railing/corner/end{
 	dir = 8
@@ -16325,16 +16048,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
 "dYn" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/generic,
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/box,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "dYo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -16407,24 +16124,10 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "eaa" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "rnd";
-	name = "Research Lab Shutters"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/right/directional/east{
-	name = "Research and Development Desk";
-	req_access = list("science")
-	},
-/obj/structure/desk_bell,
-/obj/machinery/door/poddoor/preopen{
-	id = "research_lockdown";
-	name = "Research Lockdown Blast Doors"
-	},
-/turf/open/floor/plating,
-/area/station/science/lab)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/bush/fullgrass/style_random,
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "eab" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -16489,7 +16192,7 @@
 /obj/item/hand_labeler,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/engine,
-/area/station/science/lower)
+/area/station/science/explab)
 "eaA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16702,7 +16405,7 @@
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "edm" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -16951,6 +16654,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/small/directional/west,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "egV" = (
@@ -16965,16 +16669,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
 "egY" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/effect/spawner/random/trash/graffiti{
-	spawn_loot_chance = 50
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/herringbone,
-/area/station/maintenance/aft)
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "ehc" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -17108,12 +16809,12 @@
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/department/engine/ghetto)
 "eiQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "ejd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -17212,9 +16913,17 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "ejZ" = (
-/obj/effect/spawner/structure/electrified_grille,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/machinery/door/window/left/directional/east{
+	name = "Containment Pen 9";
+	req_access = list("xenobiology")
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio9";
+	name = "Xenobio Pen 9 Blast Door"
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "ekb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17273,24 +16982,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/button/door/directional/north{
-	id = "research_lockdown";
-	name = "Research Lockdown Control";
-	pixel_x = 6;
-	req_one_access = list("rd","security");
-	color = "yellow"
-	},
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/purple/half{
 	dir = 1
 	},
-/obj/machinery/button/door/directional/north{
-	id = "rndsecprivacy";
-	name = "Privacy Shutter Control";
-	pixel_x = -6;
-	req_one_access = list("rd","security")
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
+/turf/open/floor/iron/white,
+/area/station/science/circuits)
 "elu" = (
 /obj/machinery/duct,
 /turf/open/floor/plating,
@@ -17301,31 +16998,24 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chemistry/ghetto)
-"elH" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white/textured_large,
-/area/station/science/xenobiology)
 "elT" = (
 /obj/structure/flora/bush/large/style_random,
 /turf/open/water/alternative/no_fishing,
 /area/station/command/bridge)
 "elW" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/science{
+	pixel_x = -4;
+	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/item/clothing/glasses/science{
+	pixel_x = 4;
+	pixel_y = -4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron,
 /area/station/science/xenobiology)
 "elY" = (
 /obj/structure/cable,
@@ -17609,7 +17299,6 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/interrogation/ghetto)
 "epH" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
@@ -17643,10 +17332,12 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "epT" = (
-/obj/effect/spawner/random/trash/garbage,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "epU" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
@@ -17701,10 +17392,15 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "erd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine/xenobio,
-/area/station/science/xenobiology)
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/storage/briefcase/secure,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/item/toy/figure/rd,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "erk" = (
 /obj/item/flashlight/flare/candle,
 /turf/open/floor/plating,
@@ -17730,21 +17426,19 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "erF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
-"erN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/light/small/directional/east,
+/obj/structure/table/wood,
+/obj/item/storage/fancy/cigarettes/dromedaryco,
+/obj/item/storage/box/matches{
+	pixel_x = -3;
+	pixel_y = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
+"erN" = (
+/obj/machinery/camera/directional/east,
+/turf/open/floor/engine,
+/area/station/science/explab)
 "erR" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17770,15 +17464,17 @@
 /turf/open/floor/wood/large,
 /area/station/service/kitchen/abandoned)
 "eso" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/purple/half,
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/area/station/command/heads_quarters/rd)
 "esq" = (
-/turf/open/floor/iron/grimy,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/effect/turf_decal/trimline/white/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/abandoned_gambling_den)
 "est" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -17792,7 +17488,16 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "esC" = (
-/obj/machinery/vending/coffee,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "esN" = (
@@ -17801,10 +17506,9 @@
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "esQ" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "esV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 8
@@ -17924,12 +17628,6 @@
 /obj/structure/frame,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"evb" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/station/maintenance/aft)
 "eve" = (
 /obj/structure/frame/computer{
 	dir = 8
@@ -17972,18 +17670,6 @@
 /obj/structure/closet/secure_closet/evidence,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
-"ewc" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 1
-	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Research - Xenobiology Cell 6";
-	network = list("ss13","xeno","rd")
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "ewd" = (
 /turf/closed/wall,
 /area/station/security/office)
@@ -18079,9 +17765,11 @@
 /turf/open/floor/carpet,
 /area/station/maintenance/starboard/aft)
 "eyx" = (
-/obj/effect/spawner/random/structure/girder,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
+	},
+/turf/open/floor/circuit/telecomms,
+/area/station/science/xenobiology)
 "eyy" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock,
@@ -18101,10 +17789,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"eyF" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
 "eyH" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -18126,12 +17810,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"ezr" = (
-/obj/effect/spawner/random/structure/grille,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
 "ezv" = (
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
@@ -18280,11 +17958,6 @@
 /obj/effect/spawner/random/structure/furniture_parts,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
-"eBh" = (
-/obj/machinery/vending/snack,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
 "eBi" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck,
@@ -18332,10 +18005,20 @@
 /turf/open/floor/carpet/black,
 /area/station/maintenance/starboard/fore)
 "eBF" = (
-/obj/effect/decal/cleanable/vomit,
-/obj/item/crowbar/red,
+/obj/structure/table,
+/obj/effect/turf_decal/tile/purple/anticorner,
+/obj/machinery/firealarm/directional/south,
+/obj/item/folder/white,
+/obj/item/computer_disk/ordnance{
+	pixel_y = 4;
+	pixel_x = -5
+	},
+/obj/item/computer_disk{
+	pixel_x = 7;
+	pixel_y = 2
+	},
 /turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/area/station/command/heads_quarters/rd)
 "eBI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18465,10 +18148,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto/central)
 "eDS" = (
-/obj/effect/turf_decal/loading_area,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/science/ordnance/office)
 "eDZ" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -18495,16 +18182,6 @@
 /obj/structure/sign/warning/docking/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
-"eEz" = (
-/obj/structure/bed{
-	dir = 4
-	},
-/mob/living/carbon/human/species/monkey,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "eEC" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/mapping_helpers/broken_floor,
@@ -18516,11 +18193,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"eEN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
 "eEP" = (
 /obj/machinery/door/airlock/bathroom{
 	id_tag = "Toilet4"
@@ -18582,13 +18254,12 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
 "eFQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/closet/l3closet/scientist,
+/obj/effect/turf_decal/tile/purple/half,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "eGb" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/cable,
@@ -18656,10 +18327,10 @@
 "eGN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "eGV" = (
@@ -18691,10 +18362,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
-"eHj" = (
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
 "eHl" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash,
@@ -18912,14 +18579,6 @@
 /obj/structure/sign/poster/contraband/tools/directional/north,
 /turf/open/floor/carpet/orange,
 /area/station/maintenance/starboard/fore)
-"eJF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/herringbone,
-/area/station/maintenance/aft)
 "eJG" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -19027,12 +18686,12 @@
 "eLd" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "eLo" = (
@@ -19177,10 +18836,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/mechbay)
 "eNk" = (
-/obj/machinery/light/directional/north,
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/iron,
-/area/station/science/genetics)
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "eNm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -19277,10 +18939,6 @@
 /obj/structure/frame/machine,
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
-"eOY" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
 "ePk" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
@@ -19371,14 +19029,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "eQp" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/washing_machine,
+/obj/effect/turf_decal/trimline/white/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/herringbone,
+/area/station/maintenance/ghetto/starboard/aft)
 "eQx" = (
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
@@ -19607,11 +19264,10 @@
 /turf/open/floor/carpet/royalblack,
 /area/station/maintenance/ghetto/fore/starboard)
 "eTT" = (
-/obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/light/directional/west,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/engine,
-/area/station/science/lower)
+/area/station/science/explab)
 "eUc" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
@@ -19629,10 +19285,6 @@
 /obj/machinery/smartfridge/food,
 /turf/open/floor/plating,
 /area/station/service/kitchen)
-"eUj" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood,
-/area/station/maintenance/aft)
 "eUs" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/layer2{
 	dir = 1
@@ -19692,9 +19344,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard/west)
 "eUZ" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/effect/turf_decal/stripes/box,
+/turf/closed/wall/r_wall,
+/area/station/maintenance/starboard/aft)
 "eVl" = (
 /obj/structure/cable,
 /obj/machinery/light/small/directional/south,
@@ -19742,12 +19394,12 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/atmos/mix/ghetto)
 "eVH" = (
-/obj/structure/railing,
-/obj/structure/chair,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "eVN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -19758,8 +19410,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "eWa" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
@@ -19787,12 +19440,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
 "eWp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/openspace,
+/area/station/science/xenobiology)
 "eWt" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small/directional/west,
@@ -19861,9 +19514,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "eXj" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood,
-/area/station/maintenance/aft)
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/flora/tree/jungle/small/style_random,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "eXr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/dim/directional/east,
@@ -19932,16 +19591,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "eYd" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/light_switch/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/mechbay)
 "eYf" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -19979,12 +19633,8 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/maintenance/department/security/ghetto/fore)
 "eYB" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/turf/closed/wall,
+/area/station/science/xenobiology)
 "eYJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
@@ -20069,16 +19719,13 @@
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/atmos/project)
 "fao" = (
-/obj/structure/railing{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/generic,
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
+/obj/structure/closet/toolcloset,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "far" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -20177,9 +19824,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "fbV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/trimline/white/warning{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/abandoned_gambling_den)
 "fbX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -20194,13 +19844,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "fcd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/machinery/light/small/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
+/obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "fcg" = (
@@ -20210,20 +19854,16 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "fcj" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "fcz" = (
-/obj/structure/table_frame/wood,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/wood,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "fcC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue,
@@ -20266,9 +19906,12 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "fdb" = (
-/obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/area/station/maintenance/starboard/upper)
 "fdc" = (
 /obj/structure/table,
 /obj/item/kitchen/spoon/plastic,
@@ -20404,24 +20047,18 @@
 /turf/open/floor/carpet/black,
 /area/station/commons/lounge)
 "ffg" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stack/sheet/mineral/plasma,
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/purple/half,
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/xenobiology)
 "ffj" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/firealarm/directional/west,
-/obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /turf/open/floor/iron/dark,
-/area/station/science/genetics)
+/area/station/science/server)
 "ffA" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -20556,16 +20193,6 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
-"fgW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/mail_sorting/science/genetics,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
 "fgX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20584,11 +20211,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "fhl" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
+/obj/effect/spawner/random/maintenance,
+/obj/structure/table,
+/obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plating,
-/area/station/maintenance/aft)
+/area/station/maintenance/starboard/upper)
 "fhp" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -20601,31 +20228,12 @@
 "fht" = (
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
-"fhA" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 4;
-	id = "rd_office_shutters";
-	name = "Privacy Shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/rd)
 "fhF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/atmos)
-"fhJ" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/delivery_chute{
-	dir = 8
-	},
-/obj/effect/turf_decal/box/red,
-/turf/open/floor/engine/xenobio,
-/area/station/science/xenobiology)
 "fhN" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -20684,11 +20292,6 @@
 /obj/structure/flora/bush/large/style_random,
 /turf/open/floor/grass,
 /area/station/commons/dorms)
-"fiG" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
 "fiH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -20721,23 +20324,20 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "fiK" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
-/turf/closed/wall/r_wall,
+/obj/machinery/portable_atmospherics/canister/air{
+	anchored = 1
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "fiO" = (
-/obj/machinery/door/window/brigdoor/left/directional/north{
-	name = "Creature Pen";
-	req_access = list("research")
-	},
 /obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno4";
-	name = "Creature Cell #4"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/aft)
 "fiQ" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/effect/turf_decal/delivery,
@@ -20775,9 +20375,17 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "fji" = (
-/obj/structure/stairs/east,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio6";
+	name = "Xenobio Pen 6 Blast Door"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/area/station/science/xenobiology)
 "fjr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office{
@@ -20927,15 +20535,11 @@
 	},
 /area/station/service/chapel)
 "flg" = (
-/obj/structure/railing{
-	dir = 8
+/obj/structure/chair/wood{
+	dir = 1
 	},
-/obj/structure/flora/bush/jungle/b/style_random,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "fli" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Construction Area";
@@ -20967,10 +20571,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical/ghetto)
-"flt" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/engine,
-/area/station/science/explab)
 "flM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21079,16 +20679,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"fmP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "fmX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -21215,11 +20805,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "foW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "fpc" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/firealarm/directional/south,
@@ -21243,14 +20834,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "fpz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
 "fpA" = (
@@ -21389,9 +20983,11 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "frC" = (
-/obj/effect/spawner/random/structure/steam_vent,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/service/abandoned_gambling_den)
 "frD" = (
 /obj/structure/barricade/wooden,
 /obj/effect/spawner/structure/window/reinforced,
@@ -21485,24 +21081,26 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "fst" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/rd)
+/turf/closed/wall/r_wall,
+/area/station/security/checkpoint/science)
 "fsy" = (
 /obj/structure/chair/office/light,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/large,
 /area/station/maintenance/ghetto/central)
 "fsA" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/storage/box/syringes{
+	pixel_y = 9;
+	pixel_x = -4
 	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 8
+/obj/item/storage/box/beakers{
+	pixel_x = 7;
+	pixel_y = 3
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
+/obj/item/storage/box/petridish,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "fsD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
@@ -21556,10 +21154,10 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "ftz" = (
-/obj/machinery/light/small/directional/north,
-/obj/machinery/deepfryer,
-/turf/open/floor/wood,
-/area/station/maintenance/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/flora/bush/jungle/b/style_random,
+/turf/open/floor/asphalt,
+/area/station/maintenance/ghetto/garden)
 "ftC" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -21598,13 +21196,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
-"fuc" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
 "fuk" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -21763,18 +21354,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "fvV" = (
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/scanning_module,
-/obj/item/stock_parts/scanning_module,
-/obj/effect/turf_decal/tile/purple/anticorner,
-/obj/item/stock_parts/capacitor,
-/obj/structure/table,
-/turf/open/floor/iron/white,
-/area/station/science/lab)
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "fwa" = (
 /obj/item/clothing/mask/breath,
 /obj/effect/decal/cleanable/dirt,
@@ -21823,7 +21404,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "fwy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
@@ -22004,13 +21584,6 @@
 "fyN" = (
 /turf/open/floor/iron/airless,
 /area/station/science/ordnance/bomb)
-"fyT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "fyW" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -22063,8 +21636,9 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "fzv" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "fzC" = (
@@ -22163,13 +21737,18 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "fAT" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/machinery/camera{
+	c_tag = "Research Test Lab";
+	network = list("ss13","rd");
 	dir = 1
 	},
-/obj/structure/table,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/circuits)
 "fBf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22257,13 +21836,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "fCh" = (
-/obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/door/window/right/directional/west{
-	req_access = list("science")
-	},
-/turf/open/floor/iron/white,
-/area/station/science/lab)
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "fCk" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -22286,11 +21861,6 @@
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"fCw" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/structure/table_or_rack,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "fCB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance,
@@ -22362,8 +21932,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "fDn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
@@ -22518,11 +22086,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
-"fFb" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/tree/jungle/style_random,
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
 "fFc" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
 	dir = 4
@@ -22682,12 +22245,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "fGO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/loading_area{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/mechbay)
 "fGS" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/lawyer,
@@ -22772,18 +22335,20 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/fore/starboard)
 "fHC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder{
+	pixel_x = -1;
+	pixel_y = 8
 	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_y = 4
+	},
 /obj/effect/turf_decal/tile/purple/half{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/duct,
+/obj/structure/sign/xenobio_guide/directional/north,
 /turf/open/floor/iron/white,
-/area/station/science/genetics)
+/area/station/science/xenobiology)
 "fHF" = (
 /obj/structure/cable,
 /obj/structure/rack,
@@ -22794,12 +22359,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "fHM" = (
-/obj/structure/table,
-/obj/item/mmi,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_y = 4
+/obj/structure/table/optable{
+	name = "Robotics Operating Table"
 	},
-/obj/item/radio/intercom/directional/west,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/tank/internals/anesthetic,
 /turf/open/floor/iron/freezer,
 /area/station/science/robotics/lab)
 "fHS" = (
@@ -22843,27 +22407,9 @@
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "fIv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/vomit,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/aft)
-"fIA" = (
-/obj/machinery/door/window/brigdoor/left/directional/south{
-	name = "Creature Pen";
-	req_access = list("research")
-	},
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno6";
-	name = "Creature Cell #6"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/circuits)
 "fIE" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -22891,9 +22437,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "fIR" = (
-/obj/effect/spawner/random/trash/graffiti,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "fIY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/yellow{
@@ -22901,14 +22448,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
-"fJa" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/sign/warning/deathsposal/directional/east,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "fJb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22949,12 +22488,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "fJB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "fJD" = (
@@ -22965,16 +22499,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "fJH" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "fJJ" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -22996,10 +22523,13 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/station/engineering/atmos/project)
 "fKh" = (
-/obj/structure/cable,
-/obj/effect/landmark/generic_maintenance_landmark,
-/turf/open/floor/iron,
-/area/station/maintenance/aft)
+/obj/effect/turf_decal/trimline/white/end{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/caution_sign,
+/turf/open/floor/iron/white/herringbone,
+/area/station/maintenance/ghetto/starboard/aft)
 "fKk" = (
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
@@ -23028,15 +22558,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "fKC" = (
-/obj/structure/disposaloutlet,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/effect/turf_decal/box/white/corners{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/obj/machinery/power/shieldwallgen/xenobiologyaccess,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/station/science/xenobiology)
 "fKJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -23055,18 +22579,12 @@
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison)
 "fLd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light/directional/south,
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
-/obj/machinery/door/poddoor/preopen{
-	id = "research_lockdown";
-	name = "Research Lockdown Blast Doors"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/freezer,
 /area/station/science/robotics/lab)
 "fLk" = (
 /obj/structure/table,
@@ -23078,16 +22596,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "fLB" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "xeno8";
-	name = "Containment Control";
-	req_access = list("xenobiology")
-	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/effect/turf_decal/bot,
+/obj/machinery/light/small/directional/west,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/science/xenobiology)
+/area/station/maintenance/ghetto/aft)
 "fLC" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern,
@@ -23171,16 +22683,10 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "fMF" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/spawner/random/structure/barricade,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/area/station/maintenance/ghetto/aft)
 "fMH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -23396,9 +22902,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "fOH" = (
-/obj/item/storage/box/bodybags,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/mechbay)
 "fOS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23520,10 +23026,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
-"fRD" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
 "fRG" = (
 /obj/structure/table/wood/poker,
 /obj/item/coin/iron,
@@ -23621,13 +23123,16 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "fSv" = (
-/obj/structure/filingcabinet,
-/obj/structure/sign/poster/official/space_cops/directional/east,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/dropper,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
+/area/station/science/circuits)
 "fSw" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -23654,11 +23159,9 @@
 	},
 /area/station/command/gateway)
 "fSN" = (
-/obj/structure/railing,
 /obj/structure/cable,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den)
 "fSQ" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
@@ -23686,14 +23189,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
 "fTg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
+/area/station/science/research)
 "fTi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -23801,13 +23303,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
-"fVc" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "fVf" = (
 /obj/structure/table/glass,
 /obj/item/cigarette/pipe,
@@ -23856,12 +23351,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
-"fVJ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
 "fVL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -23903,9 +23392,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
 "fVX" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/modular_computer/preset/cargochat/science{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/turf/open/floor/iron/white,
+/area/station/science/lab)
 "fVY" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/random/contraband/prison,
@@ -24263,10 +23756,8 @@
 /turf/open/floor/iron/airless,
 /area/station/science/ordnance/bomb)
 "gaA" = (
-/obj/structure/table/wood/poker,
-/obj/item/coin/diamond,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/area/station/service/abandoned_gambling_den)
 "gaJ" = (
 /obj/structure/disposalpipe/trunk/multiz/down{
 	dir = 8
@@ -24331,12 +23822,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/black,
 /area/station/commons/lounge)
-"gbq" = (
-/obj/structure/chair/comfy/teal{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
 "gbs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24441,15 +23926,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
-"gdb" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/table/glass,
-/obj/item/storage/box/monkeycubes,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "gdf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -24467,10 +23943,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
-"gdj" = (
-/obj/effect/decal/cleanable/insectguts,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
 "gdr" = (
 /obj/machinery/light_switch/directional/west,
 /obj/structure/closet/secure_closet/lawyer,
@@ -24537,12 +24009,13 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "gef" = (
-/obj/structure/chair/stool{
-	dir = 4
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood,
-/area/station/maintenance/aft)
+/obj/machinery/suit_storage_unit/rd,
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "gep" = (
 /obj/machinery/meter{
 	name = "Mixed Air Tank In"
@@ -24697,15 +24170,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical/ghetto)
 "ggl" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio_maint_aft";
-	name = "Xenobiology Blast Door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor{
-	id = "xenobio_maint_fore";
-	name = "Xenobiology Blast Door"
+/obj/machinery/light/small/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
@@ -24727,11 +24194,11 @@
 /turf/open/floor/carpet/black,
 /area/station/command/meeting_room)
 "ggB" = (
-/obj/structure/table/wood,
-/obj/machinery/cell_charger,
-/obj/item/coin/diamond,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/area/station/maintenance/ghetto/aft)
 "ggE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -24740,28 +24207,14 @@
 	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "ggR" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"ghj" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/structure/flora/rock/pile/style_random,
-/turf/open/water,
-/area/station/maintenance/ghetto/garden)
 "ghm" = (
 /obj/machinery/door/poddoor{
 	id = "2131331fdfsf";
@@ -24934,9 +24387,9 @@
 "gjd" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "gjv" = (
@@ -24946,10 +24399,10 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "gjF" = (
-/obj/structure/table/wood,
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/open/floor/wood,
-/area/station/maintenance/aft)
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/railing/corner,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "gjK" = (
 /obj/machinery/door/airlock/engineering,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -24958,16 +24411,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "gjO" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 1
-	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Research - Xenobiology Cell 8";
-	network = list("ss13","xeno","rd")
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/aft)
 "gjP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/random/directional/north,
@@ -25026,10 +24476,6 @@
 /obj/machinery/meter,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"gkS" = (
-/obj/structure/sign/poster/contraband/random,
-/turf/closed/wall,
-/area/station/maintenance/ghetto/aft)
 "gle" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/oxygen_output{
 	dir = 1
@@ -25049,16 +24495,15 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
 "gls" = (
-/obj/machinery/light/small/directional/north,
-/obj/machinery/camera/directional/east{
-	c_tag = "Research - Server Room";
-	network = list("ss13","rd");
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/science/server)
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "glu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25066,11 +24511,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
-"glx" = (
-/obj/item/seeds/ambrosia/deus,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
 "glz" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25177,14 +24617,19 @@
 /turf/open/floor/eighties/red,
 /area/station/maintenance/port/aft)
 "gmX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Research Maintenance"
 	},
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/plating,
+/area/station/science/robotics/lab)
 "gnb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table/wood,
@@ -25226,11 +24671,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/fore)
-"gnl" = (
-/obj/effect/turf_decal/box/white/corners,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "gnn" = (
 /obj/structure/stairs/east{
 	dir = 1
@@ -25238,24 +24678,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "gno" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/closet/secure_closet/personal{
+	anchored = 1
 	},
-/obj/structure/table,
-/obj/item/storage/belt/utility,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass{
-	amount = 20;
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard/aft)
 "gnq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -25314,16 +24742,6 @@
 /obj/effect/turf_decal/tile/neutral/anticorner,
 /turf/open/floor/iron,
 /area/station/science/lobby)
-"goo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno1";
-	name = "Creature Cell #1"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "goA" = (
 /obj/item/book/manual/wiki/cytology{
 	pixel_x = -4;
@@ -25336,19 +24754,10 @@
 /obj/structure/table,
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/ghetto)
-"goE" = (
-/obj/structure/flora/bush/jungle/b/style_random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
 "goM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/structure/chair/stool/bar/directional/north,
+/turf/open/floor/iron/grimy,
+/area/station/service/abandoned_gambling_den)
 "goP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -25374,14 +24783,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "gph" = (
-/obj/effect/turf_decal/siding/wideplating_new{
-	dir = 1
+/obj/structure/flora/bush/jungle/b/style_random,
+/obj/structure/railing/corner{
+	dir = 8
 	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/iron/herringbone,
-/area/station/maintenance/aft)
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "gpq" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/light/directional/south,
@@ -25395,11 +24802,6 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
-"gpy" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
 "gpE" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/random/maintenance/two,
@@ -25430,7 +24832,7 @@
 /obj/machinery/door/window/right/directional/north,
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/engine,
-/area/station/science/lower)
+/area/station/science/explab)
 "gpY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -25446,13 +24848,17 @@
 /turf/open/floor/plating,
 /area/station/medical/paramedic)
 "gqq" = (
-/obj/machinery/light/small/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/server)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard/aft)
 "gqs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -25480,10 +24886,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
 "gqS" = (
-/obj/machinery/light/small/directional/east,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 8
+	},
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/science/robotics/mechbay)
 "gqT" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -25511,17 +24920,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/sorting)
-"grH" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/research,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "research_lockdown";
-	name = "Research Lockdown Blast Doors"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
 "grQ" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
@@ -25784,18 +25182,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/starboard)
-"gwr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/garden)
 "gwt" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "gwz" = (
 /obj/structure/marker_beacon/olive,
 /turf/open/floor/plating/airless,
@@ -25906,23 +25299,21 @@
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "gxU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/door/airlock/command/rd,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
-/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
-/obj/effect/mapping_helpers/airlock/access/any/science/rd,
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/rd)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "genetics_shutters";
+	name = "Genetics Shutters"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/plating,
+/area/station/science/genetics)
 "gxY" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/cup/glass/waterbottle,
-/turf/open/floor/wood,
-/area/station/maintenance/aft)
+/obj/machinery/holopad,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "gyF" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -25973,9 +25364,9 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "gzg" = (
-/obj/machinery/light/directional/west,
-/obj/structure/table,
-/obj/effect/spawner/random/trash/food_packaging,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "gzm" = (
@@ -26188,17 +25579,15 @@
 /turf/open/floor/carpet,
 /area/station/commons/vacant_room/office)
 "gCj" = (
-/obj/structure/railing{
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/structure/flora/rock/pile/style_random,
+/turf/open/water,
+/area/station/maintenance/ghetto/garden)
 "gCn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -26388,12 +25777,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "gEP" = (
-/obj/structure/flora/bush/jungle/b/style_random,
-/obj/structure/chair/pew/left{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "gEZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/barricade/wooden/crude,
@@ -26458,13 +25847,6 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/nanotrasen_representative)
-"gGd" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "gGf" = (
 /obj/structure/closet/body_bag,
 /obj/effect/spawner/random/maintenance,
@@ -26527,17 +25909,15 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "gGO" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
+/obj/effect/turf_decal/tile/purple/half{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/west,
+/obj/structure/sink/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "gHb" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/cable,
@@ -26564,10 +25944,17 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "gHp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/grille_or_waste,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/machinery/door/window/left/directional/east{
+	name = "Containment Pen 7";
+	req_access = list("xenobiology")
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio7";
+	name = "Xenobio Pen 7 Blast Door"
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "gHq" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -26730,11 +26117,6 @@
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
-"gIU" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/wooden,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
 "gIV" = (
 /obj/effect/spawner/random/structure/chair_maintenance{
 	dir = 8
@@ -26861,9 +26243,6 @@
 /obj/structure/railing/corner/end/flip{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "gKL" = (
@@ -26876,9 +26255,14 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
 "gKM" = (
-/obj/structure/closet/crate/preopen,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/glasses/welding,
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/purple/anticorner,
+/turf/open/floor/iron/white,
+/area/station/science/lab)
 "gKZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -26977,8 +26361,7 @@
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "gLG" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "gLM" = (
@@ -27013,11 +26396,20 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
 "gMn" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock,
+/obj/machinery/door/airlock/research,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/area/station/science/xenobiology)
 "gMr" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
@@ -27033,12 +26425,9 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "gML" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/turf_decal/box/white/corners,
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "gMN" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -27074,18 +26463,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "gNf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/genetics,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard/aft)
 "gNu" = (
 /turf/closed/wall/r_wall,
 /area/station/science/server)
@@ -27137,13 +26517,17 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "gNZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
+/obj/machinery/monkey_recycler,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/camera/directional/east{
+	c_tag = "Xenobiology Pens - Starboard Aft";
+	network = list("ss13","rd","xeno");
+	dir = 2
+	},
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "gOb" = (
 /obj/structure/table/wood,
 /obj/item/modular_computer/laptop,
@@ -27221,11 +26605,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
-"gOt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
 "gOu" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
@@ -27244,14 +26623,15 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
 "gOH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/obj/structure/sign/gym/mirrored{
-	pixel_y = -32
+/obj/structure/flora/bush/large/style_2{
+	pixel_y = 0
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/turf/open/water,
+/area/station/maintenance/ghetto/garden)
 "gOQ" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/yellow/full,
@@ -27489,16 +26869,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"gQK" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/science/research)
 "gRa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27529,10 +26899,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "gRP" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/wood,
-/area/station/maintenance/aft)
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/asphalt,
+/area/station/maintenance/ghetto/garden)
 "gRS" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
@@ -27628,16 +26999,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "gTQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/station/maintenance/ghetto/starboard/aft)
-"gTU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/airlock/command{
+	name = "Research Director's Quarters"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
+"gTU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "gUf" = (
@@ -27693,11 +27067,6 @@
 "gUL" = (
 /turf/closed/wall,
 /area/station/service/library/artgallery)
-"gUR" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
 "gVh" = (
 /turf/closed/wall,
 /area/station/maintenance/department/security/ghetto/fore)
@@ -27721,20 +27090,21 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "gVu" = (
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
-"gVD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/kitchen)
+/area/station/service/abandoned_gambling_den)
+"gVD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "gVF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/sorting/mail,
+/obj/effect/mapping_helpers/mail_sorting/science/robotics,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "gVI" = (
@@ -27750,6 +27120,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "gVU" = (
@@ -27955,17 +27328,24 @@
 /turf/open/floor/wood,
 /area/station/service/kitchen/abandoned)
 "gXY" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/landmark/start/roboticist,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "rnd";
+	name = "Research Lab Shutters"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/right/directional/east{
+	name = "Research and Development Desk";
+	req_access = list("science")
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
+/obj/structure/desk_bell,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/iron,
+/area/station/science/lab)
 "gYd" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -27986,20 +27366,13 @@
 /turf/open/floor/carpet/red,
 /area/station/service/library/ghetto)
 "gYr" = (
-/obj/machinery/griddle,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/wood,
-/area/station/maintenance/aft)
-"gYx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/machinery/door/firedoor,
+/obj/structure/table/wood/poker,
+/obj/item/stack/spacecash/c1{
+	pixel_y = 5
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
+/area/station/service/abandoned_gambling_den)
 "gYA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -28047,11 +27420,12 @@
 /turf/open/floor/wood/parquet,
 /area/station/security/courtroom)
 "gZl" = (
-/obj/machinery/light/small/directional/east,
-/obj/structure/table,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "gZq" = (
@@ -28073,12 +27447,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
-"gZB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
 "gZC" = (
 /obj/structure/sign/departments/restroom/directional/north,
 /turf/open/floor/iron,
@@ -28108,10 +27476,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "gZR" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "gZZ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -28215,9 +27583,11 @@
 /turf/open/water,
 /area/station/maintenance/ghetto/garden)
 "hbu" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/table,
+/obj/item/storage/bag/plants/portaseeder,
+/obj/item/plant_analyzer,
 /turf/open/floor/plating,
-/area/station/science/lower)
+/area/station/maintenance/starboard/aft)
 "hbD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -28424,8 +27794,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple/half,
+/obj/machinery/camera/directional/south,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "heS" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 4
@@ -28440,14 +27812,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/nanotrasen_representative)
-"hfu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wideplating_new/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/herringbone,
-/area/station/maintenance/aft)
 "hfy" = (
 /obj/structure/table/reinforced/rglass,
 /turf/open/floor/light{
@@ -28456,16 +27820,6 @@
 	light_color = "#a659ff"
 	},
 /area/station/commons/lounge)
-"hfD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenosecure";
-	name = "Secure Pen Shutters"
-	},
-/obj/structure/cable,
-/obj/structure/sign/warning/electric_shock/directional/west,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "hfG" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
@@ -28628,19 +27982,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "hgY" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
+/obj/structure/table/reinforced,
+/obj/item/wrench,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
 /area/station/science/xenobiology)
 "hhB" = (
 /obj/machinery/door/poddoor/preopen{
@@ -28676,11 +28024,17 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "hhW" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio2";
+	name = "Xenobio Pen 2 Blast Door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/machinery/light/small/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/area/station/science/xenobiology)
 "hhY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -28783,14 +28137,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "hjg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/warning{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/turf/open/floor/iron/dark,
+/area/station/service/abandoned_gambling_den)
 "hjn" = (
 /obj/machinery/atmospherics/components/unary/passive_vent/layer2{
 	dir = 8
@@ -28885,10 +28236,6 @@
 /area/station/security/prison)
 "hkN" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "research_lockdown";
-	name = "Research Lockdown Blast Doors"
-	},
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
 "hkP" = (
@@ -28949,10 +28296,9 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/atmos)
 "hlC" = (
-/obj/structure/cable,
-/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/chair/wood,
 /turf/open/floor/wood,
-/area/station/maintenance/ghetto/aft)
+/area/station/service/abandoned_gambling_den)
 "hlF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -28979,16 +28325,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard/west)
 "hmg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
+/obj/machinery/door/window/right/directional/west{
+	name = "Containment Pen 2";
+	req_access = list("xenobiology")
 	},
-/obj/structure/table/wood,
-/obj/item/food/canned/peaches/maint,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio2";
+	name = "Xenobio Pen 2 Blast Door"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "hmi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/grille,
@@ -29128,10 +28475,6 @@
 "hnS" = (
 /turf/closed/wall,
 /area/station/maintenance/department/engine/atmos)
-"hnT" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
 "hnW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29176,10 +28519,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "hob" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
+/obj/structure/table/wood,
+/obj/effect/spawner/random/entertainment/gambling,
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "hoi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/frame/machine,
@@ -29212,10 +28555,9 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "hoA" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/chair/wood,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/mob/living/basic/cockroach,
+/turf/open/floor/iron/dark,
+/area/station/service/abandoned_gambling_den)
 "hoB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
@@ -29248,14 +28590,6 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/carpet/royalblack,
 /area/station/maintenance/port/aft)
-"hpd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
 "hpg" = (
 /obj/structure/table,
 /obj/item/analyzer,
@@ -29280,13 +28614,15 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/incinerator)
 "hpu" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 9
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
 	},
-/turf/open/floor/iron/dark/textured_corner{
-	dir = 1
-	},
-/area/station/science/xenobiology)
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "hpw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29361,16 +28697,14 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "hqy" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 9
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/station/science/research)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "hqz" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/entry)
@@ -29383,24 +28717,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hqD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table_frame,
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/obj/machinery/processor,
-/obj/item/clothing/suit/apron/chef,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/turf/open/floor/engine/xenobio,
+/area/station/science/xenobiology)
 "hqJ" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/flora/bush/lavendergrass,
@@ -29487,9 +28808,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "hrZ" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "hsc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -29502,9 +28825,8 @@
 /area/station/engineering/supermatter/room)
 "hsn" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "hsw" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/carpet,
@@ -29580,11 +28902,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/plating/reinforced,
 /area/station/cargo/storage)
-"htI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/garden)
 "htO" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/grimy,
@@ -29613,18 +28930,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/blueshield)
-"hur" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "hut" = (
 /obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
@@ -29646,10 +28951,6 @@
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
-"huy" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
 "huA" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -29685,21 +28986,20 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"huV" = (
-/obj/effect/decal/remains/xeno,
-/turf/open/floor/engine/xenobio,
-/area/station/science/xenobiology)
 "hve" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/seeds/corn,
 /turf/open/misc/grass,
 /area/station/security/prison/garden)
 "hvn" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/aft)
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "hvp" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -29786,14 +29086,6 @@
 /obj/machinery/meter,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/garden)
-"hwy" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/rd)
 "hwz" = (
 /obj/structure/table/glass,
 /obj/effect/spawner/random/maintenance/two,
@@ -29959,6 +29251,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "hyp" = (
@@ -30034,23 +29327,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
 "hzs" = (
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
 	},
-/obj/item/reagent_containers/cup/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/dropper,
-/obj/machinery/camera/directional/east{
-	c_tag = "Research - Research and Development Lab";
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/tile/purple/anticorner,
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/station/science/lab)
+/obj/machinery/dna_scannernew,
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "hzz" = (
 /obj/effect/turf_decal/tile/purple/half,
 /turf/open/floor/iron,
@@ -30060,9 +29342,9 @@
 /turf/open/floor/iron/dark,
 /area/station/construction)
 "hzG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/structure/cable,
+/turf/open/floor/iron/white/textured,
+/area/station/science/xenobiology)
 "hzQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30073,17 +29355,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "hzV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8
 	},
-/obj/structure/railing/corner/end/flip{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/herringbone,
+/area/station/maintenance/ghetto/starboard/aft)
 "hzY" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plating,
@@ -30143,13 +29420,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/abandoned)
 "hBh" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "hBi" = (
 /obj/structure/bookcase/random/adult,
@@ -30304,15 +29580,12 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "hDa" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "hDf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -30325,11 +29598,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
-"hDn" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/purple/half,
-/turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
 "hDp" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/donkpockets,
@@ -30558,14 +29826,15 @@
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
 "hFm" = (
-/obj/structure/disposalpipe/segment,
+/turf/open/floor/circuit/green,
+/area/station/science/robotics/mechbay)
+"hFo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
-"hFo" = (
-/obj/machinery/light/small/directional/east,
-/obj/item/kirbyplants/random,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
 "hFx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30595,10 +29864,11 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/central)
 "hFO" = (
-/obj/structure/barricade/wooden,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table/wood/poker,
+/obj/item/storage/briefcase,
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "hFR" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -30656,14 +29926,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"hGn" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "hGp" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
@@ -30738,29 +30000,17 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "hHq" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock,
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "hHv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/glasses/welding,
+/obj/structure/window/reinforced/spawner/directional/west,
+/mob/living/carbon/human/species/monkey,
 /obj/machinery/light/directional/south,
-/obj/item/disk/tech_disk{
-	pixel_x = -4;
-	pixel_y = -7
-	},
-/obj/item/disk/tech_disk{
-	pixel_x = -2;
-	pixel_y = -6
-	},
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/science/lab)
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "hHC" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency{
@@ -30997,24 +30247,10 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "hKL" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/table/glass,
-/obj/item/paper_bin{
-	pixel_y = 4
-	},
-/obj/item/folder/white{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/pen{
-	pixel_x = -4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/effect/spawner/random/trash/grille_or_waste,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor/iron,
+/area/station/maintenance/starboard/aft)
 "hKS" = (
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white/corner{
@@ -31057,11 +30293,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/dronefabricator)
 "hLv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/aft)
 "hLw" = (
@@ -31157,8 +30391,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
 "hMV" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/closed/wall/r_wall,
+/obj/machinery/portable_atmospherics/canister{
+	anchored = 1
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "hMX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31219,13 +30456,18 @@
 /turf/open/floor/plating,
 /area/station/security/lockers)
 "hND" = (
-/obj/structure/disposalpipe/trunk{
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/purple/half,
-/turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
+/obj/machinery/newscaster/directional/west,
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/machinery/camera/directional/west{
+	c_tag = "Research - Security Post";
+	network = list("ss13","rd");
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "hNK" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -31277,32 +30519,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/ghetto/fore/starboard)
-"hOm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door_buttons/access_button{
-	idDoor = "xeno_airlock_exterior";
-	idSelf = "xeno_airlock_control";
-	name = "Xeno Access Button";
-	req_access = list("xenobiology");
-	pixel_y = 24
-	},
-/obj/effect/landmark/navigate_destination,
-/obj/effect/mapping_helpers/airlock/access/all/science/general,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/research{
-	frequency = 1450;
-	autoclose = 0;
-	id_tag = "xeno_airlock_exterior"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "hOt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31313,15 +30529,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"hOD" = (
-/obj/machinery/power/shieldwallgen/xenobiologyaccess,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/sign/warning/secure_area/directional/south,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "hOF" = (
 /obj/item/soap/syndie,
 /obj/item/toy/figure/syndie,
@@ -31529,10 +30736,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
-"hSq" = (
-/obj/structure/closet/wardrobe/black,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
 "hSt" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
@@ -31652,11 +30855,11 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
 "hTZ" = (
-/obj/structure/rack,
-/obj/item/wrench,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
+/obj/structure/table/wood,
+/obj/machinery/cell_charger,
+/obj/item/coin/diamond,
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "hUa" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Chapel - Coffin Storage"
@@ -31837,13 +31040,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
-"hWd" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/structure/closet/firecloset,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard/west)
 "hWn" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -31868,9 +31064,17 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "hWp" = (
-/obj/structure/chair/wood,
-/turf/open/floor/wood,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio7";
+	name = "Xenobio Pen 7 Blast Door"
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "hWq" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -31980,16 +31184,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/stone,
 /area/station/maintenance/ghetto/bar)
-"hYK" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "xeno6";
-	name = "Containment Control";
-	req_access = list("xenobiology")
-	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "hYU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32003,14 +31197,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
-"hZc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
 "hZf" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating,
@@ -32025,42 +31211,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
-"hZk" = (
-/obj/machinery/modular_computer/preset/research{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 1
-	},
-/obj/machinery/button/door/directional/west{
-	id = "rd_office_shutters";
-	name = "Privacy Shutters Control";
-	req_access = list("rd");
-	pixel_y = -10
-	},
-/obj/machinery/button/door/directional/west{
-	id = "research_lockdown";
-	name = "Research Lockdown Control";
-	req_access = list("rd");
-	pixel_y = 10;
-	color = "yellow"
-	},
-/obj/machinery/button/door/directional/west{
-	id = "rd_robotics_window_shutters";
-	name = "Upper Privacy Shutters Control";
-	req_access = list("rd")
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
 "hZl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
 "hZm" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window/hollow/reinforced/directional,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/area/station/service/abandoned_gambling_den)
 "hZp" = (
 /obj/structure/table/reinforced,
 /obj/item/hand_labeler,
@@ -32225,15 +31385,6 @@
 /mob/living/basic/butterfly,
 /turf/open/floor/asphalt,
 /area/station/maintenance/ghetto/garden)
-"ibq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "ibH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/shieldgen,
@@ -32504,20 +31655,13 @@
 /turf/closed/wall,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ifY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/poddoor/shutters{
-	id = "Skynet_launch";
-	name = "Mech Bay"
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "research_lockdown";
-	name = "Research Lockdown Blast Doors"
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/station/science/lab)
 "igb" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -32528,20 +31672,11 @@
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "igh" = (
-/obj/structure/plasticflaps{
-	opacity = 1
+/obj/structure/chair/pew/left{
+	dir = 1
 	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=8";
-	location = "Research Division"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "research_lockdown";
-	name = "Research Lockdown Blast Doors"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "igl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor{
@@ -32710,15 +31845,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/arrivals)
-"iiS" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light/small/directional/east,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/upper)
 "iiT" = (
 /obj/item/flashlight/lantern,
 /turf/open/floor/plating,
@@ -32875,12 +32001,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/ghetto)
-"ikS" = (
-/obj/machinery/door/airlock/wood,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
 "ikT" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8
@@ -33007,10 +32127,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
 "imp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/garden)
+/obj/structure/closet/l3closet/scientist,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "imq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33075,41 +32194,20 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"inS" = (
-/obj/machinery/door/window/brigdoor/left/directional/north{
-	name = "Creature Pen";
-	req_access = list("research")
-	},
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno3";
-	name = "Creature Cell #3"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "inV" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/ghetto)
 "ioa" = (
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = -7
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/item/reagent_containers/condiment/saltshaker,
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/wood,
-/area/station/maintenance/aft)
+/turf/open/floor/iron/dark/textured_large,
+/area/station/science/xenobiology)
 "iob" = (
-/obj/machinery/washing_machine,
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/cafeteria,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/machinery/smartfridge/petri/preloaded,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "iod" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
@@ -33163,32 +32261,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
-"ioA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id = "quarantine";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/medical/break_room)
 "ioD" = (
-/obj/machinery/door/airlock,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/mapping_helpers/broken_machine,
-/turf/open/floor/iron/white/textured_large,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "ioE" = (
 /obj/structure/girder,
 /turf/open/floor/iron,
@@ -33378,14 +32456,13 @@
 /turf/open/floor/iron/dark/small,
 /area/station/service/chapel/monastery)
 "irF" = (
-/obj/machinery/door/window/right/directional/south{
-	name = "Genetics Desk";
-	req_access = list("genetics")
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
 	},
-/obj/effect/landmark/start/geneticist,
-/obj/effect/turf_decal/tile/neutral/anticorner,
-/turf/open/floor/iron,
-/area/station/science/genetics)
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "irK" = (
 /obj/machinery/door/airlock/public,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -33403,14 +32480,17 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "irW" = (
-/obj/structure/railing/corner/end{
-	dir = 8
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio10";
+	name = "Xenobio Pen 10 Blast Door"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/maintenance/aft)
+/area/station/science/xenobiology)
 "irX" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
@@ -33430,16 +32510,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "isn" = (
-/obj/structure/chair/stool{
-	dir = 8
-	},
-/obj/effect/landmark/start/research_director,
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/rd)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "isp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33579,9 +32655,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "iuc" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/obj/structure/chair/pew/left{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "iuf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
@@ -33745,15 +32823,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"iwl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/science/research)
 "iwo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -33768,15 +32837,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
-"iwu" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/knife/kitchen{
-	pixel_x = 1;
-	pixel_y = 3
-	},
-/turf/open/floor/wood,
-/area/station/maintenance/aft)
 "iwv" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/flashlight,
@@ -33895,14 +32955,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/storage)
-"iyY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "izv" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -33924,9 +32976,12 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/tcommsat/server)
 "izA" = (
-/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/purple/half,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "izJ" = (
@@ -34158,13 +33213,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
-"iCW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/herringbone,
-/area/station/maintenance/aft)
 "iDc" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -34206,10 +33254,24 @@
 /turf/open/floor/engine/cult,
 /area/station/service/library)
 "iDA" = (
-/obj/machinery/door/airlock/wood,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/garden)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass{
+	amount = 20;
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
+	},
+/obj/item/storage/belt/utility/full,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "iDR" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/table/wood,
@@ -34258,15 +33320,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "iEn" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/crowbar/large,
-/obj/item/toy/figure/roboticist{
-	pixel_y = 4;
-	pixel_x = -6
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
+/turf/open/floor/iron/freezer,
+/area/station/science/robotics/lab)
 "iEp" = (
 /obj/structure/chair/sofa/corp/right,
 /turf/open/floor/iron,
@@ -34337,15 +33395,8 @@
 /obj/effect/turf_decal/tile/purple/anticorner{
 	dir = 8
 	},
-/obj/machinery/door/window/right/directional/north{
-	name = "Window Door"
-	},
-/obj/effect/turf_decal/delivery/red,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "iFy" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -34401,11 +33452,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "iFX" = (
-/obj/machinery/door/airlock/bathroom,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/cafeteria,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "iGa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34423,27 +33474,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical/ghetto)
-"iGe" = (
-/obj/structure/table/glass,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	pixel_x = -3;
-	pixel_y = 9
-	},
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "iGi" = (
 /obj/structure/chair{
 	dir = 4
@@ -34627,22 +33657,16 @@
 /turf/open/floor/plating,
 /area/station/command/meeting_room)
 "iIJ" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/pipe/smart/simple{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/item/relic,
-/obj/item/assembly/signaler{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/taperecorder,
-/obj/item/tape/random,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
+/obj/machinery/camera/directional/east{
+	c_tag = "Xenobiology Pens - Starboard Aft";
+	network = list("ss13","rd","xeno");
+	dir = 2
 	},
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/xenobiology)
 "iIM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,
@@ -34650,7 +33674,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/prison/ghetto)
 "iJe" = (
-/turf/closed/wall,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "rdoffice";
+	name = "Research Director's Shutters"
+	},
+/turf/open/floor/plating,
 /area/station/command/heads_quarters/rd)
 "iJg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34759,16 +33789,10 @@
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "iKc" = (
-/obj/machinery/button/door/directional/north{
-	id = "Skynet_launch";
-	name = "Mech Bay Door Control";
-	req_access = list("robotics")
-	},
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "iKg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35122,10 +34146,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical/ghetto)
 "iOy" = (
-/obj/structure/fermenting_barrel,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood,
-/area/station/maintenance/starboard/upper)
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "iOJ" = (
 /obj/item/clothing/head/collectable/kitty,
 /obj/item/clothing/head/collectable/rabbitears,
@@ -35227,12 +34251,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"iQs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
 "iQE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35491,18 +34509,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "iTE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/table,
-/obj/item/stock_parts/power_store/cell/high{
-	pixel_y = 6
+/obj/effect/turf_decal/tile/purple/half,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/machinery/cell_charger{
-	pixel_y = 5
-	},
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/science/lab)
+/obj/machinery/light/directional/south,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "iTG" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -35547,10 +34562,18 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "iUb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/structure/table,
+/obj/item/toy/plush/slimeplushie{
+	name = "Gish"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "iUd" = (
 /obj/item/latexballoon,
 /turf/open/floor/plating,
@@ -35588,13 +34611,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "iUI" = (
-/mob/living/carbon/human/species/monkey,
-/obj/structure/sink/directional/east,
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/science/genetics)
+/obj/machinery/airalarm/directional/north,
+/obj/item/kirbyplants/random,
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "iUJ" = (
 /turf/open/floor/iron,
 /area/station/science/ordnance)
@@ -35691,7 +34711,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/engine,
-/area/station/science/lower)
+/area/station/science/explab)
 "iWx" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
@@ -35753,15 +34773,13 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/science/lab)
-"iXl" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
 "iXs" = (
-/obj/structure/frame/machine,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "iXt" = (
 /obj/structure/table,
 /obj/effect/spawner/random/mod/maint,
@@ -35774,8 +34792,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "iXB" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "iXL" = (
 /obj/machinery/teleport/station,
@@ -35783,15 +34802,12 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/command/teleporter)
 "iXS" = (
-/obj/structure/rack,
-/obj/item/storage/box/bodybags,
-/obj/item/radio/intercom/directional/west,
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 8
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
+/turf/open/floor/iron/dark/textured_large,
+/area/station/science/xenobiology)
 "iXT" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet,
@@ -35801,15 +34817,17 @@
 /turf/open/floor/iron/dark,
 /area/station/construction)
 "iXW" = (
-/obj/machinery/modular_computer/preset/civilian{
-	dir = 8
+/obj/structure/sink/directional/west,
+/obj/machinery/camera{
+	c_tag = "Research Access";
+	network = list("ss13","rd");
+	dir = 1
 	},
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/purple/half{
+/obj/effect/turf_decal/tile/purple/anticorner{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "iXZ" = (
 /obj/machinery/status_display/evac/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -35925,33 +34943,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
-"iYX" = (
-/obj/structure/sink/directional/west,
-/obj/machinery/camera/directional/north{
-	c_tag = "Research - Access";
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "iZh" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "iZv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/shieldwallgen/xenobiologyaccess,
 /obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/area/station/science/xenobiology)
 "iZA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/meter,
@@ -35964,18 +34965,21 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
 "iZF" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Research - Secure Lab Test Chamber";
+/obj/machinery/camera{
+	c_tag = "Secure Lab - Test Chamber";
+	dir = 4;
 	network = list("ss13","rd","test")
 	},
 /turf/open/floor/engine,
-/area/station/science/lower)
+/area/station/science/explab)
 "iZN" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/clothing/costume,
-/obj/structure/sign/poster/contraband/random/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/structure/chair/sofa/middle/brown{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/food/grown/cannabis,
+/turf/open/floor/carpet,
+/area/station/maintenance/starboard/aft)
 "iZO" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Brig - Lobby - East"
@@ -36177,12 +35181,14 @@
 "jcj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/explab)
+/obj/machinery/door/airlock/research{
+	name = "Circuits Lab"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/turf/open/floor/iron/dark,
+/area/station/science/circuits)
 "jct" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36302,14 +35308,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"jed" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "jef" = (
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/iron,
@@ -36445,10 +35443,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "jfZ" = (
-/obj/structure/closet/emcloset,
-/obj/structure/sign/warning/vacuum/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "jga" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36476,17 +35474,13 @@
 /area/station/maintenance/port/fore)
 "jgi" = (
 /obj/structure/table/reinforced,
-/obj/item/tape/random{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/taperecorder,
 /obj/machinery/atmospherics/pipe/smart/simple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple/half,
+/obj/machinery/recharger,
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "jgp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/table,
@@ -36513,17 +35507,9 @@
 /obj/item/trash/pistachios,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
-"jgF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/lower)
 "jgG" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -36539,14 +35525,10 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/arrivals)
 "jgK" = (
-/obj/machinery/rnd/production/circuit_imprinter/department/science,
-/obj/item/radio/intercom/directional/east,
-/obj/machinery/light_switch/directional/north,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
+/obj/effect/spawner/random/structure/crate,
+/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/area/station/maintenance/ghetto/aft)
 "jha" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36555,22 +35537,20 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "jhd" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/maintenance/department/security/ghetto)
 "jhg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno8";
-	name = "Creature Cell #8"
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "jhn" = (
 /obj/structure/table,
 /obj/item/toy/figure/prisoner,
@@ -36739,12 +35719,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "jjv" = (
-/obj/structure/chair/stool{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/machinery/module_duplicator,
+/obj/effect/turf_decal/tile/purple/half,
+/turf/open/floor/iron/white,
+/area/station/science/circuits)
 "jjz" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal{
@@ -36991,27 +35969,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "jnH" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/monkeycubes{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = -6;
-	pixel_y = -6
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 6;
-	pixel_y = -6
-	},
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/tile/purple/half,
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/engine/xenobio,
+/area/station/science/xenobiology)
 "jnP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 10
@@ -37120,11 +36080,14 @@
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "jqv" = (
-/obj/structure/table/wood,
-/obj/structure/mirror/directional/north,
-/obj/effect/spawner/random/entertainment/drugs,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/machinery/status_display/ai/directional/south,
+/obj/structure/table,
+/obj/item/mmi,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_y = 4
+	},
+/turf/open/floor/iron/freezer,
+/area/station/science/robotics/lab)
 "jqC" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/aft)
@@ -37156,15 +36119,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "jqR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "jqT" = (
 /obj/effect/decal/remains/human,
 /obj/item/shard,
@@ -37265,10 +36224,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
-"jsl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance/office)
 "jsm" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
@@ -37284,15 +36239,12 @@
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "jsr" = (
-/obj/structure/chair/office/light{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/effect/landmark/start/geneticist,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 4
-	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/science/genetics)
+/area/station/science/server)
 "jst" = (
 /obj/structure/flora/rock/style_2,
 /turf/open/floor/grass,
@@ -37329,9 +36281,23 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto)
 "jsR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/table/glass,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 1
+	},
+/obj/item/disk/tech_disk{
+	pixel_x = 3;
+	pixel_y = 5
+	},
+/obj/item/disk/tech_disk{
+	pixel_x = -4;
+	pixel_y = -2
+	},
+/obj/item/toy/figure/scientist,
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/lab)
 "jtc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
@@ -37360,22 +36326,18 @@
 /area/station/hallway/secondary/service)
 "jtA" = (
 /obj/structure/table,
-/obj/machinery/camera/directional/north{
-	c_tag = "Research - Test Lab";
-	network = list("ss13","rd")
-	},
 /obj/item/healthanalyzer/advanced,
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/ears/earmuffs{
 	pixel_x = 4;
 	pixel_y = -2
 	},
-/obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 1
 	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "jtG" = (
 /obj/machinery/button/door/directional{
 	id = "atmos_pro";
@@ -37556,9 +36518,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "jwP" = (
-/obj/item/seeds/berry,
-/turf/open/floor/wood,
-/area/station/maintenance/starboard/upper)
+/obj/structure/dresser,
+/obj/structure/mirror/directional/north,
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "jwX" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1
@@ -37729,13 +36695,8 @@
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "jyC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenosecure";
-	name = "Secure Pen Shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/machinery/processor/slime,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "jyF" = (
 /obj/machinery/door/firedoor,
@@ -37763,14 +36724,12 @@
 /turf/open/floor/iron,
 /area/station/service/chapel/monastery)
 "jze" = (
-/obj/structure/table/glass,
-/obj/structure/cable,
-/obj/item/hand_labeler,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/lab)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "jzr" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
@@ -37907,12 +36866,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "jAZ" = (
-/obj/structure/chair/stool{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio5";
+	name = "Xenobio Pen 5 Blast Door"
 	},
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/machinery/door/window/right/directional/west{
+	name = "Containment Pen 5";
+	req_access = list("xenobiology")
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "jBk" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/flora/bush/pointy/style_random,
@@ -37984,10 +36948,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
-"jCI" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
 "jCQ" = (
 /obj/structure/railing/corner/end/flip,
 /obj/effect/turf_decal/delivery,
@@ -38031,11 +36991,6 @@
 /obj/item/clothing/head/utility/welding,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"jDM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/science/lower)
 "jDO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -38071,12 +37026,11 @@
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "jDW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "jEb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38096,14 +37050,12 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "jEn" = (
-/obj/structure/chair/stool{
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
-/obj/structure/sign/poster/contraband/fun_police/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "jEt" = (
 /obj/machinery/door/poddoor/shutters/window/preopen{
 	dir = 1;
@@ -38172,17 +37124,6 @@
 /obj/item/clothing/shoes/jackboots,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/aft)
-"jEU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/item/kitchen/rollingpin,
-/obj/item/reagent_containers/condiment/sugar,
-/obj/item/reagent_containers/condiment/enzyme,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
 "jFb" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
@@ -38335,28 +37276,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/office)
-"jGD" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
 "jGH" = (
 /obj/structure/grille,
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"jGM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 4
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
 "jGO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
@@ -38368,6 +37292,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/light/small/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "jGT" = (
@@ -38440,11 +37367,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/hallway/secondary/dock)
-"jHD" = (
-/obj/structure/table/wood/poker,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/grimy,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
 "jHK" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -38496,15 +37418,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"jIc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno6";
-	name = "Creature Cell #6"
-	},
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "jIe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38555,10 +37468,22 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
 "jJa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/iron/dark,
-/area/station/science/server)
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/obj/machinery/camera/directional/east{
+	c_tag = "Science - Research Director's Office";
+	name = "science camera";
+	network = list("ss13","rd");
+	dir = 10
+	},
+/obj/machinery/computer/robotics{
+	dir = 4
+	},
+/obj/machinery/computer/security/telescreen/rd/directional/west,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "jJb" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -38612,11 +37537,14 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/hallway)
 "jJD" = (
-/obj/effect/spawner/random/vending/snackvend,
-/obj/effect/turf_decal/tile/purple/anticorner{
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/purple/half{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "jJG" = (
@@ -38669,10 +37597,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "jKc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/iron/white,
+/area/station/science/lab)
 "jKd" = (
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/dark,
@@ -38691,11 +37619,14 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "jKo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/trunk/multiz/down{
+	dir = 2
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/area/station/maintenance/starboard/upper)
 "jKt" = (
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hop)
@@ -38732,15 +37663,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "jLm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/directional/west,
-/turf/open/floor/iron,
+/obj/structure/sign/warning/gas_mask/directional/south,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "jLr" = (
 /obj/structure/chair{
@@ -38900,19 +37824,11 @@
 	},
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/starboard/aft)
-"jNa" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/dropper,
-/turf/open/floor/engine,
-/area/station/science/lower)
 "jNb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
+/obj/structure/table,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "jNh" = (
 /obj/structure/table_frame,
 /turf/open/floor/plating,
@@ -38935,15 +37851,10 @@
 /turf/open/floor/wood,
 /area/station/service/kitchen/abandoned)
 "jNy" = (
-/obj/machinery/power/shieldwallgen/xenobiologyaccess,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/obj/structure/sign/warning/secure_area/directional/north,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
+/obj/structure/lattice,
+/obj/item/clothing/shoes/clown_shoes,
+/turf/open/space/openspace,
+/area/space/nearstation)
 "jNz" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
@@ -39051,10 +37962,6 @@
 "jPJ" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/paramedic)
-"jPM" = (
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
 "jPN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
@@ -39119,28 +38026,9 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos/storage/gas)
 "jQE" = (
-/obj/structure/closet/secure_closet/personal{
-	anchored = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/departments/restroom/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
-"jQV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/machinery/duct,
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
-/turf/open/floor/plating,
-/area/station/science/research)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "jQX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39370,12 +38258,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "jUq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
@@ -39415,15 +38298,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"jUH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
 "jUN" = (
 /obj/machinery/holopad/secure,
 /obj/effect/landmark/event_spawn,
@@ -39435,19 +38309,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
-"jUY" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/structure/flora/grass/jungle/b/style_random,
-/turf/open/water,
-/area/station/maintenance/ghetto/garden)
 "jVd" = (
 /obj/machinery/button/door/directional/east{
 	id = "vacantstore_east"
@@ -39571,10 +38432,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "jWi" = (
-/obj/structure/barricade/wooden,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/area/station/maintenance/ghetto/aft)
 "jWl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -39598,12 +38460,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "jWy" = (
-/obj/structure/chair/stool{
+/obj/structure/railing{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/open/floor/iron/herringbone,
+/area/station/maintenance/starboard/aft)
 "jWz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39637,9 +38502,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "jXa" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark,
+/area/station/service/abandoned_gambling_den)
 "jXc" = (
 /obj/machinery/photocopier,
 /turf/open/floor/iron/dark/small,
@@ -39649,9 +38514,12 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "jXs" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
+/obj/machinery/camera/directional/west{
+	c_tag = "Xenobiology Kill Chamber";
+	network = list("ss13","rd","xeno")
+	},
+/turf/open/floor/circuit/telecomms,
+/area/station/science/xenobiology)
 "jXx" = (
 /obj/structure/table/glass,
 /obj/machinery/light/small/directional/north,
@@ -39717,10 +38585,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "jYo" = (
-/obj/structure/rack,
-/obj/item/wrench,
-/turf/open/floor/iron/dark,
-/area/station/science/server)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/stamp/head/rd,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "jYs" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
@@ -39833,14 +38705,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"jZL" = (
-/obj/structure/closet/firecloset/full,
-/obj/item/radio/intercom/directional/west,
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "jZN" = (
 /obj/structure/table/reinforced,
 /obj/item/hfr_box/corner,
@@ -39908,10 +38772,6 @@
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry/ghetto)
-"kak" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
 "kar" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39920,15 +38780,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "kat" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
-/obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
+"kaw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
-"kaw" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/science/server)
 "kaz" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
@@ -40062,12 +38923,10 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "kcM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
 "kcN" = (
@@ -40098,15 +38957,6 @@
 "kcZ" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/command/nuke_storage)
-"kdc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/obj/structure/table_frame,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
 "kdj" = (
 /obj/structure/table,
 /obj/item/flatpack{
@@ -40134,14 +38984,11 @@
 /turf/open/floor/iron/white/diagonal,
 /area/station/maintenance/ghetto/starboard/aft)
 "kds" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "kdz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
@@ -40172,10 +39019,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "kdW" = (
-/obj/item/storage/box/bodybags,
-/obj/structure/rack,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/area/station/service/abandoned_gambling_den)
 "kea" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -40190,13 +39038,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
 "kel" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "kem" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -40204,19 +39049,23 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "ker" = (
-/obj/structure/closet/emcloset,
-/obj/structure/sign/warning/vacuum/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
-"key" = (
-/obj/structure/closet/wardrobe/botanist,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/landmark/start/geneticist,
+/obj/effect/landmark/start/geneticist,
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
+"key" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "keB" = (
 /turf/open/floor/iron/edge{
 	dir = 8
@@ -40386,11 +39235,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"khb" = (
-/obj/effect/spawner/random/vending/snackvend,
-/obj/effect/turf_decal/tile/purple/half,
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "khd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -40424,16 +39268,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"khv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno7";
-	name = "Creature Cell #7"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "khw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -40616,12 +39450,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard/west)
 "kko" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
+/obj/machinery/camera/directional/west{
+	c_tag = "Xenobiology Pens - Port Mid";
+	network = list("ss13","rd","xeno")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/structure/sign/warning/docking/directional/west,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "kkq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -40771,15 +39606,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
-"kmy" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
 "kmA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/transit_tube/station/dispenser/reverse,
@@ -40814,10 +39640,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "kmK" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/machinery/light/small/directional/west,
+/obj/structure/sign/poster/contraband/random/directional/west,
+/turf/open/floor/iron/grimy,
+/area/station/service/abandoned_gambling_den)
 "kmO" = (
 /obj/structure/railing/corner,
 /turf/open/floor/iron/dark,
@@ -40833,12 +39659,14 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "kmU" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "kna" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
@@ -40856,16 +39684,6 @@
 /obj/machinery/papershredder,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
-"knt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "knx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/blue{
@@ -40893,12 +39711,14 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "knL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/purple/half{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/rd)
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/light_switch/directional/south,
+/obj/effect/landmark/start/depsec/science,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "knT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
@@ -41036,15 +39856,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/commons/vacant_room/office)
-"kpd" = (
-/obj/structure/railing{
-	dir = 5
-	},
-/obj/effect/spawner/random/structure/closet_maintenance,
-/obj/effect/spawner/random/maintenance/two,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
 "kpe" = (
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 4
@@ -41056,8 +39867,9 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
 "kpj" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Research - Toxins Mixing";
+/obj/machinery/camera{
+	c_tag = "Research Toxins Mixing";
+	dir = 8;
 	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/tile/purple/half{
@@ -41167,14 +39979,6 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"kqJ" = (
-/obj/structure/table/wood,
-/obj/structure/bedsheetbin{
-	pixel_y = -2
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
 "kqR" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron/dark/smooth_large,
@@ -41186,11 +39990,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port)
 "krq" = (
-/obj/machinery/light/small/directional/south,
 /obj/structure/table_frame/wood,
 /obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den)
 "krr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
@@ -41248,12 +40051,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "ksf" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/box,
-/obj/machinery/computer/security/telescreen/test_chamber/directional/north,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/machinery/light/small/directional/east,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 8
+	},
+/turf/open/floor/iron/grimy,
+/area/station/service/abandoned_gambling_den)
 "ksh" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -41301,11 +40104,17 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "ksv" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/obj/effect/spawner/random/bureaucracy/paper,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/machinery/door/window/left/directional/east{
+	name = "Containment Pen 10";
+	req_access = list("xenobiology")
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio10";
+	name = "Xenobio Pen 10 Blast Door"
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "ksw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41331,11 +40140,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "ksH" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/server)
+/turf/closed/wall/r_wall,
+/area/station/command/heads_quarters/rd)
 "ksQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41343,12 +40149,11 @@
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "ksS" = (
-/obj/machinery/vending/wardrobe/gene_wardrobe,
-/obj/machinery/light/directional/south,
-/obj/machinery/status_display/evac/directional/south,
-/obj/effect/turf_decal/tile/purple/anticorner,
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "ksT" = (
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 8
@@ -41434,31 +40239,25 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
 "ktW" = (
-/obj/structure/railing{
-	dir = 8
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/scalpel,
-/obj/item/hemostat,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -3
-	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
-"ktZ" = (
-/obj/effect/spawner/random/structure/barricade,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
-"kub" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno2";
-	name = "Creature Cell #2"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"ktZ" = (
+/obj/structure/rack,
+/obj/item/wrench,
+/obj/machinery/camera/directional/east{
+	c_tag = "Research - Server Room";
+	network = list("ss13","rd");
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "kup" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -41488,11 +40287,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "kuy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/iron/herringbone,
+/area/station/maintenance/starboard/aft)
 "kuE" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -41506,12 +40309,12 @@
 /obj/structure/table,
 /obj/item/electropack,
 /obj/item/assembly/signaler,
-/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 1
 	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "kuW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/dark_green,
@@ -41540,19 +40343,11 @@
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/ghetto/fore/starboard)
 "kvp" = (
-/obj/structure/table,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/item/stack/cable_coil,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "kvr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41659,13 +40454,20 @@
 /turf/open/floor/catwalk_floor,
 /area/station/cargo/storage/ghetto/depot)
 "kwR" = (
-/obj/structure/closet/secure_closet/cytology,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/bottle/rum{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/cup/glass/bottle/whiskey{
+	pixel_y = 7
+	},
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den)
 "kxa" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "kxe" = (
@@ -41717,12 +40519,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/large,
 /area/station/maintenance/ghetto/central)
-"kxV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
 "kxW" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/dirt,
@@ -41732,7 +40528,6 @@
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
 "kys" = (
@@ -41775,16 +40570,12 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
 "kzo" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/flora/bush/grassy/style_random,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/tank_holder/extinguisher,
+/obj/effect/turf_decal/tile/purple/half,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "kzp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -42005,9 +40796,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "kBT" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/purple/half,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "kBV" = (
@@ -42019,16 +40810,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
-"kBY" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/effect/landmark/start/roboticist,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/science/robotics/lab)
 "kCd" = (
 /obj/machinery/light_switch/directional/south,
 /obj/structure/table,
@@ -42057,14 +40838,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"kCm" = (
-/obj/machinery/newscaster/directional/south,
-/obj/effect/turf_decal/tile/purple/half,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
 "kCn" = (
 /obj/structure/flora/grass/jungle,
 /obj/effect/spawner/structure/window,
@@ -42083,8 +40856,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "kCy" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/decal/cleanable/cobweb,
+/obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "kCK" = (
@@ -42222,10 +40995,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
-"kEb" = (
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
 "kEh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42278,23 +41047,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "kEz" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "kEA" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "kEC" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/decal/cleanable/dirt,
@@ -42364,11 +41127,9 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "kFp" = (
-/obj/machinery/door/airlock/virology/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "kFt" = (
@@ -42411,13 +41172,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "kFF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "kFH" = (
 /obj/structure/table,
 /obj/item/folder{
@@ -42458,18 +41216,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/theater)
-"kFX" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/flora/rock/pile/style_2,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
 "kGo" = (
 /obj/effect/spawner/random/structure/barricade,
 /turf/open/floor/plating,
@@ -42580,14 +41326,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
-"kHF" = (
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/shower/directional/west,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "kHI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/random/dead,
@@ -42621,12 +41359,6 @@
 	},
 /turf/open/misc/beach/sand,
 /area/station/service/hydroponics)
-"kIk" = (
-/obj/machinery/hydroponics/soil,
-/obj/item/seeds/ambrosia,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/grass,
-/area/station/maintenance/starboard/aft)
 "kIw" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/table/wood,
@@ -42649,15 +41381,6 @@
 /obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
-"kIC" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/water,
-/area/station/maintenance/ghetto/garden)
 "kIG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -42714,16 +41437,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "kJj" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Research - Xenobiology Killroom Chamber";
-	network = list("ss13","xeno","rd")
-	},
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/science/xenobiology)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "kJl" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -42805,23 +41521,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/storage)
 "kKc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id = "quarantine";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/grunge,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "kKh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -42875,8 +41577,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "kKF" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/rack,
 /obj/item/assembly/igniter{
 	pixel_x = -6;
 	pixel_y = 2
@@ -42894,8 +41594,9 @@
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 8
 	},
+/obj/structure/rack,
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "kKG" = (
 /obj/structure/chair/comfy/black,
 /obj/machinery/newscaster/directional/north,
@@ -42925,12 +41626,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
-"kKX" = (
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/closet,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
 "kKZ" = (
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/wood/parquet,
@@ -42944,10 +41639,9 @@
 /turf/open/floor/iron/telecomms,
 /area/station/tcommsat/server)
 "kLy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "kLA" = (
 /obj/structure/railing{
 	dir = 10
@@ -42978,12 +41672,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
-"kLX" = (
-/obj/structure/chair/stool{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
 "kLY" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -43023,9 +41711,11 @@
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
-/area/station/science/lab)
+/obj/machinery/computer/scan_consolenew{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "kMk" = (
 /obj/effect/turf_decal/tile/dark_green/fourcorners,
 /obj/effect/decal/cleanable/dirt,
@@ -43120,10 +41810,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/security/prison)
-"kNT" = (
-/obj/machinery/power/floodlight,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
 "kNW" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -43204,11 +41890,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "kPk" = (
-/obj/effect/turf_decal/tile/bar/half{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/table/reinforced,
+/obj/item/crowbar/large,
+/obj/item/clothing/head/utility/welding,
+/obj/item/toy/figure/roboticist,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/science/robotics/mechbay)
 "kPp" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -43328,9 +42015,6 @@
 /area/station/medical/medbay/lobby)
 "kQM" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43467,28 +42151,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/aft)
-"kSu" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
 "kSv" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/storage)
-"kSA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
 "kSC" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -43590,13 +42257,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"kTU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/aft)
 "kUk" = (
 /obj/structure/table/wood,
 /obj/machinery/button/door/directional/south{
@@ -43622,9 +42282,11 @@
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
 "kUl" = (
-/obj/machinery/smartfridge/organ,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/structure/spacevine{
+	can_spread = 0
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/garden)
 "kUq" = (
 /obj/structure/training_machine,
 /turf/open/floor/iron,
@@ -43647,12 +42309,6 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
-"kVf" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/maintenance/starboard/aft)
 "kVp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -43685,9 +42341,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "kVP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
 	},
@@ -43728,10 +42381,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "kWk" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/cup/glass/mug,
-/turf/open/floor/wood,
-/area/station/maintenance/starboard/upper)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/maint,
+/obj/item/bedsheet/blue,
+/turf/open/floor/iron/white,
+/area/station/maintenance/aft)
 "kWn" = (
 /obj/machinery/atmospherics/pipe/smart/simple{
 	dir = 1
@@ -43742,7 +42396,7 @@
 	id = "RnDChem"
 	},
 /turf/open/floor/engine,
-/area/station/science/lower)
+/area/station/science/explab)
 "kWs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43814,12 +42468,18 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "kXk" = (
-/obj/machinery/pdapainter/research,
-/obj/effect/turf_decal/tile/purple/half{
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/rd)
+/obj/structure/cable,
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/radio/off,
+/obj/item/screwdriver{
+	pixel_y = 10
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "kXl" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -43828,11 +42488,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/cafeteria)
-"kXt" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
 "kXD" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -43917,14 +42572,12 @@
 /turf/open/floor/iron/large,
 /area/station/maintenance/ghetto/central)
 "kYs" = (
-/obj/structure/table,
 /obj/structure/cable,
-/obj/item/reagent_containers/cup/glass/bottle/beer,
-/obj/item/reagent_containers/cup/glass/bottle/beer{
-	pixel_x = -7
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "kYx" = (
 /obj/machinery/bluespace_vendor/directional/south,
 /obj/effect/turf_decal/bot,
@@ -43946,10 +42599,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "kYH" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/chair/pew{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "kYI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44067,14 +42722,6 @@
 /obj/structure/sign/departments/exam_room,
 /turf/open/floor/plating,
 /area/station/medical/treatment_center)
-"las" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "law" = (
 /obj/structure/cable,
 /obj/structure/table,
@@ -44107,17 +42754,9 @@
 	dir = 4
 	},
 /area/station/commons/dorms)
-"laY" = (
-/obj/structure/table,
-/obj/effect/spawner/random/mod/maint,
-/obj/item/healthanalyzer,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
 "laZ" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/turf/open/floor/iron/grimy,
+/area/station/service/abandoned_gambling_den)
 "lbi" = (
 /obj/effect/landmark/navigate_destination/dockarrival,
 /obj/machinery/holopad,
@@ -44254,7 +42893,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "lcD" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -44335,12 +42973,6 @@
 /obj/item/kirbyplants/random/dead,
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/ghetto/starboard)
-"ldY" = (
-/obj/structure/chair/stool{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
 "leb" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -44399,24 +43031,23 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/ghetto/central/aft)
 "lfw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/spawner/random/trash/mess,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "lfL" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood/parquet,
 /area/station/security/courtroom)
 "lfM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/seeds/ambrosia,
+/turf/open/floor/wood,
+/area/station/maintenance/starboard/aft)
 "lfP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44480,10 +43111,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/smartfridge/extract/preloaded,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "lgQ" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -44576,14 +43205,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/service/chapel)
-"lhZ" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/bodycontainer/morgue{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/morgue)
 "lic" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
@@ -44626,23 +43247,26 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "liy" = (
-/obj/structure/table/wood/poker,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/wood,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
-"liz" = (
-/obj/effect/spawner/random/trash/grille_or_waste,
-/turf/open/floor/catwalk_floor/iron,
-/area/station/maintenance/aft)
-"liF" = (
-/obj/machinery/door/poddoor{
-	id = "xenobio_maint_fore";
-	name = "Xenobiology Blast Door"
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"liz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
+"liF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/textured,
+/area/station/science/xenobiology)
 "liP" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -44715,10 +43339,11 @@
 	},
 /area/station/medical/chemistry/ghetto)
 "ljJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/curtain,
+/obj/machinery/atmospherics/pipe/smart/simple{
+	dir = 9
+	},
 /turf/open/floor/plating,
-/area/station/medical/virology)
+/area/station/maintenance/starboard/upper)
 "ljR" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/trimline/dark_blue/line{
@@ -44841,30 +43466,10 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/gravity_generator)
-"lmn" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 8
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Research - Xenobiology Cell 3";
-	network = list("ss13","xeno","rd")
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "lmq" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/obj/structure/table/glass,
-/obj/item/storage/toolbox/emergency{
-	pixel_y = 4
-	},
-/obj/item/wrench/medical,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "lmt" = (
@@ -44913,17 +43518,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
-"lnb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "lnc" = (
 /obj/effect/spawner/random/structure/table_or_rack,
 /obj/effect/spawner/random/maintenance,
@@ -45063,6 +43657,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/starboard)
 "lor" = (
@@ -45071,7 +43668,8 @@
 /area/station/maintenance/port/aft)
 "low" = (
 /obj/structure/cable,
-/turf/open/floor/engine/hull/reinforced,
+/obj/structure/lattice/catwalk,
+/turf/open/space/openspace,
 /area/space/nearstation)
 "loy" = (
 /obj/effect/landmark/start/atmospheric_technician,
@@ -45100,9 +43698,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "loJ" = (
-/obj/effect/spawner/random/trash,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio4";
+	name = "Xenobio Pen 4 Blast Door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/area/station/science/xenobiology)
 "loN" = (
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
@@ -45192,7 +43798,7 @@
 	},
 /obj/effect/turf_decal/tile/purple/half,
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "lpK" = (
 /obj/structure/safe,
 /obj/effect/spawner/random/maintenance/six,
@@ -45292,20 +43898,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/light/small/directional/west,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
-"lqP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "lqQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -45347,14 +43943,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "lrj" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/effect/turf_decal/bot,
+/obj/machinery/recharge_station,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/science/robotics/mechbay)
 "lrk" = (
 /obj/structure/cable,
 /obj/machinery/holopad/secure,
@@ -45483,17 +44075,23 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "lsE" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
+"lsJ" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
-"lsJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/aft)
 "lsK" = (
 /obj/machinery/computer/records/security{
 	dir = 8
@@ -45554,16 +44152,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
-"ltz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/machinery/door/airlock,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
 "ltD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/machinery/door/morgue{
@@ -45595,8 +44183,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "lun" = (
-/obj/effect/spawner/random/structure/steam_vent,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/spawner/random/structure/grille,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "luq" = (
@@ -45609,15 +44197,9 @@
 /turf/open/floor/asphalt,
 /area/station/maintenance/ghetto/garden)
 "luu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno6";
-	name = "Creature Cell #6"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "luy" = (
 /obj/structure/table/reinforced,
 /obj/item/electropack,
@@ -45666,12 +44248,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "luY" = (
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
@@ -45683,19 +44259,17 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
 "lvh" = (
-/obj/machinery/door/window/brigdoor/left/directional/north{
-	name = "Creature Pen";
-	req_access = list("research")
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno2";
-	name = "Creature Cell #2"
+/obj/effect/decal/cleanable/generic,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/mob/living/basic/snake,
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "lvi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -45955,20 +44529,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "lzH" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
-"lzI" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/aft)
 "lzJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46173,16 +44737,15 @@
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "lBV" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/obj/structure/flora/rock/pile,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
-	},
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
+/obj/machinery/door/airlock/research/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/genetics,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/science/genetics)
 "lCe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -46209,13 +44772,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"lCq" = (
-/obj/structure/closet/radiation,
-/obj/effect/landmark/start/hangover/closet,
-/obj/effect/turf_decal/tile/purple/anticorner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
 "lCE" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -46237,10 +44793,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "lCP" = (
+/obj/effect/turf_decal/tile/purple/anticorner,
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/science/server)
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "lDb" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/table,
@@ -46425,21 +44982,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"lFJ" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/table/glass,
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/dropper{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/dropper,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "lFQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46565,11 +45107,6 @@
 /obj/effect/spawner/random/techstorage/tcomms_all,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
-"lHy" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
-/obj/item/storage/bag/trash,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
 "lHC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -46601,12 +45138,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
-"lHO" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "lHP" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
@@ -46628,19 +45159,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "lId" = (
-/obj/structure/rack,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
-"lIf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/aft)
+/obj/structure/sign/warning/docking/directional/west,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "lIn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/random/dead,
@@ -46655,18 +45176,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "lIs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/door/airlock/research,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/research,
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/research)
 "lIt" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/turf_decal/bot,
@@ -46702,6 +45216,9 @@
 /area/station/maintenance/department/security/ghetto)
 "lJc" = (
 /obj/effect/landmark/start/coroner,
+/obj/machinery/door/window/right/directional/east{
+	name = "Coroner"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "lJi" = (
@@ -46769,17 +45286,13 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "lJY" = (
+/obj/machinery/light/small/directional/west,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "lKb" = (
 /obj/effect/turf_decal/bot,
 /obj/item/stack/rods{
@@ -47038,13 +45551,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/processing)
-"lMr" = (
-/obj/structure/chair/comfy/teal{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
 "lMu" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -47081,10 +45587,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "lMT" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/random/structure/tank_holder,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "lMW" = (
 /turf/open/floor/iron,
 /area/station/security/range)
@@ -47127,14 +45634,8 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/starboard/fore)
 "lNo" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/turf/closed/wall/r_wall,
+/area/station/science/genetics)
 "lNt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -47193,9 +45694,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "lOl" = (
-/obj/structure/chair/wood,
+/obj/machinery/vending/snack,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/area/station/service/abandoned_gambling_den)
 "lOr" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
@@ -47238,14 +45740,6 @@
 "lOR" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/port)
-"lOV" = (
-/obj/machinery/door/airlock/atmos,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/upper)
 "lOX" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/item/phone{
@@ -47316,12 +45810,10 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/central)
 "lPH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 5
 	},
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple/half,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "lPK" = (
@@ -47348,14 +45840,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "lPV" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "lQa" = (
 /obj/structure/table,
 /obj/item/taperecorder{
@@ -47397,15 +45885,28 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/interrogation/ghetto)
 "lQd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/table_frame/wood,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/robotics/lab)
 "lQm" = (
-/obj/machinery/light/small/directional/east,
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id = "mech_bay";
+	name = "Mech Bay"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/button/door/directional/north{
+	id = "mech_bay";
+	name = "Mech Bay Door Control";
+	req_access = list("robotics");
+	pixel_y = -24
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/mechbay)
 "lQu" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /turf/open/floor/grass,
@@ -47477,18 +45978,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
-"lSo" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "lSt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -47541,11 +46030,6 @@
 /obj/structure/closet/secure_closet/evidence,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
-"lTy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
 "lTF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/decal/cleanable/dirt,
@@ -47554,14 +46038,16 @@
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/port/aft)
 "lTG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/glass,
+/obj/item/clothing/glasses/science{
+	pixel_y = 8
 	},
-/obj/structure/cable,
-/obj/effect/landmark/start/geneticist,
-/obj/machinery/duct,
+/obj/item/clothing/glasses/science,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/station/science/genetics)
+/area/station/science/xenobiology)
 "lTM" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/decal/cleanable/dirt,
@@ -47593,17 +46079,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
-"lTX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/obj/machinery/door/poddoor/preopen{
-	id = "research_lockdown";
-	name = "Research Lockdown Blast Doors"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
 "lUd" = (
 /obj/structure/table/reinforced,
 /obj/item/vending_refill/snack{
@@ -47712,21 +46187,9 @@
 	},
 /area/station/service/bar)
 "lVn" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/disks{
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/storage/box/syringes{
-	pixel_y = 9
-	},
-/obj/item/toy/figure/geneticist,
+/obj/effect/turf_decal/trimline/white/warning,
 /turf/open/floor/iron/dark,
-/area/station/science/genetics)
+/area/station/service/abandoned_gambling_den)
 "lVo" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -47917,12 +46380,6 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
-"lXy" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/explab)
 "lXz" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -47945,17 +46402,6 @@
 /obj/effect/spawner/random/trash/bin,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"lYf" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/machinery/light_switch/directional/west,
-/obj/effect/landmark/start/geneticist,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
 "lYr" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -47982,11 +46428,14 @@
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison)
 "lYy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/structure/urinal/directional/north,
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 9
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/random/dead,
+/turf/open/floor/iron/white/herringbone,
+/area/station/maintenance/ghetto/starboard/aft)
 "lYC" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -48072,18 +46521,10 @@
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "lZQ" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/structure/fermenting_barrel,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/wood,
+/area/station/maintenance/starboard/upper)
 "lZU" = (
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
@@ -48173,14 +46614,10 @@
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/ghetto/bar)
 "maN" = (
-/obj/structure/table/wood/poker,
-/obj/item/stack/spacecash/c10,
-/obj/item/stack/spacecash/c10,
-/obj/item/stack/spacecash/c1{
-	pixel_y = 5
-	},
-/turf/open/floor/iron/grimy,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "maQ" = (
 /turf/closed/wall,
 /area/station/ai_monitored/turret_protected/aisat/maint)
@@ -48194,15 +46631,14 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "maY" = (
-/obj/structure/table,
-/obj/item/cautery{
-	pixel_x = 4
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/item/hemostat,
-/obj/item/retractor,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/freezer,
-/area/station/science/robotics/lab)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "mbi" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/dark,
@@ -48216,9 +46652,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "mbz" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/structure/table/wood,
+/obj/item/stack/rods,
+/obj/item/stack/cable_coil,
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "mbG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48270,11 +46708,11 @@
 /turf/open/floor/iron/dark/small,
 /area/station/maintenance/ghetto/central)
 "mcc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/jungle/b/style_random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "mcd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48439,10 +46877,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/medical)
-"mdW" = (
-/obj/machinery/light/floor,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "mes" = (
 /obj/machinery/autolathe,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -48601,26 +47035,21 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "mgr" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/camera/directional/north{
-	c_tag = "Research - Robotics Lab North";
-	network = list("ss13","rd");
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/service/abandoned_gambling_den)
+"mgu" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio9";
+	name = "Xenobio Pen 9 Blast Door"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
-"mgu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/research,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "mgy" = (
 /obj/machinery/portable_atmospherics/pipe_scrubber,
 /obj/effect/turf_decal/box,
@@ -48732,15 +47161,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
-"mir" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
-	},
-/obj/machinery/status_display/evac/directional/north,
-/obj/effect/turf_decal/box,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "mis" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/chair{
@@ -49149,10 +47569,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/sorting)
-"mpp" = (
-/obj/structure/curtain/bounty,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
 "mpA" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -49171,25 +47587,22 @@
 /area/station/command/bridge)
 "mpE" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/aft)
 "mpF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/door/airlock/atmos,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/effect/mapping_helpers/airlock/access/all/engineering,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
-"mpV" = (
-/obj/structure/railing/corner,
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/engine/hull/reinforced,
-/area/space/nearstation)
 "mpW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/cable,
@@ -49208,13 +47621,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "mqd" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/machinery/button/door/directional/north{
+	name = "Test Chamber Blast Doors";
+	req_access = list("xenobiology");
+	id = "misclab"
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "mqp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49353,10 +47767,14 @@
 "mrE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "mrI" = (
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
 	id = "robotics_window";
 	name = "Robotics Lab Shutters"
 	},
@@ -49366,7 +47784,7 @@
 	name = "Research Lockdown Blast Doors"
 	},
 /turf/open/floor/plating,
-/area/station/science/robotics/mechbay)
+/area/station/science/robotics/lab)
 "mrK" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/plating,
@@ -49376,29 +47794,22 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "mrQ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/vomit,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "mrR" = (
-/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/area/station/maintenance/ghetto/aft)
 "mse" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/cult,
 /area/station/maintenance/starboard/fore)
-"msg" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
 "msj" = (
 /obj/structure/cable,
 /obj/machinery/camera/directional/north{
@@ -49464,12 +47875,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "mtc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "mtm" = (
@@ -49484,13 +47890,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
-"mts" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/hedge,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/ghetto/starboard/aft)
 "mtw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49511,11 +47910,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
-"mtM" = (
-/obj/item/flashlight,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "mtO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood,
@@ -49544,17 +47938,32 @@
 /area/station/maintenance/starboard/fore)
 "mua" = (
 /obj/structure/cable,
-/mob/living/basic/slime,
-/turf/open/floor/circuit/green,
-/area/station/science/xenobiology)
-"muc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/effect/turf_decal/delivery,
-/obj/item/knife/kitchen,
-/obj/item/storage/box/donkpockets,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/area/station/maintenance/ghetto/aft)
+"muc" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/status_display/ai/directional/east,
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/structure/table,
+/obj/item/healthanalyzer,
+/obj/item/healthanalyzer,
+/obj/item/healthanalyzer,
+/obj/item/storage/medkit/regular{
+	empty = 1;
+	name = "First-Aid (empty)"
+	},
+/obj/item/storage/medkit/regular{
+	empty = 1;
+	name = "First-Aid (empty)"
+	},
+/obj/item/storage/medkit/regular{
+	empty = 1;
+	name = "First-Aid (empty)"
+	},
+/turf/open/floor/iron,
+/area/station/science/robotics/lab)
 "mul" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/kitchen/small,
@@ -49581,12 +47990,11 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
 "muS" = (
-/obj/structure/rack,
-/obj/item/clothing/gloves/boxing/green{
-	pixel_x = -3;
-	pixel_y = 2
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/item/clothing/gloves/boxing/yellow,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "muX" = (
@@ -49662,9 +48070,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/abandoned)
 "mvr" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
@@ -49765,16 +48170,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "mxa" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 8
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Research - Xenobiology Cell 1";
-	network = list("ss13","xeno","rd")
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/dark,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/iron,
 /area/station/science/xenobiology)
 "mxh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49821,11 +48219,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
-"mxG" = (
-/obj/structure/cable,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
 "mxX" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
@@ -49841,26 +48234,15 @@
 	},
 /turf/open/openspace,
 /area/station/cargo/storage)
-"mym" = (
-/obj/structure/rack,
-/obj/machinery/light/directional/west,
-/obj/item/wirecutters,
-/obj/item/screwdriver,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "myz" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "myA" = (
-/obj/item/kirbyplants/random/dead,
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/herringbone,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "myC" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -49883,15 +48265,12 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "myR" = (
-/obj/structure/table/glass,
-/obj/machinery/fax{
-	fax_name = "Research Director's Office";
-	name = "Research Director's Fax Machine"
-	},
 /obj/effect/turf_decal/tile/purple/half{
-	dir = 4
+	dir = 8
 	},
-/turf/open/floor/iron/white,
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "myU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50063,9 +48442,8 @@
 "mAR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/sorting/mail,
-/obj/effect/mapping_helpers/mail_sorting/science/robotics,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "mBa" = (
@@ -50086,11 +48464,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"mBn" = (
-/obj/effect/spawner/random/engineering/tracking_beacon,
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
 "mBo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -50130,13 +48503,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
-"mCa" = (
-/obj/machinery/module_duplicator,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/science/explab)
 "mCc" = (
 /obj/structure/ladder,
 /obj/effect/turf_decal/stripes/box,
@@ -50164,21 +48530,18 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "mCu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/aft)
 "mCv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "mCw" = (
 /obj/effect/turf_decal/siding/wood{
@@ -50231,14 +48594,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
-"mCP" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Research - Testing Lab Chamber";
-	network = list("ss13","rd");
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/station/science/explab)
 "mCX" = (
 /obj/structure/cable,
 /obj/machinery/power/port_gen/pacman,
@@ -50586,11 +48941,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
-"mGA" = (
-/obj/machinery/light/small/directional/east,
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
 "mGC" = (
 /obj/machinery/light_switch/directional/west,
 /obj/structure/disposalpipe/segment,
@@ -50641,14 +48991,11 @@
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/blueshield)
 "mHp" = (
-/obj/machinery/door/window/brigdoor/left/directional/south{
-	name = "Creature Pen";
-	req_access = list("research")
-	},
 /obj/structure/cable,
-/obj/effect/turf_decal/bot,
-/obj/machinery/light/floor,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "mHq" = (
 /obj/structure/sink/directional/north,
@@ -50789,9 +49136,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "mIs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/area/station/service/abandoned_gambling_den)
 "mIz" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -50857,9 +49204,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/theater)
 "mJr" = (
-/obj/structure/table,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "mJA" = (
 /turf/open/openspace,
@@ -50978,12 +49326,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "mKL" = (
-/obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 4
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/item/surgical_drapes,
+/obj/structure/table,
+/obj/item/circular_saw,
+/obj/item/scalpel{
+	pixel_y = 12
 	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/turf/open/floor/iron/freezer,
+/area/station/science/robotics/lab)
 "mKN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51099,9 +49450,10 @@
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "mMe" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "mMg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light_switch/directional/west,
@@ -51166,23 +49518,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
-"mNz" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/table/glass,
-/obj/effect/turf_decal/stripes/line,
-/obj/item/paper_bin{
-	pixel_y = 4
-	},
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/pen{
-	pixel_x = -4
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "mNQ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -51311,10 +49646,11 @@
 /turf/open/openspace,
 /area/station/security/prison)
 "mPy" = (
-/obj/structure/lattice,
-/obj/structure/grille/broken,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "mPA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron,
@@ -51346,9 +49682,19 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "mPO" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/grimy,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/airlock/research/glass,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/mechbay)
 "mPT" = (
 /obj/machinery/light/small/directional/north{
 	name = "maintenance light";
@@ -51396,18 +49742,11 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/magistrate,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/magistrate)
-"mQo" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/station/maintenance/aft)
 "mQp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/morgue)
+/obj/structure/sign/poster/official/random/directional/west,
+/obj/machinery/vending/wardrobe/robo_wardrobe,
+/turf/open/floor/iron/white,
+/area/station/science/robotics/lab)
 "mQq" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/circuit,
@@ -51451,14 +49790,10 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "mRd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/station/science/research)
+/obj/structure/table/wood/poker,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "mRh" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -51490,19 +49825,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/station/service/library/ghetto)
-"mSc" = (
-/obj/machinery/light_switch/directional/east,
-/obj/structure/table,
-/obj/item/crowbar,
-/obj/item/wrench,
-/obj/item/clothing/mask/gas,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/light/cold/directional/north,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "mSh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -51568,12 +49890,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "mTa" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/light/small/directional/south,
+/obj/structure/chair/wood,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/area/station/service/abandoned_gambling_den)
 "mTb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51591,26 +49911,20 @@
 /turf/open/floor/wood/large,
 /area/station/service/theater)
 "mTi" = (
-/obj/structure/closet/secure_closet/research_director,
-/obj/machinery/light_switch/directional/west,
-/obj/machinery/keycard_auth/wall_mounted/directional/south,
 /obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 8
+	dir = 4
 	},
+/obj/structure/closet/secure_closet/research_director,
+/obj/item/pai_card,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "mTk" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/cafeteria,
-/area/station/maintenance/ghetto/starboard/aft)
-"mTq" = (
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/mask/muzzle,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/effect/turf_decal/tile/bar,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 8
+	},
+/obj/structure/sign/warning/biohazard/directional/south,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "mTu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table/wood,
@@ -51711,11 +50025,22 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "mUQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/turf/open/floor/iron/dark,
-/area/station/science/server)
+/obj/structure/table/reinforced,
+/obj/machinery/button/door/directional/south{
+	id = "research_lockdown";
+	name = "Research Lockdown Control";
+	req_access = list("rd");
+	pixel_y = 7;
+	color = "yellow"
+	},
+/obj/machinery/button/door{
+	id = "rdoffice";
+	name = "Privacy Control";
+	pixel_y = -3;
+	req_access = list("rd")
+	},
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "mUU" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
@@ -51740,9 +50065,8 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "mVm" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/wood,
+/obj/effect/spawner/random/structure/tank_holder,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "mVz" = (
 /obj/structure/sign/poster/official/here_for_your_safety/directional/east,
@@ -51769,13 +50093,6 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
-"mVM" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/structure/flora/grass/jungle/b/style_2,
-/turf/open/water,
-/area/station/maintenance/ghetto/garden)
 "mVR" = (
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /obj/machinery/door/airlock/hatch,
@@ -51796,8 +50113,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
 "mWc" = (
+/obj/machinery/door/window/right/directional/west{
+	name = "Containment Pen 1";
+	req_access = list("xenobiology")
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio1";
+	name = "Xenobio Pen 1 Blast Door"
+	},
 /obj/structure/cable,
-/turf/open/floor/circuit/green,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "mWh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -52010,12 +50335,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto/central)
 "mYH" = (
-/obj/machinery/component_printer,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 4
-	},
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/rack,
+/obj/item/wrench,
+/obj/item/screwdriver,
+/obj/item/knife/kitchen,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted,
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/xenobiology)
 "mYI" = (
 /obj/item/clipboard{
 	pixel_y = 3
@@ -52060,13 +50388,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/prison)
-"mZd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
 "mZo" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -52082,23 +50403,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "mZu" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/disposaloutlet{
+	dir = 8
 	},
-/turf/open/floor/iron/white/textured,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "mZB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/table/wood/poker,
-/obj/item/stack/spacecash/c1{
-	pixel_y = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/area/station/service/abandoned_gambling_den)
 "mZE" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -52106,12 +50423,16 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "mZH" = (
-/obj/machinery/suit_storage_unit/rd,
-/obj/effect/turf_decal/tile/purple/anticorner{
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/rd)
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "mZJ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -52174,10 +50495,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "naH" = (
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/tile/purple/anticorner,
-/turf/open/floor/iron,
-/area/station/science/lab)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "naI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -52259,10 +50579,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
 "nbz" = (
-/obj/machinery/vending/cola,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white,
+/area/station/maintenance/aft)
 "nbI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -52344,13 +50664,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "ndl" = (
-/obj/item/radio/intercom/directional/west,
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 1
+/obj/structure/table/glass,
+/obj/structure/cable,
+/obj/item/hand_labeler,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
 	},
+/obj/structure/sign/poster/official/periodic_table/directional/west,
 /turf/open/floor/iron/white,
-/area/station/science/research)
+/area/station/science/lab)
 "ndm" = (
 /obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/siding/wood{
@@ -52380,8 +50702,14 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "ndV" = (
-/turf/closed/wall,
-/area/station/science/server)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "rdoffice";
+	name = "Research Director's Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/rd)
 "ndY" = (
 /obj/machinery/vending/cola/red,
 /turf/open/floor/iron,
@@ -52443,37 +50771,10 @@
 /area/station/command/bridge)
 "neD" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
+	dir = 8
 	},
-/obj/structure/table/glass,
-/obj/machinery/camera/directional/south{
-	c_tag = "Medbay - Cryogenics";
-	network = list("ss13","medbay")
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/storage/pill_bottle/mannitol,
-/obj/effect/mapping_helpers/requests_console/assistance,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
-	},
-/obj/machinery/requests_console/directional/south{
-	department = "Medbay";
-	name = "Medbay Requests Console"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
@@ -52482,9 +50783,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "neY" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/machinery/door/window/right/directional/west{
+	name = "Containment Pen 3";
+	req_access = list("xenobiology")
+	},
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio3";
+	name = "Xenobio Pen 3 Blast Door"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "nfi" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
@@ -52548,6 +50857,9 @@
 /area/station/maintenance/ghetto/sorting)
 "ngd" = (
 /obj/effect/spawner/random/trash/garbage,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "ngq" = (
@@ -52620,22 +50932,20 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "ngX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/freezer,
-/area/station/science/robotics/lab)
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "nhg" = (
 /obj/machinery/power/smes,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "nhj" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/cafeteria,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "nho" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -52695,9 +51005,6 @@
 /turf/open/floor/carpet,
 /area/station/service/library/ghetto)
 "nhZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -52729,10 +51036,17 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard/west)
 "niJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/window/left/directional/east{
+	name = "Containment Pen 8";
+	req_access = list("xenobiology")
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio8";
+	name = "Xenobio Pen 8 Blast Door"
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/garden)
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "niR" = (
 /obj/structure/table,
 /obj/machinery/camera/directional/north{
@@ -52827,13 +51141,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
 "njG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/turf/open/floor/iron/dark/textured_corner,
+/area/station/science/xenobiology)
 "njH" = (
 /obj/structure/chair/comfy/black,
 /turf/open/floor/carpet/royalblack,
@@ -52876,13 +51188,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "nks" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/door/poddoor/preopen{
+	id = "misclab";
+	name = "Test Chamber Blast Door"
 	},
-/turf/open/floor/iron/white/textured,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "nku" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -52944,11 +51259,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
-"nlb" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/aft)
 "nle" = (
 /obj/machinery/status_display/evac/directional/north,
 /obj/item/grenade/chem_grenade/smart_metal_foam{
@@ -53140,7 +51450,7 @@
 	pixel_x = -25
 	},
 /turf/open/floor/engine,
-/area/station/science/lower)
+/area/station/science/explab)
 "nnt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -53160,10 +51470,6 @@
 /obj/structure/fireaxecabinet/empty/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port/aft)
-"nnJ" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
 "nnO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -53192,12 +51498,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"nnT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
 "nnU" = (
 /turf/closed/wall,
 /area/station/maintenance/starboard/upper)
@@ -53223,9 +51523,18 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
 "noi" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/area/space/nearstation)
 "noj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -53247,13 +51556,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port/aft)
 "noo" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 5
-	},
-/obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/floor/iron/dark/textured_corner{
-	dir = 4
-	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "nop" = (
 /obj/effect/decal/cleanable/blood,
@@ -53325,7 +51629,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/station/science/lower)
+/area/station/science/explab)
 "npt" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -53424,11 +51728,13 @@
 /turf/closed/wall,
 /area/station/tcommsat/server/upper)
 "nqn" = (
-/obj/effect/turf_decal/tile/purple/half{
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/north,
+/obj/structure/closet/secure_closet/security/science,
 /turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
+/area/station/security/checkpoint/science)
 "nqo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53534,11 +51840,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "nrE" = (
-/obj/machinery/computer/scan_consolenew{
-	dir = 8
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "nrH" = (
 /turf/closed/wall,
 /area/station/service/hydroponics)
@@ -53581,13 +51888,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/trash)
-"nsI" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/light/floor/broken,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/maintenance/ghetto/starboard/aft)
 "nsJ" = (
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/chem_master/condimaster{
@@ -53623,24 +51923,18 @@
 /turf/open/misc/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ntf" = (
-/obj/machinery/button/door/directional/north{
-	id = "mech_bay";
-	name = "Mech Bay Door Control";
-	req_access = list("robotics");
-	pixel_y = -24
+/obj/structure/table,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass{
+	amount = 20;
+	pixel_x = -3;
+	pixel_y = 6
 	},
-/obj/machinery/door/poddoor/shutters{
-	dir = 4;
-	id = "mech_bay";
-	name = "Mech Bay"
-	},
-/obj/machinery/door/firedoor,
+/obj/item/storage/belt/utility/full,
 /turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
-"ntv" = (
-/obj/effect/spawner/random/structure/barricade,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/area/station/science/robotics/lab)
 "ntK" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -53657,19 +51951,10 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "ntO" = (
-/obj/machinery/door/window/brigdoor/left/directional/south{
-	name = "Creature Pen";
-	req_access = list("research")
-	},
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno8";
-	name = "Creature Cell #8"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/seeds/ambrosia,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "ntS" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 1
@@ -53695,15 +51980,24 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "ntY" = (
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/science/explab)
+/obj/item/pen{
+	pixel_x = -4
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "nuf" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -53783,13 +52077,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/common/cryopods)
-"nvl" = (
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
 "nvs" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -53830,13 +52117,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
-"nvS" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/light/small/directional/west,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "nvV" = (
 /obj/structure/transit_tube/horizontal{
 	dir = 1
@@ -53863,10 +52143,13 @@
 /turf/open/floor/grass,
 /area/station/maintenance/ghetto/garden)
 "nwj" = (
-/obj/machinery/light/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/camera/directional/east{
+	c_tag = "Xenobiology Pens - Starboard Mid";
+	network = list("ss13","rd","xeno")
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "nwo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/spawner/structure/window/reinforced,
@@ -54048,11 +52331,17 @@
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "nyB" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/storage/fancy/cigarettes/cigpack_robust{
+	pixel_x = 6
+	},
+/obj/item/lighter{
+	pixel_x = -6
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
 "nyL" = (
@@ -54113,12 +52402,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
-"nzQ" = (
-/obj/structure/table,
-/obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/tile/purple/half,
-/turf/open/floor/iron/white,
-/area/station/science/explab)
 "nAb" = (
 /obj/structure/ladder,
 /obj/effect/turf_decal/stripes/box,
@@ -54326,18 +52609,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
-"nBZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/small/directional/west,
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
 "nCb" = (
+/obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/engine,
-/area/station/science/lower)
+/area/station/science/explab)
 "nCd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
@@ -54592,10 +52868,10 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
 "nFj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/wood,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/frame/machine,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "nFn" = (
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
 	color = "#0000ff";
@@ -54610,12 +52886,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "nFH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/trimline/white/warning{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/turf/open/floor/iron/dark,
+/area/station/service/abandoned_gambling_den)
 "nFI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54623,9 +52899,6 @@
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
-"nFL" = (
-/turf/open/floor/carpet,
-/area/station/maintenance/aft)
 "nFU" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance)
@@ -54648,15 +52921,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"nGp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
 "nGs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/trimline/dark_blue/corner{
@@ -54688,22 +52952,24 @@
 /turf/open/floor/wood,
 /area/station/security/prison/mess)
 "nGz" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 1
+	},
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/iron/dark,
+/area/station/science/breakroom)
 "nGB" = (
 /obj/structure/transit_tube/horizontal,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/transit_tube)
 "nGC" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/landmark/start/research_director,
+/obj/structure/chair/office/light{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "nGE" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp{
@@ -54808,10 +53074,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"nHW" = (
-/obj/structure/sign/poster/contraband/punch_shit/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
 "nIb" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/yellow{
@@ -54831,10 +53093,14 @@
 /turf/open/floor/plating,
 /area/station/commons/storage/emergency)
 "nIk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/obj/machinery/modular_computer/preset/id{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "nIl" = (
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -54915,12 +53181,12 @@
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/engineering/gravity_generator)
 "nKg" = (
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/tile/purple/anticorner{
+/obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/science/lab)
+/obj/machinery/vending/wardrobe/gene_wardrobe,
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "nKj" = (
 /obj/machinery/light/small/directional/south{
 	name = "maintenance light";
@@ -54955,10 +53221,6 @@
 /obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"nKH" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/white,
-/area/station/science/explab)
 "nKK" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -55075,23 +53337,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/small,
 /area/station/security/interrogation/ghetto)
-"nMm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "nMx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/landmark/start/depsec/science,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
+/turf/open/floor/iron/white,
+/area/station/science/circuits)
 "nMz" = (
 /turf/closed/wall,
 /area/station/security/checkpoint/customs)
@@ -55102,15 +53351,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library/ghetto)
-"nMG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno4";
-	name = "Creature Cell #4"
-	},
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "nMK" = (
 /obj/structure/girder,
 /turf/open/floor/plating/airless,
@@ -55208,10 +53448,14 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
 "nNJ" = (
-/obj/machinery/portable_atmospherics/pump,
 /obj/machinery/light/directional/east,
+/obj/structure/closet/crate,
+/obj/item/target/clown,
+/obj/item/target/alien,
+/obj/item/target/syndicate,
+/obj/item/gun/energy/laser/practice,
 /turf/open/floor/engine,
-/area/station/science/lower)
+/area/station/science/explab)
 "nNL" = (
 /obj/structure/chair{
 	dir = 4
@@ -55234,7 +53478,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "nNX" = (
@@ -55262,22 +53505,17 @@
 /obj/machinery/shower/directional/south,
 /obj/structure/curtain,
 /obj/structure/fluff/shower_drain,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "nOj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/general/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nOm" = (
-/obj/machinery/door/window/right/directional/east{
-	name = "Coroner"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "nOp" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -55324,24 +53562,15 @@
 "nPb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "nPg" = (
 /obj/structure/chair/wood,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/starboard/fore)
-"nPk" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/closet/emcloset,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard/west)
 "nPl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -55425,17 +53654,9 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/prison/ghetto)
 "nQs" = (
-/obj/structure/table/glass,
-/obj/item/biopsy_tool{
-	pixel_x = -10;
-	pixel_y = 3
-	},
-/obj/structure/microscope{
-	pixel_x = -1;
-	pixel_y = 4
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/herringbone,
+/area/station/maintenance/ghetto/starboard/aft)
 "nQu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55467,10 +53688,8 @@
 /turf/open/floor/iron/half,
 /area/station/commons/dorms)
 "nQP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/turf/closed/wall,
+/area/station/service/abandoned_gambling_den)
 "nQT" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -55530,10 +53749,13 @@
 /turf/closed/wall/r_wall,
 /area/station/security/processing)
 "nRE" = (
-/obj/effect/spawner/random/structure/crate,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "nRP" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/structure/closet/crate/goldcrate,
@@ -55721,9 +53943,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "nTN" = (
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/iron,
-/area/station/maintenance/aft)
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "nTO" = (
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance)
@@ -55989,9 +54217,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "nXO" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/effect/turf_decal/tile/purple/half,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/robotics/lab)
 "nXP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56049,13 +54279,10 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "nYo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple/half,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "nYw" = (
 /obj/structure/sign/departments/botany/directional/north,
 /turf/open/floor/iron,
@@ -56139,17 +54366,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
-"nZt" = (
-/obj/machinery/smartfridge/extract/preloaded,
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "nZC" = (
 /obj/effect/spawner/random/engineering/tank,
 /obj/effect/turf_decal/stripes/line{
@@ -56224,10 +54440,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "oax" = (
-/obj/structure/sign/warning/xeno_mining/directional/north,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/structure/table,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/scanning_module,
+/obj/item/stock_parts/scanning_module,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/turf/open/floor/iron/white,
+/area/station/science/lab)
 "oay" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
@@ -56239,13 +54459,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto/fore)
-"oaU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
 "oaV" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -56512,12 +54725,10 @@
 /turf/open/floor/iron,
 /area/station/security/range)
 "odl" = (
-/obj/structure/table,
-/obj/item/reagent_containers/spray/plantbgone,
-/obj/item/cultivator/rake,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/chair/stool/bar/directional/north,
+/turf/open/floor/iron/grimy,
+/area/station/service/abandoned_gambling_den)
 "odo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56574,22 +54785,20 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/ghetto)
 "odY" = (
-/obj/machinery/light/small/directional/west,
-/obj/structure/table/wood/poker,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den)
 "oef" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
+/obj/machinery/door/window/right/directional/west{
+	name = "Containment Pen 9";
+	req_access = list("xenobiology")
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/spawner/random/structure/barricade,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light/floor,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "oek" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/steam_vent,
@@ -56754,33 +54963,23 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "ogS" = (
-/obj/machinery/light/directional/south,
-/obj/structure/closet/secure_closet/personal/patient{
-	name = "test subject's closet"
+/obj/structure/table/glass,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/tile/purple/half,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
-"ogW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
-"oha" = (
-/obj/structure/table,
-/obj/item/wrench,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science{
-	pixel_y = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
+/obj/item/reagent_containers/dropper,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"ogW" = (
+/obj/structure/urinal/directional/north,
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/random/dead,
+/turf/open/floor/iron/white/herringbone,
+/area/station/maintenance/ghetto/starboard/aft)
 "ohj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/stripes/line,
@@ -56836,12 +55035,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
 "oib" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "oic" = (
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
@@ -56905,18 +55106,6 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
-"oiR" = (
-/obj/structure/table/reinforced/rglass,
-/obj/item/food/grown/banana,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "oja" = (
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -56983,20 +55172,9 @@
 	pixel_y = 9
 	},
 /obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
-"ojE" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "ojI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57013,25 +55191,17 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ojU" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/machinery/newscaster/directional/east,
-/obj/effect/turf_decal/tile/red/half/contrasted{
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/science,
+/obj/item/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'";
+	name = "Chemistry Cleaner"
+	},
+/obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Research - Security Post";
-	network = list("ss13","rd");
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
-"okh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
+/turf/open/floor/iron/white,
+/area/station/science/circuits)
 "okj" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -57230,10 +55400,10 @@
 /turf/open/floor/iron/small,
 /area/station/cargo/drone_bay/ghetto)
 "onD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/area/station/maintenance/ghetto/aft)
 "onE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/wood,
@@ -57300,17 +55470,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "oof" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/table/glass,
-/obj/item/slime_scanner,
-/obj/item/book/manual/wiki/cytology{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/maintenance/starboard/upper)
 "ooh" = (
 /obj/structure/chair/comfy/brown{
 	color = "#514E58";
@@ -57443,11 +55605,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "opl" = (
-/obj/structure/table/glass,
-/obj/item/stack/cable_coil,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 4
 	},
+/obj/structure/table,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/cable_coil,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "opm" = (
@@ -57465,11 +55630,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "opA" = (
-/obj/structure/table,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/structure/sign/poster/contraband/random/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/machinery/door/window/left/directional/south{
+	name = "Cytology Pen";
+	req_access = list("research")
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/science/xenobiology)
 "opB" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -57495,29 +55662,18 @@
 "opS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "opW" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 8
-	},
-/obj/item/storage/box/syringes{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/structure/sign/departments/xenobio/directional/west,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "oqa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "oqb" = (
@@ -57546,7 +55702,7 @@
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/structure/sign/poster/official/random/directional/east,
 /obj/machinery/camera/directional/south{
-	c_tag = "Research - Break Room";
+	c_tag = "Research Division Break Room";
 	network = list("ss13","rd");
 	dir = 4
 	},
@@ -57754,20 +55910,12 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/ghetto)
 "osV" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags{
-	pixel_x = -4;
-	pixel_y = -4
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/obj/item/storage/box/masks,
-/obj/item/storage/box/gloves{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/tank/internals/anesthetic,
-/obj/item/clothing/mask/breath/medical,
-/turf/open/floor/iron/freezer,
-/area/station/science/robotics/lab)
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "osX" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
 	dir = 8
@@ -58010,17 +56158,16 @@
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "ovQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "ovU" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/mechbay)
 "ovV" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -58089,10 +56236,9 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "owY" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/garden)
 "owZ" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/filingcabinet/chestdrawer,
@@ -58131,8 +56277,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/engineering/atmos)
 "oxz" = (
-/obj/structure/table,
-/obj/item/melee/baseball_bat,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/crate,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "oxG" = (
@@ -58221,9 +56369,9 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/fore/starboard)
 "oyA" = (
-/obj/machinery/light/small/broken/directional/north,
-/turf/open/floor/iron/cafeteria,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "oyJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -58277,13 +56425,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
-"ozx" = (
-/obj/structure/flora/bush/grassy/style_random,
-/obj/structure/chair/pew/right{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
 "ozC" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
@@ -58318,11 +56459,8 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "oAw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/random/structure/table,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "oAz" = (
@@ -58444,13 +56582,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "oBO" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "xeno5";
-	name = "Containment Control";
-	req_access = list("xenobiology")
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "oBS" = (
@@ -58476,14 +56611,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
-"oCy" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "oCD" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/carpet,
@@ -58507,18 +56634,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/carpet/red,
 /area/station/maintenance/department/security/ghetto)
-"oDc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
 "oDd" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -58549,14 +56664,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
 "oDC" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small/directional/east,
-/obj/machinery/chem_dispenser/drinks{
-	pixel_y = 8;
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/disposaloutlet{
 	dir = 8
 	},
-/turf/open/floor/wood,
-/area/station/maintenance/starboard/upper)
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "oDM" = (
 /obj/structure/table/wood,
 /obj/machinery/airalarm/directional/north,
@@ -58575,10 +56690,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "oDP" = (
-/obj/effect/spawner/random/structure/tank_holder,
-/obj/machinery/light/small/directional/east,
+/obj/machinery/light/small/directional/west,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
+/area/station/maintenance/ghetto/aft)
 "oDR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -58623,11 +56738,16 @@
 /turf/open/floor/iron,
 /area/station/science/lobby)
 "oEi" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/siding/wideplating_new/corner{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wideplating_new/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/open/floor/iron/herringbone,
+/area/station/maintenance/starboard/aft)
 "oEo" = (
 /obj/structure/sign/warning/radiation/directional/north,
 /turf/closed/wall/r_wall,
@@ -58658,16 +56778,14 @@
 	},
 /area/station/engineering/gravity_generator)
 "oEO" = (
-/obj/structure/railing/corner{
-	dir = 4
+/obj/machinery/computer/camera_advanced/xenobio{
+	dir = 1
 	},
-/obj/structure/flora/bush/jungle/b/style_random,
-/obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "oEQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -58774,19 +56892,6 @@
 "oFW" = (
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/blueshield)
-"oFX" = (
-/obj/machinery/computer/camera_advanced/xenobio{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "oGf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
@@ -58838,6 +56943,7 @@
 /obj/machinery/door/airlock/research/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "oHp" = (
@@ -58867,11 +56973,11 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "oHD" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/grass,
-/area/station/maintenance/starboard/aft)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "oHF" = (
 /obj/structure/sign/poster/random/directional/north,
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
@@ -58882,13 +56988,10 @@
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "oId" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/obj/machinery/light/small/directional/west,
+/obj/structure/table/wood/poker,
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "oIf" = (
 /obj/effect/turf_decal/tile/dark/half,
 /obj/structure/weightmachine/weightlifter,
@@ -59009,11 +57112,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
-"oJH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/iron,
-/area/station/maintenance/aft)
 "oJP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59053,9 +57151,9 @@
 /turf/open/floor/cult,
 /area/station/maintenance/starboard/fore)
 "oKn" = (
-/obj/machinery/light/small/directional/west,
 /obj/structure/sign/departments/engineering/directional/west,
-/obj/machinery/door/firedoor,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "oKr" = (
@@ -59141,14 +57239,14 @@
 /turf/open/floor/plating,
 /area/station/security/courtroom)
 "oLe" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/structure/sign/poster/official/space_cops/directional/west,
+/obj/structure/filingcabinet,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
+/area/station/security/checkpoint/science)
 "oLi" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -59198,11 +57296,16 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
 "oLF" = (
-/obj/structure/table,
-/obj/item/storage/fancy/cigarettes/cigpack_robust,
-/obj/structure/sign/departments/medbay/alt/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/structure/flora/bush/jungle/b/style_random,
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "oLG" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
@@ -59322,12 +57425,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "oNO" = (
-/obj/machinery/requests_console/auto_name/directional/north,
-/obj/effect/mapping_helpers/requests_console/supplies,
-/obj/effect/mapping_helpers/requests_console/ore_update,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/machinery/door/airlock/wood,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/garden)
 "oNQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59397,14 +57499,6 @@
 	dir = 8
 	},
 /area/station/commons/dorms)
-"oOE" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
 "oOF" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/holopad/secure,
@@ -59490,7 +57584,8 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/project)
 "oQi" = (
-/obj/item/food/grown/cannabis,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/seeds/banana,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "oQk" = (
@@ -59505,31 +57600,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "oQA" = (
-/obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
-	},
+/obj/machinery/door/airlock/command/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /turf/open/floor/iron/dark,
-/area/station/science/genetics)
+/area/station/science/server)
 "oQF" = (
-/obj/machinery/atmospherics/pipe/smart/simple{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "testlab";
-	name = "Test Chamber Blast Door"
-	},
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/engine,
-/area/station/science/explab)
-"oQL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno2";
-	name = "Creature Cell #2"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "oQV" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -59609,17 +57688,10 @@
 /turf/open/floor/iron/dark/small,
 /area/station/command/bridge)
 "oSc" = (
-/obj/machinery/computer/camera_advanced/xenobio{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "oSf" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/machinery/light_switch/directional/north,
@@ -59716,20 +57788,25 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/command/teleporter)
-"oTc" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Research - Xenobiology Pens Observation North";
-	network = list("ss13","rd","xeno");
-	dir = 1
-	},
-/turf/open/openspace,
-/area/station/science/xenobiology)
 "oTd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/poster/official/random/directional/west,
-/turf/open/floor/iron/white,
-/area/station/science/robotics/lab)
+/obj/effect/turf_decal/tile/purple/anticorner,
+/obj/structure/table,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/cup/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/machinery/camera{
+	c_tag = "Research Research and Development Lab";
+	dir = 4;
+	network = list("ss13","rd")
+	},
+/turf/open/floor/iron,
+/area/station/science/lab)
 "oTm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -59784,25 +57861,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/aft)
-"oTP" = (
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/freezer,
-/area/station/science/robotics/lab)
 "oTQ" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/fore)
 "oUd" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/mechbay)
 "oUL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -59848,9 +57917,6 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "oVo" = (
@@ -59894,11 +57960,9 @@
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
 "oVO" = (
-/obj/structure/cable,
-/obj/machinery/light/directional/north,
-/obj/machinery/door/window/left/directional/east,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "oVR" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/deepfryer,
@@ -59943,15 +58007,16 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
 "oWo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/camera{
+	c_tag = "Research Hallway North";
+	network = list("ss13","rd")
 	},
-/obj/structure/sign/poster/official/random/directional/west,
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "oWr" = (
 /obj/machinery/pdapainter,
 /obj/structure/cable,
@@ -59981,21 +58046,13 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
-"oWz" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
 "oWA" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "oWF" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "oWI" = (
@@ -60027,10 +58084,16 @@
 /turf/closed/wall,
 /area/station/maintenance/port/aft)
 "oXd" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/destructive_scanner,
+/obj/effect/turf_decal/stripes/box,
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/effect/turf_decal/tile/neutral/half,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/area/station/science/lobby)
 "oXf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60051,22 +58114,16 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
-"oXt" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "oXy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "robotics_window";
-	name = "Robotics Lab Shutters"
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "research_lockdown";
-	name = "Research Lockdown Blast Doors"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/station/science/robotics/lab)
+/area/station/maintenance/ghetto/aft)
 "oXI" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/machinery/button/door/directional/west{
@@ -60155,14 +58212,13 @@
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "oZf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/machinery/mech_bay_recharge_port,
+/obj/effect/turf_decal/siding/wideplating_new/dark/end{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/mechbay)
 "oZm" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -60410,13 +58466,14 @@
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "pcO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio2";
+	name = "Xenobio Pen 2 Blast Door"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor/broken,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/aft)
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "pcP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -60443,28 +58500,22 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "pdc" = (
-/obj/machinery/light/small/directional/east{
-	name = "maintenance light";
-	nightshift_allowed = 0;
-	nightshift_enabled = 1;
-	nightshift_light_power = 0.4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "pdl" = (
 /obj/item/stack/rods,
 /turf/open/space/openspace,
 /area/space/nearstation)
 "pdo" = (
-/obj/structure/table/optable{
-	name = "Robotics Operating Table"
+/obj/structure/closet/secure_closet/medical2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/freezer,
-/area/station/science/robotics/lab)
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "pdp" = (
 /obj/structure/displaycase,
 /obj/effect/turf_decal/tile/neutral/full,
@@ -60503,20 +58554,17 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/camera/directional/west{
+/obj/machinery/camera/autoname/directional/west{
 	c_tag = "Research Hallway South"
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "ped" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/aft)
+/area/station/maintenance/starboard/upper)
 "pee" = (
 /obj/structure/table,
 /obj/item/plant_analyzer{
@@ -60582,11 +58630,11 @@
 /turf/open/floor/iron/white/diagonal,
 /area/station/maintenance/ghetto/starboard/aft)
 "peT" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "peV" = (
@@ -60680,17 +58728,9 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
-"pgF" = (
-/obj/structure/sign/warning/secure_area/directional/west,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "pgK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "pgL" = (
@@ -60761,27 +58801,14 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "phm" = (
-/obj/structure/table,
-/obj/item/multitool/circuit{
-	pixel_x = -8
-	},
-/obj/item/multitool/circuit{
-	pixel_x = -4
-	},
-/obj/item/multitool/circuit,
-/obj/item/stock_parts/power_store/cell/high{
-	pixel_x = 8;
-	pixel_y = 9
-	},
-/obj/item/stock_parts/power_store/cell/high{
-	pixel_x = 8;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/tile/purple/anticorner{
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/xenobiology)
 "phu" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -60849,16 +58876,9 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "piI" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 4;
-	name = "killroom vent"
-	},
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/science/xenobiology)
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "piJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -60907,12 +58927,12 @@
 /turf/open/floor/carpet/black,
 /area/station/command/meeting_room)
 "pjb" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/power_store/cell/high,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/science/robotics/mechbay)
 "pjd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -60925,12 +58945,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "pjh" = (
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/science/xenobiology)
+/obj/machinery/hydroponics/soil,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/grass,
+/area/station/maintenance/starboard/aft)
 "pjp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass,
@@ -60962,10 +58980,7 @@
 /turf/open/floor/carpet,
 /area/station/service/library)
 "pjT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "pjU" = (
@@ -61011,14 +59026,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
 "pkv" = (
-/obj/machinery/light/small/directional/south,
-/obj/machinery/chem_dispenser/drinks/beer{
-	pixel_y = 8;
+/obj/structure/bed{
 	dir = 1
 	},
-/obj/structure/table/wood,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/item/bedsheet/rd{
+	dir = 1
+	},
+/obj/machinery/status_display/ai/directional/west,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "pkA" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/machinery/light/directional/north,
@@ -61029,18 +59048,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "pkI" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Research - Xenobiology Access";
-	network = list("ss13","rd","xeno")
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance,
+/obj/item/flashlight,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "pkK" = (
 /obj/structure/chair{
 	dir = 4
@@ -61442,11 +59454,6 @@
 "ppF" = (
 /turf/closed/wall,
 /area/station/science/research)
-"ppI" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/effect/turf_decal/tile/purple/anticorner,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "ppJ" = (
 /obj/structure/table,
 /obj/item/reagent_containers/cup/glass/shaker{
@@ -61517,12 +59524,11 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/fore)
 "pqx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/bar/half{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "pqy" = (
 /obj/structure/spacevine{
 	can_spread = 0;
@@ -61663,7 +59669,7 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "psK" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "psV" = (
@@ -61676,16 +59682,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "pte" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/research,
 /obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "research_lockdown";
-	name = "Research Lockdown Blast Doors"
-	},
-/turf/open/floor/plating,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
 /area/station/science/research)
 "ptj" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -61843,7 +59842,7 @@
 "puQ" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
@@ -61890,10 +59889,6 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
-"pvg" = (
-/obj/machinery/light/directional/south,
-/turf/open/openspace,
-/area/station/science/xenobiology)
 "pvh" = (
 /obj/structure/transit_tube/crossing/horizontal,
 /obj/structure/lattice/catwalk,
@@ -61903,9 +59898,12 @@
 /turf/closed/wall/r_wall,
 /area/station/command/bridge)
 "pvt" = (
-/obj/structure/cable,
-/obj/machinery/status_display/ai/directional/south,
-/turf/open/floor/iron,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/purple/half,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "pvv" = (
 /obj/machinery/light/directional/north,
@@ -61982,12 +59980,6 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"pww" = (
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
 "pwx" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -62027,10 +60019,14 @@
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/department/security/ghetto)
 "pwQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "pwS" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -62045,13 +60041,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "pwX" = (
+/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
+	dir = 6
 	},
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "pwZ" = (
@@ -62075,11 +60070,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "pxn" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/turf_decal/box/white/corners,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/effect/spawner/structure/electrified_grille,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "pxq" = (
 /obj/effect/spawner/random/trash/bin,
 /turf/open/floor/plating,
@@ -62089,11 +60082,12 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
 "pxu" = (
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
+/obj/machinery/door/window/brigdoor/left/directional/north{
+	name = "Chamber Access";
+	req_access = list("science")
 	},
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "pxB" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /obj/machinery/door/airlock/external,
@@ -62118,14 +60112,6 @@
 /obj/effect/spawner/random/glass_shards/mini,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
-"pxU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/smartfridge/petri/preloaded,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "pya" = (
 /obj/structure/railing{
 	dir = 5
@@ -62407,12 +60393,12 @@
 	},
 /area/station/medical/chemistry/ghetto)
 "pBE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/turf_decal/trimline/white/warning{
+	dir = 9
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/small,
-/area/station/medical/morgue)
+/turf/open/floor/iron/dark,
+/area/station/service/abandoned_gambling_den)
 "pBF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -62442,29 +60428,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "pBU" = (
-/obj/structure/rack,
-/obj/item/controller{
-	pixel_x = -7
-	},
-/obj/item/compact_remote{
-	pixel_x = -7
-	},
-/obj/item/compact_remote{
-	pixel_x = -7
-	},
-/obj/item/integrated_circuit/loaded/speech_relay{
-	pixel_x = 7
-	},
-/obj/item/integrated_circuit/loaded/hello_world{
-	pixel_x = 7
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/xenobiology)
 "pBY" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
@@ -62587,10 +60554,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "pDf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/effect/spawner/structure/electrified_grille,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "pDl" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -62690,17 +60660,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
 "pEu" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/table/glass,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/reagentgrinder{
-	desc = "Used to grind things up into raw materials and liquids.";
-	pixel_y = 5
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/door/airlock/wood,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/garden)
 "pEv" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto)
@@ -62761,12 +60725,18 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
 "pEZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/cable,
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "pFd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/decal/cleanable/dirt,
@@ -62785,10 +60755,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "pFr" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/maintenance/four,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/machinery/light/small/directional/south,
+/obj/structure/table_frame/wood,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/dark,
+/area/station/service/abandoned_gambling_den)
 "pFA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -62834,7 +60805,7 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/camera/directional/south{
-	c_tag = "Research - Ordnance Lower Mix Lab";
+	c_tag = "Ordnance Lower Mix Lab";
 	network = list("ss13","rd")
 	},
 /obj/structure/sign/warning/directional/south,
@@ -62849,16 +60820,17 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "pGr" = (
-/obj/structure/railing{
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "pGs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 9
@@ -62906,16 +60878,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
-"pGV" = (
-/obj/structure/flora/bush/grassy/style_random,
-/obj/structure/chair/pew/left{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
 "pHh" = (
 /turf/closed/wall,
 /area/station/service/kitchen)
@@ -62966,10 +60928,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/port/aft)
 "pHJ" = (
-/obj/structure/cable,
-/obj/structure/chair/sofa/middle/brown,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
+/obj/structure/table/wood/poker,
+/obj/effect/spawner/random/maintenance/three,
+/turf/open/floor/iron/grimy,
+/area/station/service/abandoned_gambling_den)
 "pHM" = (
 /obj/effect/spawner/random/trash/grime,
 /turf/open/floor/plating,
@@ -62984,10 +60946,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "pHR" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/structure/table,
+/obj/item/experi_scanner{
+	pixel_x = 4
+	},
+/obj/item/experi_scanner,
+/obj/item/experi_scanner{
+	pixel_x = -4
+	},
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/science/lab)
 "pHY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -63010,13 +60981,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "pIn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno3";
-	name = "Creature Cell #3"
+/obj/structure/chair/office/light{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "pIo" = (
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -63055,16 +61023,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"pIy" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/effect/landmark/start/research_director,
-/obj/machinery/computer/security/telescreen/research/directional/south{
-	network = list("rd","xeno","test","ordnance")
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
 "pIJ" = (
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron,
@@ -63145,10 +61103,9 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/aft)
 "pJM" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/obj/structure/sink/directional/east,
+/turf/open/floor/iron/freezer,
+/area/station/science/robotics/lab)
 "pJY" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/coroner,
@@ -63161,21 +61118,24 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "pKo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
+/obj/machinery/light/floor,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "pKp" = (
 /turf/closed/wall,
 /area/station/security/execution)
 "pKt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/science/research)
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/closet/firecloset/full,
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "pKB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external,
@@ -63233,34 +61193,30 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "pLh" = (
-/obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/modular_computer/preset/civilian{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
+/area/station/science/robotics/lab)
 "pLn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/black,
 /area/station/commons/lounge)
-"pLp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
 "pLr" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/turf/open/floor/iron/white/textured_large,
+/turf/open/floor/iron,
 /area/station/science/xenobiology)
 "pLs" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
@@ -63340,6 +61296,9 @@
 /area/station/hallway/primary/central/aft)
 "pMa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "pMn" = (
@@ -63364,16 +61323,6 @@
 "pMA" = (
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/ghetto)
-"pMG" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "pNd" = (
 /obj/machinery/light/directional/north,
 /obj/structure/chair/pew/left{
@@ -63385,14 +61334,8 @@
 /turf/open/floor/wood/parquet,
 /area/station/security/courtroom)
 "pNj" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "Skynet_launch";
-	name = "Mech Bay"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "research_lockdown";
-	name = "Research Lockdown Blast Doors"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
@@ -63424,11 +61367,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "pND" = (
-/obj/structure/chair/sofa/right/brown{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/table,
+/obj/item/hatchet,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "pNN" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -63578,11 +61520,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
-"pPt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "pPw" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
@@ -63680,13 +61617,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
-"pRh" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/steam_vent,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "pRl" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -63711,23 +61641,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "pRu" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
+/obj/effect/spawner/random/structure/table_or_rack,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/area/station/maintenance/starboard/upper)
 "pRx" = (
-/obj/machinery/door/window/brigdoor/left/directional/north{
-	name = "Creature Pen";
-	req_access = list("research")
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/bot,
-/obj/machinery/light/floor,
-/turf/open/floor/iron,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "pRz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63775,17 +61694,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "pSl" = (
-/obj/structure/rack,
-/obj/item/clothing/gloves/boxing/blue{
-	pixel_x = 2;
-	pixel_y = -3
-	},
-/obj/item/clothing/gloves/boxing{
-	pixel_x = 5;
-	pixel_y = -6
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/effect/landmark/start/geneticist,
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "pSm" = (
 /obj/machinery/vending/assist,
 /obj/machinery/status_display/evac/directional/west,
@@ -63795,12 +61706,12 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
 "pSp" = (
-/obj/machinery/door/airlock/command,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/rd,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/iron/dark,
-/area/station/science/server)
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "pSx" = (
 /obj/structure/table/glass,
 /obj/item/storage/bag/trash,
@@ -63881,10 +61792,13 @@
 /area/station/maintenance/starboard/aft)
 "pTl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/machinery/button/door/directional/north{
+	id = "Skynet_launch";
+	name = "Mech Bay Door Control";
+	req_access = list("robotics")
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/mechbay)
 "pTm" = (
 /obj/structure/broken_flooring/singular/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -63930,14 +61844,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
 "pTR" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/button/door{
-	id = "xeno3";
-	name = "Containment Control";
-	req_access = list("xenobiology")
-	},
-/turf/open/floor/iron,
+/obj/structure/sink/directional/south,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "pTS" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
@@ -63967,10 +61875,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
-"pUv" = (
-/obj/effect/decal/cleanable/xenoblood,
-/turf/open/floor/engine/xenobio,
-/area/station/science/xenobiology)
 "pUx" = (
 /obj/docking_port/stationary{
 	shuttle_id = "argos_home";
@@ -64076,10 +61980,9 @@
 /turf/closed/wall,
 /area/station/maintenance/ghetto/port/aft)
 "pVF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/area/station/service/abandoned_gambling_den)
 "pVG" = (
 /obj/structure/holosign/barrier/engineering,
 /obj/structure/broken_flooring/singular/directional/south,
@@ -64102,17 +62005,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/storage)
-"pVR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wideplating_new{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/iron/herringbone,
-/area/station/maintenance/aft)
 "pVS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/cable,
@@ -64149,19 +62041,23 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/trash)
 "pWj" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
-"pWl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/wood,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 8
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
+"pWl" = (
+/obj/effect/turf_decal/siding/wideplating_new/corner{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/obj/effect/turf_decal/siding/wideplating_new/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/open/floor/iron/herringbone,
+/area/station/maintenance/starboard/aft)
 "pWy" = (
 /obj/structure/rack,
 /obj/item/mop{
@@ -64194,13 +62090,10 @@
 /turf/open/floor/iron/white,
 /area/station/common/cryopods)
 "pWT" = (
-/obj/structure/table/glass,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple/anticorner{
+/obj/effect/turf_decal/tile/purple/half{
 	dir = 1
 	},
-/obj/item/toy/figure/scientist,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "pWU" = (
@@ -64253,14 +62146,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "pXp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/floor/engine/hull/reinforced,
-/area/space/nearstation)
+/obj/machinery/light/small/directional/west,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "pXB" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
@@ -64374,13 +62263,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"pZF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/aft)
 "pZN" = (
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/ghetto/fore/starboard)
@@ -64393,17 +62275,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "qac" = (
-/obj/structure/table,
-/obj/item/storage/belt/utility,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass{
-	amount = 20;
-	pixel_x = -3;
-	pixel_y = 6
+/obj/machinery/light_switch/directional/north,
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/rnd/production/circuit_imprinter/department/science,
+/turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "qad" = (
 /obj/machinery/light/cold/directional/north,
@@ -64475,9 +62353,11 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
 "qaT" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/turf/open/floor/iron/freezer,
+/area/station/science/robotics/lab)
 "qaY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64548,11 +62428,10 @@
 /turf/open/floor/carpet/black,
 /area/station/commons/lounge)
 "qcf" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
+/obj/structure/table/wood/poker,
+/obj/item/coin/diamond,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/area/station/service/abandoned_gambling_den)
 "qcp" = (
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/cafeteria,
@@ -64587,10 +62466,11 @@
 /turf/open/misc/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "qcS" = (
-/obj/structure/table/wood/poker,
-/obj/effect/spawner/random/maintenance/three,
-/turf/open/floor/iron/grimy,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/station/science/robotics/mechbay)
 "qde" = (
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
@@ -64670,8 +62550,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/fore)
 "qed" = (
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/engine,
-/area/station/science/lower)
+/area/station/science/explab)
 "qen" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -64722,13 +62603,8 @@
 /turf/open/floor/carpet,
 /area/station/service/lawoffice)
 "qeT" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/obj/effect/turf_decal/bot_white,
-/obj/machinery/light/small/red/dim/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/maintenance/ghetto/starboard/aft)
+/turf/closed/wall/r_wall,
+/area/station/science/research)
 "qfe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64745,18 +62621,6 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
-"qfp" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenosecure";
-	name = "Secure Pen Shutters"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "qfr" = (
 /obj/structure/railing,
 /obj/structure/flora/bush/grassy/style_random,
@@ -64780,10 +62644,22 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "qfL" = (
-/obj/machinery/iv_drip,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/flora/bush/jungle/b/style_random,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "qfX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/tank/plasma,
@@ -64809,17 +62685,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
 "qgo" = (
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/research,
-/obj/machinery/door/poddoor/preopen{
-	id = "testlab";
-	name = "Test Chamber Blast Door"
-	},
-/obj/effect/turf_decal/stripes,
-/obj/machinery/door/firedoor,
-/turf/open/floor/engine,
-/area/station/science/explab)
+/obj/structure/chair/office/light,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "qgy" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -64900,8 +62769,12 @@
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/blueshield)
 "qhM" = (
-/turf/closed/wall/r_wall,
-/area/station/science/lower)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/healthanalyzer,
+/obj/item/reagent_containers/cup/glass/bottle/vodka/badminka,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "qhN" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/grimy,
@@ -64911,10 +62784,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
 "qim" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/generic_maintenance_landmark,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/obj/structure/flora/bush/grassy/style_random,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/structure/chair/pew/right{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "qio" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -65080,12 +62958,14 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage)
 "qjN" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	id = "rd_robotics_window_shutters"
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio10";
+	name = "Xenobio Pen 10 Blast Door"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/science/robotics/lab)
+/area/station/science/xenobiology)
 "qjV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -65182,9 +63062,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "qll" = (
-/obj/structure/sign/warning/secure_area/directional/east,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/obj/machinery/door/window/right/directional/west{
+	name = "Containment Pen 6";
+	req_access = list("xenobiology")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light/floor,
+/turf/open/floor/iron,
 /area/station/science/xenobiology)
 "qlv" = (
 /obj/effect/turf_decal/siding/wood{
@@ -65231,10 +63118,9 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/hallway/secondary/entry)
 "qlS" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/railing,
-/turf/open/floor/engine/hull/reinforced,
-/area/space/nearstation)
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron/white,
+/area/station/maintenance/aft)
 "qlX" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "engsm";
@@ -65332,15 +63218,11 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "qnk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wideplating_new/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating_new/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/herringbone,
-/area/station/maintenance/aft)
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/west,
+/mob/living/carbon/human/species/monkey,
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "qnH" = (
 /obj/machinery/door/airlock/public/glass{
 	autoclose = 0;
@@ -65382,10 +63264,15 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "qof" = (
-/obj/machinery/vending/snack,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
+	},
+/obj/effect/landmark/start/roboticist,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/kitchen)
+/area/station/science/robotics/lab)
 "qow" = (
 /obj/structure/easel,
 /obj/effect/decal/cleanable/dirt,
@@ -65488,17 +63375,6 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
-"qpD" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/flora/bush/jungle/b/style_random,
-/obj/effect/decal/cleanable/generic,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
 "qpI" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
@@ -65596,14 +63472,11 @@
 /turf/open/floor/iron/white/herringbone,
 /area/station/maintenance/ghetto/starboard/aft)
 "qqM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/effect/spawner/random/mod/maint,
+/turf/open/floor/iron/white,
+/area/station/maintenance/aft)
 "qqN" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/ghetto/starboard/aft)
@@ -65651,6 +63524,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "qrS" = (
@@ -65708,14 +63584,8 @@
 "qtp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "qtw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -65723,12 +63593,13 @@
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/ghetto/bar)
 "qtA" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
+/obj/machinery/modular_computer/preset/research,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "qtE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -65777,7 +63648,7 @@
 "qup" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/area/station/service/abandoned_gambling_den)
 "qut" = (
 /obj/structure/cable/layer3,
 /turf/open/floor/circuit,
@@ -65789,13 +63660,10 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "quH" = (
-/obj/structure/sink/directional/north,
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/iron,
-/area/station/science/xenobiology)
+/area/station/maintenance/ghetto/aft)
 "quL" = (
 /obj/item/storage/box/monkeycubes{
 	pixel_y = 3
@@ -65848,12 +63716,7 @@
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/blueshield)
 "qvj" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/turf_decal/box/white/corners{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white/textured,
 /area/station/science/xenobiology)
 "qvy" = (
 /obj/structure/disposalpipe/segment{
@@ -65962,10 +63825,9 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
 "qxg" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/upper)
 "qxh" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
@@ -66084,15 +63946,11 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
 "qyx" = (
-/obj/structure/rack,
-/obj/item/book/manual/wiki/engineering_guide,
-/obj/effect/spawner/random/maintenance,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
+/obj/structure/window/reinforced/spawner/directional/north{
+	pixel_y = 2
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "qyB" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/camera/directional/west{
@@ -66129,15 +63987,10 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "qzl" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/openspace,
-/area/station/science/xenobiology)
+/obj/structure/flora/bush/jungle/b/style_random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "qzo" = (
 /obj/machinery/door/airlock/security,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -66273,9 +64126,10 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs)
 "qAC" = (
-/obj/item/seeds/banana,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/machinery/door/airlock/wood,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "qAE" = (
 /obj/machinery/seed_extractor,
@@ -66366,12 +64220,6 @@
 /obj/item/reagent_containers/cup/watering_can,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/garden)
-"qBU" = (
-/obj/effect/spawner/random/trash/graffiti{
-	spawn_loot_chance = 50
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
 "qBZ" = (
 /obj/machinery/light/cold/directional/north,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -66432,15 +64280,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
 "qCX" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/machinery/bci_implanter,
+/obj/effect/turf_decal/tile/purple/anticorner{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/station/science/circuits)
 "qCY" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -66454,16 +64300,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet/black,
 /area/station/commons/lounge)
-"qDk" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/server)
 "qDl" = (
 /obj/structure/table/glass,
 /obj/machinery/camera/directional/south{
@@ -66542,9 +64378,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"qEP" = (
-/turf/closed/wall/rust,
-/area/station/maintenance/ghetto/kitchen)
 "qEY" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/dark,
@@ -66594,20 +64427,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "qFQ" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/delivery_chute{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery/red,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/door/window/right/directional/east{
-	name = "Morgue Disposal"
-	},
-/turf/open/floor/iron/freezer,
+/turf/closed/wall/r_wall,
 /area/station/science/robotics/lab)
 "qFR" = (
 /obj/structure/lattice,
@@ -66621,11 +64441,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "qFT" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/purple/half,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "qFW" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -66643,9 +64464,8 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical/ghetto/morgue)
 "qFZ" = (
-/obj/effect/spawner/random/trash/garbage{
-	spawn_scatter_radius = 1
-	},
+/obj/structure/ladder,
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "qGd" = (
@@ -66700,19 +64520,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "qGG" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard/aft)
 "qGI" = (
-/turf/open/floor/wood,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/structure/table/wood/poker,
+/obj/item/storage/wallet/random,
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "qGX" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
@@ -66744,24 +64561,13 @@
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
-"qHD" = (
-/obj/structure/table,
-/obj/item/soap/deluxe,
-/obj/item/clothing/neck/stethoscope,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
 "qHG" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/engine_smes)
 "qHI" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/shower/directional/east,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/effect/spawner/random/trash/graffiti,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "qHO" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/siding/wood/corner,
@@ -66894,11 +64700,16 @@
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/magistrate)
 "qJs" = (
-/obj/effect/turf_decal/stripes/red/line{
+/obj/machinery/door/window/right/directional/west{
+	name = "Containment Pen 10";
+	req_access = list("xenobiology")
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/door/window/brigdoor/left/directional/west,
-/turf/open/floor/iron/dark/textured_large,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light/floor,
+/turf/open/floor/iron,
 /area/station/science/xenobiology)
 "qJy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66967,9 +64778,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "qKv" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/turf/open/floor/iron,
-/area/station/science/lab)
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/light/directional/west,
+/obj/structure/closet/radiation,
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "qKz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66995,16 +64812,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto)
-"qKG" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
 "qKH" = (
 /obj/machinery/computer/upload/borg{
 	dir = 1
@@ -67136,9 +64943,11 @@
 /turf/open/floor/light,
 /area/station/maintenance/starboard/aft)
 "qMG" = (
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "qMM" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
@@ -67163,7 +64972,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "qMX" = (
 /obj/structure/chair/sofa/corp/left,
 /obj/effect/turf_decal/siding/purple{
@@ -67171,24 +64980,17 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/station/service/bar)
-"qMY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "qMZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/station/maintenance/starboard/aft)
 "qNe" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/science/robotics/mechbay)
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "qNg" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -67199,15 +65001,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "qNi" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/landmark/start/roboticist,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
+/obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/white,
+/area/station/science/circuits)
 "qNk" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small/directional/south,
@@ -67249,21 +65046,14 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "qNJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio1";
+	name = "Xenobio Pen 1 Blast Door"
 	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "qNK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard,
@@ -67281,11 +65071,14 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
 "qNP" = (
-/obj/machinery/light/small/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio4";
+	name = "Xenobio Pen 4 Blast Door"
+	},
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "qNX" = (
 /obj/structure/sign/poster/contraband/random/directional/north,
 /obj/machinery/light/small/broken/directional/north,
@@ -67371,13 +65164,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "qPp" = (
-/obj/structure/table/wood/poker,
-/obj/item/stack/spacecash/c10,
-/obj/item/stack/spacecash/c1{
-	pixel_y = 5
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron/grimy,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "qPu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -67414,18 +65206,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
-"qQb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/obj/item/chair/plastic,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
 "qQf" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
@@ -67465,16 +65245,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"qQJ" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/lattice/catwalk,
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/open/openspace,
-/area/station/science/xenobiology)
 "qQR" = (
 /obj/machinery/power/solar_control{
 	dir = 1;
@@ -67652,17 +65422,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"qTk" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
 "qTo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/loading_area,
@@ -67671,20 +65430,27 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "qTt" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/wood,
-/area/station/maintenance/starboard/upper)
+/obj/structure/table/wood/poker,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/grimy,
+/area/station/service/abandoned_gambling_den)
 "qTw" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "qTy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/electric_shock/directional/south,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/door/window/right/directional/west{
+	name = "Containment Pen 7";
+	req_access = list("xenobiology")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light/floor,
 /turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
+/area/station/science/xenobiology)
 "qTA" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -67781,8 +65547,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "qVj" = (
-/turf/closed/wall,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "qVo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -67837,11 +65605,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"qWa" = (
-/obj/machinery/light/small/directional/south,
-/obj/machinery/vending/boozeomat,
-/turf/open/floor/wood,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
 "qWd" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -67876,9 +65639,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "qWs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/structure/table,
 /obj/item/extinguisher{
 	pixel_x = 4;
@@ -68154,6 +65914,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
 "qZL" = (
@@ -68162,10 +65925,16 @@
 /turf/open/floor/wood,
 /area/station/service/library/ghetto)
 "qZQ" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/beakers,
+/obj/machinery/door/airlock/research,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	name = "Biohazard Shutter";
+	id = "RnDChem"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/engine,
-/area/station/science/lower)
+/area/station/science/explab)
 "qZW" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -68343,8 +66112,9 @@
 	},
 /area/station/cargo/storage)
 "rbX" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "rcb" = (
@@ -68353,13 +66123,6 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/plating,
 /area/station/security/interrogation/ghetto)
-"rcd" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/hedge,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/ghetto/starboard/aft)
 "rcg" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -68490,10 +66253,17 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "reb" = (
-/obj/structure/table/reinforced,
-/obj/item/food/sandwich/cheese/grilled,
-/turf/open/floor/wood,
-/area/station/maintenance/aft)
+/obj/machinery/door/window/left/directional/east{
+	name = "Containment Pen 4";
+	req_access = list("xenobiology")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light/floor,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "red" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -68578,16 +66348,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
-"rfp" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
 "rft" = (
 /obj/item/shard{
 	icon_state = "medium"
@@ -68734,9 +66494,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "rhr" = (
@@ -68781,9 +66538,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "rhw" = (
-/obj/item/kirbyplants/random,
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/area/station/service/abandoned_gambling_den)
 "rhx" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/structure/grille,
@@ -68803,11 +66563,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "rik" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "rip" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/red{
@@ -68967,11 +66730,14 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos/project)
 "rjZ" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio7";
+	name = "Xenobio Pen 7 Blast Door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "rki" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/dark_green{
@@ -69026,12 +66792,6 @@
 /obj/structure/lattice,
 /turf/open/space/openspace,
 /area/space/nearstation)
-"rkL" = (
-/obj/machinery/light_switch/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
 "rkX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -69114,10 +66874,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "rlH" = (
-/obj/effect/decal/cleanable/blood,
-/obj/machinery/door/window/right/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/item/kirbyplants/random,
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "rlP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -69158,10 +66917,16 @@
 /turf/closed/wall,
 /area/station/maintenance/ghetto/sorting)
 "rmw" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/asphalt,
-/area/station/maintenance/ghetto/garden)
+/obj/item/storage/box/beakers{
+	pixel_x = 7
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/box/pillbottles{
+	pixel_x = -7
+	},
+/obj/effect/turf_decal/tile/purple/anticorner,
+/turf/open/floor/iron/white,
+/area/station/science/circuits)
 "rmB" = (
 /obj/machinery/light/directional/north,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -69223,12 +66988,12 @@
 /turf/open/floor/grass,
 /area/station/maintenance/ghetto/garden)
 "rna" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/wood,
-/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable,
+/obj/structure/table/wood,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/garden)
+/area/station/service/abandoned_gambling_den)
 "rnb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/right/directional/west{
@@ -69276,12 +67041,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/engineering/storage)
-"rnD" = (
-/obj/machinery/hydroponics/soil,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/cup/watering_can,
-/turf/open/floor/grass,
-/area/station/maintenance/starboard/aft)
 "rnE" = (
 /obj/structure/closet/crate/freezer,
 /obj/effect/spawner/random/maintenance,
@@ -69289,11 +67048,7 @@
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/starboard/aft)
 "rnF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
-/obj/machinery/door/airlock/atmos,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering,
-/obj/effect/mapping_helpers/airlock/unres{
+/obj/machinery/atmospherics/components/binary/valve/on{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -69358,11 +67113,17 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port/greater)
 "roD" = (
-/obj/effect/spawner/random/trash/garbage{
-	spawn_scatter_radius = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio5";
+	name = "Xenobio Pen 5 Blast Door"
+	},
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "roH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -69407,7 +67168,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/engine/hull/reinforced,
+/turf/open/floor/plating/airless,
 /area/station/maintenance/aft)
 "roX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -69438,12 +67199,14 @@
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "rpy" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 6
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/siding/wideplating_new/corner{
+	dir = 1
 	},
-/obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/floor/iron/dark/textured_corner,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "rpF" = (
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/iron,
@@ -69527,10 +67290,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "rqA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/bar/fourcorners,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 4
+	},
+/area/station/science/xenobiology)
 "rqF" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -69606,19 +67373,13 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
-"rrM" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "rrN" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "rrQ" = (
@@ -69643,12 +67404,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"rsb" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/clothing/costume,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
 "rsn" = (
 /obj/structure/railing{
 	dir = 8
@@ -69677,9 +67432,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/trash)
 "rsz" = (
-/obj/machinery/vending/cytopro,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/aft)
 "rsF" = (
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
@@ -69778,14 +67539,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"rtt" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "rtu" = (
 /obj/structure/table/glass,
 /obj/effect/spawner/random/engineering/flashlight,
@@ -69842,11 +67595,12 @@
 /turf/open/openspace,
 /area/station/science/ordnance/office)
 "rui" = (
-/obj/machinery/door/window/right/directional/south{
-	name = "ChangKitchen"
+/obj/machinery/light/small/directional/east,
+/obj/structure/chair/wood{
+	dir = 4
 	},
 /turf/open/floor/wood,
-/area/station/maintenance/aft)
+/area/station/service/abandoned_gambling_den)
 "ruq" = (
 /obj/machinery/button/door/directional/west{
 	id = "Toilet2";
@@ -69959,10 +67713,6 @@
 /obj/effect/mapping_helpers/apc/cell_10k,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"rvk" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/engine/hull/reinforced,
-/area/space/nearstation)
 "rvn" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/port/aft)
@@ -70019,10 +67769,9 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "rws" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron/cafeteria,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/structure/sign/warning/cold_temp/directional/west,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "rwC" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/basic/goose/vomit,
@@ -70055,12 +67804,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
 "rxj" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/openspace,
+/area/station/science/xenobiology)
 "rxr" = (
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/atmos/project)
@@ -70240,38 +67989,22 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "rAO" = (
-/obj/structure/chair/sofa/right/brown,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
+/obj/structure/cable,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "rAW" = (
 /turf/closed/wall,
 /area/station/commons/locker)
 "rAZ" = (
-/obj/structure/chair/stool{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "rBd" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"rBg" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/button/door{
-	id = "xenosecure";
-	name = "Containment Control";
-	pixel_y = -3;
-	req_access = list("xenobiology")
-	},
-/obj/item/radio/intercom{
-	pixel_y = 10
-	},
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "rBm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -70283,15 +68016,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "rBy" = (
-/obj/effect/spawner/random/maintenance,
-/obj/effect/spawner/random/trash/garbage,
-/obj/item/trash/semki,
-/obj/item/trash/sosjerky,
-/obj/item/trash/raisins,
-/obj/effect/spawner/random/trash/garbage,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/effect/turf_decal/tile/purple/half,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/science/lab)
 "rBA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -70322,11 +68050,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/mechbay)
-"rBQ" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/cup/glass/drinkingglass,
-/turf/open/floor/wood,
-/area/station/maintenance/starboard/upper)
 "rBZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
@@ -70334,29 +68057,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
-"rCa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
-"rCe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
 "rCj" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/landmark/start/hangover/closet,
@@ -70399,14 +68099,14 @@
 /area/station/medical/virology)
 "rCL" = (
 /obj/machinery/light/directional/west,
-/obj/structure/closet/emcloset,
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
-/area/station/science/research)
+/area/station/science/lab)
 "rCO" = (
-/obj/structure/disposalpipe/segment,
 /obj/item/clothing/glasses/science{
 	pixel_y = 4
 	},
@@ -70426,23 +68126,15 @@
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/security/lockers)
 "rDd" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/bodycontainer/morgue{
-	dir = 2
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/morgue)
+/obj/machinery/light/small/directional/west,
+/obj/structure/sign/poster/contraband/random/directional/west,
+/obj/structure/chair/stool/bar/directional/north,
+/turf/open/floor/iron/grimy,
+/area/station/service/abandoned_gambling_den)
 "rDh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"rDq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/light/small/directional/north,
-/obj/effect/spawner/random/structure/steam_vent,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
 "rDD" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/decal/cleanable/dirt,
@@ -70484,10 +68176,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "rEu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/landmark/start/scientist,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 2
+	},
+/obj/machinery/holopad,
+/obj/effect/mapping_helpers/mail_sorting/science/research,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "rEy" = (
@@ -70536,11 +68229,12 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/storage)
 "rEX" = (
-/obj/effect/turf_decal/loading_area{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/purple/half{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
+/turf/open/floor/iron/white,
+/area/station/science/robotics/lab)
 "rFc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood/parquet,
@@ -70565,15 +68259,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "rFp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/hallway/primary/starboard/west)
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "rFs" = (
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood/tile,
@@ -70671,9 +68361,17 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "rGV" = (
-/obj/structure/sink/directional/west,
-/turf/open/floor/iron/freezer,
-/area/station/science/robotics/lab)
+/obj/machinery/door/window/right/directional/west{
+	name = "Containment Pen 4";
+	req_access = list("xenobiology")
+	},
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio4";
+	name = "Xenobio Pen 4 Blast Door"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "rHk" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/stripes/corner,
@@ -70784,13 +68482,6 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"rIX" = (
-/obj/structure/chair/stool{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
 "rIZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -70868,22 +68559,23 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/locker)
 "rJT" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "rJX" = (
-/obj/structure/table,
-/obj/item/circular_saw,
-/obj/item/scalpel{
-	pixel_y = 12
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron/freezer,
-/area/station/science/robotics/lab)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "rJZ" = (
 /obj/item/chair/stool{
 	pixel_x = 6;
@@ -70908,13 +68600,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "rKi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/mechbay)
 "rKx" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
@@ -70929,15 +68617,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"rKG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno5";
-	name = "Creature Cell #5"
-	},
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "rKL" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -71011,34 +68690,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
-"rLu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/science/general,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door_buttons/access_button{
-	idDoor = "xeno_airlock_interior";
-	idSelf = "xeno_airlock_control";
-	name = "Xeno Access Button";
-	pixel_x = -24;
-	req_access = list("xenobiology")
-	},
-/obj/machinery/door/airlock/research{
-	frequency = 1450;
-	autoclose = 0;
-	id_tag = "xeno_airlock_interior"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable,
-/obj/machinery/duct,
-/obj/machinery/door/poddoor/preopen{
-	id = "research_lockdown";
-	name = "Research Lockdown Blast Doors"
-	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "rLx" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/tool,
@@ -71107,19 +68758,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"rMt" = (
-/obj/machinery/computer/records/security{
-	dir = 1
-	},
-/obj/machinery/requests_console/directional/south{
-	department = "Security";
-	name = "Security Requests Console"
-	},
-/obj/effect/mapping_helpers/requests_console/information,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
 "rMx" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
@@ -71213,9 +68851,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "rNF" = (
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "rNG" = (
 /obj/structure/closet/secure_closet/hop,
 /obj/machinery/camera/directional/south{
@@ -71256,10 +68895,10 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "rOh" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
+/obj/machinery/door/window/right/directional/north,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/area/station/service/abandoned_gambling_den)
 "rOk" = (
 /obj/structure/sink/directional/west,
 /obj/structure/mirror/directional/east,
@@ -71317,10 +68956,13 @@
 	name = "Quarantine Lockdown";
 	opacity = 0
 	},
-/obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/duct,
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/medical/medbay)
 "rPa" = (
@@ -71408,15 +69050,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "rQM" = (
-/obj/machinery/computer/mecha{
-	dir = 4
-	},
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "rQR" = (
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
@@ -71654,9 +69290,6 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "rTW" = (
@@ -71678,9 +69311,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "rUb" = (
-/obj/machinery/status_display/evac/directional/south,
-/obj/machinery/vending/wardrobe/robo_wardrobe,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/purple/half,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "rUn" = (
@@ -71713,13 +69349,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "rUy" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 4
 	},
 /obj/machinery/disposal/bin,
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/purple/anticorner,
-/obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "rUF" = (
@@ -71829,10 +69464,9 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/theater)
 "rVN" = (
-/obj/item/seeds/ambrosia,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/area/station/maintenance/ghetto/garden)
 "rVV" = (
 /obj/structure/flora/bush/jungle/b/style_random,
 /obj/structure/spacevine{
@@ -71867,15 +69501,13 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/gravity_generator)
 "rWg" = (
-/obj/structure/table,
-/obj/item/trash/chips,
-/obj/structure/cable,
-/obj/structure/desk_bell{
-	pixel_y = 9;
-	pixel_x = 8
+/obj/structure/table/wood/poker,
+/obj/item/stack/spacecash/c10,
+/obj/item/stack/spacecash/c1{
+	pixel_y = 5
 	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
+/turf/open/floor/iron/grimy,
+/area/station/service/abandoned_gambling_den)
 "rWh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -71883,19 +69515,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "rWq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/bed/maint,
+/turf/open/floor/iron/white,
+/area/station/maintenance/aft)
 "rWy" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/cleanable/dirt,
@@ -72118,19 +69741,21 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "rYl" = (
-/obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
 "rYm" = (
-/obj/structure/chair/sofa/middle/brown{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet,
+/obj/item/seeds/ambrosia/deus,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "rYq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -72138,20 +69763,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage/ghetto)
-"rYu" = (
-/obj/machinery/light/small/directional/east,
-/obj/effect/spawner/random/structure/tank_holder,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
 "rYA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/gravity_generator)
 "rYC" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard/west)
+/obj/effect/landmark/start/research_director,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "rYE" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72189,19 +69811,16 @@
 /area/station/science/ordnance/office)
 "rZm" = (
 /obj/machinery/atmospherics/components/binary/pump/off,
-/obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "rZo" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "rZq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "rZB" = (
@@ -72274,9 +69893,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "saM" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/machinery/computer/camera_advanced/xenobio{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "saO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72315,14 +69936,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
-"sbf" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "sbn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/unres{
@@ -72397,16 +70010,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay/ghetto)
-"sbO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno3";
-	name = "Creature Cell #3"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "sbQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -72456,10 +70059,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "scq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/station/maintenance/aft)
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/chair/pew/left{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "scr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/corner/directional/west,
@@ -72575,27 +70180,17 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "sdy" = (
-/obj/machinery/computer/rdconsole{
-	dir = 8
+/obj/effect/turf_decal/tile/red/anticorner/contrasted,
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 8
 	},
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/rd)
+/obj/item/pen,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "sdA" = (
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"sdE" = (
-/obj/machinery/dna_infuser,
-/obj/machinery/camera/directional/south{
-	c_tag = "Research - Genetics";
-	network = list("ss13","rd")
-	},
-/obj/item/infuser_book,
-/obj/effect/turf_decal/tile/purple/half,
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
 "sdH" = (
 /obj/structure/closet/secure_closet/captains,
 /obj/machinery/firealarm/directional/west,
@@ -72751,12 +70346,13 @@
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "sgc" = (
-/obj/structure/urinal/directional/north,
-/obj/effect/turf_decal/trimline/white/line{
+/obj/effect/turf_decal/trimline/white/line,
+/obj/machinery/light/small/broken/directional/south,
+/obj/effect/turf_decal/trimline/white/corner{
 	dir = 1
 	},
+/obj/effect/spawner/random/trash/garbage,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/washing_machine,
 /turf/open/floor/iron/white/herringbone,
 /area/station/maintenance/ghetto/starboard/aft)
 "sgf" = (
@@ -72808,15 +70404,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
-"sha" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "shc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -72960,18 +70547,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "siP" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/bot,
-/obj/machinery/holopad,
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio3";
+	name = "Xenobio Pen 3 Blast Door"
 	},
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/station/science/xenobiology)
 "siR" = (
 /obj/structure/bed/medical/anchored{
@@ -72993,12 +70578,10 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/ghetto)
 "sjf" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/effect/spawner/random/maintenance,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "sjj" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4,
@@ -73194,13 +70777,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto)
-"skY" = (
-/obj/machinery/light/small/directional/east,
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
 "sla" = (
 /obj/structure/girder,
 /turf/open/floor/iron,
@@ -73209,13 +70785,8 @@
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/item/flatpack{
-	board = /obj/item/circuitboard/machine/flatpacker
-	},
-/obj/item/multitool,
-/turf/open/floor/iron,
-/area/station/science/lab)
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "slm" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -73237,8 +70808,12 @@
 /turf/open/floor/iron,
 /area/station/command/teleporter)
 "slu" = (
-/obj/structure/closet/l3closet/scientist,
-/turf/open/floor/plating,
+/obj/structure/chair/sofa/right/brown{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/carpet,
 /area/station/maintenance/starboard/aft)
 "slJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -73332,14 +70907,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "smN" = (
-/obj/structure/table,
-/obj/item/cigarette/rollie/cannabis,
-/obj/item/cigarette/rollie/cannabis{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/obj/effect/decal/cleanable/generic,
+/obj/structure/flora/bush/fullgrass/style_random,
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "smO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73348,15 +70919,23 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "smU" = (
-/turf/open/floor/iron/stairs/right{
+/obj/machinery/camera/directional/west{
+	c_tag = "Xenobiology Pens - Port Fore";
+	network = list("ss13","rd","xeno")
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
+"snc" = (
+/obj/effect/turf_decal/tile/purple/half{
 	dir = 8
 	},
-/area/station/maintenance/ghetto/garden)
-"snc" = (
-/obj/effect/landmark/start/scientist,
-/obj/effect/turf_decal/tile/purple/fourcorners,
-/turf/open/floor/iron,
-/area/station/science/lab)
+/obj/machinery/newscaster/directional/west,
+/obj/machinery/light/directional/west,
+/obj/structure/closet/secure_closet/personal/patient{
+	name = "test subject's closet"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "snj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -73396,15 +70975,9 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/machinery/computer/security/telescreen/research/directional/north{
-	network = list("rd","xeno","test","ordnance");
-	pixel_y = 35;
-	name = "Research Security Monitor"
-	},
-/obj/effect/landmark/start/depsec/science,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron/white,
+/area/station/science/circuits)
 "snN" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp/green,
@@ -73483,12 +71056,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "soG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard/west)
+/obj/machinery/door/poddoor/shutters{
+	dir = 1;
+	id = "Skynet_launch";
+	name = "Mech Bay"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/mechbay)
 "soH" = (
 /obj/structure/easel,
 /obj/item/canvas/twentythree_twentythree,
@@ -73584,13 +71163,10 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "sqp" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
+/obj/effect/turf_decal/bot,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
+/area/station/science/robotics/mechbay)
 "sqq" = (
 /obj/structure/table,
 /obj/effect/spawner/random/contraband/prison,
@@ -73674,12 +71250,12 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "srh" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "srj" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
@@ -73748,9 +71324,11 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/ghetto)
 "ssd" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "ssh" = (
 /obj/effect/turf_decal/tile/red/half{
 	dir = 1
@@ -73831,17 +71409,11 @@
 /turf/open/space/openspace,
 /area/space)
 "stz" = (
-/obj/machinery/light/floor,
-/obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/floor/asphalt,
-/area/station/maintenance/ghetto/garden)
-"stA" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
+/obj/machinery/hydroponics/soil,
+/obj/item/reagent_containers/cup/watering_can,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/grass,
+/area/station/maintenance/starboard/aft)
 "stB" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -73856,16 +71428,15 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "stV" = (
-/obj/structure/table/wood,
-/obj/machinery/light/directional/south,
-/obj/machinery/microwave/engineering/cell_included,
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/camera/directional/south{
-	c_tag = "Medbay - Break Room";
-	network = list("ss13","medbay")
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "stY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -73889,27 +71460,30 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "suj" = (
-/obj/structure/chair{
-	dir = 8
+/obj/structure/table,
+/obj/item/melee/baseball_bat,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
+"suk" = (
+/obj/machinery/button/door/directional/south{
+	id = "xenobiomain";
+	name = "Xenobiology Containment Blast Door";
+	req_access = list("xenobiology")
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
+"sun" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Xenobiology Maintenance"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
-"suk" = (
-/turf/open/floor/iron/cafeteria,
-/area/station/maintenance/ghetto/starboard/aft)
-"sun" = (
-/obj/machinery/door/window/brigdoor/left/directional/south{
-	name = "Creature Pen";
-	req_access = list("research")
-	},
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno5";
-	name = "Creature Cell #5"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "sux" = (
 /turf/open/floor/iron/white,
@@ -74027,18 +71601,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "swe" = (
-/obj/machinery/newscaster/directional/east,
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/sign/warning/cold_temp/directional/south,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/light/cold/directional/south,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "swg" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -74047,9 +71615,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "swh" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet,
-/area/station/maintenance/aft)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "swj" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -74232,15 +71802,6 @@
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/maintenance/ghetto/bar)
-"syV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "szb" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -74286,10 +71847,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "szL" = (
+/obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/shaker,
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/station/maintenance/aft)
+/obj/item/reagent_containers/dropper,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den)
 "szM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -74315,10 +71877,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "sAe" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 5
+	},
 /obj/structure/cable,
-/obj/machinery/door/window/right/directional/north,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/area/station/service/abandoned_gambling_den)
 "sAh" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -74356,10 +71920,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/sorting)
 "sBa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple/half,
+/obj/structure/filingcabinet/chestdrawer,
+/obj/item/taperecorder{
+	pixel_y = 7
+	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "sBd" = (
@@ -74410,10 +71977,10 @@
 /turf/open/floor/iron,
 /area/station/security/range)
 "sCc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/structure/table/wood,
+/obj/item/food/grown/cannabis,
+/obj/item/storage/fancy/rollingpapers,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "sCf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -74432,10 +71999,25 @@
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
 "sCn" = (
-/obj/effect/spawner/random/structure/tank_holder,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table,
+/obj/item/storage/box/bodybags{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/hand_labeler{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "sCt" = (
 /obj/machinery/ore_silo,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -74457,12 +72039,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "sCF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/rack,
+/obj/item/storage/box/lights/tubes,
+/obj/item/crowbar/red,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "sCR" = (
 /obj/structure/chair{
 	dir = 8
@@ -74481,12 +72066,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "sCV" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den)
 "sCY" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/computer/atmos_control/ordnancemix{
@@ -74520,8 +72102,9 @@
 /area/station/cargo/storage/ghetto/depot)
 "sDi" = (
 /obj/machinery/newscaster/directional/south,
+/obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/engine,
-/area/station/science/lower)
+/area/station/science/explab)
 "sDw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -74555,10 +72138,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
 "sDE" = (
-/obj/machinery/light/small/directional/north,
-/obj/structure/table,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/mob/living/basic/cockroach,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den)
 "sDH" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -74810,9 +72393,15 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "sGh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/cigarette/rollie/cannabis{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/item/cigarette/rollie/cannabis,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/aft)
 "sGr" = (
 /obj/machinery/door/airlock/public,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -74889,14 +72478,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/office)
-"sHr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor/broken,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/aft)
 "sHs" = (
 /obj/effect/turf_decal/tile/purple/half,
 /turf/open/floor/iron/white,
@@ -74975,12 +72556,17 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
 "sHZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/sofa/left/brown{
+/obj/machinery/door/window/left/directional/east{
+	name = "Containment Pen 2";
+	req_access = list("xenobiology")
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light/floor,
 /turf/open/floor/iron,
-/area/station/maintenance/aft)
+/area/station/science/xenobiology)
 "sIn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/small/directional/east,
@@ -75041,13 +72627,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "sIX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno1";
-	name = "Creature Cell #1"
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "sIY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -75062,11 +72647,11 @@
 /turf/open/floor/stone,
 /area/station/maintenance/ghetto/bar)
 "sJo" = (
-/obj/machinery/firealarm/directional/south,
 /obj/structure/table,
 /obj/machinery/fax{
 	fax_name = "Research Division";
-	name = "Research Division Fax Machine"
+	name = "Research Division Fax Machine";
+	pixel_x = 1
 	},
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
@@ -75111,16 +72696,21 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard/west)
 "sKf" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/openspace,
-/area/station/maintenance/aft)
-"sKi" = (
-/obj/effect/turf_decal/box/white/corners{
+/obj/structure/chair/wood{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
+"sKi" = (
+/obj/machinery/disposal/bin,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/station/science/xenobiology)
 "sKl" = (
 /obj/effect/turf_decal/stripes/line{
@@ -75225,11 +72815,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"sLJ" = (
-/obj/structure/closet/toolcloset,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
 "sLP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -75293,18 +72878,17 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "sNa" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/structure/table,
+/obj/item/toy/plush/slimeplushie{
+	name = "Nanners"
 	},
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "sNf" = (
-/obj/structure/chair/sofa/left/brown,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "sNg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -75526,9 +73110,9 @@
 	},
 /area/station/hallway/secondary/entry)
 "sRe" = (
-/obj/effect/turf_decal/tile/purple/half,
-/turf/open/floor/iron/white,
-/area/station/science/explab)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/circuit/green,
+/area/station/science/robotics/mechbay)
 "sRg" = (
 /obj/structure/chair/pew/left{
 	dir = 8
@@ -75548,14 +73132,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/sorting)
-"sRz" = (
-/obj/structure/bed,
-/mob/living/carbon/human/species/monkey,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "sRE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -75662,10 +73238,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"sTk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
 "sTw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -75694,29 +73266,12 @@
 "sTJ" = (
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
-"sTP" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "sTU" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"sUh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
 "sUj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -75736,13 +73291,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "sUq" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table,
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_y = 6
 	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 8
+/obj/machinery/cell_charger{
+	pixel_y = 5
 	},
+/obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "sUF" = (
@@ -75794,12 +73352,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "sVn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio9";
+	name = "Xenobio Pen 9 Blast Door"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/aft)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "sVs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -75908,9 +73468,10 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/station/cargo/storage)
 "sWX" = (
-/obj/structure/lattice/catwalk,
-/turf/open/openspace,
-/area/station/science/xenobiology)
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/open/floor/asphalt,
+/area/station/maintenance/ghetto/garden)
 "sWY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -75994,23 +73555,10 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/security/prison/ghetto)
-"sYA" = (
-/obj/structure/chair/pew/right,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
 "sYD" = (
 /obj/machinery/atmospherics/components/tank/air/layer4,
 /turf/open/floor/iron/large,
 /area/station/maintenance/ghetto/central)
-"sYI" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/chem_master,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "sYO" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -76077,17 +73625,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"sZN" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
-"sZT" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine/hull/reinforced,
-/area/space/nearstation)
 "sZW" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/trash)
@@ -76115,19 +73652,20 @@
 /turf/open/floor/iron,
 /area/station/command/teleporter)
 "taN" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/latex,
-/obj/item/surgical_drapes,
-/obj/item/razor,
-/turf/open/floor/iron/freezer,
-/area/station/science/robotics/lab)
-"taO" = (
-/obj/structure/table,
-/obj/item/toy/plush/slimeplushie{
-	name = "Gish"
+/obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/turf/open/floor/iron/white,
+/area/station/science/research)
+"taO" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/iron/stairs/right{
+	dir = 8
+	},
+/area/station/maintenance/ghetto/garden)
 "tbe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
@@ -76158,20 +73696,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "tbp" = (
-/obj/structure/table,
-/obj/item/experi_scanner{
-	pixel_x = -4
-	},
-/obj/item/experi_scanner,
-/obj/item/experi_scanner{
-	pixel_x = 4
-	},
-/obj/structure/sign/poster/official/periodic_table/directional/east,
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/science/lab)
+/obj/machinery/light/directional/east,
+/obj/machinery/computer/scan_consolenew{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "tbI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -76192,9 +73725,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "tcd" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "tci" = (
 /obj/structure/chair/stool{
@@ -76224,15 +73755,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/commons/vacant_room/office)
-"tcJ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/tile/purple/anticorner,
-/obj/structure/sign/departments/xenobio/directional/south,
-/turf/open/floor/iron,
-/area/station/science/research)
 "tcN" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/textured_large,
@@ -76244,10 +73766,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "tda" = (
-/obj/machinery/recharger,
-/obj/structure/table,
-/turf/open/floor/iron/white,
-/area/station/science/lab)
+/mob/living/carbon/human/species/monkey,
+/turf/open/floor/grass,
+/area/station/science/genetics)
 "tdc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -76310,11 +73831,17 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "tea" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/effect/spawner/random/trash/moisture_trap,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "genetics_shutters";
+	name = "Genetics Shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/turf/open/floor/plating,
+/area/station/science/genetics)
 "tef" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -76524,18 +74051,18 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
 "thB" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "medical_break"
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
-/turf/open/floor/plating,
-/area/station/medical/break_room)
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "thD" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/wood,
-/area/station/maintenance/aft)
+/obj/structure/marker_beacon/indigo,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "thQ" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -76549,11 +74076,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/storage)
-"tib" = (
-/obj/structure/sign/warning/vacuum/directional/east,
-/obj/effect/spawner/random/trash/graffiti,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
 "tif" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general{
 	dir = 10
@@ -76836,14 +74358,17 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "tls" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
 	},
-/turf/open/floor/iron,
-/area/station/science/robotics/lab)
+/turf/open/floor/plating,
+/area/space/nearstation)
 "tlt" = (
 /obj/machinery/light/directional/south,
 /obj/structure/railing/corner/end/flip{
@@ -76890,23 +74415,17 @@
 /area/station/maintenance/port)
 "tlZ" = (
 /obj/structure/cable,
-/obj/structure/table/wood,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/area/station/service/abandoned_gambling_den)
 "tmo" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
 "tmq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "tms" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow,
@@ -77018,13 +74537,32 @@
 /turf/open/misc/beach/sand,
 /area/station/hallway/secondary/exit/departure_lounge)
 "tnn" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/purple/anticorner{
 	dir = 1
 	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/rack,
+/obj/item/assembly/timer{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/assembly/timer{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/assembly/timer{
+	pixel_x = -1
+	},
+/obj/item/assembly/timer{
+	pixel_x = -1
+	},
+/obj/item/assembly/timer{
+	pixel_x = 1;
+	pixel_y = -2
+	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "tnr" = (
 /obj/effect/decal/cleanable/vomit,
 /obj/item/toy/gun,
@@ -77204,18 +74742,15 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "toV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/unres{
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "toY" = (
 /obj/machinery/button/door/directional/west{
 	id = "Toilet4";
@@ -77371,13 +74906,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "tqC" = (
-/obj/machinery/atmospherics/components/binary/valve/on{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/valve/on,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
 "tqG" = (
@@ -77515,11 +75048,14 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/gravity_generator)
 "tsA" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan{
+	dir = 8
+	},
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
 "tsD" = (
@@ -77529,19 +75065,28 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "tsI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/server)
-"tsW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/science/server)
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard)
+"tsW" = (
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
+	},
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "tsY" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow,
@@ -77632,6 +75177,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
 "ttM" = (
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/obj/structure/table/reinforced,
+/obj/machinery/fax{
+	fax_name = "Research Director's Office";
+	name = "Research Director's Fax Machine"
+	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "ttR" = (
@@ -77824,20 +75378,15 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
-"tvA" = (
-/obj/effect/spawner/random/maintenance,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
 "tvB" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "genetics_shutters";
+	name = "Genetics Shutters"
 	},
-/turf/open/floor/iron,
-/area/station/science/lab)
+/turf/open/floor/plating,
+/area/station/science/genetics)
 "tvE" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/rnd_secure_all,
@@ -77864,9 +75413,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port)
 "tvW" = (
-/obj/structure/cable,
+/obj/structure/table/wood/poker,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/wood,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/area/station/service/abandoned_gambling_den)
 "tvY" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -77874,10 +75424,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "tvZ" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/cafeteria,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/machinery/holopad,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "twh" = (
 /turf/open/floor/glass/reinforced,
 /area/station/service/chapel/monastery)
@@ -77921,10 +75470,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/commons/toilet/restrooms)
-"twP" = (
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/engine,
-/area/station/science/lower)
 "twT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -77951,8 +75496,11 @@
 /turf/open/floor/plating,
 /area/station/security/courtroom)
 "txo" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Research Mech Bay";
+	dir = 4;
+	network = list("ss13","rd")
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "txs" = (
@@ -78000,12 +75548,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "txP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance/two,
-/obj/item/crowbar/red,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/structure/sign/warning/docking/directional/east,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "tya" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/wood,
@@ -78213,11 +75758,11 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "tBB" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
-	id = "xeno8";
-	name = "Creature Cell #8"
+	id = "xenobio5";
+	name = "Xenobio Pen 5 Blast Door"
 	},
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
@@ -78289,12 +75834,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"tCx" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "tCz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -78310,9 +75849,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/gravity_generator)
 "tCI" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/open/floor/asphalt,
+/area/station/maintenance/ghetto/garden)
 "tCP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -78708,12 +76247,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "tHY" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron,
+/area/station/science/lab)
 "tHZ" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -78755,7 +76291,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple/half,
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "tIF" = (
 /obj/structure/displaycase/trophy,
 /obj/structure/sign/painting/library{
@@ -78852,9 +76388,14 @@
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
 "tJN" = (
-/obj/structure/rack,
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
+/obj/machinery/door/airlock/research,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "tJP" = (
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -78938,16 +76479,19 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "tKy" = (
-/obj/effect/spawner/random/trash/graffiti{
-	spawn_loot_chance = 50
+/obj/machinery/door/window/left/directional/east{
+	name = "Test Chamber";
+	req_access = list("xenobiology")
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "tKE" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
@@ -78971,26 +76515,6 @@
 /obj/item/clothing/glasses/regular,
 /turf/open/floor/wood,
 /area/station/service/library/ghetto)
-"tKJ" = (
-/obj/machinery/newscaster/directional/south,
-/obj/structure/table/glass,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -10;
-	pixel_y = 12
-	},
-/obj/item/radio/headset/headset_medsci{
-	pixel_x = -7
-	},
-/obj/item/hand_labeler{
-	pixel_x = 4;
-	pixel_y = 10
-	},
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = 7
-	},
-/obj/effect/turf_decal/tile/purple/half,
-/turf/open/floor/iron/dark,
-/area/station/science/genetics)
 "tLc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -79091,18 +76615,17 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "tMe" = (
-/obj/machinery/door/window/brigdoor/left/directional/west{
-	name = "Secure Creature Pen";
-	req_access = list("research")
+/obj/structure/rack,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenosecure";
-	name = "Secure Pen Shutters"
+/obj/item/stack/sheet/iron/fifty,
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/turf/open/floor/iron,
+/area/station/science/lab)
 "tMr" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/port/greater)
@@ -79182,13 +76705,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/commons/vacant_room/office)
-"tNT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/starboard/aft)
 "tNX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -79247,9 +76763,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "tOz" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/small,
-/area/station/medical/morgue)
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "tOL" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Holodeck - North"
@@ -79341,11 +76859,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "tPP" = (
-/obj/structure/falsewall,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/aft)
+/area/station/maintenance/starboard/upper)
 "tPU" = (
 /obj/structure/grille/broken,
 /obj/item/stack/rods,
@@ -79512,12 +77031,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/ghetto)
 "tSK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/wood,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/garden)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "tTc" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -79607,13 +77123,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"tUK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
 "tUP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,
@@ -79631,9 +77140,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "tUV" = (
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/iron/cafeteria,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/breakroom)
 "tUY" = (
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
@@ -79674,7 +77185,12 @@
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/captain)
 "tVq" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "tVr" = (
@@ -79685,12 +77201,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "tVt" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/chair/pew/right{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/mechbay)
 "tVv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -79731,9 +77245,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "tVC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/asphalt,
-/area/station/maintenance/ghetto/garden)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "tVE" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/hos)
@@ -79773,22 +77291,19 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "tWg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/flora/grass/jungle/b/style_2,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
 	},
-/obj/structure/sign/gym/mirrored/right{
-	pixel_y = -32
-	},
-/turf/open/floor/iron/herringbone,
-/area/station/maintenance/aft)
+/turf/open/water,
+/area/station/maintenance/ghetto/garden)
 "tWi" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/mechbay)
 "tWj" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -79826,12 +77341,18 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/interrogation/ghetto)
 "tWs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/rd)
+/obj/machinery/computer/security/telescreen/research/directional/north{
+	network = list("rd","xeno","test","ordnance");
+	pixel_y = 35;
+	name = "Research Security Monitor"
+	},
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/landmark/start/depsec/science,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "tWy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -80052,10 +77573,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
-"tZp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/science/robotics/mechbay)
 "tZs" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -80140,11 +77657,6 @@
 /turf/open/floor/carpet,
 /area/station/service/library/ghetto)
 "uaw" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "uax" = (
@@ -80261,11 +77773,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ubo" = (
-/obj/machinery/computer/scan_consolenew{
-	dir = 4
+/obj/structure/chair/office{
+	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/science/genetics)
+/area/station/science/server)
 "ubr" = (
 /obj/effect/turf_decal/tile/green/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -80340,6 +77853,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "ucu" = (
@@ -80361,13 +77875,13 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "udb" = (
-/obj/structure/displaycase/labcage,
-/obj/structure/sign/poster/contraband/lamarr/directional/north,
-/obj/effect/turf_decal/tile/purple/half{
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/effect/landmark/start/depsec/science,
+/obj/structure/reagent_dispensers/wall/peppertank/directional/north,
 /turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
+/area/station/security/checkpoint/science)
 "udm" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -80429,18 +77943,6 @@
 /obj/effect/turf_decal/tile/red/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/checkpoint/medical)
-"ueh" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/camera/directional/south{
-	c_tag = "Research - Hallway North";
-	network = list("ss13","rd")
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "uej" = (
 /turf/open/openspace,
 /area/station/security/brig)
@@ -80554,18 +78056,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
-"ufy" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/glass{
-	amount = 50;
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/monkeycubes,
-/obj/item/storage/box/pillbottles,
-/turf/open/floor/engine,
-/area/station/science/lower)
 "ufz" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -80582,16 +78072,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/storage)
-"ufD" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "xeno7";
-	name = "Containment Control";
-	req_access = list("xenobiology")
-	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "ufE" = (
 /obj/structure/closet/wardrobe/white,
 /obj/item/clothing/shoes/jackboots,
@@ -80669,13 +78149,9 @@
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "ugS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/structure/sign/warning/gas_mask/directional/south,
-/turf/open/floor/plating,
+/obj/machinery/light/small/directional/east,
+/obj/structure/fermenting_barrel,
+/turf/open/floor/wood,
 /area/station/maintenance/starboard/upper)
 "ugU" = (
 /obj/structure/disposalpipe/segment,
@@ -80685,12 +78161,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
-"ugX" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/food_or_drink/cake_ingredients,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
 "uhc" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -80706,6 +78176,7 @@
 "uhq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "uhw" = (
@@ -80765,9 +78236,16 @@
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
 "uhV" = (
-/obj/structure/holosign/barrier/atmos,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/obj/effect/landmark/start/roboticist,
+/turf/open/floor/iron,
+/area/station/science/robotics/lab)
 "uhZ" = (
 /turf/closed/wall,
 /area/station/security/checkpoint/supply)
@@ -80793,14 +78271,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "uiy" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Research - Xenobiology Secure Cell Interior";
-	network = list("ss13","xeno","rd")
-	},
-/obj/machinery/status_display/ai/directional/west,
-/obj/machinery/light/cold/directional/west,
-/turf/open/floor/engine/xenobio,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "uiE" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -80843,23 +78317,23 @@
 /turf/open/floor/iron/small,
 /area/station/maintenance/ghetto/central)
 "uiT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet,
-/obj/effect/spawner/random/maintenance/two,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
-"uiY" = (
-/obj/machinery/modular_computer/preset/id{
+/obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
-/obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
+"uiY" = (
+/obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/asphalt,
+/area/station/maintenance/ghetto/garden)
 "uiZ" = (
 /obj/machinery/door/airlock/atmos,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -80980,11 +78454,20 @@
 /turf/open/floor/carpet/royalblack,
 /area/station/maintenance/port/aft)
 "ulb" = (
-/obj/item/bedsheet/blue,
-/obj/structure/bed/maint,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/plasticflaps{
+	name = "Science Deliveries"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	location = "Research Division"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/aft)
+/area/station/science/research)
 "ull" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -81013,22 +78496,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "ulv" = (
-/obj/structure/table,
-/obj/machinery/camera/directional/north{
-	c_tag = "Research - Lobby";
-	network = list("ss13","rd")
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/research,
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
 	},
-/obj/machinery/light_switch/directional/north,
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
-	},
-/obj/item/folder,
-/obj/item/pen,
-/turf/open/floor/iron,
-/area/station/science/lobby)
+/turf/open/floor/plating,
+/area/station/science/research)
 "ulA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -81048,25 +78527,25 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "ulV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/purple/half,
-/turf/open/floor/iron,
-/area/station/science/lab)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "umd" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/item/stack/sheet/mineral/plasma,
+/obj/effect/turf_decal/tile/purple/half,
+/turf/open/floor/iron/white,
+/area/station/science/circuits)
 "umf" = (
 /obj/effect/turf_decal/tile/green/fourcorners,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
@@ -81200,24 +78679,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/command/storage/eva)
-"uov" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/delivery_chute{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/effect/turf_decal/delivery/red,
-/obj/machinery/door/window/right/directional/east{
-	name = "Morgue Disposal"
-	},
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/floor/iron/white,
-/area/station/science/genetics)
 "uoO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -81247,9 +78708,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto)
 "upi" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/science/genetics)
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "upq" = (
 /obj/structure/table/optable{
 	dir = 1
@@ -81288,7 +78750,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "upX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -81306,8 +78768,16 @@
 /turf/open/floor/catwalk_floor,
 /area/station/cargo/drone_bay/ghetto)
 "uqi" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron,
+/obj/machinery/door/poddoor/preopen{
+	id = "misclab";
+	name = "Test Chamber Blast Door"
+	},
+/obj/machinery/door/window/left/directional/west{
+	name = "Test Chamber";
+	req_access = list("xenobiology")
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "uql" = (
 /obj/structure/rack,
@@ -81408,19 +78878,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/garden)
 "urR" = (
-/obj/machinery/requests_console/directional/south{
-	department = "Research Director's Desk";
-	name = "Research Director's Requests Console"
-	},
-/obj/effect/mapping_helpers/requests_console/information,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/effect/mapping_helpers/requests_console/ore_update,
-/obj/effect/mapping_helpers/requests_console/announcement,
-/obj/machinery/computer/robotics{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple/half,
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/station/command/heads_quarters/rd)
 "usf" = (
 /obj/effect/turf_decal/siding/wood{
@@ -81447,14 +78907,19 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay/ghetto)
 "usX" = (
-/turf/closed/wall/rust,
-/area/station/maintenance/ghetto/garden)
-"uta" = (
-/obj/structure/disposalpipe/trunk/multiz/down{
-	dir = 2
+/obj/item/kirbyplants/random/dead/research_director,
+/obj/effect/turf_decal/tile/purple/half,
+/obj/machinery/camera/directional/south{
+	c_tag = "Science - Research Director's Quarters";
+	name = "science camera";
+	network = list("ss13","rd")
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
+"uta" = (
+/obj/effect/turf_decal/loading_area,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/mechbay)
 "utg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/chair/office{
@@ -81546,7 +79011,7 @@
 /area/station/security/range)
 "uuk" = (
 /obj/effect/decal/cleanable/blood,
-/obj/structure/sign/warning/gas_mask/directional/north,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "uum" = (
@@ -81569,8 +79034,13 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
 "uuw" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/sign/poster/official/random/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "uuD" = (
@@ -81622,11 +79092,11 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/mechbay)
 "uvq" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "uvI" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -81651,12 +79121,10 @@
 /area/station/hallway/secondary/entry)
 "uvR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/structure/cable,
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "uvW" = (
@@ -81734,14 +79202,16 @@
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hos)
 "uxd" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood,
-/area/station/maintenance/ghetto/aft)
-"uxi" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/area/station/maintenance/starboard/upper)
+"uxi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/asphalt,
+/area/station/maintenance/ghetto/garden)
 "uxn" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -81819,9 +79289,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "uxX" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/water,
+/area/station/maintenance/ghetto/garden)
 "uyg" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Starboard Primary Hallway 6"
@@ -81862,11 +79337,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "uyR" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 8
+/obj/machinery/door/airlock/research/glass{
+	name = "Kill Chamber";
+	normalspeed = 0
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "uyS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -81876,8 +79353,11 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/fore/starboard)
 "uyT" = (
-/turf/closed/wall,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "uzk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -81904,8 +79384,27 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "uzL" = (
-/turf/closed/wall,
-/area/station/science/lower)
+/obj/item/multitool/circuit{
+	pixel_x = -8
+	},
+/obj/item/multitool/circuit{
+	pixel_x = -4
+	},
+/obj/item/multitool/circuit,
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/science/circuits)
 "uzM" = (
 /obj/structure/table,
 /obj/item/assembly/timer{
@@ -81977,15 +79476,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "uAE" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/button/door{
-	id = "xeno2";
-	name = "Containment Control";
-	req_access = list("xenobiology")
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den)
 "uAG" = (
 /obj/structure/railing/corner/end{
 	dir = 8
@@ -82029,13 +79523,14 @@
 "uBe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "uBk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "uBq" = (
@@ -82093,6 +79588,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "uCr" = (
@@ -82107,11 +79603,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "uCA" = (
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/genetics,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/station/science/genetics)
+/area/station/science/xenobiology)
 "uCH" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral,
@@ -82167,9 +79665,8 @@
 "uDf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/sorting/mail,
-/obj/effect/mapping_helpers/mail_sorting/science/rd_office,
 /obj/structure/cable,
+/obj/structure/disposalpipe/junction/yjunction,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "uDi" = (
@@ -82206,12 +79703,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"uEt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
 "uEL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -82353,21 +79844,11 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "uGN" = (
-/obj/structure/table/reinforced/rglass,
-/obj/item/food/grown/banana,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple{
+	dir = 5
 	},
-/obj/machinery/light/small/directional/west,
-/obj/machinery/camera/directional/west{
-	c_tag = "Virology - Observation";
-	network = list("ss13","medbay")
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "uGO" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/trash/cigbutt,
@@ -82437,14 +79918,6 @@
 "uHN" = (
 /turf/closed/wall/r_wall,
 /area/station/security/interrogation/ghetto)
-"uHT" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/air{
-	anchored = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
 "uHW" = (
 /obj/machinery/camera/autoname/directional/north{
 	network = list("ss13","prison")
@@ -82455,11 +79928,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
+/turf/open/floor/iron/white,
+/area/station/science/circuits)
 "uIb" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Central Hallway - West"
@@ -82679,8 +80149,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage/gas)
 "uKw" = (
-/obj/machinery/vending/wardrobe/science_wardrobe,
 /obj/effect/turf_decal/tile/purple,
+/obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "uKC" = (
@@ -82698,19 +80168,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "uKS" = (
-/obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/science/genetics)
-"uLj" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Research - Mech Bay";
-	network = list("ss13","rd")
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
+/area/station/science/server)
 "uLk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -82780,10 +80242,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "uMf" = (
-/obj/structure/railing,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/structure/flora/rock/pile/style_2,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "uMg" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -82908,11 +80376,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"uNe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/hobo_squat,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
 "uNh" = (
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
@@ -82950,18 +80413,11 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/ghetto/port/greater)
 "uNF" = (
-/obj/effect/turf_decal/tile/purple/fourcorners,
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 6;
-	pixel_y = 4
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
 	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = -5;
-	pixel_y = 1
-	},
-/obj/structure/table/glass,
 /turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/area/station/medical/virology)
 "uNM" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/decal/cleanable/dirt,
@@ -83096,25 +80552,12 @@
 "uPA" = (
 /turf/closed/wall,
 /area/station/maintenance/ghetto/auxiliary)
-"uPP" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/station/science/explab)
 "uPS" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"uQa" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "uQg" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
@@ -83129,12 +80572,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "uQw" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 1
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/turf_decal/trimline/white/warning{
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/turf/open/floor/iron/dark,
+/area/station/service/abandoned_gambling_den)
 "uQL" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/dirt,
@@ -83199,11 +80642,27 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard/west)
 "uRz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/lower)
+/obj/structure/table/reinforced,
+/obj/item/folder,
+/obj/item/pen{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "genetics_shutters";
+	name = "Genetics Shutters"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "research_lockdown";
+	name = "Research Lockdown Blast Doors"
+	},
+/obj/machinery/door/window/right/directional/south{
+	name = "Genetics Desk";
+	req_access = list("genetics")
+	},
+/turf/open/floor/plating,
+/area/station/science/genetics)
 "uRE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -83280,10 +80739,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "uSG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
@@ -83338,19 +80793,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
-"uTK" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/structure/flora/grass/jungle/b/style_random,
-/turf/open/water,
-/area/station/maintenance/ghetto/garden)
 "uTL" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/security/cell/left/directional/north{
@@ -83388,11 +80830,9 @@
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen/abandoned)
 "uUb" = (
-/obj/structure/table/wood,
-/obj/structure/mirror/directional/north,
-/obj/effect/spawner/random/entertainment/coin,
+/obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/area/station/maintenance/starboard/upper)
 "uUh" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/clothing/funny_hats,
@@ -83609,10 +81049,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "uYk" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "uYv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -83624,18 +81063,6 @@
 /obj/item/flashlight/flare/candle,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/fore)
-"uYE" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/obj/machinery/button/door/directional/south{
-	id = "Psychological office";
-	name = "Medical Break Room Shutters Control";
-	normaldoorcontrol = 1;
-	specialfunctions = 4;
-	pixel_y = 24
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
 "uYI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -83670,8 +81097,6 @@
 	pixel_y = 8
 	},
 /obj/effect/turf_decal/tile/green/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "uYT" = (
@@ -83687,14 +81112,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "uYW" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "uYX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold/orange/visible,
@@ -83711,12 +81137,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/stairs/left,
 /area/station/engineering/hallway/west)
-"uZi" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
 "uZj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/red/fourcorners,
@@ -83776,20 +81196,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/security/prison/mess)
-"vaA" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/openspace,
-/area/station/science/xenobiology)
-"vaB" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/food_or_drink/cake_ingredients,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
 "vaF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -83858,12 +81264,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/nanotrasen_representative)
-"vbv" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "vbG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
@@ -83956,7 +81356,7 @@
 	id = "RnDChem"
 	},
 /turf/open/floor/engine,
-/area/station/science/lower)
+/area/station/science/explab)
 "vcU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -84219,15 +81619,15 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "vgI" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/effect/turf_decal/tile/purple/anticorner{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
-/obj/item/toy/figure/rd{
-	pixel_y = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/command/heads_quarters/rd)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "vgJ" = (
 /obj/structure/closet/body_bag,
 /turf/open/floor/plating,
@@ -84328,11 +81728,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"viw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
 "vix" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/service)
@@ -84347,13 +81742,14 @@
 /obj/structure/bodycontainer/morgue{
 	dir = 2
 	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "viO" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "viR" = (
 /obj/effect/spawner/random/maintenance,
@@ -84410,15 +81806,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/carpet,
 /area/station/commons/vacant_room/office)
-"vjE" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "vjG" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -84539,6 +81926,7 @@
 "vkt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/closet/l3closet/scientist,
 /turf/open/floor/iron/white,
 /area/station/maintenance/starboard/aft)
 "vku" = (
@@ -84549,13 +81937,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "vky" = (
-/obj/effect/turf_decal/tile/neutral/half,
-/obj/effect/turf_decal/tile/neutral/half,
-/obj/effect/turf_decal/tile/neutral/half,
-/obj/effect/turf_decal/tile/neutral/half,
-/obj/structure/sink/kitchen/directional/south,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/engineering/tank,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "vkz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -84588,20 +81974,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "vkW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
-/area/station/science/research)
+/area/station/maintenance/starboard/aft)
 "vkZ" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
@@ -84686,8 +82069,14 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "vlJ" = (
-/turf/open/floor/wood,
-/area/station/maintenance/aft)
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "vlM" = (
 /obj/machinery/jukebox,
 /turf/open/floor/wood/parquet,
@@ -84801,9 +82190,9 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "vny" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "vnA" = (
@@ -84828,10 +82217,11 @@
 /turf/open/floor/glass/reinforced,
 /area/station/service/chapel/monastery)
 "vnE" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron,
 /area/station/science/xenobiology)
 "vnH" = (
 /obj/effect/turf_decal/weather/dirt,
@@ -84950,7 +82340,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
 "voT" = (
-/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "voU" = (
@@ -84976,24 +82366,22 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "vpo" = (
-/obj/effect/spawner/random/structure/grille,
-/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio1";
+	name = "Xenobio Pen 1 Blast Door"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/area/station/science/xenobiology)
 "vpp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/cargo/storage/ghetto/depot)
-"vps" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno7";
-	name = "Creature Cell #7"
-	},
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "vpt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/entertainment/arcade{
@@ -85046,15 +82434,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
-"vpW" = (
-/obj/structure/urinal/directional/north,
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/garbage,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/herringbone,
-/area/station/maintenance/ghetto/starboard/aft)
 "vpY" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -85069,10 +82448,9 @@
 	},
 /area/station/security/mechbay)
 "vqm" = (
-/obj/structure/table,
-/obj/item/reagent_containers/spray/cleaner,
 /obj/effect/spawner/random/maintenance,
-/obj/machinery/light/small/directional/east,
+/obj/structure/table,
+/obj/item/storage/crayons,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "vqu" = (
@@ -85105,17 +82483,14 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/aft)
 "vqE" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_y = 8
+/obj/machinery/modular_computer/preset/civilian{
+	dir = 4
 	},
-/obj/item/pen,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
+/obj/effect/turf_decal/tile/purple/half{
 	dir = 8
 	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
+/turf/open/floor/iron/white,
+/area/station/science/circuits)
 "vqH" = (
 /obj/structure/railing{
 	dir = 4
@@ -85216,17 +82591,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"vrD" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 8;
-	name = "killroom vent"
-	},
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/science/xenobiology)
 "vrG" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -85240,17 +82604,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "vrJ" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Research - Xenobiology East";
-	network = list("ss13","xeno","rd");
-	dir = 1
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/structure/flora/grass/jungle/b/style_random,
+/turf/open/water,
+/area/station/maintenance/ghetto/garden)
 "vrL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -85383,11 +82742,20 @@
 /turf/closed/wall,
 /area/station/medical/psychology)
 "vsR" = (
-/obj/effect/turf_decal/trimline/white/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/broken/directional/south,
-/turf/open/floor/iron/white/herringbone,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/structure/table,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/obj/item/stack/cable_coil,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/white,
+/area/station/science/robotics/lab)
 "vsX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -85418,11 +82786,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "vti" = (
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 4
-	},
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "vto" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 1;
@@ -85534,11 +82900,10 @@
 	},
 /area/station/security/prison/ghetto)
 "vun" = (
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/science/explab)
+/area/station/science/xenobiology)
 "vuo" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/conveyor{
@@ -85712,10 +83077,11 @@
 /turf/open/floor/wood,
 /area/station/service/library/ghetto)
 "vwS" = (
-/obj/structure/cable,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "vwW" = (
 /obj/machinery/computer/shuttle/mining/common{
 	dir = 1
@@ -85799,14 +83165,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
-"vye" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/station/science/research)
 "vyg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -85974,10 +83332,17 @@
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
 "vAr" = (
-/obj/structure/flora/bush/lavendergrass/style_random,
-/mob/living/basic/butterfly,
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
+/obj/machinery/door/window/right/directional/west{
+	name = "Containment Pen 8";
+	req_access = list("xenobiology")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light/floor,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "vAs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -85991,10 +83356,12 @@
 	},
 /area/station/hallway/secondary/entry)
 "vAt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/area/station/maintenance/starboard/upper)
 "vAw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 8
@@ -86116,11 +83483,6 @@
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"vCB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "vCC" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -86309,22 +83671,14 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "vEX" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/structure/railing/corner,
-/turf/open/floor/engine/hull/reinforced,
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
 /area/space/nearstation)
 "vFc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"vFh" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
 "vFz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/dark_green{
@@ -86362,14 +83716,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "vGw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id = "xeno5";
-	name = "Creature Cell #5"
-	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "vGB" = (
 /obj/item/radio/intercom/directional/west,
@@ -86505,10 +83856,12 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "vHV" = (
-/obj/item/kirbyplants/random,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/landmark/start/geneticist,
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "vIc" = (
 /obj/structure/rack,
 /turf/open/floor/iron,
@@ -86960,15 +84313,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"vNQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "vOa" = (
 /turf/closed/wall,
 /area/station/commons/lounge)
@@ -86998,10 +84342,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "vOs" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
 "vOU" = (
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "vPa" = (
@@ -87115,15 +84463,14 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "vQV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/effect/turf_decal/siding/wideplating_new/corner{
-	dir = 4
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
 	},
-/obj/effect/turf_decal/siding/wideplating_new/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/herringbone,
-/area/station/maintenance/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "vRs" = (
 /turf/open/floor/plating,
 /area/station/maintenance/port)
@@ -87172,51 +84519,41 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "vSb" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/area/station/science/research)
 "vSd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 2
-	},
-/obj/effect/mapping_helpers/mail_sorting/science/research,
 /obj/structure/cable,
-/obj/machinery/holopad,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "vSw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/landmark/start/scientist,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
-/area/station/science/lower)
-"vSx" = (
-/obj/structure/grille,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/area/station/science/explab)
 "vSA" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/structure/sign/warning/cold_temp/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "vSF" = (
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "vSK" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/chem_heater/withbuffer,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/machinery/light/small/directional/south,
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den)
 "vSP" = (
 /obj/structure/flora/rock/pile/jungle/style_random,
 /obj/effect/decal/cleanable/dirt,
@@ -87241,9 +84578,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "vTk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/freezer,
-/area/station/science/robotics/lab)
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/table,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "vTr" = (
 /obj/machinery/door/poddoor{
 	elevator_mode = 1;
@@ -87379,13 +84720,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "vVf" = (
-/obj/effect/turf_decal/box/red,
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1
-	},
-/obj/structure/sign/warning/gas_mask/directional/north,
-/turf/open/floor/engine/xenobio,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/mechbay)
 "vVi" = (
 /obj/machinery/photocopier,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -87471,11 +84810,6 @@
 "vWi" = (
 /turf/closed/wall,
 /area/station/maintenance/ghetto/central/aft)
-"vWk" = (
-/obj/machinery/holopad,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
 "vWn" = (
 /obj/structure/table/reinforced,
 /obj/structure/railing{
@@ -87585,11 +84919,23 @@
 /turf/open/floor/iron/dark,
 /area/station/construction)
 "vXn" = (
-/obj/machinery/door/airlock/command/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/science/rd,
-/turf/open/floor/iron/dark,
-/area/station/science/server)
+/obj/machinery/computer/mecha{
+	dir = 4
+	},
+/obj/machinery/requests_console/directional/west{
+	department = "Research Director's Desk";
+	name = "Research Director's Requests Console"
+	},
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/mapping_helpers/requests_console/ore_update,
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/white,
+/area/station/command/heads_quarters/rd)
 "vXo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -87602,10 +84948,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
-"vXr" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
 "vXt" = (
 /turf/closed/wall/r_wall,
 /area/station/security/medical)
@@ -87628,14 +84970,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port/aft)
 "vXP" = (
-/obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/light/directional/south,
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/landmark/start/depsec/science,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/science)
+/turf/open/floor/iron/white,
+/area/station/science/circuits)
 "vXV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -87675,10 +85011,15 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
 "vYz" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/cable,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/vending/cytopro,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/station/science/research)
+/area/station/science/xenobiology)
 "vYL" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 8
@@ -87755,12 +85096,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "wae" = (
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/chair/pew{
-	dir = 8
+/obj/machinery/door/window/right/directional/west{
+	name = "Monkey Pen";
+	req_access = list("genetics")
 	},
 /turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
+/area/station/science/genetics)
 "waf" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine/o2,
@@ -87770,25 +85111,27 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "waq" = (
-/obj/machinery/washing_machine,
-/obj/effect/turf_decal/siding/dark_blue{
-	dir = 9
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/cafeteria,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	pixel_y = 4
+	},
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_x = -4
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "was" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"wav" = (
-/obj/machinery/light/directional/west,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/science/lab)
 "way" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -87797,31 +85140,13 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/ghetto/central/aft)
 "waJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/rack,
-/obj/item/assembly/timer{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/obj/item/assembly/timer{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/assembly/timer{
-	pixel_x = -1
-	},
-/obj/item/assembly/timer{
-	pixel_x = -1
-	},
-/obj/item/assembly/timer{
-	pixel_x = 1;
-	pixel_y = -2
-	},
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 8
 	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "waM" = (
 /obj/structure/rack,
 /obj/item/circuitboard/machine/exoscanner{
@@ -88039,11 +85364,16 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "wdB" = (
-/obj/structure/chair/stool{
-	dir = 4
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/open/floor/iron/herringbone,
+/area/station/maintenance/starboard/aft)
 "wdH" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/stairs/left,
@@ -88319,11 +85649,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "whJ" = (
-/obj/structure/chair/pew/left{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/garden)
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/table,
+/obj/item/clothing/gloves/latex,
+/obj/item/razor,
+/turf/open/floor/iron/freezer,
+/area/station/science/robotics/lab)
 "whM" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -88369,17 +85700,19 @@
 /turf/open/floor/iron,
 /area/station/science/lab)
 "whU" = (
-/obj/structure/sign/poster/contraband/random/directional/west,
-/obj/effect/mapping_helpers/burnt_floor,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "wia" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "wic" = (
 /obj/machinery/door/airlock/security/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -88597,12 +85930,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/prison)
-"wkB" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
-	},
-/turf/open/water,
-/area/station/maintenance/ghetto/garden)
 "wkF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -88657,11 +85984,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
-"wlQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
 "wlR" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
@@ -88718,8 +86040,8 @@
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
 /obj/machinery/camera/directional/west{
-	c_tag = "Research - Ordnance Watching Room";
-	network = list("ss13","rd","ordnance");
+	c_tag = "Science - Ordnance Watching Room";
+	network = list("ss13","rd");
 	dir = 10
 	},
 /turf/open/floor/iron,
@@ -88760,12 +86082,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "wnx" = (
-/obj/structure/chair/comfy/teal{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "wnH" = (
 /obj/machinery/mecha_part_fabricator,
 /turf/open/floor/iron/dark,
@@ -88845,12 +86167,14 @@
 /turf/open/floor/carpet/red,
 /area/station/commons/dorms/apartment1)
 "woY" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
+/obj/structure/table/wood/poker,
+/obj/item/stack/spacecash/c10,
+/obj/item/stack/spacecash/c10,
+/obj/item/stack/spacecash/c1{
+	pixel_y = 5
 	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/science/xenobiology)
+/turf/open/floor/iron/grimy,
+/area/station/service/abandoned_gambling_den)
 "wpf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -88860,8 +86184,9 @@
 /area/station/security/range)
 "wpg" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "wpt" = (
@@ -88901,12 +86226,9 @@
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "wqe" = (
-/obj/machinery/atmospherics/components/binary/valve/on,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "wqi" = (
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -88926,17 +86248,16 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/locker)
 "wqA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/break_room)
+/area/station/medical/cryo)
 "wqI" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -88949,9 +86270,8 @@
 /area/station/commons/vacant_room/office)
 "wqQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "wrh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/bed{
@@ -88961,12 +86281,12 @@
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "wrk" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/light/small/directional/south,
+/obj/effect/spawner/random/structure/crate,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/aft)
 "wrm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -88991,10 +86311,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "wrs" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
+/obj/item/storage/box/bodybags,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "wrt" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron/freezer,
@@ -89053,9 +86374,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
 "wsd" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/aft)
+/obj/structure/training_machine,
+/turf/open/floor/engine,
+/area/station/science/explab)
 "wse" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -89130,27 +86451,27 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
 "wti" = (
-/obj/structure/table/wood/poker,
-/obj/effect/spawner/random/maintenance,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/area/station/service/abandoned_gambling_den)
 "wtj" = (
 /obj/structure/closet/firecloset,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wtl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/computer/records/security{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
+/obj/machinery/requests_console/directional/south{
+	department = "Security";
+	name = "Security Requests Console"
 	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "wtn" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/closet{
@@ -89201,12 +86522,11 @@
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/port/fore)
 "wue" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "wuv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -89241,36 +86561,10 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/arrivals)
-"wuS" = (
-/obj/structure/table,
-/obj/machinery/firealarm/directional/east,
-/obj/item/clothing/suit/hooded/wintercoat/science{
-	pixel_y = 8
-	},
-/obj/item/clothing/suit/hooded/wintercoat/science{
-	pixel_y = 8
-	},
-/obj/item/clothing/shoes/winterboots{
-	pixel_y = 3
-	},
-/obj/item/clothing/shoes/winterboots{
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
 "wuV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/effect/turf_decal/siding/wideplating_new{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/iron/herringbone,
-/area/station/maintenance/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den)
 "wva" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -89304,26 +86598,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"wvD" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/radio/intercom/directional/east,
-/obj/machinery/camera/directional/east{
-	c_tag = "Research - Xenobiology Maintenance Access";
-	network = list("ss13","xeno","rd")
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
-"wvI" = (
-/obj/structure/chair/comfy/teal{
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
 "wvJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -89348,14 +86622,12 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/aft)
 "wvS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/structure/table,
+/turf/open/floor/iron/dark,
+/area/station/security/checkpoint/science)
 "wvT" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -89367,12 +86639,10 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/maintenance/department/security/ghetto/fore)
 "wwb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/rack,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/machinery/vending/cola,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/service/abandoned_gambling_den)
 "wwh" = (
 /obj/effect/turf_decal/tile/dark_red,
 /obj/item/radio/intercom/directional/east,
@@ -89511,9 +86781,12 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/command/nuke_storage)
 "wyu" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "wyw" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
@@ -89615,11 +86888,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
-"wzL" = (
-/obj/item/trash/pistachios,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/station/maintenance/starboard/aft)
 "wzM" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/large,
@@ -89681,11 +86949,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "wAt" = (
+/obj/structure/table/glass,
 /obj/effect/turf_decal/tile/purple/half{
-	dir = 4
+	dir = 1
 	},
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/area/station/science/lab)
 "wAv" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/stripes/line,
@@ -89802,10 +87073,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/fore)
-"wBw" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
 "wBx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 1
@@ -89887,11 +87154,10 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
 "wCv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/structure/steam_vent,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "wCz" = (
 /obj/structure/grille/broken,
 /obj/item/stack/rods,
@@ -89994,14 +87260,6 @@
 /obj/effect/turf_decal/trimline/yellow/warning,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
-"wDz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "wDC" = (
 /obj/machinery/status_display,
 /turf/closed/wall,
@@ -90025,8 +87283,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "wDN" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/research,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
 /obj/machinery/door/poddoor/preopen{
@@ -90034,8 +87290,10 @@
 	id = "RnDChem"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
-/area/station/science/lower)
+/area/station/science/explab)
 "wDU" = (
 /obj/effect/turf_decal/arrows,
 /obj/structure/disposalpipe/segment{
@@ -90132,10 +87390,6 @@
 /area/station/engineering/atmos/hfr_room)
 "wEM" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "research_lockdown";
-	name = "Research Lockdown Blast Doors"
-	},
 /turf/open/floor/plating,
 /area/station/science/ordnance/office)
 "wER" = (
@@ -90160,12 +87414,6 @@
 "wEY" = (
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
-"wFa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/bar/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
 "wFi" = (
 /obj/item/toy/basketball,
 /obj/effect/decal/cleanable/dirt,
@@ -90400,11 +87648,10 @@
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "wIF" = (
-/obj/structure/table/wood,
-/obj/item/stack/rods,
-/obj/item/stack/cable_coil,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/service/abandoned_gambling_den)
 "wIG" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -90478,13 +87725,6 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
-"wJW" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "wJX" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -90613,11 +87853,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
 "wLp" = (
-/obj/item/seeds/cannabis,
-/obj/item/food/grown/ambrosia/vulgaris,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/south,
+/obj/machinery/chem_dispenser/drinks/beer{
+	pixel_y = 8;
+	dir = 1
+	},
+/obj/structure/table/wood,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
+/area/station/service/abandoned_gambling_den)
 "wLq" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -90686,10 +87929,12 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "wMk" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/small/directional/east,
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 10
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/area/station/service/abandoned_gambling_den)
 "wMn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -90830,9 +88075,13 @@
 /turf/open/floor/iron/large,
 /area/station/maintenance/ghetto/central)
 "wOD" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
+/obj/machinery/camera/directional/west{
+	c_tag = "Xenobiology Test Chamber";
+	network = list("ss13","test","rd","xeno")
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/engine/xenobio,
+/area/station/science/xenobiology)
 "wOL" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/small/directional/north,
@@ -90928,11 +88177,10 @@
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "wPO" = (
-/obj/machinery/door/airlock,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/white/textured_large,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "wQa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -91120,10 +88368,13 @@
 /turf/open/floor/iron/freezer,
 /area/station/science/robotics/lab)
 "wSc" = (
-/obj/structure/table/glass,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/effect/landmark/start/depsec/science,
+/obj/machinery/light/directional/south,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
+/area/station/security/checkpoint/science)
 "wSm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -91158,8 +88409,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "wSC" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Research - Hallway Center";
+/obj/machinery/camera{
+	c_tag = "Research Hallway Center";
+	dir = 1;
 	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -91174,11 +88426,6 @@
 /obj/machinery/computer/operating,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/aft)
-"wSJ" = (
-/obj/structure/ladder,
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
 "wSU" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -91256,14 +88503,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
-"wTE" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white/textured,
-/area/station/science/xenobiology)
 "wTH" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/trash/food_packaging,
@@ -91424,9 +88663,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "wWN" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/abandoned_gambling_den)
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/service/abandoned_gambling_den)
 "wWP" = (
 /obj/structure/sink/directional/south,
 /obj/effect/turf_decal/siding/wood{
@@ -91449,14 +88691,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/bar)
-"wWV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "wWY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -91596,13 +88830,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "wYT" = (
-/obj/structure/cable,
-/obj/structure/table,
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/door/window/left/directional/east{
+	name = "Containment Pen 3";
+	req_access = list("xenobiology")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light/floor,
 /turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/area/station/science/xenobiology)
 "wYX" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -91710,19 +88948,15 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "xaW" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/aft)
+/obj/structure/cable,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "xaY" = (
 /obj/structure/bed,
 /obj/structure/curtain/cloth/fancy,
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/department/security/ghetto)
-"xba" = (
-/obj/item/radio/intercom/directional/west,
-/turf/closed/wall/r_wall,
-/area/station/science/ordnance)
 "xbb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -91740,28 +88974,26 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "xbg" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Research Director's Office";
-	network = list("ss13","rd")
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
 	},
-/obj/structure/table/glass,
-/obj/item/radio/intercom/directional/north,
-/obj/item/computer_disk{
-	pixel_x = 7;
-	pixel_y = 2
+/obj/machinery/button/door/directional/north{
+	id = "research_lockdown";
+	name = "Research Lockdown Control";
+	pixel_x = 6;
+	req_one_access = list("rd","security");
+	color = "yellow"
 	},
-/obj/item/computer_disk/ordnance{
-	pixel_y = 4;
-	pixel_x = -5
-	},
-/obj/item/computer_disk/ordnance,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 4
+/obj/machinery/button/door/directional/north{
+	id = "rndsecprivacy";
+	name = "Privacy Shutter Control";
+	pixel_x = -6;
+	req_one_access = list("rd","security")
 	},
 /turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
+/area/station/security/checkpoint/science)
 "xbk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -91842,9 +89074,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "xcf" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/station/maintenance/aft)
+/obj/effect/spawner/random/structure/table,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "xck" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
@@ -91878,16 +89110,6 @@
 /obj/item/paper_bin,
 /turf/open/floor/wood,
 /area/station/maintenance/port/greater)
-"xcZ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/openspace,
-/area/station/science/xenobiology)
 "xda" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -91901,13 +89123,11 @@
 "xdc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "xdh" = (
@@ -91986,8 +89206,10 @@
 /area/station/security/execution)
 "xdP" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "xdU" = (
@@ -92339,7 +89561,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "xhf" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -92353,16 +89574,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
-"xhj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/directional/west,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/mechbay)
 "xhv" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -92394,18 +89605,28 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "xii" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
+/obj/machinery/door/window/left/directional/east{
+	name = "Containment Pen 6";
+	req_access = list("xenobiology")
 	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio6";
+	name = "Xenobio Pen 6 Blast Door"
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "xim" = (
-/obj/machinery/vending/cola,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/machinery/door/window/left/directional/west{
+	name = "Research Division Delivery";
+	req_access = list("research")
+	},
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "xiu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -92439,13 +89660,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/ordnance)
-"xiX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "xjf" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/tile/yellow,
@@ -92470,14 +89684,16 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "xjo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/modular_computer/preset/cargochat/science{
-	dir = 1
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 8
 	},
-/obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/tile/purple/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/science/lab)
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron/dark,
+/area/station/science/genetics)
 "xju" = (
 /obj/machinery/atmospherics/components/binary/valve/on{
 	dir = 4
@@ -92555,10 +89771,19 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "xjV" = (
-/obj/machinery/recharge_station,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/science/robotics/mechbay)
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/table,
+/obj/item/storage/box/gloves{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/box/masks,
+/obj/item/storage/box/bodybags{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/turf/open/floor/iron/freezer,
+/area/station/science/robotics/lab)
 "xka" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -92582,10 +89807,15 @@
 /turf/open/floor/iron/smooth,
 /area/station/medical/chemistry/ghetto)
 "xkk" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/science/robotics/mechbay)
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/random/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "xkl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -92627,11 +89857,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"xkU" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
 "xkX" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -92854,19 +90079,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "xnV" = (
-/obj/machinery/door/airlock/research/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/structure/chair/stool/bar/directional/south,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den)
 "xod" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "xof" = (
@@ -92889,11 +90109,12 @@
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/cmo)
 "xov" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
 	id = "robotics_window";
 	name = "Robotics Lab Shutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "research_lockdown";
 	name = "Research Lockdown Blast Doors"
@@ -92911,14 +90132,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "xoI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/spacevine{
+	can_spread = 0;
+	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/floor,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/structure/spacevine{
+	can_spread = 0
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/garden)
 "xoP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -92979,8 +90201,10 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/fore)
 "xpY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/virology)
 "xqb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -93006,22 +90230,11 @@
 /area/station/security/brig)
 "xqB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/table/glass,
-/obj/item/folder/white{
-	pixel_x = 4
-	},
-/obj/item/pen{
-	pixel_x = 4
-	},
-/obj/item/stamp/head/rd{
-	pixel_x = 7;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
+/area/station/security/checkpoint/science)
 "xqH" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/structure/toilet{
@@ -93098,6 +90311,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "xrP" = (
@@ -93154,10 +90369,7 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "xsU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/light/small/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "xsW" = (
@@ -93236,7 +90448,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/sign/departments/xenobio/alt/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "xtG" = (
@@ -93331,9 +90545,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "xun" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 5
-	},
+/obj/effect/spawner/random/trash/soap,
+/obj/effect/spawner/random/structure/table_or_rack,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "xur" = (
@@ -93453,9 +90666,13 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
 "xww" = (
-/obj/effect/spawner/structure/electrified_grille,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/machinery/camera/directional/east{
+	c_tag = "Xenobiology Pens - Starboard Fore";
+	network = list("ss13","rd","xeno")
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "xwx" = (
 /turf/closed/wall,
 /area/station/security/detectives_office)
@@ -93501,8 +90718,8 @@
 /turf/open/misc/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "xxe" = (
-/obj/effect/spawner/random/structure/tank_holder,
-/obj/structure/sign/warning/vacuum/directional/south,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
 "xxn" = (
@@ -93671,14 +90888,7 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "xyV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/event_spawn,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/obj/machinery/holopad,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "xyZ" = (
@@ -93890,6 +91100,7 @@
 "xCS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/caution,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "xCX" = (
@@ -93974,20 +91185,15 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
 "xEz" = (
-/obj/structure/railing{
-	dir = 8
+/obj/structure/table/glass,
+/obj/item/storage/toolbox/emergency{
+	pixel_y = 4
 	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/item/wrench/medical,
+/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "xEL" = (
 /obj/effect/turf_decal/bot_white,
 /obj/structure/tank_dispenser/oxygen,
@@ -94221,11 +91427,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"xHx" = (
-/obj/effect/spawner/random/structure/crate,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
 "xHy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -94313,19 +91514,18 @@
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/starboard/fore)
 "xJd" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/catwalk_floor/iron,
+/area/station/maintenance/starboard/aft)
 "xJe" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/cult,
 /area/station/maintenance/starboard/fore)
 "xJj" = (
-/obj/machinery/light/directional/north,
-/turf/open/openspace,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "xJl" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -94333,15 +91533,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
-"xJn" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/turf_decal/box/white/corners{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "xJq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -94464,13 +91655,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
-"xLq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit,
-/obj/effect/turf_decal/tile/bar/fourcorners,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
 "xLv" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 8
@@ -94534,18 +91718,17 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "xLX" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobiomain";
+	name = "Containment Blast Door"
+	},
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "xLZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
-"xMa" = (
-/obj/effect/landmark/generic_maintenance_landmark,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "xMu" = (
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/stripes/red/end{
@@ -94554,10 +91737,10 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "xMv" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/effect/turf_decal/tile/neutral/half,
-/turf/open/floor/iron,
-/area/station/science/genetics)
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/freezer,
+/area/station/science/robotics/lab)
 "xMB" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -94622,10 +91805,6 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
-"xMU" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
 "xMV" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -94679,12 +91858,13 @@
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/magistrate)
 "xNB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
+/obj/machinery/door/poddoor/preopen{
+	id = "misclab";
+	name = "Test Chamber Blast Door"
 	},
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "xNC" = (
 /obj/structure/table/wood,
@@ -94701,11 +91881,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
-"xNQ" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/clothing/costume,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
 "xNU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -94811,15 +91986,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"xPp" = (
-/obj/machinery/modular_computer/preset/civilian{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/science/explab)
 "xPx" = (
 /turf/closed/wall,
 /area/station/maintenance/port)
@@ -94851,19 +92017,20 @@
 /area/station/engineering/atmos/project)
 "xPQ" = (
 /obj/structure/table,
-/obj/item/clothing/glasses/science,
-/obj/item/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'";
-	name = "Chemistry Cleaner"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple/anticorner{
 	dir = 4
 	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/item/taperecorder,
+/obj/item/tape/random{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /turf/open/floor/iron/white,
-/area/station/science/lower)
+/area/station/science/explab)
 "xPT" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -94886,16 +92053,18 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/abandoned)
 "xQn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
+/obj/structure/spacevine{
+	can_spread = 0;
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "xQu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/cable,
@@ -94910,9 +92079,6 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "xQz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -95238,12 +92404,8 @@
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
 "xUW" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Research - Xenobiology Pens Observation South";
-	network = list("ss13","rd","xeno");
-	dir = 2
-	},
-/turf/open/openspace,
+/obj/machinery/atmospherics/components/unary/passive_vent,
+/turf/open/floor/circuit/telecomms,
 /area/station/science/xenobiology)
 "xUX" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -95294,16 +92456,24 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
 "xVM" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 1
+	},
+/area/station/science/xenobiology)
 "xWi" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/emergency,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/chem_master,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "xWk" = (
 /obj/item/bedsheet/captain{
 	dir = 4
@@ -95408,12 +92578,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "xXN" = (
-/obj/item/kirbyplants/random/dead,
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 5
-	},
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/herringbone,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
 "xXO" = (
 /obj/structure/railing{
@@ -95467,16 +92634,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "xYz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "xYA" = (
 /turf/open/floor/iron/white,
@@ -95531,18 +92693,10 @@
 /obj/machinery/suit_storage_unit/industrial/loader,
 /turf/open/floor/iron,
 /area/station/cargo/storage/ghetto/depot)
-"xZh" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/effect/landmark/blobstart,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "xZk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/science/robotics/mechbay)
+/obj/effect/landmark/start/roboticist,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "xZs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -95587,12 +92741,13 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "xZX" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister{
-	anchored = 1
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/machinery/light_switch/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "xZZ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Port to Fuel Pipe";
@@ -95604,12 +92759,14 @@
 /turf/closed/wall/rust,
 /area/station/security/interrogation/ghetto)
 "yaj" = (
-/obj/structure/ladder{
-	pixel_y = 7
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/reagent_dispensers/watertank,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "yam" = (
 /obj/structure/chair/comfy/brown{
 	color = "#514E58"
@@ -95631,10 +92788,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
-"yaq" = (
-/obj/structure/sink/directional/west,
-/turf/open/floor/iron/white,
-/area/station/science/xenobiology)
 "yay" = (
 /obj/effect/spawner/random/trash/graffiti{
 	spawn_loot_chance = 50
@@ -95675,18 +92828,10 @@
 /turf/open/floor/eighties/red,
 /area/station/maintenance/port/aft)
 "yaU" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/item/lighter{
-	pixel_x = -6
-	},
-/obj/item/storage/fancy/cigarettes/cigpack_robust{
-	pixel_x = 6
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/iron,
-/area/station/maintenance/starboard/upper)
+/area/station/maintenance/ghetto/aft)
 "ybc" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/iron/dark,
@@ -95853,8 +92998,15 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
 "ydt" = (
-/turf/open/floor/iron,
-/area/station/science/xenobiology)
+/obj/effect/turf_decal/siding/wideplating_new/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/open/floor/iron/herringbone,
+/area/station/maintenance/starboard/aft)
 "ydu" = (
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
@@ -95918,8 +93070,14 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "yeD" = (
-/turf/closed/wall,
-/area/station/medical/break_room)
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "yeF" = (
 /obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/tile/blue{
@@ -95975,11 +93133,6 @@
 "yfh" = (
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
-"yfi" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/aft)
 "yfn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/table,
@@ -96086,12 +93239,6 @@
 /obj/structure/railing,
 /turf/open/floor/glass/reinforced,
 /area/station/hallway/secondary/dock)
-"yhc" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/emergency,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
 "yhf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -96136,10 +93283,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
 "yhy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/iron/cafeteria,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/structure/chair/office/light,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "yhD" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -96194,17 +93340,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "yiF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /obj/machinery/light/small/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "yiG" = (
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
@@ -96449,35 +93596,28 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "ylO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/displaycase/labcage,
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/lamarr/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
+"ylP" = (
+/obj/machinery/smartfridge/petri/preloaded,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/server)
-"ylP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/radio{
-	desc = "An old handheld radio. You could use it, if you really wanted to.";
-	icon_state = "radio";
-	name = "old radio";
-	pixel_y = 15
-	},
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = 3
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/kitchen)
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "ylQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /turf/open/floor/engine,
-/area/station/science/lower)
+/area/station/science/explab)
 "ylX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -134951,12 +132091,12 @@ qUM
 ceC
 ceC
 doz
-qVj
-qVj
-qVj
-qVj
-qVj
-ceC
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -135208,22 +132348,22 @@ mOI
 ceC
 ceC
 ceC
-qVj
-mTq
-cHV
-jEU
-qVj
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
 ceC
 doz
 doz
 doz
-doz
-doz
-ceC
-ceC
-doz
-doz
-vbK
 doz
 fif
 xXv
@@ -135465,22 +132605,22 @@ mOI
 ceC
 vbK
 ceC
-qVj
-vky
-rqA
-hqD
-qVj
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
+ceC
 ceC
 doz
 doz
-doz
-doz
-doz
-ceC
-ceC
-ceC
-doz
-vbK
 doz
 fif
 xXv
@@ -135500,9 +132640,9 @@ uPA
 bFB
 xgd
 uPA
-doz
-doz
 ceC
+doz
+doz
 doz
 doz
 doz
@@ -135722,22 +132862,22 @@ mOI
 ceC
 vbK
 ceC
-qVj
-byg
-csD
-nIk
-qVj
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 ceC
 ceC
 ceC
 ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-vbK
+doz
+doz
 ceC
 fif
 xXv
@@ -135757,10 +132897,10 @@ uPA
 pZA
 bFB
 uPA
+ceC
 doz
 doz
-ceC
-ceC
+doz
 doz
 doz
 doz
@@ -135979,22 +133119,22 @@ qUM
 ceC
 vbK
 doz
-qVj
-qVj
-gpy
-qVj
-qVj
-qVj
-sGh
-sGh
-qVj
-qVj
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 vbK
 doz
 doz
 doz
-ceC
-ceC
+doz
+doz
 ceC
 fif
 fuD
@@ -136014,12 +133154,12 @@ fif
 tdm
 fif
 fif
-fif
-fzk
-fif
-fzk
-fif
-fif
+ceC
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -136236,22 +133376,22 @@ mOI
 ceC
 vbK
 doz
-qVj
-mZd
-csD
-pqx
-qVj
-kdc
-xii
-xii
-gVD
-qVj
-vbK
 doz
 doz
 doz
-vbK
-ceC
+doz
+doz
+doz
+doz
+doz
+oVL
+oVL
+tls
+doz
+doz
+doz
+doz
+doz
 doz
 fif
 rQp
@@ -136265,18 +133405,18 @@ rQp
 tGu
 khQ
 gYJ
-opS
-xXv
-xXv
-xXv
+muS
+pXp
+dvv
+dvv
 oKn
-xXv
-xXv
-xXv
-xXv
-xXv
-neY
-fif
+bPl
+ceC
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -136493,20 +133633,20 @@ mOI
 ceC
 vbK
 doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+oVL
 qVj
-muc
-xLq
-qNJ
-gIU
-avs
-xii
-xii
-cys
-qVj
-vbK
-doz
-doz
-doz
+noi
+bPs
+bPs
+cQk
 vbK
 doz
 fif
@@ -136524,16 +133664,16 @@ llq
 ltF
 opS
 xXv
-etx
-etx
-etx
-etx
-etx
-etx
-etx
 xXv
 xXv
 fzk
+ceC
+ceC
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -136750,20 +133890,20 @@ mOI
 ceC
 cfT
 ceC
-qVj
-bOW
-nGp
-pqx
-coB
-wtl
-xii
-gNZ
-ylP
-qVj
-vbK
 doz
 doz
-vbK
+doz
+doz
+doz
+doz
+doz
+doz
+oVL
+job
+oVL
+doz
+doz
+hrZ
 fif
 fif
 fif
@@ -136780,30 +133920,30 @@ mwW
 rKW
 ltF
 opS
-etx
-etx
-tLJ
-tLJ
-uiy
-tLJ
-tLJ
-etx
-etx
-xXv
 fif
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
+fif
+fif
+fif
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
 ceC
 ceC
 ceC
@@ -137007,25 +134147,25 @@ qUM
 ceC
 vbK
 ceC
-qVj
-dTr
-wFa
-bDp
-qVj
-yiF
-xQn
-xii
-qNP
-qVj
-vbK
 doz
 doz
-jEk
-gJc
-xXv
-bRL
-xXv
-xXv
+doz
+doz
+doz
+doz
+doz
+doz
+oVL
+oVL
+oVL
+doz
+doz
+thD
+eNk
+dvv
+oXy
+dvv
+dWz
 vkn
 fif
 wfp
@@ -137037,18 +134177,18 @@ mhF
 chV
 fif
 opS
-etx
-tLJ
-tLJ
-tLJ
-qEp
-tLJ
-tLJ
-tLJ
-etx
-xXv
-fzk
+fif
+ceC
+ceC
+ceC
+ceC
 doz
+doz
+doz
+doz
+doz
+doz
+ceC
 doz
 doz
 doz
@@ -137264,17 +134404,17 @@ mOI
 ceC
 vbK
 doz
-qVj
-vaB
-dys
-kPk
-uYk
-pLp
-lfw
-xii
-gVD
-qVj
-vbK
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 vbK
@@ -137282,7 +134422,7 @@ fif
 fif
 fif
 wch
-rQp
+mrQ
 rQp
 fif
 fif
@@ -137294,18 +134434,18 @@ ltF
 fif
 fif
 gVQ
-etx
-tLJ
-erd
-huV
-tLJ
-pUv
-tLJ
-tLJ
-etx
-xXv
 fif
+ceC
 doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
 doz
 doz
 doz
@@ -137521,17 +134661,17 @@ mOI
 ceC
 vbK
 doz
-qVj
-ugX
-chY
-pEZ
-uYk
-qQb
-hjg
-xii
-xim
-qVj
-vbK
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -137539,7 +134679,7 @@ ceC
 ceC
 fif
 fif
-xXv
+lgM
 xXv
 fif
 vXi
@@ -137551,20 +134691,20 @@ kDW
 wfp
 fif
 jGR
-etx
-tLJ
-tLJ
-tLJ
-tLJ
-tLJ
-tLJ
-tLJ
-etx
-xXv
 fif
-fif
-fif
-fif
+ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
+doz
+doz
 doz
 doz
 doz
@@ -137773,30 +134913,30 @@ meC
 meC
 sEm
 siJ
-jKW
+mOI
 mOI
 ceC
-ipz
-ipz
-qVj
-wYT
-sZN
-okh
-qVj
-hmg
-hjg
-gmX
-qof
-qVj
-vbK
-vbK
-vbK
-ceC
-ceC
-ceC
 doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
+ceC
+ceC
 fif
-rQp
+mrQ
 wfp
 fif
 pmr
@@ -137807,39 +134947,39 @@ kDW
 wiD
 ocX
 fif
-dLc
-etx
-bZr
-bZr
-vVf
-tLJ
-fhJ
-aPQ
-aPQ
-etx
-oax
-xXv
-xXv
-rQp
+bvP
 fif
-fif
-fif
-fif
-fif
-fzk
-fzk
-fzk
-fzk
-fif
-fif
-fif
-fif
-fif
+ceC
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
 ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 ceC
+doz
+doz
+doz
+doz
+doz
 ceC
 doz
 doz
@@ -138017,43 +135157,43 @@ ipz
 ipz
 doz
 siJ
-tlu
-tlu
-siJ
-oef
-siJ
-fMF
-tlu
-tlu
-siJ
-ntv
-siJ
-siJ
-siJ
-toV
 ipz
+hRA
+hRA
 ipz
+tsI
 ipz
-dcV
-qVj
-qVj
-dIb
-qEP
-qVj
-qVj
-qKG
-wlQ
-qVj
-qVj
-iYR
-iYR
-vbK
-job
+siJ
+siJ
+siJ
+siJ
+siJ
+siJ
+siJ
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 ceC
-doz
 fif
-cmE
+ggl
 vIH
 wJT
 hpg
@@ -138063,42 +135203,42 @@ iuG
 gyV
 kwo
 ocX
-dLc
-dLc
-etx
-jNy
-jyC
-jyC
-tMe
-qfp
-hfD
-hOD
-etx
-etx
-etx
-etx
-rQp
-xXv
-qFZ
-xXv
-pLh
-xXv
-xXv
-xXv
-xXv
-xXv
-xXv
-xXv
-neY
-xXv
+kmU
+cZo
 fif
+ceC
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
 doz
 ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 ceC
+doz
+doz
+doz
+doz
+doz
 ceC
+doz
 doz
 doz
 doz
@@ -138277,38 +135417,38 @@ ipz
 vIX
 dmA
 wBP
-cwi
-cwi
-cwi
-cwi
-cwi
-ayj
-cwi
-qTP
+vqJ
 ipz
-qTP
-rik
-cwi
-bjo
-cwi
-cwi
-cwi
-cwi
-cwi
-cwi
-cwi
-cSQ
-cSQ
-cSQ
-cSQ
-cSQ
-cSQ
-iYR
-vbK
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 ceC
+ceC
+ceC
 doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
 fif
 vOU
 emy
@@ -138321,34 +135461,27 @@ fif
 fif
 fif
 xtC
-etx
-etx
-mir
-fVc
-rBg
-dvv
-gGO
-lHO
-pvt
-aPQ
-pjh
-piI
-etx
-cDt
-emy
 fif
 fif
-bqL
-ocX
-ocX
-fif
-fif
-ocX
-bqL
-ocX
-fif
-xXv
-fif
+ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -138358,9 +135491,16 @@ doz
 ceC
 ceC
 ceC
-doz
-doz
-doz
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
 ceC
 ceC
 ceC
@@ -138534,40 +135674,40 @@ qTP
 jrb
 qTP
 qTP
-cwi
-kEb
+gfa
 ipz
-ipz
-ipz
-ipz
-cwi
-cwi
-gYx
-dpz
-cwi
-qTP
-ipz
-ipz
-ipz
-ipz
-oDP
-qTP
-ker
-ipz
-iYR
-iYR
-iYR
-iYR
-iYR
-cSQ
-iYR
-vbK
 doz
 doz
 ceC
+tmq
+tmq
+nQP
+tmq
+nQP
+tmq
+tmq
+ceC
 doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
 fif
-rQp
+mrQ
 kPe
 fif
 tNY
@@ -138577,41 +135717,41 @@ rvu
 lBj
 eZq
 fif
-dLc
-etx
-ksf
-bDa
-cFX
-syV
-knt
-syV
-hur
-las
-xnV
-fRk
-fRk
-etx
-qFZ
-gKM
-ocX
-wfp
-wfp
-wfp
-wfp
+xtC
 fif
-wfp
-wfp
-wfp
-wfp
-fif
-msg
-fif
+ceC
+ceC
 doz
 doz
 doz
 doz
 doz
 doz
+doz
+doz
+doz
+ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
+doz
+doz
+doz
+doz
+doz
+ceC
 doz
 doz
 ceC
@@ -138791,38 +135931,38 @@ woL
 tZs
 adQ
 woL
-cwi
-ipz
-hUE
-doz
-doz
-ipz
-ipz
-ipz
-ipz
-ipz
-ipz
-ipz
+gfa
 ipz
 doz
 ceC
-ipz
-ipz
-oFI
-ipz
-ipz
-doz
-iYR
-lMT
-tNT
-qqN
-cSQ
-iYR
+ceC
+tmq
+rlH
+kmK
+rWg
+rDd
+rlH
+tmq
 ceC
 ceC
 ceC
 ceC
 doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
 fif
 ngd
 xXv
@@ -138834,41 +135974,41 @@ vKu
 fif
 fif
 fif
-hdh
-bZx
-wCv
-cQI
-lSo
-lSo
-siP
-fJH
-fJH
-bKc
-vCB
-ezO
-fRk
-etx
-rQp
-fTZ
+tVq
 fif
-fif
-fif
-fif
-fif
-fif
-fif
-fif
-fif
-fif
-fif
-xXv
-fif
-fif
+ceC
+ceC
 doz
 doz
 doz
 doz
 doz
+doz
+doz
+doz
+doz
+ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
+doz
+doz
+doz
+doz
+doz
+ceC
 doz
 doz
 ceC
@@ -139050,77 +136190,51 @@ ipz
 ipz
 lol
 ipz
+nQP
+tmq
+nQP
+tmq
+gaA
+laZ
+apb
+odl
+gaA
+tmq
+nQP
+tmq
+nQP
+nQP
 doz
 doz
 doz
 doz
 doz
 doz
-vbK
-vbK
-vbK
-vbK
 doz
 doz
-ceC
 doz
-ipz
-qTP
-ipz
-ceC
 doz
-iYR
-key
-gdj
-ktZ
-cSQ
-iYR
-fif
-fif
-fif
-fif
-fif
+doz
+doz
+doz
+doz
+doz
+doz
 fif
 qrO
-dLc
-dLc
+jDW
+jDW
 uCp
 ucp
 fpt
-dLc
-cAC
-cAC
+jDW
+isn
+isn
 egU
-cAC
-etx
-mSc
-wvD
-wuS
-viO
-mpE
-iXB
-fJa
-swe
-aPQ
-kJj
-vrD
-etx
-rQp
-xXv
-wfp
+hqy
 fif
-pFr
-whU
-opA
-fif
-fji
-hzV
-xXv
-xAJ
-xXv
-rQp
-xXv
-fif
+ceC
+ceC
 doz
 doz
 doz
@@ -139128,6 +136242,32 @@ doz
 doz
 doz
 doz
+doz
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
 ceC
 ceC
 ceC
@@ -139305,8 +136445,22 @@ rlo
 aXE
 llI
 hRA
-vqJ
+gfa
 ipz
+jXa
+kKc
+wwb
+rlH
+gaA
+woY
+qTt
+goM
+gaA
+hlC
+oId
+flg
+rlH
+nQP
 doz
 doz
 doz
@@ -139315,78 +136469,64 @@ doz
 doz
 doz
 doz
-ceC
-ceC
 doz
 doz
-vbK
 doz
-ipz
-fHl
-ipz
-ceC
-ceC
-iYR
-kKX
-mrR
-qqN
-cSQ
-iQs
-sCF
-dLc
-dLc
-dLc
-dLc
-cAC
-cAC
+doz
+doz
+doz
+doz
+doz
+fif
+hdh
 rQp
 xXv
 emy
 rQp
 xXv
 rQp
-iJV
+cAC
 xXv
-etx
-etx
-etx
-aPQ
-aPQ
-aPQ
-ojE
-qGG
-hDa
-aPQ
-aPQ
-aPQ
-aPQ
-aPQ
-etx
 xXv
-fTZ
-wfp
-ocX
-apb
 xXv
-lId
 fif
-fji
-rCe
-iJV
-fDa
-iJV
-qFT
-qFT
-fif
-doz
-doz
-doz
-doz
-doz
-doz
-doz
 ceC
 ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -139564,86 +136704,86 @@ jwl
 gEZ
 qVL
 ipz
+gVu
+mZB
+mgr
+mZB
+mZB
+sCV
+sDE
+mZB
+mZB
+mgr
+frC
+gVu
+uyT
+tmq
+dVk
 doz
 doz
-ceC
-ceC
-ceC
 doz
 doz
 doz
-ceC
-ceC
-ceC
 doz
-doz
-doz
-vbK
-jEk
-vbK
-doz
-doz
-iYR
-iYR
-iYR
-iYR
-cSQ
-iYR
 fif
 fif
 fif
 fif
 fif
 fif
-mDG
+fif
+fif
+fif
+fif
+hdh
 xXv
-jfZ
+fif
 fif
 fif
 fif
 etx
 xod
 bAH
-etx
-aNd
-pgF
-eso
-nMG
-bev
-viO
-mpE
-iXB
-fLB
-tBB
-gnl
-pgF
-rtt
-etx
-cmE
-ooa
-wfp
-ocX
-xXv
-xXv
-xXv
 fif
 fif
-vFh
-iox
-gkS
-oVO
-rOh
-fzk
-fzk
-fzk
-fzk
-doz
-doz
-doz
-doz
-doz
-doz
+fif
+fif
+fif
+fif
+fif
+fif
+fif
+fif
+fif
+fif
+fif
+fif
+fif
 ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -139821,86 +136961,86 @@ dzZ
 gEZ
 gfa
 ipz
-ceC
-doz
-doz
-hZm
-hZm
+rlH
+mZB
+odY
+qup
+gaA
 uyT
-hZm
+rui
 uyT
-hZm
-hZm
+qup
+qup
+qup
+gVu
+pFr
+nQP
+dVk
 ceC
-doz
-doz
-doz
-doz
 vbK
 vbK
 vbK
 vbK
 vbK
-vbK
-iYR
+fif
 djK
-cSQ
-hzG
-doz
-doz
-ceC
-doz
-doz
-fif
-fif
+hdh
+dLc
+dLc
+dLc
+dLc
+dLc
+dLc
+dLc
+liz
 sNa
 fif
-fif
+doz
 doz
 doz
 etx
 xrG
 mrE
-liF
-mpE
-mWc
-mpE
+mua
 fiO
-mHp
+cAC
+mua
+fiO
+fiO
 lJY
-bIg
 gwt
-pRx
-ntO
-mpE
+gwt
+gwt
+cAC
+cAC
 mua
 mpE
-ggl
-xXv
-rQp
-yfi
 fif
-iZN
-xXv
-eUZ
-rfp
-rQp
-xAJ
-kYs
-lzI
-pcO
-kTU
-kTU
-kTU
-lIf
-fzk
-doz
-doz
-doz
-doz
-doz
-doz
 ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -140078,86 +137218,86 @@ xwI
 hRA
 gfa
 ipz
-ceC
-ceC
-ceC
-hZm
+hTZ
+mgr
+gaA
+qNe
 rhw
-mPO
-qPp
-mPO
 rhw
-hZm
-ceC
-doz
-ceC
-ceC
-doz
-ceC
+rhw
+rhw
+rhw
+wMk
+gaA
+gVu
+sKf
+tmq
+tmq
+tmq
 doz
 doz
 doz
 doz
 vbK
-iYR
-fKk
-cSQ
-hzG
-doz
-doz
-ceC
-ceC
-ceC
-ceC
 fif
 xXv
+hdh
+xXv
+bTY
+xXv
+xXv
+xXv
+xXv
+xXv
+xXv
+cBA
 fif
 doz
 doz
 doz
 etx
-hhW
+vky
 oWA
-etx
-uyR
-iXB
-bwl
-afy
-mqd
-xNB
-elH
-uqi
-srh
-jhg
-fKC
-iXB
+tag
+kDW
+xAJ
+kDW
+xXv
+xXv
+xAJ
+xAJ
+yaU
+xAJ
+xAJ
+xXv
+kDW
 gjO
-etx
-qFZ
-rQp
-nnJ
 fif
 fif
-fif
-fif
-fif
-huy
-kDW
-rAO
-lzI
-aoa
-kDW
-esQ
-oXd
-mrQ
-fzk
 doz
 doz
 doz
 doz
 doz
 doz
-oUZ
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -140335,86 +137475,86 @@ ipz
 ipz
 gfa
 ipz
-uyT
-hZm
-uyT
-hZm
-gVu
+rna
+iKc
+fSN
+rOh
+pBE
 esq
-bPl
 dQm
-gVu
+dQm
+gaA
 hZm
-uyT
-hZm
-uyT
-uyT
-doz
-ceC
+odY
+qup
+odY
+gaA
+gaA
+tmq
 doz
 doz
 doz
 doz
 vbK
-iYR
-fKJ
-cSQ
-hzG
-ceC
-ceC
-ceC
-vbK
-doz
-doz
 fif
-kmy
+rQM
+hdh
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+onD
+fiO
+rJT
 fif
 doz
 doz
-oVL
-etx
-uiT
-mrE
-etx
-gML
-tcd
-qvj
-pIn
-pTR
-xNB
-wTE
-uqi
-ufD
-vps
-pxn
-tcd
-xJn
-etx
-xXv
-rQp
-jXs
-fif
-jqv
-jAZ
-xXv
-ocX
-qBU
-xXv
-pHJ
-lzI
-aoa
-oXd
-kDW
-oXd
-nlb
-fzk
 doz
 doz
 doz
 doz
 doz
 doz
-oUZ
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -140593,85 +137733,85 @@ ipz
 gfa
 ipz
 mbz
-fVX
-nbz
-rhw
-gVu
-maN
-jHD
-esq
-gVu
-hWp
+dnt
+qup
+nrE
+aNd
+pVF
+gaA
+pVF
+lVn
+hZm
 odY
 aye
-rhw
-uyT
+mRd
+qup
+wLp
+nQP
 doz
-vbK
-doz
-doz
-doz
-doz
-vbK
-iYR
-wSJ
-uxw
-iYR
-doz
-doz
-ceC
 doz
 doz
 doz
 vbK
-vbK
-jEk
-ceC
-doz
-doz
-etx
-qyx
-oWA
-liF
-mpE
-mWc
-mpE
-inS
-mHp
-ibq
-mZu
-aHB
-pRx
-cjR
-mpE
-mWc
-mpE
-ggl
-rQp
-xXv
-qQf
 fif
-bJM
-ldY
-eUZ
-ocX
-kDW
 xXv
-sNf
-lzI
-aoa
-oXd
-esQ
-kDW
-nlb
-fzk
+mrR
+aPQ
+ezO
+ezO
+jXs
+aPQ
+smU
+lId
+aLi
+qyx
+lId
+aLi
+qyx
+kko
+aLi
+qyx
+lId
+aLi
+qyx
+bKc
+aLi
+aPQ
+tLJ
+tLJ
+qEp
+wOD
+tLJ
+tLJ
+aPQ
+xXv
+iox
+rQp
+fif
 doz
 doz
 doz
 doz
 doz
 doz
-oUZ
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -140849,86 +137989,86 @@ aao
 gEZ
 gfa
 ipz
-crJ
-mIs
+cbS
 dnt
-mIs
-mIs
+mTa
+nrE
+nFH
+byD
 cFo
-cFo
 mIs
-mIs
-dnt
-ogW
-crJ
-qcf
+gaA
 hZm
-ceC
-vbK
-vbK
-doz
-iYR
-iYR
-iYR
-iYR
-iYR
-oDc
-iYR
-iYR
-iYR
-iYR
-iYR
-doz
-doz
-doz
-doz
-doz
+gaA
+aye
+qcf
+gaA
+kwR
+tmq
 ceC
 doz
-oVL
-etx
-uhq
-mrE
-etx
-lmn
-iXB
-bwl
-sbO
-mqd
-xNB
-mZu
-uqi
-srh
-khv
-fKC
-iXB
-wue
-etx
-rQp
-tVq
-wfp
+doz
+doz
+doz
 fif
-uUb
-jjv
+dLc
+dLc
+aPQ
+xUW
+fRk
+eyx
+aPQ
+tcd
+bZr
+tcd
+qyx
+bZr
+tcd
+qyx
+tcd
+tcd
+qyx
+tcd
+tcd
+qyx
+tcd
+tcd
+aPQ
+tLJ
+tLJ
+tLJ
+jnH
+tLJ
+tLJ
+aPQ
 xXv
+iox
+kDW
 fif
-rQp
-rQp
-rWg
-lzI
-jDW
-fIv
-sVn
-sVn
-sHr
-fzk
 doz
 doz
 doz
 doz
 doz
 doz
-oUZ
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -141106,86 +138246,86 @@ rYk
 nYA
 qVL
 ipz
-rhw
+iUI
+dnt
+cXa
+nrE
+nFH
+gaA
 mIs
-qGI
+gaA
+lVn
+hZm
 qup
-gVu
-qcf
-skY
-qcf
-qup
-qup
-qup
-crJ
+aye
 krq
-uyT
-ceC
-ceC
-ceC
-doz
-iYR
-aFM
-wyq
-dil
-iYR
-cSQ
-iYR
-aEP
-iYR
-aEP
-iYR
+gaA
+vSK
+nQP
+vEX
 doz
 doz
 doz
 doz
-doz
-vbK
-doz
-doz
-etx
+fif
+liz
+mDG
+aPQ
+ezO
+fRk
+fRk
+aPQ
+oDC
+tcd
+tcd
 dyr
-mrE
-etx
-pxn
 tcd
-qvj
-oQL
-uAE
-xNB
-mZu
-uqi
-hYK
-jIc
-pxn
 tcd
-qvj
-etx
-rQp
-jCI
-wfp
+dyr
+tcd
+tcd
+dyr
+tcd
+tcd
+dyr
+tcd
+tcd
+aPQ
+tLJ
+tLJ
+tLJ
+hqD
+tLJ
+tLJ
+aPQ
+fMF
+fDa
+xAJ
 fif
-xXv
-kDW
-xXv
-fif
-qBU
-wsd
-iJV
-gkS
-bUe
-rOh
-fzk
-fzk
-fzk
-fzk
 doz
 doz
 doz
 doz
 doz
 doz
-oUZ
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -141363,76 +138503,61 @@ ldW
 gEZ
 gfa
 ipz
-ggB
+gaA
 dnt
-gVu
+hlC
+nrE
+gaA
+gaA
+hjg
+uQw
+fbV
 hZm
-hZm
-hZm
-hZm
-hZm
-hZm
-hZm
-gVu
-crJ
-bTY
-hZm
-hZm
-hZm
+qup
+xnV
+qcf
+odY
+szL
+tmq
 ceC
 iYR
 iYR
-lqb
 iYR
-oID
 iYR
-cSQ
 iYR
+gqq
+aPQ
+aPQ
 wPO
-iYR
+uyR
 ioD
-iYR
-iYR
-doz
-doz
-vbK
-ceC
-vbK
-ceC
-doz
-etx
+aPQ
+roD
+jAZ
+tBB
+loJ
+rGV
+qNP
+siP
+neY
+bOW
 hhW
-xXv
-liF
-mpE
+hmg
+pcO
+vpo
 mWc
-mpE
-lvh
-mHp
-ibq
+qNJ
+aPQ
+aPQ
+aPQ
 mZu
 aHB
-pRx
-fIA
-mpE
-mua
-mpE
-ggl
-roD
-fTZ
-wfp
-fif
-ocX
-mpp
-fif
-fif
-iXl
-rIX
-iJV
-hlC
-iJV
-suj
-suj
+tLJ
+aPQ
+aPQ
+aPQ
+fDa
+xAJ
 fif
 doz
 doz
@@ -141442,7 +138567,22 @@ doz
 doz
 doz
 doz
-mPy
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -141619,76 +138759,61 @@ vnl
 syN
 ipz
 gfa
-ipz
+rkA
 tlZ
-viw
+dnt
 tvW
 sAe
-wyu
-crJ
 wWN
 wWN
-gVu
-hZm
+wWN
+wWN
+cPo
+caH
+odY
+gaA
 qGI
-qup
-qGI
-gVu
-gVu
-hZm
+tmq
+tmq
+tmq
 ceC
 iYR
-myA
-dIw
-iYR
-xge
+aFM
+wyq
+dil
 iYR
 cSQ
-iYR
+aPQ
+imp
 rws
+oyA
 mTk
-mTk
-suk
-iYR
-doz
-doz
-doz
-doz
-doz
-ceC
-doz
-etx
-bBc
-kDW
-etx
+aPQ
+pGr
+azO
+iOy
+brm
+reb
+iOy
+brm
+wYT
+iOy
 sKi
-iXB
-bwl
-kub
-mqd
+sHZ
+iOy
+sKi
+bbR
+iOy
+aPQ
+iZv
 xNB
 nks
 uqi
-srh
-luu
+xNB
+xNB
 fKC
-iXB
-ewc
-etx
-cmE
-xHx
-wfp
-ocX
-xNQ
-xXv
-xXv
-oib
-xXv
-rQp
-xXv
-jWy
-iJV
-iJV
+aPQ
+iox
 rQp
 fif
 doz
@@ -141699,7 +138824,22 @@ doz
 doz
 doz
 doz
-oUZ
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -141876,77 +139016,62 @@ iAT
 ipz
 ipz
 gfa
-ipz
+mgj
 wIF
-pVF
-qup
-hZm
+dTr
+gYr
+hFO
 crJ
 wyu
-gVu
-wyu
-crJ
-hZm
-qGI
-gVu
+byg
+uAE
+wuV
+wuV
+kdW
+gaA
 wti
-qup
-pkv
-uyT
-doz
+nQP
+ceC
+ceC
+ceC
 iYR
-vpW
-vsR
+lqb
 iYR
-jQE
-nnP
+oID
+iYR
 cSQ
-iYR
-iYR
+aPQ
+pTR
+pqx
 oyA
-mTk
+qIR
 xLX
 hzG
-doz
-doz
-doz
-doz
-doz
-ceC
-doz
-etx
-bBc
-xXv
-etx
-pxn
-tcd
 qvj
-sIX
-dWc
-xNB
+qvj
+qvj
+qvj
+qvj
+qvj
+qvj
+qvj
+qvj
+qvj
+qvj
+qvj
+qvj
+qvj
+xLX
+oyA
+qIR
 pLr
-uqi
+tKy
 oBO
-rKG
-pxn
-tcd
-qvj
-etx
-xXv
-xXv
-wfp
-ocX
-xNQ
-eUZ
-xXv
-fif
-pSl
-fIR
-rQp
-ldY
-uxd
-fDa
-fif
+qIR
+oyA
+aPQ
+iox
+dLh
 fif
 doz
 doz
@@ -141956,7 +139081,22 @@ doz
 doz
 doz
 doz
-oUZ
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -142134,75 +139274,61 @@ gwp
 ipz
 gfa
 ipz
-mbz
+gaA
 pVF
 hoA
-hZm
-wWN
-kNT
-eBF
-laZ
+gaA
 gVu
-hZm
+pVF
+pVF
+gaA
+gVu
+gVu
 gVu
 gVu
 gaA
-gVu
-mMe
-hZm
-doz
+tmq
+ceC
 iYR
-pOp
-cPV
-qqH
-ifu
-ifu
+iYR
+iYR
+fKh
+iYR
+xge
+iYR
 cSQ
+sun
 ssd
 iFX
-suk
-mTk
-qeT
-hzG
-doz
-doz
-doz
-doz
-doz
-vbK
-oVL
-etx
-uhq
-oWA
+viO
+viO
+ahc
+aFj
 liF
-mpE
-mua
-mpE
+liF
+liF
+liF
+liF
+liF
+liF
+liF
+liF
+liF
+liF
+liF
+liF
+aFj
 ahc
 mHp
 xYz
 djt
 cNP
 pRx
-sun
-mpE
-mWc
-mpE
-ggl
-xXv
-xXv
-wfp
-fif
-ooa
-xXv
-kDW
-fif
-aEU
-wsd
-xXv
-xXv
-rQp
-iJV
+qIR
+rAO
+aPQ
+oSc
+xAJ
 fif
 doz
 doz
@@ -142213,7 +139339,21 @@ doz
 doz
 doz
 doz
-ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -142391,75 +139531,61 @@ lfX
 ipz
 gfa
 ipz
-dLh
-pVF
+rlH
+kKc
 lOl
-hZm
-wWN
-gVu
+rlH
+gaA
 laZ
-gVu
-crJ
-hZm
-qup
-gVu
+laZ
+laZ
+gaA
+hob
+erF
+fJH
 fcz
-gVu
-qWa
-uyT
-ceC
+nQP
+doz
 iYR
+lYy
+hzV
 sgc
-hAl
-qqN
-pzi
-jfj
+iYR
+gno
+nnP
 cSQ
-iYR
-iYR
+aPQ
+noo
+oQF
 tvZ
 suk
-nGz
-hzG
-ceC
-ceC
-doz
-doz
-doz
-vbK
-doz
-etx
-bBc
+aPQ
+kvp
+qJs
+aXx
+mxa
+oef
+aXx
+mxa
+vAr
+aXx
+mxa
 qTy
-etx
+aXx
 mxa
 qll
 bwl
-goo
+aPQ
 mqd
 viO
+pEZ
 iXB
 iXB
-srh
 vGw
-fKC
-qll
-rrM
-etx
-xXv
-roD
-wfp
-fif
-xNQ
-rsb
-xNQ
-fif
-muS
-hTZ
-xXv
-xXv
-xXv
+xaW
+aPQ
 iJV
+xAJ
 fif
 doz
 doz
@@ -142470,7 +139596,21 @@ doz
 doz
 doz
 doz
-ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -142648,86 +139788,86 @@ qtM
 ipz
 qVL
 ipz
-gVu
-pVF
-hWp
-hZm
-gVu
-gVu
-crJ
-wyu
-wWN
-hZm
-qup
-qGI
+nQP
+tmq
+nQP
+tmq
 gaA
-qGI
-mMe
-hZm
-ceC
+brv
+laZ
+brv
+gaA
+tmq
+nQP
+tmq
+nQP
+nQP
+doz
 iYR
-xXN
+pOp
+nQs
+cPV
+qqH
 ifu
-scy
-epO
-qqN
+ifu
 cSQ
-iYR
+aPQ
+qIR
 nhj
-tUV
-ifu
-ssd
-iYR
-doz
-ceC
-doz
-doz
-doz
-vbK
-ceC
-etx
+qIR
+jyC
+aPQ
+qjN
+ksv
+irW
+sVn
+ejZ
+mgu
+dIw
+niJ
+cvE
 rjZ
 gHp
-etx
-etx
-etx
-etx
-etx
+hWp
+baH
+xii
+fji
+aPQ
 bPr
 elW
 bIq
 hgY
 deZ
+pdo
+vnE
 aPQ
-aPQ
-aPQ
-aPQ
-etx
-cbS
-rQp
+oSc
+xAJ
 fif
-fif
-fif
-fif
-fif
-fif
-fif
-ocX
-ocX
-fif
-fif
-iJV
-fif
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -142904,76 +140044,62 @@ hRA
 ipz
 ipz
 gfa
-rkA
-eyF
-pVF
-liy
-hZm
-hZm
-hZm
-hZm
-hZm
+ipz
+doz
+ceC
+ceC
+tmq
 rlH
-hZm
-qGI
-gVu
-gaA
-hZm
-hZm
-hZm
-doz
-iYR
-iYR
-kdo
-scy
-xjy
-qqN
-uxw
-iYR
-suk
-yhy
-mTk
-iYR
-doz
-doz
+ksf
+pHJ
+ksf
+rlH
+tmq
+ceC
 ceC
 doz
 doz
 doz
-doz
-ceC
-etx
-bBc
-tea
-etx
-wfp
-wfp
-wfp
-etx
-vrJ
-cMA
-uNF
-vnE
-tCI
-hBh
-sha
-sha
+iYR
+ogW
 eQp
-etx
+hAl
+qqN
+pzi
+jfj
+uxw
+aPQ
+dpz
+epT
+yhy
+saM
+aPQ
+tcd
+tcd
+toV
+tcd
+tcd
+toV
+tcd
+tcd
+toV
+tcd
+tcd
+toV
+tcd
+tcd
+rik
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+oSc
 xXv
-rQp
-fif
-wfp
-wfp
-wfp
-wfp
-fif
-wfp
-wfp
-wfp
-wfp
-fif
-qTk
 fif
 doz
 doz
@@ -142983,8 +140109,22 @@ doz
 doz
 doz
 doz
-ceC
-ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -143161,76 +140301,62 @@ asq
 asq
 ipz
 gfa
-mgj
-iUb
-dXY
-mZB
-lQd
-tmq
-goM
-nBZ
-nQP
-sTk
-sTk
-kxV
-gVu
-uxX
-uyT
-ceC
-ceC
+ipz
+doz
 doz
 ceC
+tmq
+tmq
+nQP
+tmq
+nQP
+tmq
+tmq
+ceC
+doz
+doz
+doz
+doz
 iYR
-peR
-njn
-ovo
 iYR
+iYR
+ifu
+scy
+epO
+qqN
 cSQ
-iYR
+aPQ
+dpz
 waq
 bVL
 iob
-iYR
-doz
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-etx
-uhq
-jpg
-bqL
-wfp
-loJ
-wfp
-etx
-aXx
-vjE
-ydt
-vjE
-quH
 aPQ
-aZA
-aZA
-mKL
-etx
-cDt
-emy
-fif
-ocX
-bqL
-ocX
-fif
-fif
-fif
-ocX
-bqL
-fif
-fif
+tcd
+bZr
+esQ
+tcd
+tcd
+esQ
+tcd
+tcd
+esQ
+tcd
+tcd
+esQ
+tcd
+tcd
+tcd
+aPQ
+rwp
+xAJ
+fLB
+kDW
+quH
+kDW
+xAJ
+rQp
 iJV
+akg
 fif
 doz
 doz
@@ -143238,9 +140364,23 @@ doz
 doz
 doz
 doz
-ceC
-ceC
-ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -143419,83 +140559,83 @@ asq
 kzQ
 gfa
 ipz
-gVu
-wyu
-crJ
-gVu
-crJ
-wyu
-wyu
-gVu
-crJ
-crJ
-crJ
-crJ
-gVu
-hZm
-ceC
+doz
+doz
 doz
 doz
 ceC
-iYR
-iYR
-iYR
-iYR
-iYR
-cSQ
-iYR
-iYR
-iYR
-iYR
-iYR
-doz
-doz
-ceC
-doz
-doz
-doz
-doz
 vbK
-etx
+vbK
+vbK
+vbK
+vbK
+vbK
+doz
+doz
+doz
+doz
+doz
+doz
+iYR
+kdo
+scy
+xjy
+qqN
+cSQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+xww
+txP
+esQ
 bBc
 txP
-etx
-wfp
-wfp
-wfp
-etx
-umd
-oSc
-nZt
-oFX
-jed
+esQ
+bBc
+txP
+nwj
+bBc
+txP
+esQ
+bBc
+txP
+bli
 aPQ
+pov
+oSc
+iJV
+iox
+oSc
+iJV
+fDa
 aZA
-aZA
-tCx
-etx
-qFZ
-xXv
-iJV
-iJV
-vwS
 fDa
-fDa
-fDa
-iJV
-iJV
-iJV
-iJV
-vwS
-iJV
+jgK
 fif
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -143676,28 +140816,27 @@ asq
 ipz
 gfa
 ipz
-rhw
-fVX
-eBh
-rhw
-gVu
-esq
-esq
-esq
-gVu
-gVu
-hFo
-fVX
-rhw
-uyT
+doz
+doz
+doz
+doz
+ceC
+ceC
+ceC
+doz
+doz
+ceC
 doz
 doz
 doz
 doz
 doz
 doz
-doz
-doz
+ceC
+iYR
+peR
+njn
+ovo
 iYR
 cSQ
 iYR
@@ -143705,49 +140844,50 @@ doz
 doz
 doz
 doz
-doz
-doz
-ceC
-doz
-doz
-doz
-doz
-vbK
-etx
-bLb
-eEN
-etx
-etx
-etx
-etx
-etx
-etx
-etx
-etx
-etx
-etx
-etx
-etx
-etx
-etx
-etx
-fTZ
-fTZ
-iJV
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+qQf
+fDa
 fif
 fif
 fif
-fzk
-fzk
-fzk
-fzk
+fif
 fif
 fif
 fif
 fif
 fif
 doz
-ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -143933,20 +141073,7 @@ yjW
 ipz
 gfa
 ipz
-uyT
-hZm
-uyT
-hZm
-gVu
-esq
-esq
-esq
-gVu
-hZm
-uyT
-hZm
-uyT
-uyT
+doz
 doz
 doz
 doz
@@ -143955,56 +141082,69 @@ ceC
 doz
 doz
 doz
-iYR
-oDc
+ceC
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
 iYR
 iYR
-doz
-ceC
-ceC
-ceC
-ceC
-ceC
-doz
-doz
-doz
-doz
-vbK
-etx
+iYR
+iYR
+iYR
+dWl
+iYR
+iYR
+iYR
+fif
+fif
+fif
+xcf
+xXv
+tag
+kDW
+xAJ
+rQp
+kDW
+kDW
+oDP
 rbX
 uhq
-iJV
+oSc
+iox
+iox
+oSc
+oSc
+iox
 fDa
-mxG
-iJV
-iJV
-fDa
-fDa
-iJV
-vAt
-iJV
-iJV
-fDa
-fDa
-iJV
-iJV
-fDa
-fDa
-iJV
 fif
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
+ceC
+ceC
+ceC
 ceC
 doz
 doz
-ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -144191,17 +141331,16 @@ dCn
 iHY
 ipz
 doz
+doz
+doz
+doz
 ceC
+doz
+doz
+doz
+doz
 ceC
-hZm
-rhw
-dTP
-qcS
-dTP
-rhw
-hZm
-ceC
-ceC
+doz
 doz
 doz
 doz
@@ -144214,54 +141353,55 @@ doz
 doz
 iYR
 cSQ
+gNf
 xxe
-iYR
-iYR
-iYR
-jEk
-doz
-doz
-ceC
-doz
-doz
-doz
-doz
-vbK
-etx
-xXv
+qGG
+iox
+iox
+fDa
+iox
+iox
+ggB
+oSc
+oSc
+jWi
+oSc
+iJV
+iJV
+wCv
 lun
-etx
+fif
+fTZ
+jpg
 llq
 xXv
-qQf
-jpg
-fTZ
-rwp
-pov
 xXv
-fTZ
-rQp
-xXv
-xHx
-fTZ
-ooa
 qFZ
-cYE
-xXv
 fif
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
+ceC
 ceC
 doz
 doz
-ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -144449,21 +141589,20 @@ cwi
 ipz
 doz
 doz
+doz
+doz
 ceC
-hZm
-hZm
-uyT
-hZm
-uyT
-hZm
-hZm
+doz
+doz
+doz
+doz
 ceC
+doz
 doz
 doz
 doz
 doz
 vbK
-iYR
 iYR
 iYR
 iYR
@@ -144471,56 +141610,57 @@ iYR
 iYR
 iYR
 cSQ
-fKk
-vIw
-fKk
-rgt
-vbK
+ifu
+ifu
+iYR
+fif
+fif
+fif
+fif
+fif
+fif
+fif
+fif
+fif
+fif
+fif
+fif
+fif
+fif
+fif
+fif
+fif
+fif
+fif
+fif
+fif
+fif
+ceC
 doz
 doz
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-etx
-etx
-etx
-fif
-fif
-fif
-fif
-fif
-fif
-fif
-fif
-fif
-fif
-fif
-fif
-fif
-fif
-fif
-fif
-ksv
-xXv
-fif
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -144709,12 +141849,12 @@ doz
 doz
 doz
 ceC
-ceC
-ceC
 doz
 doz
-vbK
-vbK
+doz
+doz
+ceC
+doz
 doz
 doz
 doz
@@ -144726,20 +141866,26 @@ rgt
 xQO
 fKk
 uYJ
-xQO
 cSQ
-vSA
+ifu
+lFh
 iYR
-iYR
-iYR
 ceC
-doz
-doz
 ceC
-doz
-doz
-doz
-doz
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+vbK
+vbK
+vbK
 ceC
 ceC
 ceC
@@ -144747,22 +141893,6 @@ vbK
 vbK
 vbK
 ceC
-ceC
-ceC
-vbK
-vbK
-vbK
-vbK
-ceC
-ceC
-ceC
-bOz
-doz
-doz
-iYR
-iYR
-vXr
-iYR
 doz
 doz
 doz
@@ -144772,12 +141902,22 @@ doz
 doz
 doz
 doz
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -144976,7 +142116,7 @@ doz
 doz
 doz
 doz
-doz
+vbK
 iYR
 iYR
 iYR
@@ -144984,42 +142124,15 @@ lPs
 cSQ
 cSQ
 cSQ
-uxw
+xXN
 iYR
 iYR
-vbK
-vbK
-vbK
-vbK
-doz
-ceC
-doz
-doz
-doz
-doz
-vbK
-doz
-doz
-doz
 ceC
 doz
 doz
 doz
 doz
 doz
-ceC
-ceC
-doz
-doz
-doz
-vbK
-vbK
-iYR
-iYR
-iYR
-sCn
-fKk
-iYR
 doz
 doz
 doz
@@ -145029,12 +142142,39 @@ doz
 doz
 doz
 doz
-ceC
-doz
-ceC
 doz
 doz
-ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -145240,43 +142380,43 @@ iYR
 fKJ
 cSQ
 fKk
-fKk
-fKk
+ifu
+ifu
 iYR
 vbK
-cfT
-kql
-kql
-kql
-lif
-lif
-lif
-kql
-kql
-lif
-lif
-lif
-kql
-kql
-lif
-lif
-lif
-kql
-kql
-lif
-lif
-kql
-kql
 doz
 doz
-vbK
-jEk
-vIw
-fKk
-rgt
-fKk
-fKk
-iYR
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -145497,43 +142637,43 @@ iYR
 ttK
 cSQ
 fKk
-fKk
-fKk
+ifu
+bmr
 iYR
 vbK
-ceC
-kql
-wdQ
-rmW
-rsx
-rsx
-hpB
-rsx
-rmW
-lsf
-mas
-vnH
-rWZ
-bmr
-rsx
-wdQ
-wdQ
-xkx
-bmr
-wdQ
-wdQ
-wdQ
-kql
 doz
 doz
 doz
 doz
-iYR
-iYR
-iYR
-bTl
-fKk
-iYR
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -145748,49 +142888,49 @@ cwi
 cwi
 cwi
 tBj
-cSQ
 wOr
 cSQ
 cSQ
+cSQ
 lcI
-onD
-onD
 fKk
+fKk
+xQO
 iYR
 vbK
-ceC
-kql
-wdQ
-xkx
-hgq
-pYJ
-kly
-mnZ
-hgq
-rsx
-xrv
-vnH
-xNa
-wTC
-tEH
-rsx
-rsx
-lsf
-lsf
-wdQ
-wdQ
-wdQ
-lif
 doz
 doz
 doz
 doz
 doz
 doz
-iYR
-iYR
-fKk
-hzG
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -146011,33 +143151,10 @@ qqN
 qqN
 iYR
 iYR
-iZv
+iYR
 iYR
 iYR
 vbK
-ceC
-kql
-rsx
-rsx
-kly
-gEP
-wae
-tVt
-iYb
-lsf
-qfr
-vnH
-vHw
-hpB
-wdQ
-wdQ
-wdQ
-lsf
-lsf
-rsx
-rsx
-wTC
-lif
 doz
 doz
 doz
@@ -146045,9 +143162,32 @@ doz
 doz
 doz
 doz
-iYR
-fKk
-iYR
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -146268,33 +143408,10 @@ xQO
 xQO
 xQO
 iYR
-onD
-nXO
-iYR
-vbK
 ceC
-kql
-vYk
-lsf
-mnZ
-rsx
-fFb
-cIc
-mnZ
-wdQ
-aKs
-vnH
-cXY
-hpB
-rsx
-rsx
-rsx
-wTC
-rsx
-hpB
-hpB
-rsx
-kql
+ceC
+ceC
+ceC
 doz
 doz
 doz
@@ -146302,9 +143419,32 @@ doz
 doz
 doz
 doz
-hzG
-fKk
-iYR
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -146525,43 +143665,43 @@ xQO
 qea
 xQO
 mUw
-onD
-fKk
-iYR
-ceC
-vbK
-kql
-lsf
-lsf
-mnZ
-ukI
-pYJ
-hpB
-kly
-rsx
-aEq
-aHe
-vHw
-rsx
-rsx
-wdQ
-wdQ
-hpB
-hpB
-rsx
-lsf
-uPu
-kql
-iYR
-iYR
-iYR
-iYR
 doz
 doz
 doz
-iYR
-fRD
-iYR
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -146782,44 +143922,44 @@ xQO
 qea
 xQO
 mUw
-pTl
-xQO
-iYR
-vbK
 doz
-kql
-rsx
-rsx
-ibl
-mnZ
-pYJ
-mnZ
-hgq
-lsf
-qfr
-osJ
-ogH
-rsx
-vAr
-wdQ
-wdQ
-hpB
-hpB
-rsx
-lsf
-peE
-kql
-rcd
-sCV
-rcd
-iYR
-iYR
-iYR
-iYR
-iYR
-cXa
-iYR
-iYR
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -147039,46 +144179,46 @@ xQO
 xQO
 xQO
 iYR
-onD
-eHj
-iYR
-vbK
 doz
-kql
-nwc
-nwc
-cEn
-wdQ
-hgq
-rsx
-kzo
-kFX
-lBV
-vnH
-dLM
-oEO
-rsx
-wdQ
-wdQ
-rsx
-cIc
-vGX
-whJ
-uPu
-kql
-jWi
-hFO
-ssd
-iYR
-yaj
-kpd
-ifu
-fuc
-fKk
-lFh
-hzG
-hzG
-hzG
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -147296,46 +144436,46 @@ nFU
 nFU
 nFU
 nFU
-onD
-fKk
-iYR
-vbK
 doz
-kql
-hbr
-cum
-ghj
-smU
-xeV
-doQ
-jUY
-uTK
-kIC
-mVM
-wkB
-xNa
-rsx
-xkx
-lsf
-lsf
-stz
-mnZ
-pYJ
-pYJ
-iDA
-gTQ
-hFO
-ssd
-ikS
-ifu
-fKk
-ifu
-ifu
-ifu
-fKk
-mTa
-fKk
-kSu
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -147553,46 +144693,46 @@ fqE
 gIH
 dvG
 nFU
-onD
-cYu
-iYR
-vbK
 doz
-kql
-bGb
-pGr
-eYd
-wdQ
-stz
-hpB
-dYn
-flg
-flg
-lWj
-vnH
-qpD
-hpB
-hpB
-rsx
-lsf
-kly
-rsx
-xkx
-uPu
-kql
-jWi
-jWi
-nFj
-iYR
-fKk
-fKk
-fKk
-fdb
-fKk
-vSA
-hzG
-hzG
-hzG
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -147810,44 +144950,44 @@ xLW
 gIH
 jir
 nFU
-onD
-fKk
-iYR
-vbK
-vbK
-kql
-qWJ
-xkx
-rsx
-rsx
-kly
-rsx
-wTC
-tEH
-jst
-mWK
-vnH
-aOx
-wTC
-rsx
-lQu
-tEO
-mnZ
-rsx
-rsx
-shl
-kql
-mts
-nsI
-mts
-iYR
-fKk
-iYR
-iYR
-iYR
-iYR
-iYR
-iYR
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -148067,39 +145207,39 @@ xLW
 qxa
 gpq
 nFU
-onD
-xQO
-iYR
-ceC
-vbK
-kql
-lsf
-lQu
-rsx
-tEO
-mnZ
-rsx
-wdQ
-wdQ
-rsx
-mRy
-vnH
-lLj
-hpB
-hpB
-wdQ
-sYA
-lus
-rsx
-hpB
-uPu
-kql
-iYR
-iYR
-iYR
-iYR
-lzH
-iYR
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -148324,45 +145464,45 @@ xLW
 gRN
 gRN
 nFU
-onD
-fKk
-iYR
-ceC
-vbK
-kql
-rsx
-hpB
-hpB
-vbq
-rmw
-lsf
-wdQ
-wdQ
-xkx
-uvW
-skA
-ebX
-rsx
-xkx
-wdQ
-rsx
-pCT
-rsx
-hpB
-rsx
-kql
-ceC
-ceC
-ceC
-iYR
-aIw
-iYR
-ceC
-ceC
-ceC
-ceC
-ceC
-vSx
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -148569,7 +145709,7 @@ doz
 doz
 doz
 doz
-xba
+nFU
 naG
 xOK
 gKE
@@ -148581,45 +145721,45 @@ xLW
 ybc
 qpj
 nFU
-onD
-yhc
-iYR
-ceC
-vbK
-kql
-wdQ
-wdQ
-lQu
-lQu
-tVC
-cIc
-vGX
-dlS
-wAl
-tyo
-hPv
-tyo
-rsx
-rsx
-rsx
-rsx
-wVu
-wTC
-lsf
-rsx
-lif
-doz
-doz
-doz
-iYR
-ifu
-hzG
 doz
 doz
 doz
 doz
 doz
-vSx
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -148838,45 +145978,45 @@ xLW
 aWU
 pGj
 nFU
-pTl
-fKk
-iYR
-cfT
-vbK
-kql
-wdQ
-wdQ
-wTC
-lsf
-sWA
-hlG
-dSK
-hlG
-dSK
-vcA
-qqt
-sWA
-hlG
-dSK
-abz
-lus
-wBO
-rsx
-lsf
-rsx
-lif
-doz
-doz
-doz
-iYR
-tKy
-hzG
 doz
 doz
 doz
 doz
 doz
-mPy
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -149095,45 +146235,45 @@ cVf
 vJz
 dBO
 nFU
-onD
-cYu
-iYR
-doz
-vbK
-kql
-cUx
-pqy
-dPd
-rVV
-goE
-pqy
-umx
-rVV
-dPd
-pqy
-wQw
-tyo
-tEH
-hGN
-pGV
-ozx
-rsx
-wAl
-rsx
-peE
-kql
-doz
-doz
-doz
-iYR
-fKk
-hzG
 doz
 doz
 doz
 doz
 doz
-vSx
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -149352,45 +146492,45 @@ sCY
 jtT
 eUs
 nFU
-onD
-fKk
-iYR
-vbK
-vbK
-kql
-kql
-kql
-kql
-kql
-rna
-kql
-kql
-kql
-kql
-kql
-qsk
-fao
-rsx
-lsf
-lsf
-lsf
-wdQ
-wdQ
-wdQ
-rsx
-kql
-doz
-doz
-ceC
-uhV
-fKk
-iYR
 doz
 doz
 doz
 doz
 doz
-vSx
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -149609,45 +146749,45 @@ nFU
 enM
 nFU
 nFU
-onD
-fKk
-iYR
-vbK
-ceC
-kql
-dnX
-dnX
-hwx
-xkq
-htI
-dLD
-wRG
-oIz
-uIO
-kql
-kFx
-oSx
-rsx
-wdQ
-bXy
-wTC
-wdQ
-pIo
-wdQ
-xkx
-lif
-ceC
-doz
-vbK
-iYR
-fKk
-iYR
 doz
 doz
 doz
 doz
 doz
-vSx
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -149866,45 +147006,45 @@ hcK
 bVa
 vdp
 nFU
-onD
-xQO
-iYR
-vbK
-ceC
-kql
-dnX
-dnX
-dLD
-urL
-imp
-urL
-urL
-urL
-nCG
-kql
-qGD
-rkx
-rsx
-rsx
-rsx
-rsx
-wdQ
-wdQ
-wdQ
-rsx
-lif
-ceC
-ceC
-vbK
-iYR
-fRD
-iYR
 doz
 doz
 doz
 doz
 doz
-vSx
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -150123,45 +147263,45 @@ nFU
 dOI
 osX
 nFU
-onD
-boy
-iYR
-vbK
-ceC
-kql
-dnX
-dnX
-dLD
-urL
-gwr
-dLD
-dLD
-dLD
-wRG
-kql
-pGJ
-rsx
-rNH
-lsf
-rsx
-rsx
-fMY
-rsx
-rsx
-lsf
-kql
-ceC
-doz
-vbK
-iYR
-fKk
-hzG
 doz
 doz
 doz
 doz
 doz
-mPy
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -150380,45 +147520,45 @@ hcK
 nro
 aQj
 nFU
-onD
-fKk
-iYR
-vbK
-ceC
-kql
-dnX
-dnX
-dLD
-moz
-niJ
-lrf
-wRG
-xeQ
-qBS
-kql
-kql
-kql
-kql
-kql
-kql
-kql
-kql
-lif
-lif
-kql
-kql
-doz
-doz
-vbK
-iYR
-fKk
-hzG
 doz
 doz
 doz
 doz
 doz
-vSx
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -150637,45 +147777,45 @@ nFU
 nFU
 nFU
 nFU
-rDq
-xQO
-iYR
-vbK
-ceC
-kql
-kql
-kql
-usX
-kql
-tSK
-usX
-usX
-usX
-kql
-kql
-xQO
-xQO
-xQO
-xQO
-xQO
-iYR
 doz
 doz
 doz
-ceC
-ceC
-vbK
-vbK
-ceC
-iYR
-frC
-hzG
 doz
 doz
 doz
-ceC
-ceC
-vSx
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -150893,43 +148033,43 @@ doz
 doz
 doz
 doz
-iYR
-iZv
-iYR
-iYR
-iYR
-iYR
-iYR
-xww
-fKk
-bEw
-eOY
-onD
-fKk
-eHj
-xQO
-xQO
-iYR
-qqN
-iYR
-mUw
-qqN
-qqN
-iYR
-iYR
-iYR
-iYR
-iYR
-uhV
-iYR
-iYR
-iYR
-iYR
-lzH
-iYR
 doz
-ceC
-ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -151150,41 +148290,41 @@ doz
 doz
 doz
 doz
-iYR
-onD
-onD
-onD
-onD
-onD
-jKo
-onD
-onD
-onD
-onD
-onD
-fKk
-fKk
-xQO
-fKk
-fKk
-fKk
-fKk
-nXO
-xkU
-scy
-fKk
-eOY
-fKk
-fKk
-fKk
-bEw
-fKk
-fKk
-fKk
-fKk
-fKk
-iYR
-ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -151407,40 +148547,40 @@ doz
 doz
 doz
 doz
-iYR
-bIL
-fKk
-fKk
-fKk
-fKk
-scy
-aFj
-fKk
-xww
-cYu
-fKk
-fKk
-fdb
-bEw
-fKk
-eyx
-eHj
-fdb
-fKk
-fKk
-fKk
-cYu
-fKk
-fKk
-fKk
-aFj
-eyx
-lQm
-fKk
-fKk
-fKk
-tib
-iYR
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -151664,40 +148804,40 @@ doz
 doz
 doz
 doz
-iYR
-iYR
-vSA
-fKk
-rYu
-iYR
-iYR
-iYR
-iYR
-iYR
-iYR
-iYR
-iYR
-iYR
-iYR
-iYR
-iYR
-iYR
-iYR
-iYR
-iYR
-iYR
-iYR
-iYR
-iYR
-iYR
-iYR
-iYR
-iYR
-lFh
-fKk
-mGA
-iYR
-iYR
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -151922,38 +149062,38 @@ doz
 doz
 doz
 doz
-iYR
-iYR
-pRu
-iYR
-iYR
-doz
-doz
-doz
-doz
-doz
-ceC
 doz
 doz
 doz
 doz
 doz
 doz
-ceC
 doz
 doz
 doz
 doz
 doz
-ceC
 doz
 doz
 doz
-iYR
-iYR
-pRu
-iYR
-iYR
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -152180,36 +149320,36 @@ doz
 doz
 doz
 doz
-iYR
-fKk
-iYR
 doz
 doz
 doz
 doz
 doz
 doz
-ceC
 doz
 doz
 doz
 doz
 doz
 doz
-ceC
 doz
 doz
 doz
 doz
 doz
-ceC
 doz
 doz
 doz
 doz
-iYR
-fKk
-iYR
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -152437,36 +149577,36 @@ doz
 doz
 doz
 doz
-iYR
-uYW
-iYR
-ceC
-ceC
-doz
-doz
-doz
-doz
-ceC
 doz
 doz
 doz
 doz
 doz
 doz
-ceC
 doz
 doz
 doz
 doz
 doz
-ceC
 doz
 doz
 doz
 doz
-iYR
-uYW
-iYR
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -152698,33 +149838,33 @@ doz
 doz
 doz
 doz
-ceC
-ceC
-doz
-doz
-doz
-ceC
 doz
 doz
 doz
 doz
 doz
 doz
-ceC
 doz
 doz
 doz
 doz
 doz
-ceC
-doz
-ceC
 doz
 doz
-ceC
-ceC
-ceC
-ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -152956,29 +150096,29 @@ doz
 doz
 doz
 doz
-ceC
-ceC
-ceC
-doz
-ceC
 doz
 doz
 doz
 doz
 doz
 doz
-ceC
 doz
 doz
 doz
 doz
 doz
-ceC
 doz
-ceC
-ceC
-ceC
-ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -153215,25 +150355,25 @@ doz
 doz
 doz
 doz
-ceC
-doz
-ceC
 doz
 doz
 doz
 doz
 doz
 doz
-ceC
 doz
 doz
 doz
 doz
 doz
-ceC
-ceC
-ceC
-ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -153472,21 +150612,21 @@ doz
 doz
 doz
 doz
-ceC
-doz
-ceC
 doz
 doz
 doz
 doz
 doz
 doz
-ceC
 doz
 doz
 doz
 doz
-ceC
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -153729,21 +150869,21 @@ doz
 doz
 doz
 doz
-oUZ
-oUZ
-mPy
-oUZ
-oUZ
-oUZ
-oUZ
-oUZ
-mPy
-oUZ
-oUZ
-mPy
-oUZ
-oUZ
-isY
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -201512,7 +198652,7 @@ jDR
 cMB
 tnR
 jDR
-nnU
+jDR
 nnU
 rOZ
 htm
@@ -201760,8 +198900,8 @@ oBv
 lCk
 nhZ
 bri
-tOz
-pBE
+hiQ
+xJM
 hiQ
 dKk
 adA
@@ -201769,8 +198909,8 @@ hIG
 qWw
 pMa
 neD
+dzy
 nnU
-pPG
 elu
 htm
 chc
@@ -202025,9 +199165,9 @@ adA
 bRT
 fgr
 qOg
+qOg
 fWo
 nnU
-pPG
 qOt
 htm
 mjM
@@ -202274,17 +199414,17 @@ mPJ
 mPJ
 kVP
 mZE
-kmU
-abw
+crq
+crq
 crq
 bVS
 dhQ
 jZz
 blT
 kdz
+qOg
 vjG
 nnU
-nNa
 uBe
 htm
 fsl
@@ -202527,8 +199667,8 @@ iur
 ckR
 lCk
 hGP
-wrk
-oaU
+crq
+crq
 uSG
 qze
 qze
@@ -202539,10 +199679,10 @@ adA
 bRT
 orz
 qOg
+qOg
 gNQ
 nnU
-dIf
-lpq
+uBe
 htm
 fiJ
 mcn
@@ -202797,8 +199937,8 @@ peT
 kQM
 mvr
 lmq
+xEz
 nnU
-uBe
 jgy
 htm
 ged
@@ -203049,14 +200189,14 @@ dCQ
 fwy
 ucd
 mGN
-yeD
+adA
 thB
 wqA
-thB
+iXs
 yeD
+oHD
 nnU
-lpq
-htm
+elu
 htm
 htm
 htm
@@ -203108,10 +200248,10 @@ hXT
 rHU
 hXT
 alC
-tYD
+trM
 kJd
 dNf
-ufg
+caB
 lMO
 xnC
 cEL
@@ -203297,33 +200437,33 @@ uap
 iur
 ckR
 lCk
-rDd
-nOm
-lhZ
-buy
-qze
-qze
-qze
-mQp
-qaT
-yeD
-uYE
-dbP
-saM
+lCk
+lCk
+lCk
+lCk
+lCk
+lCk
+lCk
+lCk
+lCk
+adA
+adA
+adA
+adA
 bvA
+adA
 nnU
+elu
 nPZ
-htm
-uHT
 xun
-ppe
-uHT
+cHV
+fiK
 awe
-xun
-htm
-eEz
+ppe
+fiK
+uwa
 uGN
-sTP
+wUC
 xpY
 puQ
 tVF
@@ -203366,9 +200506,9 @@ cQm
 vOl
 rON
 roV
-xRt
-xRt
-xRt
+kJd
+kJd
+vbK
 aVw
 omE
 fiH
@@ -203553,34 +200693,34 @@ qjt
 uap
 iur
 tHA
-lCk
-sjf
-kko
-tUK
-qtp
-mPJ
-mPJ
-mPJ
-qze
-qaT
-yeD
-clY
-kFF
-gbq
-wnx
 nnU
+sjf
+hkP
 nPZ
+qtp
+nPZ
+luc
+dIf
+kYb
+uGd
+nNa
+nnU
+kFF
+nPZ
+wnx
+lpq
+boy
+elu
+nPZ
+pRu
 htm
-uHT
+fiK
 ruR
 gAg
-uHT
-lzQ
-aYv
 fiK
-qtA
-oCy
-oUd
+lzQ
+ruR
+wUC
 kFp
 kEz
 umf
@@ -203622,10 +200762,10 @@ wXI
 mSN
 lXF
 alC
-xRt
-xRt
-xRt
-xRt
+trM
+kJd
+kJd
+vbK
 aVw
 aVw
 aVw
@@ -203810,35 +200950,35 @@ uCV
 pdA
 iur
 ckR
-lCk
-qze
-qze
-qze
+cnx
+unT
+unT
+jKo
 nPb
 pdc
 kds
-oWz
-fVJ
+kds
+kds
 uvq
-yeD
+foW
 dic
-qqM
-oOE
-stV
-nnU
+uvq
 bIa
+stV
+foW
+bIa
+hvn
+wqe
+nPZ
 htm
-uHT
+fiK
 ruR
 oyk
 qMf
 uwa
-uEt
-htm
-aDt
 ljJ
-aDt
-aDt
+wUC
+hDa
 dsq
 uqs
 uYQ
@@ -203868,7 +201008,7 @@ lnM
 dRA
 fbB
 hLv
-ayp
+iCA
 kot
 kot
 myz
@@ -203879,12 +201019,12 @@ hXT
 hXT
 hXT
 hpN
-hpN
-hpN
-xRt
-xRt
-xRt
-xRt
+tYD
+tYD
+kJd
+kJd
+kJd
+kJd
 kJd
 kJd
 kJd
@@ -204069,35 +201209,35 @@ rWB
 lGE
 nnU
 nnU
-nnU
-nnU
-kKc
-nnU
-nnU
-nnU
-nnU
-nnU
-nnU
-kqJ
-wvS
-wvI
-lMr
-nnU
-lpq
 htm
+htm
+htm
+htm
+htm
+htm
+htm
+htm
+htm
+htm
+nnU
+aUZ
+bgG
+luc
+pPG
+lfw
 fzv
+fJB
+htm
+pTa
 dgp
 ikW
-xZX
+hMV
 krL
 lzQ
-hMV
-kEA
-uQa
-sbf
+wUC
 kFp
 uaw
-gTy
+dLq
 tKx
 dLq
 amN
@@ -204124,24 +201264,24 @@ ezU
 cJr
 dRA
 fbB
-cVU
-hvn
+hLv
+iCA
 ovQ
-fiG
-fiG
+hXT
+hXT
 mCu
 dRA
 qDN
-bnl
+hXT
 hXT
 htZ
-htZ
-htZ
 hpN
-xRt
-xRt
-xRt
-xRt
+tYD
+tYD
+kJd
+kJd
+kJd
+kJd
 tYD
 tYD
 kJd
@@ -204324,36 +201464,36 @@ kkl
 kkl
 kkl
 sKd
-nnU
-nNa
-nPZ
-hkP
+cPM
+qcS
+eYd
+dcV
 rKi
 fOH
-luc
+ayp
+ufk
+ufk
+xTs
+kPk
+htm
+nqw
 nPZ
-nPZ
-nPZ
-nnU
-nnU
-ioA
-nnU
-nnU
-nnU
-nPZ
+bgG
+rAZ
+pPG
+gVD
+wqe
+lpq
 htm
 jan
 veB
-lfM
+cEn
 wBZ
 qAi
 jGA
-htm
-sRz
-oiR
-fcj
-xpY
+wUC
 rCF
+uNF
 hDp
 rFm
 aWA
@@ -204380,26 +201520,26 @@ uqb
 hXT
 sPP
 dRA
-lXF
+hXT
 oWF
-lsJ
-lsJ
-fbV
-fbV
+iCA
+iCA
+hXT
+hXT
 rZq
 dRA
-dRA
-dRA
+bnl
+hXT
+hXT
 iqj
 dRA
-dRA
-xVM
-dRA
-dRA
-dRA
-dRA
-dRA
-dRA
+tYD
+tYD
+tYD
+tYD
+kJd
+kJd
+kJd
 tYD
 tYD
 kJd
@@ -204582,33 +201722,33 @@ sKd
 kkl
 avQ
 rFp
-unT
-unT
-unT
+mPO
+vVf
+oUd
 oZf
+sRe
 pjb
-pjb
-pjb
-pjb
+hFm
+ruJ
 tWi
 lrj
-lrj
-rWq
+htm
+pTa
 fcd
-amp
-bxW
+bgG
+gXm
 oqa
+fdb
+wqe
+nPZ
 htm
 nqw
 nPZ
 ikW
 nPZ
 pyY
-nPZ
-htm
-htm
-htm
-htm
+uxd
+nnU
 htm
 htm
 htm
@@ -204634,32 +201774,32 @@ hpN
 hpN
 hpN
 hpN
-hpN
-hpN
-hpN
-hpN
-lXF
-hXT
-hpN
-hpN
-hfu
-rZq
-myz
-hXT
-hXT
-hXT
 dRA
-biJ
-ped
-hXT
-sHZ
-dWz
-oJH
-jPM
 dRA
+dRA
+alC
+pWj
+lif
+lif
+lif
+lif
+lif
+kql
+kql
+lif
+lif
+lif
+kql
+kql
+lif
+lif
+kql
+kql
+kJd
+kJd
 tYD
-tYD
-tYD
+vbK
+jEk
 vrd
 vrd
 vrd
@@ -204838,24 +201978,24 @@ sKd
 sKd
 kkl
 bMM
-nnU
-nnU
-kYb
+luu
+vlt
+ovU
 uta
-hFm
+kaB
 hFm
 gqS
 hFm
-vpo
+kaB
 fGO
-hFm
-hFm
+lrj
+htm
 oAw
-nFH
 lpq
-lpq
+bgG
+maN
 fJB
-lOV
+bgG
 wqe
 bCK
 mpF
@@ -204863,14 +202003,14 @@ tqC
 tsA
 fpz
 rnF
-qJE
+bEw
 qJE
 rzl
 lhE
 iuy
 nnU
 rIv
-hSq
+qJE
 rIv
 nnU
 mlU
@@ -204880,43 +202020,43 @@ nnU
 kCy
 nPZ
 iGa
-luc
+nNa
 nNa
 nPZ
 htm
-aPQ
-aPQ
-aPQ
-xcZ
-sWX
-taO
-mym
-tJN
-sWX
-aEf
-aPQ
-aPQ
-aPQ
+nCd
+htZ
+kWk
 hpN
-axX
-pVR
-rZq
-dRA
-hXT
-szb
-kXt
-dRA
-sKf
-dKD
-hXT
-hZw
-hXT
-iCA
-xcf
-dRA
-tYD
-tYD
-tYD
+hKL
+kuy
+kUl
+wdQ
+rmW
+rsx
+xkx
+uxi
+lsf
+hpB
+lsf
+mas
+vnH
+rWZ
+wdQ
+lsf
+rsx
+rsx
+hpB
+rsx
+lsf
+lsf
+wdQ
+kql
+kJd
+kJd
+kJd
+kJd
+kJd
 kJd
 kJd
 kJd
@@ -205095,31 +202235,31 @@ sKd
 sKd
 kkl
 sKd
-hWd
+vlt
+vlt
+pTl
+aIl
+lNS
+hFm
+mOr
+hFm
+lNS
+tVt
+lrj
 htm
-htm
-htm
-htm
-htm
-htm
-htm
-htm
-htm
-htm
-nnU
+mtm
+nPZ
 bgG
-nPZ
+lpq
 luc
-nPZ
-ugS
-htm
-yaU
+qPp
+wqe
 jLm
-iiS
+htm
 nyB
 rYl
 kcM
-htm
+qxg
 uuk
 qJE
 rzl
@@ -205127,7 +202267,7 @@ fNH
 aaz
 biB
 nPZ
-nPZ
+qJE
 nPZ
 nnU
 rzl
@@ -205141,38 +202281,38 @@ lpq
 lpq
 nPZ
 htm
-cuq
-cuq
-cuq
-xcZ
-sWX
-kuy
-sKl
-foW
-sWX
-aEf
-cuq
-cuq
-cuq
+nCd
+htZ
+rWq
 hpN
-axX
-pVR
-egY
-dRA
-xVM
-dRA
-dRA
-dRA
-caw
-irW
-hZw
-cYY
-lZQ
-lZQ
-lZQ
-aFr
-aFr
-aFr
+hKL
+kuy
+kUl
+wdQ
+rsx
+rsx
+rsx
+uxi
+lQu
+rsx
+rsx
+xrv
+vnH
+xNa
+wdQ
+xkx
+hgq
+pYJ
+kly
+mnZ
+hgq
+rsx
+wdQ
+lif
+kJd
+kJd
+kJd
+tYD
 tYD
 tYD
 tYD
@@ -205353,83 +202493,83 @@ ocr
 kkl
 naE
 soG
-ifY
-erF
-xhj
-afW
+pNj
+mtc
+mtc
+mtc
 pgK
 mtc
-stA
-rkL
-kYH
+ufk
+ufk
+xTs
+sqp
 htm
-pTa
 pjT
-nPZ
+hQm
+bgG
+dYn
 nnU
-mtm
-eFQ
+fao
+wqe
+xXq
 htm
 htm
 htm
 htm
 htm
 htm
-htm
-htm
-luc
-qJE
-nnU
-nnU
+asx
 nnU
 nnU
+nnU
+nnU
 nPZ
+tPP
+tPP
+tPP
+swe
+vAt
+tPP
+tPP
+vAt
+tPP
+swe
+ped
 nPZ
-nPZ
-nPZ
-nPZ
-nPZ
-nPZ
-luc
-nPZ
-nPZ
-eWp
-uGd
-nPZ
-nPZ
+uUb
 htm
-cuq
-cuq
-cuq
-xcZ
-sWX
-dWG
-qIR
+qhM
+qlS
+nbz
+hpN
+hKL
+aoT
+oNO
 tCI
 sWX
-aEf
-cuq
-cuq
-cuq
-hpN
-axX
-pVR
-eJF
-dRA
-hXT
-lXF
-jXa
-dRA
-dRA
+sWX
+tCI
+uiY
+rsx
+wTC
+lsf
+qfr
+aHe
+vHw
+rsx
+rsx
+kly
+bjo
+kYH
 scq
-iCA
-fSN
-biJ
-biJ
-biJ
-biJ
-biJ
-aFr
+iYb
+lsf
+wTC
+lif
+kJd
+kJd
+tYD
+tYD
 tYD
 tYD
 tYD
@@ -205609,84 +202749,84 @@ uRv
 sKd
 kkl
 sKd
-rYC
+soG
 pNj
-asx
+ufk
 txo
 gLG
-mBn
-jGD
+ufk
+msO
 voT
 psK
-pww
+vlt
+vlt
+htm
 htm
 htm
 bgG
-hQm
 aUZ
-luc
-kSA
-bxW
-bxW
+aUZ
+kaw
+key
 bxW
 lqL
 bfW
+fcj
 xih
 xih
-xih
-xih
+brG
 ozb
 uBk
 uBk
 uvR
+uBk
+lsE
 cwk
-cwk
-cwk
-cwk
-cwk
-eiQ
+nPZ
+nPZ
+nPZ
 xsU
-cwk
-cwk
-cwk
-cwk
-eWp
-eWp
-eWp
+jCp
+luc
+luc
+nPZ
+nPZ
+nPZ
+nPZ
 xnl
 htm
-xJj
-cuq
-cuq
-xcZ
-hKL
-gGd
-qIR
-xZh
-sWX
-aEf
-cuq
-cuq
-pvg
+qqM
+avs
+nFj
 hpN
-axX
-wuV
-eJF
-cPo
-hXT
-gOt
-nHW
-dRA
-szL
-htZ
-hZw
-eVH
-biJ
-biJ
-biJ
-biJ
-biJ
-aFr
+hKL
+bAW
+kql
+vYk
+lsf
+rsx
+rsx
+wVu
+cIc
+rsx
+wdQ
+aKs
+vnH
+cXY
+hpB
+lsf
+mnZ
+wTC
+wdQ
+cIc
+mnZ
+wdQ
+rsx
+kql
+kJd
+tYD
+tYD
+tYD
 tYD
 tYD
 tYD
@@ -205866,37 +203006,26 @@ wfV
 sKd
 kkl
 sKd
-nPk
 vlt
-iKc
-ruJ
-tZp
-qNe
-xZk
-ruJ
-uZi
-xTs
-xjV
-htm
+xOv
+aAz
+xOv
+cKt
+cKt
+lQm
+xOv
+aSr
+ugh
+whJ
+pJM
 boK
-gZR
-pwQ
-aaC
-pWj
-pWj
-pWj
-pWj
-hFm
-aYP
-hFm
-gZR
-hFm
-wMk
-hFm
-hFm
-cTB
-blE
+qFQ
+bgG
 nPZ
+nPZ
+lpq
+lpq
+lpq
 nnU
 nnU
 nnU
@@ -205905,45 +203034,56 @@ nnU
 nnU
 nnU
 nnU
-nnU
-ejZ
-rzl
-rzl
-ltz
-nnU
-htm
-cuq
-cuq
-cuq
-xcZ
-gdb
+aPQ
+aPQ
+aPQ
+aPQ
+gMn
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+aPQ
+jqC
 ydt
-mdW
-vSb
-sWX
+arb
+lsf
+lsf
 aEf
-cuq
-cuq
-cuq
-hpN
-hpN
-vQV
-cnx
-pDf
-lTy
-lTy
-lTy
-tPP
-gZB
-qyb
-fKh
-eVH
-biJ
-biJ
-biJ
-biJ
-biJ
-aFr
+rsx
+lus
+igh
+rsx
+rsx
+aEq
+osJ
+vHw
+lsf
+lsf
+mnZ
+ukI
+pYJ
+hpB
+kly
+rsx
+uPu
+kql
+kJd
+tYD
+tYD
+tYD
 tYD
 tYD
 tYD
@@ -206123,84 +203263,84 @@ wfV
 eUY
 kkl
 cpL
-vlt
-vlt
-eDS
-kaB
-tZp
+mrI
+lbS
+sHs
 xkk
-xZk
-kaB
+nYH
+nYH
+nYH
+bDp
 rEX
-xTs
+mQp
 xjV
-htm
-bgG
-hQm
-gXm
+iEn
+ilP
+gmX
+hFo
 lpq
-nnU
-nnU
-nnU
-nnU
-nnU
-nnU
-wdB
-wdB
+fJB
 nPZ
-nnU
+nPZ
+nPZ
+biB
+oof
+lpq
+fZm
+spK
+fZm
 alp
-jCp
-bgG
+ljB
+aPQ
 njG
-pPG
-nnU
-doz
-ceC
-doz
-ceC
-doz
-ceC
-doz
-nnU
-nPZ
-kat
-rzl
-eWp
-nNa
-htm
+ioa
+rqA
+afW
+pKt
+cuq
+cuq
+bJM
 cuq
 cuq
 cuq
-xcZ
-vSK
-oXt
-fNS
-pMG
-foW
-aEf
 cuq
 cuq
 cuq
-hpN
-axX
-blM
-iCW
-cPo
-hXT
-hXT
-jEn
-dRA
-pZF
-hZw
-iCA
-aLZ
-biJ
-biJ
-biJ
-biJ
-biJ
-aFr
+bJM
+cuq
+cuq
+cuq
+cuq
+cuq
+aPQ
+hKL
+aoT
+kUl
+wdQ
+tEH
+xkx
+wdQ
+lus
+lMT
+rsx
+lsf
+qfr
+vnH
+ogH
+rsx
+rsx
+ibl
+mnZ
+pYJ
+mnZ
+hgq
+lsf
+peE
+kql
+kJd
+tYD
+tYD
+tYD
 tYD
 tYD
 tYD
@@ -206381,83 +203521,83 @@ ugB
 kkl
 niF
 mrI
-iEn
-aIl
-lNS
-tZp
-mOr
+egv
+sHs
+qof
+eJe
+miI
 xZk
-lNS
-wOD
-xTs
-xjV
-htm
-bgG
-kdW
+mrl
+nXP
+nXO
+cYu
+wRY
+jqv
+qFQ
 vqm
-lpq
-nnU
-cMI
-cMI
-ljB
-ljB
-nnU
-rBQ
-rBQ
-fZm
-nnU
-nnU
-nnU
-lTX
-axO
-nnU
-nnU
-ceC
-eSZ
-eSZ
-eSZ
-eSZ
-eSZ
-ceC
-nnU
-lpq
-kat
-rzl
-eWp
 nPZ
+nPZ
+oqa
 htm
+htm
+htm
+htm
+htm
+htm
+lzb
+cMI
+lpq
+ljB
+aPQ
+axO
+baY
+opA
+sIX
+qFT
 cuq
 cuq
 cuq
-xcZ
-sYI
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+aPQ
+hKL
 aoT
 kUl
-bQI
-tCI
-aEf
-cuq
-cuq
-cuq
-hpN
-axX
+lPV
+lPV
+rsx
+wdQ
+wVu
+rsx
+gML
+dyW
 blM
 gOH
-dRA
-hXT
-hXT
+dLM
+nwc
+nwc
 oLF
-dRA
-dRA
-scq
+wdQ
+hgq
+rsx
 nTN
 uMf
 biJ
-biJ
-biJ
-biJ
-biJ
-aFr
+kql
+kJd
+tYD
+tYD
+tYD
 tYD
 tYD
 tYD
@@ -206637,84 +203777,84 @@ wfV
 qEI
 kkl
 niF
-mrI
-hnT
-wBw
-uLj
-msO
-ufk
-lYy
-nwj
-ufk
-nvl
-vlt
-htm
+ugh
+xbq
+sHs
+wBX
+xom
+miI
+wnH
+qWp
+nXP
+sHs
+mKL
+xMv
 fLd
-htm
-htm
-brm
-nnU
+qFQ
+fhl
+lpq
+qHI
 mVm
-iOy
+ksH
 jwP
-nPZ
-nnU
-fZm
-rAZ
-spK
-nnU
-iUI
-cBA
-uov
+pkv
+myR
+erd
+ksH
+lZQ
+ugS
+qBn
+ljB
+aPQ
 cCI
 iXS
-axZ
-doz
-eSZ
-bbR
-mCP
-kLj
-eSZ
-doz
-nnU
-epT
-luc
-gMn
-eWp
-nPZ
-htm
-oTc
+xVM
+sIX
+eFQ
 cuq
 cuq
-xcZ
-pEu
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+aPQ
+hKL
 aoT
-pxU
-hGn
-tHY
-aEf
-cuq
-cuq
-xUW
-hpN
+kUl
+rsx
+rsx
+rsx
+wdQ
+wVu
+rsx
+lsf
 axX
-blM
+mWK
 tWg
-dRA
-dRA
-cYB
-dRA
-dRA
-gjF
-eXj
-hXT
-fhl
+vrJ
+uxX
+cum
 gCj
+taO
+xeV
+doQ
+hbr
+cum
 gCj
-xEz
-aFr
-aFr
-aFr
+kql
+kJd
+tYD
+tYD
+tYD
 tYD
 tYD
 tYD
@@ -206894,82 +204034,82 @@ wfV
 sKd
 kkl
 niF
-vlt
-xOv
-aAz
-xOv
-cKt
-cKt
+ugh
+cAX
+sHs
+iDA
+xom
+gxY
 ntf
-xOv
-aSr
-xOv
-vlt
+qWp
+nXP
+sHs
+cYY
 fHM
-ilP
+qaT
 qFQ
-htm
-alr
-fZm
-fZm
-qTt
+luc
 nPZ
-qBn
-biB
-spK
-oDC
-kWk
-nnU
-eNk
-xMv
-nnT
+nPZ
+wrs
+ksH
+xZX
+myA
+eIh
+eso
+ksH
+gNu
+gNu
+gNu
+gNu
+aPQ
 lTG
 ogS
-axZ
-ceC
-eSZ
-kLj
-oFu
-flt
-eSZ
-ceC
-nnU
-lpq
-nRE
-nnU
+jfZ
+hBh
+pvt
 eWp
-nPZ
-htm
-cuq
-cuq
-cuq
-xcZ
-iGe
-aoT
-lgM
+eWp
+eWp
+eWp
+eWp
+eWp
+eWp
+eWp
+eWp
+eWp
+eWp
+eWp
+eWp
+eWp
+eWp
+aPQ
+hKL
+bAW
+kql
 mcc
 lPV
-aEf
-cuq
-cuq
-cuq
-hpN
-axX
+eaa
+wdQ
+wBO
+hpB
+smN
+hpB
 gph
-aOV
-dRA
+lWj
+vnH
 qfL
-nCd
 bxT
-kot
-eUj
-gef
+bxT
+rsx
+mnZ
+lsf
 vlJ
 eXj
-vlJ
-vlJ
-hrZ
-dRA
+xQn
+kql
+kJd
+tYD
 tYD
 tYD
 tYD
@@ -207152,81 +204292,81 @@ qpn
 kkl
 niF
 xov
-lbS
-sHs
-oWo
-nYH
-nYH
-nYH
+vsR
+tfT
+nCR
+bDa
+iqu
+hWn
 pwX
 nXP
-oTd
-mgu
-wRY
-wRY
-oTP
-htm
-htm
-htm
-htm
-htm
-lzb
-htm
-htm
-htm
-htm
-htm
-htm
-cDj
+sHs
+ugh
+ugh
+ugh
+ugh
+nnU
+aIw
+luc
+luc
+ksH
+gef
+gZR
+qMG
+usX
+ksH
+eiQ
+clW
+dve
 irF
-jGM
+aPQ
 fHC
-lCq
-axZ
-doz
-eSZ
-kLj
-kLj
-kLj
-eSZ
-doz
-nnU
-nPZ
-nRE
-nnU
-eWp
-xWi
-htm
-cuq
-cuq
-cuq
-xcZ
-wwb
+qIR
+tSK
+vun
 kSS
-dHo
-ovU
-opW
-aEf
-cuq
-cuq
-cuq
-hpN
-hpN
-qnk
-aOV
-dsZ
-dWl
-nCd
-ulb
-kot
-gxY
-reb
-thD
-bGf
-vlJ
-hXT
-aLi
-dRA
+sKl
+sKl
+sKl
+sKl
+sKl
+sKl
+yaj
+nRE
+sCF
+coB
+xWi
+sKl
+sKl
+sKl
+aEP
+aPQ
+jqC
+pWl
+kql
+qWJ
+xkx
+rsx
+rsx
+pCT
+rsx
+wTC
+tEH
+jst
+mWK
+vnH
+aOx
+wTC
+rsx
+lQu
+pYJ
+rsx
+rsx
+rsx
+shl
+kql
+kJd
+tYD
 tYD
 tYD
 tYD
@@ -207409,81 +204549,81 @@ xJU
 kkl
 niF
 xov
-egv
-sHs
-rJT
-eJe
-miI
-miI
-mrl
-nXP
+ymg
+ckQ
+kDm
+ePl
+dWc
+ePl
+ePl
+lQd
 kBT
 ugh
 taN
 vTk
 osV
-ugh
-hZk
-uiY
-rQM
-htm
-htm
-htm
-gqq
+bej
+bej
+bej
+bej
+ksH
+qtA
+rYC
+eIh
 ylO
-dve
-gqq
-gNu
+ksH
+nWt
+emb
+wfo
+agC
+aPQ
 axZ
-axZ
-gNf
-axZ
-axZ
-axZ
-ceC
-eSZ
-uPP
+pIn
+qIR
+vun
 cCx
-kLj
-eSZ
-ceC
-nnU
-nPZ
+cCx
+cCx
+cCx
+cCx
+cCx
+cCx
 kat
-nnU
-eWp
-nnU
-htm
+kat
+kat
+kat
+whU
+cCx
 xJj
-cuq
-cuq
-xcZ
-nMm
+qIR
+dXY
+aPQ
+xJd
 bAW
 arb
-ydt
-lFJ
-aEf
-cuq
-cuq
-pvg
-hpN
-liz
-gph
-iCW
-dRA
-laY
-htZ
-pHR
-kot
+lsf
+lQu
+rsx
+tEO
+wVu
+rsx
+wdQ
+wdQ
+rsx
+mRy
+vnH
+lLj
+hpB
+hpB
+rNF
 ftz
-hXT
-ioa
-kLX
-eXj
-evb
-dRA
-dRA
+rsx
+rsx
+hpB
+uPu
+kql
+kJd
+tYD
 tYD
 tYD
 tYD
@@ -207666,80 +204806,80 @@ sKd
 kkl
 niF
 ugh
-xbq
-sHs
-wBX
-xom
-miI
-wnH
-qWp
+ugh
+xyU
+dXj
+xyU
+ugh
+lWh
+uhV
 mCv
 izA
-ugh
+vwY
 maY
 ngX
-pdo
-qjN
+qIF
+bej
 nqn
-eIh
+hND
 oLe
-sqp
+ksH
 mTi
-gNu
-nWt
-emb
-wfo
-agC
-gNu
+gZR
+vwS
+eBF
+ksH
+tVC
+haA
 ffj
-lYf
-fgW
+fCN
+aPQ
 cKJ
 fsA
-axZ
-oSw
-eSZ
+qIR
+ahK
+oQF
 oQF
 bnr
 qgo
-htm
-nnU
-nnU
-biB
-nnU
-nnU
-eWp
-nqw
-htm
-cuq
-cuq
-cuq
-xcZ
-sWX
-dWG
-arb
-ydt
-nQs
-aEf
-cuq
-cuq
-cuq
-hpN
-hpN
-dRA
-cvE
-dRA
-dRA
-qHD
-nCd
-kot
-vlJ
-eXj
-rui
-hXT
-nFL
+oEO
+oQF
+oQF
+oQF
 swh
-dRA
+qIR
+qIR
+qIR
+qIR
+qIR
+qIR
+gNZ
+aPQ
+xJd
+aoT
+kql
+rsx
+hpB
+hpB
+vbq
+dSK
+lsf
+wdQ
+wdQ
+xkx
+uvW
+skA
+ebX
+rsx
+xkx
+wdQ
+wVu
+rsx
+wTC
+hpB
+rsx
+kql
+kJd
 tYD
 tYD
 tYD
@@ -207922,81 +205062,81 @@ wfV
 qZW
 kkl
 niF
+oKR
+cdO
+eKB
+eKB
+srj
 ugh
-cAX
-sHs
-gno
-xom
-vWk
 qac
-qWp
-mCv
+pLh
+muc
 rUb
-ugh
+lmZ
 rJX
-rGV
+uUN
 cOZ
-ugh
+bej
 udb
-pIy
+mFN
 wSc
-xMU
+fst
 urR
-gNu
-tsI
-haA
+gTQ
+urR
 ksH
-fCN
-gNu
+ksH
+ksH
+eAB
 oQA
-nrE
-hZc
+eAB
+aPQ
 dbS
-jnH
-axZ
+qIR
+qIR
 pBU
 ciR
 iIJ
 ntY
 aCH
-nnU
-rBy
-lpq
-lpq
-nPZ
-nnU
-eWp
-xXq
-htm
-cuq
-cuq
-cuq
-xcZ
-sWX
+ylP
+fNS
+fNS
+fNS
+fNS
+fNS
+fNS
+fNS
+fNS
+fNS
+fNS
+iUb
+aPQ
+xJd
 dWG
 xoI
-ydt
-akg
-aEf
-cuq
-cuq
-cuq
-jqC
-bGB
-koX
-sUh
-rMZ
-dRA
-iXs
-htZ
-dRA
+wdQ
+wdQ
+lQu
+lQu
+hlG
+cIc
+vGX
+dlS
+wAl
+tyo
+hPv
+tyo
+rsx
+rsx
+rsx
 gRP
-gYr
-iwu
-vlJ
-nFL
-mQo
-dRA
+rsx
+rsx
+lsf
+rsx
+lif
+kJd
 tYD
 tYD
 tYD
@@ -208179,84 +205319,84 @@ wfV
 bMt
 kkl
 niF
-oXy
-kvp
-tfT
-nCR
-gXY
-iqu
-hWn
-qNi
-mCv
-kCm
+oKR
+vEK
+wWf
+iJE
+vEW
 ugh
 ugh
 ugh
 ugh
 ugh
+ugh
+yiF
+uUN
+cOZ
+bej
 xbg
-aVh
+bkE
 xqB
-brs
+fst
 cpi
-gNu
-eAB
+vQV
+nIk
 jJa
 vXn
-eAB
-gNu
-upi
-lVn
-hZc
-aqm
-sdE
-axZ
-bWX
-jvh
-lXy
-cZo
-sRe
-grH
-lpq
-nPZ
-nPZ
-ezr
+ksH
+vSA
+kLy
+qzV
+aPQ
+vYz
+qIR
+jQE
+pBU
+gjF
 rxj
-cJy
-luc
-htm
+rxj
+rxj
+rxj
+rxj
+rxj
+rxj
+rxj
+rxj
+rxj
+rxj
+rxj
+rxj
+rxj
+rxj
 aPQ
-aPQ
-aPQ
-xcZ
-sWX
-dWG
-arb
-kmK
-mNz
-aEf
-aPQ
-aPQ
-aPQ
-jqC
-eTz
-rMZ
-xiX
-rMZ
-dRA
-dRA
-dRA
-dRA
-dRA
-dRA
-dRA
-dRA
-xVM
-dRA
-dRA
+xJd
+wdB
+xoI
+wdQ
+wdQ
+wTC
+lsf
+sWA
+hlG
+dSK
+hlG
+dSK
+vcA
+qqt
+sWA
+hlG
+dSK
+abz
+lus
+rsx
+rsx
+lsf
+rsx
+lif
 kJd
-kJd
-kJd
+tYD
+tYD
+tYD
 tYD
 tYD
 tYD
@@ -208436,84 +205576,84 @@ epI
 shW
 kkl
 niF
-oXy
-ymg
-ckQ
-kDm
-ePl
-mgr
-ePl
-ePl
+oEe
+bRF
+vLb
+rkX
+fUp
+vQL
+ppF
+jhg
 fTg
-hDn
-lmZ
+pCY
+ppF
 esC
 gzg
-khb
-dVk
+gzg
+qzo
 vgI
-isn
+gDg
 knL
 fst
 ttM
 pSp
-eRF
-mUQ
+bTl
+nGC
 aHl
-qzV
-ndV
-oQA
+ksH
+eRF
+jze
 ubo
-hZc
-jNb
-tKJ
-axZ
-mCa
-ffg
-nKH
-sGs
-clW
-nnU
-sDE
-amm
-nPZ
-elu
-rzl
-cJy
-luc
-htm
-bwq
-oof
-ktW
-lNo
-sKl
-oEi
-arb
+aPQ
+cuq
+ksS
 qIR
-tCI
-vaA
-qzl
-qzl
-qQJ
+vun
+ffg
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+aPQ
 jqC
-rNF
-koX
-cMg
-iuc
-iuc
-iuc
+oEi
+kql
+cUx
+pqy
+dPd
+rVV
+qzl
+pqy
+umx
+rVV
+dPd
+pqy
+wQw
+tyo
+hGN
 iuc
 qim
-owY
-brb
-gUR
-gUR
-uxi
-uxi
-brG
-bPs
-xMV
+lsf
+rsx
+wAl
+rsx
+peE
+kql
 kJd
+tYD
+tYD
+tYD
 tYD
 tYD
 tYD
@@ -208693,84 +205833,84 @@ epI
 bhN
 kkl
 hmb
-ugh
-ugh
-xyU
-dXj
-xyU
-ugh
-lWh
-kBY
-tls
-jUH
-vwY
+rfw
+jcg
+fGz
+oXd
+fzN
+xNr
+uWD
+jGZ
+jGZ
+dCJ
+xtI
 gVF
 rEu
 lPH
-gxU
+mjQ
+wvS
 tWs
-tWs
-tWs
-hwy
+wtl
+fst
 sBa
 bZw
 jYo
 mUQ
 cEB
-qDk
-ndV
+ksH
+ktZ
 uKS
 jsr
-rCa
-abG
+aPQ
+cuq
 ksS
-axZ
-vun
-jvh
-jsR
-sGs
-nzQ
-nnU
-pPG
-elu
-elu
-elu
-rzl
-cJy
-nnU
-htm
-oNO
 qIR
-vNQ
-xJd
-xJd
-xJd
-erN
-qMG
-wJW
-foW
+vun
+kzo
 cuq
 cuq
-dzy
-jqC
-slu
-koX
-nGC
-rMZ
-eaK
-bTH
-uNe
-koX
-koX
-rMZ
-wxD
-rMZ
-fCw
-fCw
-bTH
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+aPQ
+xJd
+jWy
+kql
+kql
+kql
+kql
+kql
+pEu
+kql
+kql
+kql
+kql
+kql
+qsk
+lvh
+rsx
+lsf
+lsf
+lsf
+wdQ
+wdQ
+wdQ
+rsx
+kql
 kJd
-kJd
-kJd
+tYD
+tYD
+tYD
 tYD
 tYD
 tYD
@@ -208950,81 +206090,81 @@ iSr
 ocr
 kkl
 niF
-oKR
-cdO
-eKB
-eKB
-srj
-ugh
-jgK
+oEe
+bRF
+ulB
+uiF
+gLA
+dmb
+ppF
 iXW
-caH
-hND
-lmZ
-xdc
-uUN
+hJI
+dVb
+ppF
+uuw
+lIs
 kQc
-dVk
+mjQ
 mZH
 kXk
 sdy
-myR
+fst
 rUy
-ndV
+uiT
 gls
 tsW
 lCP
-kaw
-ndV
+ksH
+uiy
+gEP
 upi
-upi
-cPM
+aPQ
 uCA
-upi
-axZ
+egY
+jEn
 phm
 mYH
-xPp
-jcj
+cuq
+cuq
 ahi
-nnU
-pPG
-nPZ
-lHy
-xWi
-nnU
-cJy
-nPZ
-htm
-oha
-vHV
-fmP
-azO
-kwR
+cuq
+cuq
+cuq
+cuq
+cuq
+cuq
+ahi
+cuq
+cuq
+cuq
+cuq
+cuq
+aPQ
+xJd
 rsz
-mdW
-qIR
-yaq
-qxg
-cuq
-cuq
-dzy
-jqC
-tuz
-rMZ
-nGC
-rMZ
-bTH
-bTH
-htd
-htd
-bTH
-bGB
-rMZ
-bTH
-bTH
-bTH
-bTH
+kql
+dnX
+dnX
+hwx
+xkq
+owY
+dLD
+wRG
+oIz
+uIO
+kql
+kFx
+oSx
+rsx
+wdQ
+bXy
+wTC
+wdQ
+pIo
+wdQ
+xkx
+lif
+kJd
 tYD
 tYD
 tYD
@@ -209208,80 +206348,80 @@ sKd
 kkl
 niF
 oKR
-vEK
-wWf
-iJE
-vEW
-ugh
-ugh
-ugh
-ugh
-ugh
-ugh
+cVU
+diI
+goj
+kbG
+ord
+hub
+hub
+hub
+hub
+hub
 xdc
-uUN
-kQc
-iJe
-fhA
-fhA
-fhA
-fhA
-iJe
-ndV
-ndV
-gwK
-ndV
-ndV
-ndV
-oId
-vbv
-lnb
-uUN
-eYB
-ppF
-oSw
-qkv
-qkv
 lIs
-oSw
-nnU
-nnU
-nnU
-nnU
-nnU
-nnU
-jQV
-nnU
-htm
+kQc
+bej
+bxM
+bxM
+bxM
+fst
+iJe
+bGb
+iJe
+iJe
+ndV
+ksH
+gNu
+gwK
+gNu
+aPQ
+eYB
+eYB
+oVO
+tJN
+oVO
+eYB
+eYB
+eYB
+eYB
+eYB
+eYB
+eYB
+eYB
+eYB
+eYB
+eYB
 aPQ
 aPQ
-hOm
 aPQ
 aPQ
+aPQ
+jqC
 rpy
-qJs
-noo
-jqC
-jqC
-jqC
-jqC
-jqC
-jqC
-jqC
-bGB
-sUh
-bGB
-bGs
-hob
-hob
-sLJ
-bTH
-tvA
-rMZ
-eTz
-bTH
-job
-job
+kql
+dnX
+dnX
+dLD
+urL
+urL
+urL
+urL
+urL
+nCG
+kql
+qGD
+rkx
+rsx
+rsx
+rsx
+rsx
+wdQ
+wdQ
+wdQ
+rsx
+lif
+kJd
 tYD
 tYD
 tYD
@@ -209464,19 +206604,19 @@ twh
 sKd
 kkl
 sKd
-oEe
-bRF
-vLb
-rkX
-fUp
-vQL
-ppF
+oKR
+qxK
+lyI
+lyI
+vBO
+ord
+jsR
 ndl
 rCL
-pCY
-ppF
-xdc
-uUN
+lsJ
+iLA
+vSb
+lIs
 cKl
 jZa
 jZa
@@ -209484,60 +206624,60 @@ exb
 jZa
 jZa
 xjk
+oib
 uUN
 uUN
+eyE
+eyE
+pwQ
 lYW
-eyE
-eyE
-reB
-vbv
 uUN
-wWV
 uUN
-eyE
-cLI
+opW
 eYf
+cLI
+dys
 eyE
 eyE
-vVN
+uUN
 reB
 eyE
 pdV
-ape
+eyE
 mvt
 ppF
-brv
-vye
-gQK
-aPQ
-uQw
-qHI
-lqP
-jZL
-aPQ
-atR
-baY
-aey
-jqC
-xaW
-kRe
-kIk
-rnD
-bTH
-cRY
-rMZ
-sUh
-rMZ
-rMZ
-rMZ
-koX
-kak
-htd
-bli
-koX
 cil
-qWL
-tYD
+cNR
+rMZ
+rMZ
+rMZ
+rMZ
+rMZ
+rMZ
+ugE
+ugE
+kql
+dnX
+dnX
+dLD
+urL
+dLD
+dLD
+dLD
+dLD
+wRG
+kql
+pGJ
+rsx
+rNH
+lsf
+rsx
+rsx
+fMY
+rsx
+rsx
+lsf
+kql
 kJd
 tYD
 tYD
@@ -209721,17 +206861,17 @@ twh
 jsz
 dhd
 wUQ
-rfw
-jcg
-fGz
-baH
-fzN
-xNr
-uWD
-jGZ
-jGZ
-dCJ
-xtI
+ord
+ord
+gXY
+bUt
+bUt
+ord
+wAt
+sJI
+bCn
+gUB
+iVY
 mAR
 vSd
 uDf
@@ -209741,62 +206881,62 @@ dCJ
 dCJ
 dCJ
 chs
-qZA
-qZA
-qZA
+cTB
+mAR
+mAR
 fwx
+mAR
+mAR
+mAR
 qZA
-qZA
-qZA
-qZA
-pWl
+mAR
 qZA
 qZA
 chs
 qZA
 qZA
 eGN
-qMY
+lYW
 lYW
 fDn
-lYW
-lYW
-lYW
+kJj
+kJj
+kJj
 dvy
-pKt
-hqy
-mRd
-rLu
-kel
+sZD
+lzr
+ugE
+ugE
+ugE
 kel
 jqR
 nYo
-aPQ
-dEy
-woY
-hpu
-jqC
-xaW
-wLp
+ugE
+hDD
+kql
+dnX
+dnX
+dLD
+moz
 rVN
-oHD
-bTH
-xMa
-tLv
-sCc
-bTH
-bTH
-bTH
-rMZ
-noi
-htd
-mJr
-koX
-eaK
-qWL
-tYD
+lrf
+wRG
+xeQ
+qBS
+kql
+kql
+kql
+kql
+kql
+kql
+kql
+kql
+lif
+lif
+kql
+kql
 kJd
-tYD
+kJd
 tYD
 tYD
 tYD
@@ -209978,33 +207118,33 @@ twh
 sKd
 frw
 sKd
-oEe
-bRF
-ulB
-uiF
-gLA
-dmb
-ppF
-iYX
-hJI
-dVb
-ppF
+ord
+mTJ
+pbx
+qPc
+amp
+xsG
+bSX
+arz
+sCT
+ejf
+iLA
 rrN
-vVN
 uUN
-aGV
+srh
+qIF
 maa
 aZf
 qIF
 qIF
 sVl
-ahK
+qIF
 qIF
 sSW
 vVN
 uUN
-aZf
 qIF
+eVH
 qIF
 qIF
 qIF
@@ -210018,39 +207158,39 @@ aZf
 maa
 qIF
 qIF
-qIF
-ppF
-iwl
 apA
-tcJ
-aPQ
-pkI
-kHF
-wAt
-ppI
-jqC
-jqC
-jqC
-jqC
-jqC
-dwn
-glx
-qAC
-odl
-bTH
-cRY
-koX
-hpd
-bTH
-gJs
-bTH
-bTH
-fju
-bTH
-mJr
+ppF
+eaK
+lzr
 rMZ
-tuz
+wue
+pkI
+jqC
+jqC
+jqC
+jqC
+eUZ
+eUZ
 bTH
+bTH
+htd
+bTH
+qAC
+htd
+htd
+htd
+bTH
+bTH
+piI
+suj
+rMZ
+mJr
+bTH
+kJd
+kJd
+kJd
+kJd
+kJd
 kJd
 kJd
 kJd
@@ -210235,21 +207375,21 @@ vDD
 sKd
 frw
 bMM
-oKR
-ulv
-diI
-goj
-kbG
+qeA
+fmJ
+tHY
+iXk
+iXk
+hzz
+tqy
+nEE
+nEE
+fVX
 ord
-hub
-hub
-hub
-hub
-hub
-dyW
-vVN
-qIF
-ueh
+rrN
+uUN
+srh
+pvD
 pvD
 pvD
 kuE
@@ -210260,18 +207400,18 @@ pvD
 wSC
 vVN
 uUN
-uuw
-bej
-bxM
-bxM
-bxM
-uzL
-uzL
-hbu
-hbu
+qIF
+aVh
+fIv
+fIv
+fIv
+aVh
+oSw
+qkv
+qkv
 edl
-hbu
-uzL
+qkv
+oSw
 ppF
 gYA
 gYA
@@ -210283,31 +207423,31 @@ bTH
 jqC
 jqC
 jqC
-jqC
-jqC
-jqC
 tmR
-dny
+sCc
 oNg
 bTH
-bTH
+dny
+tOz
+vOs
+rMZ
 btA
-kLy
-koX
+sZD
+sGh
 bTH
 eTz
-koX
-nGC
-qWL
-gJs
-qWL
-mJr
+lzH
+bTH
+piI
+xVe
 rMZ
-noi
-noi
-wxD
+mJr
 bTH
-bTH
+tYD
+tYD
+tYD
+kJd
+kJd
 kJd
 kJd
 kJd
@@ -210492,22 +207632,22 @@ dsQ
 sKd
 frw
 bMM
-oKR
-qxK
-lyI
-lyI
-vBO
-ord
+qeA
+tTI
+whT
+nqx
+aOt
+rBy
 pWT
-jze
-wav
+ppE
+lnl
 sUq
-iLA
-sSW
-vVN
-qIF
+ord
+liy
+uUN
+oWo
 pvD
-pvD
+nGz
 aEt
 pfj
 uGO
@@ -210518,7 +207658,7 @@ ukQ
 vVN
 uUN
 qIF
-mjQ
+aVh
 qCX
 dqW
 vqE
@@ -210528,43 +207668,43 @@ kKF
 waJ
 jha
 iFc
-hbu
-ceC
-ceC
-ceC
-ceC
+qkv
+kJd
+jNy
+kJd
+kJd
 qWL
 cRY
-arT
+uln
 chw
 wSo
 iQi
 bTH
-kAn
-rMZ
-bTH
 wVn
 mOT
 brJ
+bTH
+ntO
+lfM
 oQi
 vOs
-jKc
 bTH
-fju
+sZD
+rMZ
 bTH
 eTz
-txL
-nGC
-qWL
-gJs
-qWL
+cJy
+bTH
+piI
+kAn
+jQj
 oxz
-koX
-cRY
-rMZ
-rMZ
 bTH
 tYD
+tYD
+tYD
+kJd
+kJd
 kJd
 tYD
 kJd
@@ -210749,23 +207889,23 @@ epI
 bhN
 frw
 igt
-ord
-ord
-eaa
-bUt
-bUt
-ord
+qeA
+tMe
+mTH
+ifY
+pHR
+oTd
 opl
-sJI
-bCn
-gUB
-iVY
-qZA
-qMY
+jKc
+oax
+gKM
+ord
+ktW
+uUN
 xdP
 pvD
 jJD
-bLz
+fHL
 msr
 oIV
 bxc
@@ -210775,53 +207915,53 @@ sSW
 vVN
 uUN
 qIF
-mjQ
+aVh
 fAT
 snG
-rMt
-uzL
-pxu
+vXP
+umd
+arT
 upO
-bvP
-uRz
+jvh
+sGs
 tIw
-qhM
-qhM
-qhM
-qhM
-qhM
+eSZ
+eSZ
+eSZ
+eSZ
+eSZ
 jqC
 tuz
-gTU
+aYy
 pao
 qWL
 leb
 bTH
 slu
-rMZ
-bTH
+iZN
+cVd
 pND
 rYm
-cVd
-wzL
-oQi
-pPt
+amm
+kRe
+cDt
+bTH
+sZD
+rMZ
+rMZ
+koX
+koX
 bTH
 cRY
-cRY
-koX
-koX
-nGC
-bTH
-gJs
-bTH
-koX
-wrs
+eaK
+rMZ
+wrk
 bTH
 bTH
 bTH
 bTH
 bTH
+doI
 dFP
 dFP
 dFP
@@ -211006,22 +208146,22 @@ sKd
 xJU
 frw
 bMM
-ord
-mTJ
-pbx
-qPc
+lNo
+lNo
+lNo
+lNo
 tvB
-xsG
-bSX
-arz
-sCT
-ejf
-iLA
+tvB
+tvB
+lNo
+lNo
+lNo
+lNo
 gZl
-vYz
+qIF
 wpg
 oHg
-fHL
+tUV
 lTT
 qIg
 sdU
@@ -211032,19 +208172,19 @@ lYW
 vVN
 lYW
 lYW
-qzo
+jcj
 uHZ
-bkE
 nMx
-uzL
+nMx
+vXP
 pxu
 byv
 qMU
 byv
 heR
-qhM
+eSZ
 npf
-qed
+kLj
 nnq
 eTT
 jqC
@@ -211054,32 +208194,32 @@ mum
 bTH
 bTH
 bTH
-cil
+bTH
+bTH
+bTH
+hbu
+pjh
+stz
+pjh
+bTH
+bTH
+sZD
 rMZ
-bTH
-bTH
-htd
-htd
-htd
-bTH
-bTH
-bTH
-smN
 rMZ
 koX
 rMZ
-nGC
 bTH
-bTH
-bTH
-koX
+cRY
 rMZ
+rMZ
+cRY
 htd
 siR
 lpk
 vEC
 bTH
-dFP
+doI
+kJd
 tYD
 tYD
 tYD
@@ -211263,21 +208403,21 @@ sKd
 sKd
 frw
 bMM
-qeA
-fmJ
+gxU
+dIb
 snc
 qKv
-whT
-hzz
-tqy
-nEE
-nEE
+dGH
+sCn
+pDf
+gGO
+hpu
 xjo
-jqC
-jqC
+lBV
+kYs
 pte
-jqC
-jqC
+sNf
+pvD
 sjx
 fHL
 mIi
@@ -211289,54 +208429,54 @@ sSW
 vVN
 uUN
 sJo
-bej
+aVh
 ekX
-gDg
+qNi
 bpH
-uzL
+bUe
 kuV
 wqQ
 vti
-cHo
+jvh
 wia
 wDN
 ylQ
-qed
-qed
-qed
+kLj
+kLj
+kLj
 iWp
 jqC
 qWs
-kVf
+oPK
 rCO
 hHq
 cUa
-pJM
-fyT
+wxD
+wxD
 bTH
-sZD
-mtM
-nvS
-byD
-sZD
-iyY
-pRh
-eWa
+htd
+htd
+htd
+htd
+bTH
+fki
+oek
+fki
 xhf
 xhf
 eWa
 jUq
-qWL
+piI
 rMZ
-cQk
-koX
+rMZ
 rMZ
 bTH
 cqE
 lPj
 oVR
 bTH
-dFP
+kJd
+kJd
 tYD
 jMT
 oSR
@@ -211520,21 +208660,21 @@ epI
 uyg
 frw
 bMM
-qeA
-tTI
-mTH
+uRz
+slk
 naH
-iXk
-hzz
-bSX
-nEE
-nEE
+naH
+naH
+mMe
+abG
+abG
+pSl
 iTE
-jqC
-cil
-sZD
-wxD
-jqC
+lNo
+jNb
+pte
+xim
+pvD
 pDR
 wDG
 tXh
@@ -211544,23 +208684,23 @@ bQl
 pvD
 xjR
 vVN
-uUN
+uYk
 uKw
-bej
+aVh
 cTb
-mFN
 vXP
-uzL
+vXP
+jjv
 jtA
-jDM
+wqQ
 hsn
 rZm
 jgi
 kWn
 dbt
-qed
-qed
-qed
+kLj
+kLj
+wsd
 gpW
 jqC
 uCo
@@ -211569,22 +208709,21 @@ mum
 bTH
 bTH
 tAt
-wDz
+fki
 lcD
-eWa
-kxa
+fki
+fki
 kxa
 vny
 vny
-cVl
+fki
 bTH
 tuz
 rMZ
 rMZ
-rMZ
 sZD
+pxn
 rMZ
-koX
 koX
 uBS
 rMZ
@@ -211593,6 +208732,7 @@ tiC
 djX
 rnE
 bTH
+kJd
 jEN
 kJd
 jMT
@@ -211777,20 +208917,20 @@ ljw
 sKd
 frw
 bMM
-qeA
+tea
 slk
-whT
-nqx
-aOt
+ker
+aqm
+vHV
 ulV
-lsE
-ppE
-lnl
+abG
+qnk
+wae
 hHv
-jqC
-iBV
-mxz
-rMZ
+lNo
+qeT
+ulv
+ulb
 jqC
 jqC
 jqC
@@ -211803,21 +208943,21 @@ bTH
 oIi
 bTH
 bTH
-bej
+aVh
 dbD
 ojU
 fSv
-uzL
+rmw
 xPQ
 ggE
-jgF
+vSw
 vSw
 lpI
 vcR
-qed
-qed
-qed
-qed
+kLj
+kLj
+kLj
+kLj
 eaz
 jqC
 gPY
@@ -211838,18 +208978,18 @@ bTH
 bTH
 bTH
 bTH
-rMZ
 sZD
-qWL
+jUq
+piI
 rMZ
 rMZ
-rMZ
 bTH
 bTH
 bTH
 bTH
 bTH
 bTH
+kJd
 kJd
 tYD
 jMT
@@ -212034,7 +209174,7 @@ cXd
 sKd
 frw
 qkC
-ord
+gxU
 dzT
 kMh
 drZ
@@ -212044,12 +209184,12 @@ nKg
 fCh
 tda
 fvV
-jqC
+lNo
 jaj
-mxz
+kEA
 rMZ
-bGs
-doX
+blE
+rMZ
 wxD
 wxD
 wxD
@@ -212064,15 +209204,15 @@ bTH
 bTH
 bTH
 bTH
-jqC
+eSZ
 cax
-qed
+cax
 qZQ
-qed
+cax
 sDi
-qhM
-qed
-qed
+eSZ
+kLj
+kLj
 iZF
 nNJ
 jqC
@@ -212095,13 +209235,13 @@ bTH
 jWH
 jWH
 htd
-rMZ
 unm
 bTH
+bTH
 eTz
-eaK
 cua
 jqC
+tYD
 tYD
 tYD
 tYD
@@ -212291,19 +209431,19 @@ dna
 swL
 yhf
 rqx
-ord
-ord
-ord
-ord
-ord
+lNo
+lNo
+lNo
+lNo
+lNo
 jqC
 jqC
-igh
+jqC
 jqC
 jqC
 jqC
 cQE
-ugE
+gTU
 ugE
 nwC
 ugE
@@ -212320,18 +209460,18 @@ eLd
 lzr
 lzr
 lzr
-lzr
-jqC
-qed
-twP
-jNa
-twP
+mPy
+eSZ
+kLj
+kLj
+kLj
+kLj
 nCb
-qhM
-qhM
-qhM
-qhM
-qhM
+eSZ
+eSZ
+eSZ
+eSZ
+eSZ
 jqC
 vkt
 uln
@@ -212353,7 +209493,7 @@ fSb
 obY
 htd
 xCS
-unm
+aEU
 bTH
 fOt
 fOt
@@ -212549,7 +209689,7 @@ eTa
 lVS
 nlH
 nNS
-fjY
+uYW
 aTJ
 fjY
 xth
@@ -212559,8 +209699,8 @@ rMZ
 aWs
 aWs
 dHi
-wxD
-tLv
+fIR
+nOm
 htd
 bTH
 fju
@@ -212578,13 +209718,13 @@ cRY
 rMZ
 rMZ
 tIN
-jqC
-cEJ
+eSZ
+kLj
+kLj
+oFu
+kLj
 qed
-ufy
-qed
-qed
-qhM
+eSZ
 ceC
 cXu
 ceC
@@ -212817,7 +209957,7 @@ sdq
 sTD
 bxo
 rMZ
-tuz
+iBV
 htd
 gUu
 rMZ
@@ -212835,13 +209975,13 @@ jqC
 oMq
 rMZ
 lzr
-jqC
-jqC
-qed
+eSZ
+kLj
+kLj
 bOi
-qed
-jqC
-jqC
+erN
+kLj
+eSZ
 bTH
 bTH
 bTH
@@ -213092,13 +210232,13 @@ jqC
 iBV
 rMZ
 lzr
-cRY
-jqC
-jqC
-jqC
-jqC
-jqC
-cRY
+eSZ
+eSZ
+eSZ
+eSZ
+eSZ
+eSZ
+eSZ
 hmi
 sLt
 sLt
@@ -213596,7 +210736,7 @@ bTH
 aly
 oLt
 yfh
-but
+yfh
 eFv
 sce
 uhw
@@ -213853,7 +210993,7 @@ cCP
 tSp
 orr
 yfh
-jsl
+yfh
 uMg
 uwD
 axy
@@ -214146,9 +211286,9 @@ bTH
 dHO
 bTH
 bTH
-xRt
-xRt
-xRt
+kJd
+kJd
+kJd
 qWL
 nCJ
 ePt
@@ -214403,9 +211543,9 @@ asr
 iod
 oWj
 bTH
-xRt
-xRt
-xRt
+kJd
+kJd
+kJd
 qWL
 jVy
 ePt
@@ -214639,7 +211779,7 @@ bTH
 rMZ
 wxD
 doX
-wxD
+rMZ
 uFB
 fRM
 bTH
@@ -214660,9 +211800,9 @@ dUT
 ePt
 eyu
 bTH
-xRt
-xRt
-xRt
+kJd
+tYD
+kJd
 bTH
 bTH
 bLW
@@ -214877,8 +212017,8 @@ kJd
 tYD
 tYD
 cCP
-uwD
-uwD
+eDS
+eDS
 dYm
 neh
 sSX
@@ -214894,7 +212034,7 @@ sZD
 iVv
 bTH
 bTH
-qMZ
+rMZ
 wfi
 jzF
 qMZ
@@ -214917,10 +212057,10 @@ aeL
 dWh
 pQs
 bTH
-xRt
-xRt
-xRt
-qlS
+kJd
+tYD
+tYD
+kJd
 bTH
 qWL
 qWL
@@ -215175,9 +212315,9 @@ obD
 bTH
 bTH
 bTH
-rvk
-xRt
-mpV
+tYD
+tYD
+tYD
 tYD
 tYD
 tYD
@@ -215432,9 +212572,9 @@ vBp
 vBp
 uYT
 bTH
-xRt
-xRt
-qlS
+tYD
+tYD
+tYD
 tYD
 tYD
 tYD
@@ -215689,9 +212829,9 @@ qMB
 vBp
 xOQ
 bTH
-xRt
-xRt
-mpV
+tYD
+tYD
+tYD
 tYD
 tYD
 tYD
@@ -215946,9 +213086,9 @@ vBp
 vBp
 xNp
 bTH
-xRt
-xRt
-qlS
+kJd
+tYD
+tYD
 tYD
 tYD
 tYD
@@ -216172,9 +213312,9 @@ hkN
 vLK
 vjX
 vLK
-aut
 xRt
-aut
+xRt
+xRt
 qWL
 lsX
 qWL
@@ -216203,9 +213343,9 @@ ouf
 xOQ
 bTH
 bTH
-rvk
-xRt
-mpV
+kJd
+tYD
+tYD
 tYD
 tYD
 tYD
@@ -216427,14 +213567,14 @@ tYD
 kJd
 kJd
 kJd
-tYD
+kJd
 trM
-xRt
-aut
-aut
-xRt
+kJd
+kJd
+kJd
+trM
 low
-xRt
+trM
 bTH
 bTH
 bTH
@@ -216459,10 +213599,10 @@ bTH
 bTH
 bTH
 bTH
-xRt
-xRt
-xRt
-qlS
+kJd
+tYD
+tYD
+tYD
 tYD
 tYD
 tYD
@@ -216686,15 +213826,15 @@ dFP
 tYD
 tYD
 trM
-xRt
-aut
-xRt
-xRt
+kJd
+kJd
+kJd
+kJd
 low
-xRt
-aut
-xRt
-xRt
+kJd
+kJd
+kJd
+kJd
 bTH
 bTH
 bTH
@@ -216711,15 +213851,15 @@ bTH
 koX
 rMZ
 bTH
-xRt
-xRt
-xRt
-rtT
-xRt
-xRt
-xRt
-xRt
-sZT
+kJd
+kJd
+kJd
+kJd
+kJd
+kJd
+tYD
+tYD
+tYD
 tYD
 tYD
 tYD
@@ -216943,18 +214083,18 @@ dFP
 tYD
 tYD
 trM
-xRt
-xRt
-xRt
-xRt
+tYD
+kJd
+kJd
+kJd
 low
-xRt
-xRt
-xRt
+kJd
+kJd
+kJd
 aut
-xRt
-xRt
-aut
+kJd
+kJd
+kJd
 bTH
 bTH
 qWL
@@ -216968,15 +214108,15 @@ bTH
 cNR
 tqg
 bTH
-xRt
-xRt
-xRt
-xRt
-xRt
-xRt
-xRt
-xRt
-mpV
+kJd
+tYD
+tYD
+tYD
+tYD
+tYD
+tYD
+tYD
+tYD
 tYD
 tYD
 tYD
@@ -217200,40 +214340,40 @@ kJd
 tYD
 tYD
 trM
-xRt
-xRt
-xRt
-xRt
+tYD
+kJd
+tYD
+tYD
 low
-xRt
-xRt
-xRt
-xRt
-xRt
-xRt
-xRt
-xRt
-xRt
-xRt
-xRt
-xRt
-xRt
-xRt
-xRt
-xRt
+tYD
+kJd
+kJd
+kJd
+kJd
+kJd
+kJd
+kJd
+kJd
+kJd
+kJd
+kJd
+kJd
+kJd
+kJd
+kJd
 bTH
 bTH
 bTH
 bTH
-jLS
-vEX
-jLS
-bQQ
-xRt
-xRt
-xRt
-dGH
-pXp
+tYD
+tYD
+tYD
+tYD
+tYD
+tYD
+tYD
+tYD
+tYD
 tYD
 tYD
 tYD
@@ -217458,15 +214598,29 @@ tYD
 tYD
 trM
 tYD
-xRt
-xRt
-xRt
+kJd
+tYD
+tYD
 low
-xRt
+tYD
+tYD
+tYD
+tYD
+tYD
+tYD
+tYD
+tYD
+tYD
+tYD
+tYD
+tYD
+tYD
+tYD
+tYD
+tYD
+tYD
 kJd
 kJd
-kJd
-kJd
 tYD
 tYD
 tYD
@@ -217476,20 +214630,6 @@ tYD
 tYD
 tYD
 tYD
-tYD
-tYD
-tYD
-kJd
-kJd
-tYD
-tYD
-tYD
-tYD
-saU
-xRt
-xRt
-dGH
-pXp
 tYD
 tYD
 tYD
@@ -217716,11 +214856,10 @@ tYD
 trM
 tYD
 kJd
-xRt
-xRt
+tYD
+tYD
 low
 tYD
-kJd
 tYD
 tYD
 tYD
@@ -217743,9 +214882,10 @@ tYD
 tYD
 tYD
 tYD
-cZP
-xRt
-dGH
+tYD
+tYD
+tYD
+tYD
 tYD
 tYD
 tYD
@@ -217973,8 +215113,8 @@ tYD
 trM
 tYD
 kJd
-xRt
-xRt
+tYD
+tYD
 low
 tYD
 tYD
@@ -218000,9 +215140,9 @@ tYD
 tYD
 tYD
 tYD
-saU
-kTP
-pXp
+tYD
+tYD
+tYD
 tYD
 tYD
 tYD


### PR DESCRIPTION
## Что этот PR делает

В рнд пересены генетика, пост сб ближе к входу, добавлена комната рд, циркуиты соединены с экспериментором, ксено перевернуто вертикально, малое изменение робо. Сад пересен с нижнего этажа на верхний.

## Почему это хорошо для игры

Приближаем огромную коробку к более понятной и удобной.

## Изображения изменений

![StrongDMM-2025-02-15 03 58 56](https://github.com/user-attachments/assets/3b46a755-7f69-4d67-8fac-782e88af8aeb)
![StrongDMM-2025-02-15 03 52 41](https://github.com/user-attachments/assets/3dd5ad59-20d6-4c29-8233-004e9588f37c)
![StrongDMM-2025-02-15 03 52 47](https://github.com/user-attachments/assets/c84cd221-ff11-44b8-9ba3-d2d3688c62bf)
![StrongDMM-2025-02-15 03 52 53](https://github.com/user-attachments/assets/9370cd12-c8a9-4a27-939d-430b525c7bbd)
![StrongDMM-2025-02-10 18 38 21](https://github.com/user-attachments/assets/07b2a6fc-3610-4b0c-b187-8f552ad92cef)
![StrongDMM-2025-02-10 18 38 13](https://github.com/user-attachments/assets/3596a139-062f-42f6-a639-d6acd9197a3d)

## Тестирование

Локалка

## Changelog

:cl: Кибериада: ремап РНД
map: Добавил, изменил или удалил что-то на карте
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
