### PR TITLE
add point to cooldown for clients and reduce animation speed for arrow

### DIFF
--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -24,7 +24,7 @@
 
 	SEND_SIGNAL(src, COMSIG_MOVABLE_POINTED, pointed_atom, visual, intentional)
 
-	animate(visual, pixel_x = (tile.x - our_tile.x) * ICON_SIZE_X + pointed_atom.pixel_x, pixel_y = (tile.y - our_tile.y) * ICON_SIZE_Y + pointed_atom.pixel_y, time = 1.7, easing = EASE_OUT)
+	animate(visual, pixel_x = (tile.x - our_tile.x) * ICON_SIZE_X + pointed_atom.pixel_x, pixel_y = (tile.y - our_tile.y) * ICON_SIZE_Y + pointed_atom.pixel_y, time = POINT_TIME / 4, easing = EASE_OUT) // BANDASTATION EDIT: 'time = 1.7' => 'time = POINT_TIME / 4'
 	return TRUE
 
 /mob/point_at(atom/pointed_atom, intentional = FALSE)
@@ -115,6 +115,11 @@
 /// either called immediately or in the tick after pointed() was called, as per the [DEFAULT_QUEUE_OR_CALL_VERB()] macro
 /mob/proc/_pointed(atom/pointing_at)
 	if(client) //Clientless mobs can just go ahead and point
+		// BANDASTATION ADDITION START - Point to cooldown
+		if(!TIMER_COOLDOWN_FINISHED(src, "pointed_cooldown"))
+			return FALSE
+		// BANDASTATION ADDITION END - Point to cooldown
+
 		if(ismovable(pointing_at))
 			var/atom/movable/pointed_movable = pointing_at
 			if(pointed_movable.flags_1 & IS_ONTOP_1)
@@ -132,5 +137,10 @@
 				to_chat(src, span_warning("You need to wait before pointing again!"))
 				return FALSE
 	point_at(pointing_at, TRUE)
+
+	// BANDASTATION ADDITION START - Point to cooldown
+	if(client)
+		TIMER_COOLDOWN_START(src, "pointed_cooldown", 1 SECONDS)
+	// BANDASTATION ADDITION END - Point to cooldown
 
 	return TRUE


### PR DESCRIPTION
## Что этот PR делает

Добавляет кулдаун в 1 секунду для point to
Анимация стрелочки занимает 0.6 секунд, вместо 0.17

## Почему это хорошо для игры

Спам стрелочкой выглядит глупо. Мне это не нравится

## Тестирование

Всё работает. Рантаймов нет.

## Changelog

:cl:
add: Добавляет кулдаун в 1 секунду для point to. Анимация стрелочки занимает 0.6 секунд, вместо 0.17
/:cl: