### PR TITLE
[TM] Trying to fix chat BSOD on 516

### DIFF
--- a/tgui/packages/tgui-panel/chat/renderer.jsx
+++ b/tgui/packages/tgui-panel/chat/renderer.jsx
@@ -83,6 +83,9 @@ const handleImageError = (e) => {
   setTimeout(() => {
     /** @type {HTMLImageElement} */
     const node = e.target;
+    if (!node) {
+      return;
+    }
     const attempts = parseInt(node.getAttribute('data-reload-n'), 10) || 0;
     if (attempts >= IMAGE_RETRY_LIMIT) {
       logger.error(`failed to load an image after ${attempts} attempts`);


### PR DESCRIPTION
## Что этот PR делает
Возможный фикс рандомного БСОДа чата на 516

## Changelog

:cl:
del: Хьюстон, у нас проблема.
/:cl:

## Обзор от Sourcery

Исправления ошибок:
- Исправлена потенциальная авария, когда не удается загрузить изображение в рендерере чата, путем добавления проверки на null для узла изображения перед попыткой получить доступ к его атрибутам.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixes a potential crash when an image fails to load in the chat renderer by adding a null check on the image node before attempting to access its attributes.

</details>