### PR TITLE
Security levels tweaks

### DIFF
--- a/code/__DEFINES/communications.dm
+++ b/code/__DEFINES/communications.dm
@@ -11,5 +11,13 @@
 #define SEC_LEVEL_BLUE 1
 /// Security level is red. (hostile threats)
 #define SEC_LEVEL_RED 2
+
+// BANDASTATION ADDITION - START
+/// Security level is gamma.
+#define SEC_LEVEL_GAMMA 3
+/// Security level is epsilon.
+#define SEC_LEVEL_EPSILON 4
+// BANDASTATION ADDITION - START
+
 /// Security level is delta. (station destruction immiment)
-#define SEC_LEVEL_DELTA 3
+#define SEC_LEVEL_DELTA 5 // BANDASTION EDIT: 3 => 5

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -206,8 +206,11 @@
 		if(!should_play_sound || (should_play_sound_callback && !should_play_sound_callback.Invoke(target)))
 			continue
 		if(target.client?.prefs.read_preference(/datum/preference/toggle/sound_announcements))
-			// SEND_SOUND(target, sound(sound_to_play)) // Bandastion Removal
-			/// SS220 TTS START
+			// BANDASTATION EDIT START - TTS
+			if(!SStts220.is_enabled)
+				SEND_SOUND(target, sound(sound_to_play))
+				return
+
 			var/datum/tts_seed/announcement_tts_seed = tts_override?.tts_seed
 			if(isnull(announcement_tts_seed))
 				var/mob/living/silicon/ai/active_ai = DEFAULTPICK(active_ais(TRUE, null), null)
@@ -225,7 +228,7 @@
 				null, \
 				sound_to_play \
 			)
-			/// SS220 TTS END
+			// BANDASTATION EDIT END - TTS
 
 #undef MAJOR_ANNOUNCEMENT_TITLE
 #undef MAJOR_ANNOUNCEMENT_TEXT

--- a/code/controllers/subsystem/security_level.dm
+++ b/code/controllers/subsystem/security_level.dm
@@ -7,10 +7,23 @@ SUBSYSTEM_DEF(security_level)
 	/// A list of initialised security level datums.
 	var/list/available_levels = list()
 
+// BANDASTATION ADDITION - START
+/proc/cmp_security_levels(datum/security_level/a, datum/security_level/b)
+	return cmp_numeric_asc(a.number_level, b.number_level)
+// BANDASTATION ADDITION - END
+
 /datum/controller/subsystem/security_level/Initialize()
+	// BANDASTATION EDIT - START
+	var/list/levels = list()
 	for(var/iterating_security_level_type in subtypesof(/datum/security_level))
-		var/datum/security_level/new_security_level = new iterating_security_level_type
-		available_levels[new_security_level.name] = new_security_level
+		levels += new iterating_security_level_type
+
+	sortTim(levels, GLOBAL_PROC_REF(cmp_security_levels))
+
+	for(var/datum/security_level/level as anything in levels)
+		available_levels[level.name] = level
+	// BANDASTATION EDIT - END
+
 	current_security_level = available_levels[number_level_to_text(SEC_LEVEL_GREEN)]
 	return SS_INIT_SUCCESS
 

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -508,10 +508,7 @@
 			if(get_malf_status(user))
 				malfvacate()
 		if("reboot")
-			failure_timer = 0
-			force_update = FALSE
-			update_appearance()
-			update()
+			reboot() // BANDASTATION EDIT START - moved code to reboot proc
 		if("emergency_lighting")
 			emergency_lights = !emergency_lights
 			for (var/list/zlevel_turfs as anything in area.get_zlevel_turf_lists())
@@ -527,6 +524,14 @@
 	. = ..()
 	if(user == remote_control_user)
 		disconnect_remote_access()
+
+// BANDASTATION ADDITION START
+/obj/machinery/power/apc/proc/reboot()
+	failure_timer = 0
+	force_update = FALSE
+	update_appearance()
+	update()
+// BANDASTATION ADDITION END
 
 /**
  * APC early processing. This gets processed after any other machine on the powernet does.

--- a/modular_bandastation/security_levels/code/security_level_datums.dm
+++ b/modular_bandastation/security_levels/code/security_level_datums.dm
@@ -1,21 +1,15 @@
-/// Security level is gamma.
-#define SEC_LEVEL_GAMMA 4
-/// Security level is epsilon.
-#define SEC_LEVEL_EPSILON 5
-
-//
 /datum/config_entry/string/alert_gamma
-	default = "Центральным Командованием был установлен Код Гамма. Служба безопасности должна быть полностью вооружена. Гражданский персонал обязан немедленно обратиться к Главам отделов для получения дальнейших указаний."
+	default = "Центральным Командованием был установлен Код Гамма.\
+	 Служба безопасности должна быть полностью вооружена. Гражданский персонал обязан немедленно обратиться к Главам отделов для получения дальнейших указаний."
+
 /datum/config_entry/string/alert_epsilon
 	default = "Центральным командованием был установлен код ЭПСИЛОН. Все контракты расторгнуты."
-//
 
 /**
  * Gamma
  *
  * Station major hostile threats
  */
-
 /datum/security_level/gamma
 	name = "gamma"
 	announcement_color = "orange"
@@ -23,6 +17,7 @@
 	status_display_icon_state = "gammaalert"
 	fire_alarm_light_color = LIGHT_COLOR_ORANGE
 	number_level = SEC_LEVEL_GAMMA
+	lowering_to_configuration_key = /datum/config_entry/string/alert_gamma
 	elevating_to_configuration_key = /datum/config_entry/string/alert_gamma
 	shuttle_call_time_mod = ALERT_COEFF_RED
 
@@ -31,7 +26,6 @@
  *
  * Station is not longer under the Central Command and to be destroyed by Death Squad (Or maybe not)
  */
-
 /datum/security_level/epsilon
 	name = "epsilon"
 	announcement_color = "purple"
@@ -39,6 +33,7 @@
 	number_level = SEC_LEVEL_EPSILON
 	status_display_icon_state = "epsilonalert"
 	fire_alarm_light_color = LIGHT_COLOR_BLOOD_MAGIC
+	lowering_to_configuration_key = /datum/config_entry/string/alert_epsilon
 	elevating_to_configuration_key = /datum/config_entry/string/alert_epsilon
 	shuttle_call_time_mod = 10
 

--- a/modular_bandastation/tts/code/tts_subsystem.dm
+++ b/modular_bandastation/tts/code/tts_subsystem.dm
@@ -39,7 +39,7 @@ SUBSYSTEM_DEF(tts220)
 	VAR_PRIVATE/tts_rrps = 0
 	VAR_PRIVATE/tts_rrps_counter = 0
 
-	VAR_PRIVATE/is_enabled = TRUE
+	var/is_enabled = TRUE
 	/// List of all available TTS seeds
 	var/list/datum/tts_seed/tts_seeds = list()
 	/// List of all available TTS providers


### PR DESCRIPTION
## Что этот PR делает

Когда устанавливается код Epsilon, воспроизводится специальный эффект до и после установки кода
Звук оповещений теперь проигрывается корректно, даже с выключенным ТТСом
Корректный текст оповещения при снижении кода до Гамма или Эпсилон.

## Почему это хорошо для игры

Прикольный эффект для кода эпсилон, а фиксы багов всегда хорошо

## Changelog

:cl:
add: Когда устанавливается код Epsilon, воспроизводится специальный эффект до и после установки кода
fix: Звук оповещений теперь проигрывается корректно, даже с выключенным ТТСом
fix: Корректный текст оповещения при снижении кода до Гамма или Эпсилон
/:cl:
