### PR TITLE
Add: Crew Monitor now can sort by Department Head

### DIFF
--- a/tgui/packages/tgui/interfaces/CrewConsole.tsx
+++ b/tgui/packages/tgui/interfaces/CrewConsole.tsx
@@ -21,12 +21,13 @@ const SORT_NAMES = {
   name: 'Name',
   area: 'Position',
   health: 'Vitals',
+  head: 'Head',
 };
 
 const STAT_LIVING = 0;
 const STAT_DEAD = 4;
 
-const SORT_OPTIONS = ['health', 'ijob', 'name', 'area'];
+const SORT_OPTIONS = ['health', 'ijob', 'name', 'area', 'head'];
 
 const jobIsHead = (jobId: number) => jobId % 10 === 0;
 
@@ -82,6 +83,12 @@ const areaSort = (a: CrewSensor, b: CrewSensor) => {
   if (a.area < b.area) return -1;
   if (a.area > b.area) return 1;
   return 0;
+};
+
+const headSort = (a: CrewSensor, b: CrewSensor) => {
+  if (a.ijob % 10 === 0 && b.ijob % 10 !== 0) return -1;
+  else if (a.ijob % 10 !== 0 && b.ijob % 10 === 0) return 1;
+  else return a.ijob - b.ijob;
 };
 
 const healthToAttribute = (
@@ -168,6 +175,8 @@ const CrewTable = () => {
         return sortAsc ? healthSort(a, b) : healthSort(b, a);
       case 'area':
         return sortAsc ? areaSort(a, b) : areaSort(b, a);
+      case 'head':
+        return sortAsc ? headSort(a, b) : headSort(b, a);
       default:
         return 0;
     }


### PR DESCRIPTION

## Что этот PR делает
Добавляет новую сортировку списка экипажа по главам в Crew Monitor (handheld, machinery).
## Почему это хорошо для игры
Теперь станция может видеть статус своих глав первыми, ведь они важнее ассистоса. БЩ легче жить, антагам легче найти главу с хайриском и т.п.
## Изображения изменений
![image](https://github.com/user-attachments/assets/af90e0a8-bcdb-4266-bdb0-0419a84f5716)
## Тестирование
Локалка, куча тел с датчиками из разных департаментов.
## Changelog

:cl: Ez-Briz
add: В Crew Monitor добавлена возможность сортировки по главам департаментов.
/:cl:
