### PR TITLE
Slowdown BS floors

### DIFF
--- a/modular_bandastation/balance/code/speed/base_speed.dm
+++ b/modular_bandastation/balance/code/speed/base_speed.dm
@@ -21,3 +21,7 @@
 /mob/living/basic/clown/banana
 	// Базовое значение -1
 	speed = 0.5
+
+/turf/open/floor/bluespace
+	// Базовое значение -1
+	slowdown = -0.25


### PR DESCRIPTION
## Что этот PR делает
Замедлил БС плитки

## Почему это хорошо для игры
Не такое сильное превышение РП скорости
Closes #1179

## Changelog

:cl:
balance: Блюспейс пол теперь ускоряет не так сильно (1/4 от изначального ускорения)
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
