### PR TITLE
Cyberiad: minor fixes

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -29975,6 +29975,7 @@
 /obj/machinery/airalarm/directional/south,
 /obj/structure/closet/secure_closet/security/cargo,
 /obj/item/book/manual/wiki/security_space_law,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "hmw" = (
@@ -62599,8 +62600,9 @@
 	name = "Engineering Security Doors";
 	id = "engineering_lockdown"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "phb" = (
@@ -94133,8 +94135,9 @@
 	name = "Engineering Security Doors";
 	id = "engineering_lockdown"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "wUN" = (


### PR DESCRIPTION
## Что этот PR делает

Фикс проводов в кпп сб в карго по ишуе https://github.com/ss220club/BandaStation/issues/1208
Исправление доступов на входе в инженерки (как на оффах)

## Почему это хорошо для игры

КПП было без света из-за нехватки провода
Доступ парамеду, т.к. доступ в карго есть, в рнд есть, а в инженерке внезапно нет

## Тестирование

Локалка

## Changelog

:cl:
map: Кибериада: Фикс проводов на КПП СБ в Карго.
map: Кибериада: Изменение доступов на входе в инженерный.
/:cl:
