### PR TITLE
FIx: Correct security level ru_name

### DIFF
--- a/modular_bandastation/translations/code/translate_security_level.dm
+++ b/modular_bandastation/translations/code/translate_security_level.dm
@@ -12,3 +12,9 @@
 
 /datum/security_level/delta
 	ru_name = "дельта"
+
+/datum/security_level/gamma
+	ru_name = "гамма"
+
+/datum/security_level/epsilon
+	ru_name = "эпсилон"


### PR DESCRIPTION

## Что этот PR делает
Чинит отсутствие перевода для кода гамма и эпсилон.
## Почему это хорошо для игры
Буквы это круто.
## Изображения изменений
## Тестирование
На локалке поставил код, увидел перевод.
## Changelog

:cl:
fix: Код гамма и эпсилон теперь имеют перевод и не обозначаются как "не назначен"
/:cl:
