### PR TITLE
prison cryopods work again

### DIFF
--- a/modular_bandastation/cryosleep/code/cryopod/cryopod.dm
+++ b/modular_bandastation/cryosleep/code/cryopod/cryopod.dm
@@ -90,7 +90,7 @@ GLOBAL_LIST_EMPTY(objectives)
 
 	open_machine(density_to_set = TRUE)
 
-/obj/machinery/cryopod/close_machine(atom/movable/target, density_to_set = TRUE)
+/obj/machinery/cryopod/close_machine(atom/movable/target, density_to_set)
 	find_control_computer()
 
 	if(!can_be_put_inside(target))

--- a/modular_bandastation/cryosleep/code/cryopod/prison_cryopod.dm
+++ b/modular_bandastation/cryosleep/code/cryopod/prison_cryopod.dm
@@ -7,10 +7,11 @@
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/cryopod/prison, 18)
 
-/obj/machinery/cryopod/prison/close_machine(atom/movable/target, density_to_set = FALSE)
+/obj/machinery/cryopod/prison/close_machine(atom/movable/target, density_to_set)
 	. = ..()
 	flick("prisonpod-open", src)
+	set_density(FALSE)
 
-/obj/machinery/cryopod/prison/open_machine(drop = TRUE, density_to_set = FALSE)
+/obj/machinery/cryopod/prison/open_machine(drop = TRUE, density_to_set)
 	. = ..()
 	flick("prisonpod-open", src)


### PR DESCRIPTION
## Что этот PR делает

fixes https://github.com/ss220club/BandaStation/issues/1168

## Почему это хорошо для игры

Баги плохо

## Changelog

:cl:
fix: Тюремная криокапсула снова работаает
/:cl:

## Обзор от Sourcery

Исправления ошибок:
- Исправлена проблема, из-за которой криокамеры в тюрьме функционировали некорректно, путем обеспечения правильной установки плотности при закрытии камеры.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where prison cryopods were not functioning correctly by ensuring density is properly set when closing the pod.

</details>