### PR TITLE
Nuke codes for station SD, small rework of centcom gear and captain's pen font

### DIFF
--- a/code/datums/components/stationloving.dm
+++ b/code/datums/components/stationloving.dm
@@ -133,9 +133,11 @@
 		/area/shuttle/pod_2,
 		/area/shuttle/pod_3,
 		/area/shuttle/pod_4,
-		/area/shuttle/specops, // BANDASTATION ADDITION - Nuke disk and centcom gear rework
-		/area/shuttle/transport, // BANDASTATION ADDITION - Nuke disk and centcom gear rework
-		/area/shuttle/argos, // BANDASTATION ADDITION - Nuke disk and centcom gear rework
+		// BANDASTATION ADDITION START - Nuke disk and centcom gear rework
+		/area/shuttle/specops,
+		/area/shuttle/transport,
+		/area/shuttle/argos,
+		// BANDASTATION ADDITION END - Nuke disk and centcom gear rework
 	))
 	// Typecache of areas on the centcom Z-level that we allow the disk to stay on
 	var/static/list/disallowed_centcom_areas = typecacheof(list(

--- a/code/datums/components/stationloving.dm
+++ b/code/datums/components/stationloving.dm
@@ -133,6 +133,9 @@
 		/area/shuttle/pod_2,
 		/area/shuttle/pod_3,
 		/area/shuttle/pod_4,
+		/area/shuttle/specops, // BANDASTATION ADDITION - Nuke disk and centcom gear rework
+		/area/shuttle/transport, // BANDASTATION ADDITION - Nuke disk and centcom gear rework
+		/area/shuttle/argos, // BANDASTATION ADDITION - Nuke disk and centcom gear rework
 	))
 	// Typecache of areas on the centcom Z-level that we allow the disk to stay on
 	var/static/list/disallowed_centcom_areas = typecacheof(list(

--- a/modular_bandastation/antagonists/_antagonists.dm
+++ b/modular_bandastation/antagonists/_antagonists.dm
@@ -1,0 +1,4 @@
+/datum/modpack/antagonists
+	name = "Antagonists"
+	desc = "Всякие изменения, которые как либо касаются антагонистов и/или их подтипов."
+	author = "Aloe"

--- a/modular_bandastation/antagonists/_antagonists.dme
+++ b/modular_bandastation/antagonists/_antagonists.dme
@@ -1,0 +1,3 @@
+#include "_antagonists.dm"
+
+#include "code/ert.dm"

--- a/modular_bandastation/antagonists/code/ert.dm
+++ b/modular_bandastation/antagonists/code/ert.dm
@@ -1,14 +1,6 @@
-/datum/antagonist/ert/deathsquad/on_gain() // Give deathsquad nuke code when ERT is summoned
-	. = ..()
-	var/datum/objective/missionobj = new()
-	var/nuke_code
+/datum/antagonist/ert/deathsquad/leader
+	outfit = /datum/outfit/centcom/death_commando/officer // Now death squad have a leader
+
+/datum/ert/deathsquad/New()
 	var/obj/machinery/nuclearbomb/selfdestruct/nuke = locate() in SSmachines.get_machines_by_type(/obj/machinery/nuclearbomb/selfdestruct)
-	nuke_code = random_nukecode()
-	if(nuke.r_code == NUKE_CODE_UNSET) // Create code for a nuclear bomb if it doesn't exist for some reason
-		nuke.r_code = nuke_code
-	else
-		nuke_code = nuke.r_code
-	missionobj.owner = owner
-	missionobj.explanation_text = "Запустите механизм самоуничтожения на [station_name()], коды активации: [nuke.r_code]"
-	missionobj.completed = TRUE
-	objectives |= missionobj
+	mission = "Запустите механизм самоуничтожения на [station_name()], коды активации: [nuke.r_code]"

--- a/modular_bandastation/antagonists/code/ert.dm
+++ b/modular_bandastation/antagonists/code/ert.dm
@@ -1,6 +1,6 @@
 /datum/antagonist/ert/deathsquad/on_gain() // Give deathsquad nuke code when ERT is summoned
 	. = ..()
-	var/datum/objective/missionobj = new ()
+	var/datum/objective/missionobj = new()
 	var/nuke_code
 	var/obj/machinery/nuclearbomb/selfdestruct/nuke = locate() in SSmachines.get_machines_by_type(/obj/machinery/nuclearbomb/selfdestruct)
 	nuke_code = random_nukecode()

--- a/modular_bandastation/antagonists/code/ert.dm
+++ b/modular_bandastation/antagonists/code/ert.dm
@@ -1,0 +1,14 @@
+/datum/antagonist/ert/deathsquad/on_gain() // Give deathsquad nuke code when ERT is summoned
+	. = ..()
+	var/datum/objective/missionobj = new ()
+	var/nuke_code
+	var/obj/machinery/nuclearbomb/selfdestruct/nuke = locate() in SSmachines.get_machines_by_type(/obj/machinery/nuclearbomb/selfdestruct)
+	nuke_code = random_nukecode()
+	if(nuke.r_code == NUKE_CODE_UNSET) // Create code for a nuclear bomb if it doesn't exist for some reason
+		nuke.r_code = nuke_code
+	else
+		nuke_code = nuke.r_code
+	missionobj.owner = owner
+	missionobj.explanation_text = "Запустите механизм самоуничтожения на [station_name()], коды активации: [nuke.r_code]"
+	missionobj.completed = TRUE
+	objectives |= missionobj

--- a/modular_bandastation/modular_bandastation.dme
+++ b/modular_bandastation/modular_bandastation.dme
@@ -12,6 +12,7 @@
 #include "aesthetics_sounds/_aesthetics_sounds.dme"
 #include "ai_laws/_ai_laws.dme"
 #include "announcers/_announcers.dme"
+#include "antagonists/_antagonists.dme"
 #include "autohiss/_autohiss.dme"
 #include "automapper/_automapper.dme"
 #include "automatic_crew_transfer/_automatic_crew_transfer.dme"

--- a/modular_bandastation/objects/_objects.dme
+++ b/modular_bandastation/objects/_objects.dme
@@ -16,6 +16,8 @@
 #include "code/items/id_stickers.dm"
 #include "code/items/material_pouch.dm"
 #include "code/items/papers.dm"
+#include "code/items/pen.dm"
+#include "code/items/role_tablet_presets.dm"
 #include "code/items/stamp.dm"
 #include "code/items/wallets.dm"
 #include "code/items/clothing/accessories/accessories.dm"
@@ -72,7 +74,9 @@
 #include "code/items/weapons/melee/centcom/legendary_swords.dm"
 #include "code/items/weapons/ranged/energy/awaymission_gun.dm"
 #include "code/items/weapons/ranged/energy/eg_14.dm"
+#include "code/items/weapons/ranged/energy/pulse.dm"
 
+#include "code/machinery/nuclear_bomb.dm"
 #include "code/machinery/papershredder.dm"
 #include "code/machinery/photocopier.dm"
 #include "code/machinery/suit_storage_unit.dm"

--- a/modular_bandastation/objects/code/items/pen.dm
+++ b/modular_bandastation/objects/code/items/pen.dm
@@ -1,0 +1,3 @@
+/obj/item/pen/fountain/captain // It makes the captain's pen delightful to read
+	font = PEN_FONT
+	colour = "#000000"

--- a/modular_bandastation/objects/code/items/role_tablet_presets.dm
+++ b/modular_bandastation/objects/code/items/role_tablet_presets.dm
@@ -1,0 +1,13 @@
+/obj/item/modular_computer/pda/heads/centcom // Special PDA for centcom cause they don't have their own
+	name = "centcom officer PDA"
+	greyscale_config = /datum/greyscale_config/tablet/stripe_double
+	greyscale_colors = "#141414#FFD700#FFD700"
+	internal_cell = /obj/item/stock_parts/power_store/cell/infinite
+	inserted_item = /obj/item/pen/fountain/captain
+	starting_programs = list(
+		/datum/computer_file/program/status,
+		/datum/computer_file/program/science,
+		/datum/computer_file/program/records/medical,
+		/datum/computer_file/program/records/security,
+		/datum/computer_file/program/budgetorders,
+	)

--- a/modular_bandastation/objects/code/items/weapons/ranged/energy/pulse.dm
+++ b/modular_bandastation/objects/code/items/weapons/ranged/energy/pulse.dm
@@ -1,0 +1,2 @@
+/obj/item/gun/energy/pulse/loyalpin
+	cell_type = /obj/item/stock_parts/power_store/cell/infinite // This gun used only by deathsquad, it has to be infinite

--- a/modular_bandastation/objects/code/machinery/nuclear_bomb.dm
+++ b/modular_bandastation/objects/code/machinery/nuclear_bomb.dm
@@ -1,0 +1,3 @@
+/obj/machinery/nuclearbomb/Initialize(mapload)
+	. = ..()
+	r_code = random_nukecode() // Gives every nuke a unique code by default instead of "ADMIN"

--- a/modular_bandastation/outfits/code/centcom.dm
+++ b/modular_bandastation/outfits/code/centcom.dm
@@ -167,8 +167,3 @@
 		/obj/item/storage/medkit/regular = 1,
 		/obj/item/disk/nuclear,
 	)
-
-/datum/outfit/centcom/death_commando/post_equip(mob/living/carbon/human/squaddie, visuals_only = FALSE) // For some reasons these guys don't have by default
-	. = ..()
-	var/obj/item/implant/mindshield/mindshield = new /obj/item/implant/mindshield(squaddie)
-	mindshield.implant(squaddie, null, silent = TRUE)

--- a/modular_bandastation/outfits/code/centcom.dm
+++ b/modular_bandastation/outfits/code/centcom.dm
@@ -1,6 +1,7 @@
 // MARK: Nanotrasen CentCom //
 
 /datum/outfit/centcom/post_equip(mob/living/carbon/human/centcom_member, visuals_only = FALSE)
+	. = ..() // Now centcom staff have mindshield implants
 	if(centcom_member.mind)
 		centcom_member.mind.centcom_role = CENTCOM_ROLE_OFFICER
 
@@ -69,6 +70,8 @@
 	backpack_contents = list(
 		/obj/item/storage/box/survival/centcom,
 		/obj/item/stamp/centcom,
+		/obj/item/lighter,
+		/obj/item/door_remote/omni,
 	)
 	belt = /obj/item/gun/energy/pulse/pistol/m1911
 	ears = /obj/item/radio/headset/headset_cent/commander
@@ -77,7 +80,7 @@
 	head = /obj/item/clothing/head/helmet/space/beret
 	mask = /obj/item/cigarette/cigar/cohiba
 	shoes = /obj/item/clothing/shoes/laceup
-	r_pocket = /obj/item/lighter
+	r_pocket = /obj/item/modular_computer/pda/heads/centcom
 	l_pocket = /obj/item/reagent_containers/hypospray/combat/nanites
 
 /datum/id_trim/centcom/commander
@@ -99,7 +102,7 @@
 	head = /obj/item/clothing/head/helmet/space/beret
 	mask = /obj/item/cigarette/cigar/cohiba
 	shoes = /obj/item/clothing/shoes/jackboots/centcom
-	r_pocket = /obj/item/lighter
+	r_pocket = /obj/item/modular_computer/pda/heads/centcom
 
 /datum/id_trim/centcom/commander/field
 	assignment = "Nanotrasen Navy Field Officer"
@@ -153,3 +156,19 @@
 /datum/id_trim/centcom/ert/commander/New()
 	. = ..()
 	access = access = list(ACCESS_CENT_GENERAL, ACCESS_CENT_SPECOPS, ACCESS_CENT_LIVING) | (SSid_access.get_region_access_list(list(REGION_ALL_STATION)) - ACCESS_CHANGE_IDS)
+
+// DeathSquad outifit
+/datum/outfit/centcom/death_commando/officer
+	backpack_contents = list(
+		/obj/item/ammo_box/a357 = 1,
+		/obj/item/flashlight = 1,
+		/obj/item/grenade/c4/x4 = 1,
+		/obj/item/storage/box/flashbangs = 1,
+		/obj/item/storage/medkit/regular = 1,
+		/obj/item/disk/nuclear,
+	)
+
+/datum/outfit/centcom/death_commando/post_equip(mob/living/carbon/human/squaddie, visuals_only = FALSE) // For some reasons these guys don't have by default
+	. = ..()
+	var/obj/item/implant/mindshield/mindshield = new /obj/item/implant/mindshield(squaddie)
+	mindshield.implant(squaddie, null, silent = TRUE)


### PR DESCRIPTION
## Что этот PR делает

У каждой нюки теперь всегда есть код, вместо "ADMIN".
Ядерный диск теперь не исчезает при перелете с ним на ЕРТ шаттлах.
При вызове дедов (через ерт панель) у них появляется миссия по уничтожению станции и коды для взведения механизма самоуничтожения станции.
У дедов теперь спавнится лидер отряда.
Пульс-винтовка у дедов теперь с бесконечной батарейкой.
Создан новый модпак для работы с подтипами "Antagonists" и связанными с ними изменениями;
У цкшников и дедов теперь есть мщ.
У ОЦК теперь есть ПДА и омниремоутер (выглядит как у НТРа).
У ручки капитана теперь черный цвет текста и не вырвиглазный шрифт.

## Почему это хорошо для игры

Фиксим наши косяки и странности апрстрима впридачу, закрываю гештальт связанный с переработкой этого дела, который я обещал когда-то в прошлом

## Тестирование

Локалка

## Changelog

:cl:
add: У ядерных боеголовок теперь есть нормальный код, вместо "ADMIN"
fix: У дедов теперь спавнится лидер
fix: Ядерный диск теперь не пропадает на ЦК шаттлах при перемещении
fix: У ЦК ролей теперь есть МЩ
qol: Ручка кепа теперь имеет не вырвиглазный шрифт и цвет текста
qol: У некоторых ЦК ролей появился омниремоутер
qol: У некоторых ЦК ролей появился свой ПДА
qol: У дедов теперь бесконечная пульсовая винтовка
/:cl:

## Обзор от Sourcery

Этот запрос на включение содержит несколько изменений, связанных с ЦентрКомом, ядерным оружием и антагонистами. Он гарантирует, что ядерные бомбы имеют уникальные коды, исправляет ошибку, из-за которой исчезали ядерные диски, предоставляет ролям ЦентрКома дополнительное снаряжение, улучшает ручку Капитана и дает Отряду Смерти миссию по уничтожению станции.

Новые возможности:
- Каждой ядерной бомбе по умолчанию присваивается уникальный код вместо "ADMIN".
- Добавлен новый модпак для изменений, связанных с антагонистами.
- Отряду Смерти дается миссия по уничтожению станции с помощью кодов ядерного оружия, когда их вызывают через панель ERT.

Исправления ошибок:
- Исправлена проблема, из-за которой ядерный диск исчезал при передаче на шаттлах ЦентрКома.

Улучшения:
- Ролям ЦентрКома выдаются импланты защиты разума, КПК и всепульты.
- Изменен цвет текста ручки Капитана на черный и использован более читаемый шрифт.
- Отряду Смерти выдается бесконечный боезапас для импульсных винтовок.

Мелкие задачи:
- Добавлены новые области в список областей, где разрешен ядерный диск.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

This pull request introduces several changes related to CentCom, nukes, and antagonists. It ensures that nukes have unique codes, fixes a bug where nuke disks disappear, provides CentCom roles with additional gear, improves the Captain's pen, and gives the Death Squad a mission to destroy the station.

New Features:
- Gives every nuke a unique code by default instead of "ADMIN".
- Adds a new modpack for antagonist-related changes.
- Gives the Death Squad a mission to destroy the station with the nuke codes when they are called via the ERT panel.

Bug Fixes:
- Fixes an issue where the nuclear disk would disappear when transferring on CentCom shuttles.

Enhancements:
- Gives CentCom roles mindshield implants, PDAs, and omniremoters.
- Changes the Captain's pen to use a black text color and a more readable font.
- Gives the Death Squad infinite ammo on their pulse rifles.

Chores:
- Adds new areas to the list of areas where the nuke disk is allowed.

</details>