### PR TITLE
Update map position for all users who use UI

### DIFF
--- a/tgui/packages/tgui/interfaces/CameraConsole220.tsx
+++ b/tgui/packages/tgui/interfaces/CameraConsole220.tsx
@@ -11,7 +11,6 @@ import {
 } from 'tgui-core/components';
 import { BooleanLike, classes } from 'tgui-core/react';
 import { createSearch } from 'tgui-core/string';
-import { useLocalStorage } from 'usehooks-ts';
 
 import { useBackend } from '../backend';
 import { Window } from '../layouts';
@@ -208,33 +207,13 @@ export const CameraMapSelector = (props) => {
   const { act, data } = useBackend<Data>();
   const { activeCamera, mapData } = data;
   const cameras = selectCameras(data.cameras, '');
-
-  const [zoom, setZoom] = useState<number>();
   const [selectedLevel, setSelectedLevel] = useState<number>(mapData.mainFloor);
-  const [tracking, setTracking] = useLocalStorage(
-    'camera-console-tracking',
-    false,
-  );
+
   return (
     <NanoMap
       mapData={mapData}
       uiName="camera-console"
-      selectedTarget={!!activeCamera?.ref}
-      onZoomChange={setZoom}
       onLevelChange={setSelectedLevel}
-      buttons={
-        <Button
-          icon="wheelchair-move"
-          selected={tracking}
-          tooltip={
-            tracking
-              ? 'Не перемещать к выбранной камере'
-              : 'Перемещать к выбранной камере'
-          }
-          tooltipPosition="right"
-          onClick={() => setTracking(!tracking)}
-        />
-      }
     >
       {cameras.map((camera) => (
         <NanoMap.Button
@@ -245,8 +224,6 @@ export const CameraMapSelector = (props) => {
           color={!camera.status && 'red'}
           selected={activeCamera?.ref === camera.ref}
           hidden={camera.z !== selectedLevel}
-          tracking={tracking}
-          zoom={zoom}
           onClick={() =>
             act('switch_camera', {
               camera: camera.ref,

--- a/tgui/packages/tgui/interfaces/common/NanoMap.tsx
+++ b/tgui/packages/tgui/interfaces/common/NanoMap.tsx
@@ -199,11 +199,12 @@ export function NanoMap(props: Props) {
               />
             </div>
             <NanoMapTransformComponent
-              children={children}
               mapState={mapState}
               uiName={uiName}
               getMapImage={getMapImage}
-            />
+            >
+              {children}
+            </NanoMapTransformComponent>
           </Stack.Item>
         </Stack>
       </Section>

--- a/tgui/packages/tgui/interfaces/common/NanoMap.tsx
+++ b/tgui/packages/tgui/interfaces/common/NanoMap.tsx
@@ -19,7 +19,6 @@ import {
 } from 'tgui-core/components';
 import { clamp01 } from 'tgui-core/math';
 import { BooleanLike, classes } from 'tgui-core/react';
-import { debounce } from 'tgui-core/timer';
 import { useLocalStorage } from 'usehooks-ts';
 
 import { resolveAsset } from '../../assets';
@@ -127,22 +126,18 @@ export function NanoMap(props: Props) {
 
   // Send component data to UI, if he has useState for them.
   onLevelChange && onLevelChange(mapState.currentLevel);
-  const handleTransformed = useMemo(
-    () =>
-      debounce(({ state }) => {
-        setMapState({
-          scale: state.scale,
-          positionX: state.positionX,
-          positionY: state.positionY,
-          currentLevel: mapState.currentLevel,
-        });
+  function handleTransformed({ state }) {
+    setMapState({
+      scale: state.scale,
+      positionX: state.positionX,
+      positionY: state.positionY,
+      currentLevel: mapState.currentLevel,
+    });
 
-        if (onZoomChange) {
-          onZoomChange(state.scale);
-        }
-      }, 125),
-    [mapState.currentLevel],
-  );
+    if (onZoomChange) {
+      onZoomChange(state.scale);
+    }
+  }
 
   return (
     <TransformWrapper
@@ -153,10 +148,12 @@ export function NanoMap(props: Props) {
       initialPositionX={mapState.positionX}
       initialPositionY={mapState.positionY}
       smooth={false}
+      limitToBounds={false}
       wheel={{ step: defaultScale }}
       panning={{ velocityDisabled: mapPrefs.velocity }}
       doubleClick={{ disabled: true }}
-      onTransformed={handleTransformed}
+      onZoomStop={handleTransformed}
+      onPanningStop={handleTransformed}
     >
       <Section fill>
         {prefs && (

--- a/tgui/packages/tgui/interfaces/common/NanoMap.tsx
+++ b/tgui/packages/tgui/interfaces/common/NanoMap.tsx
@@ -140,6 +140,7 @@ export function NanoMap(props: Props) {
       wheel={{ step: defaultScale }}
       panning={{ velocityDisabled: true }}
       doubleClick={{ disabled: true }}
+      alignmentAnimation={{ disabled: true }}
       onZoomStop={handleTransformed}
       onPanningStop={handleTransformed}
     >
@@ -210,7 +211,6 @@ function NanoMapTransformComponent(props) {
       prevMapState.positionY !== mapState.positionY ||
       prevMapState.scale !== mapState.scale
     ) {
-      // TODO: Найти способ красиво отсрочить это, дабы оно не возвращало позицию за края карты, когда юзер пытается за них выйти.
       setTransform(mapState.positionX, mapState.positionY, mapState.scale);
     }
     mapStateRef.current = mapState;

--- a/tgui/packages/tgui/interfaces/common/NanoMap.tsx
+++ b/tgui/packages/tgui/interfaces/common/NanoMap.tsx
@@ -202,16 +202,35 @@ export function NanoMap(props: Props) {
                 selectedTarget={selectedTarget}
               />
             </div>
-            <TransformComponent
-              wrapperStyle={{ width: '100%', height: '100%' }}
-            >
-              {getMapImage(mapState.currentLevel)}
-              <div>{children}</div>
-            </TransformComponent>
+            <NanoMapTransformComponent
+              children={children}
+              mapState={mapState}
+              uiName={uiName}
+              getMapImage={getMapImage}
+            />
           </Stack.Item>
         </Stack>
       </Section>
     </TransformWrapper>
+  );
+}
+
+function NanoMapTransformComponent(props) {
+  const { children, mapState, uiName, getMapImage } = props;
+  const { setTransform } = useControls();
+
+  uiName &&
+    useMemo(
+      () =>
+        setTransform(mapState.positionX, mapState.positionY, mapState.scale),
+      [mapState.positionX, mapState.positionY, mapState.scale],
+    );
+
+  return (
+    <TransformComponent wrapperStyle={{ width: '100%', height: '100%' }}>
+      {getMapImage(mapState.currentLevel)}
+      <div>{children}</div>
+    </TransformComponent>
   );
 }
 

--- a/tgui/packages/tgui/interfaces/common/NanoMap.tsx
+++ b/tgui/packages/tgui/interfaces/common/NanoMap.tsx
@@ -140,7 +140,7 @@ export function NanoMap(props: Props) {
       wheel={{ step: defaultScale }}
       panning={{ velocityDisabled: true }}
       doubleClick={{ disabled: true }}
-      alignmentAnimation={{ disabled: true }}
+      alignmentAnimation={{ animationTime: 0 }}
       onZoomStop={handleTransformed}
       onPanningStop={handleTransformed}
     >

--- a/tgui/packages/tgui/interfaces/common/NanoMap.tsx
+++ b/tgui/packages/tgui/interfaces/common/NanoMap.tsx
@@ -89,7 +89,6 @@ export function NanoMap(props: Props) {
 
   const [prefs, setPrefs] = useState(false);
   const [mapPrefs, setMapPrefs] = useLocalStorage('nanomap-preferences', {
-    velocity: true,
     minimap: true,
     minimapPosition: 'top-left',
   });
@@ -150,7 +149,7 @@ export function NanoMap(props: Props) {
       smooth={false}
       limitToBounds={false}
       wheel={{ step: defaultScale }}
-      panning={{ velocityDisabled: mapPrefs.velocity }}
+      panning={{ velocityDisabled: true }}
       doubleClick={{ disabled: true }}
       onZoomStop={handleTransformed}
       onPanningStop={handleTransformed}
@@ -373,17 +372,6 @@ function NanoMapPreferences(props) {
                 </Button>
               ))}
             </Stack>
-          </LabeledList.Item>
-          <LabeledList.Item
-            label="Инерция"
-            tooltip="Если включено, карта продолжит двигаться по инерции после отпускания мыши при перемещении."
-          >
-            <Button.Checkbox
-              checked={!mapPrefs.velocity}
-              onClick={() =>
-                setMapPrefs((old) => ({ ...old, velocity: !old.velocity }))
-              }
-            />
           </LabeledList.Item>
           <LabeledList.Item label="Мини-карта">
             <Button.Checkbox

--- a/tgui/packages/tgui/interfaces/common/NanoMap.tsx
+++ b/tgui/packages/tgui/interfaces/common/NanoMap.tsx
@@ -130,7 +130,7 @@ export function NanoMap(props: Props) {
 
   return (
     <TransformWrapper
-      centerOnInit={!uiName}
+      centerOnInit={mapState.positionX === 0 && mapState.positionY === 0}
       minScale={defaultScale}
       maxScale={maxScale}
       initialScale={mapState.scale}

--- a/tgui/packages/tgui/interfaces/common/NanoMap.tsx
+++ b/tgui/packages/tgui/interfaces/common/NanoMap.tsx
@@ -206,11 +206,7 @@ function NanoMapTransformComponent(props) {
 
   if (uiName) {
     const prevMapState = mapStateRef.current;
-    if (
-      prevMapState.positionX !== mapState.positionX ||
-      prevMapState.positionY !== mapState.positionY ||
-      prevMapState.scale !== mapState.scale
-    ) {
+    if (JSON.stringify(prevMapState) !== JSON.stringify(mapState)) {
       setTransform(mapState.positionX, mapState.positionY, mapState.scale);
     }
     mapStateRef.current = mapState;


### PR DESCRIPTION
## Что этот PR делает
Теперь положение и зум карты будут синхронизированы между всему пользователями интерфейса, а не только во время открытия.

Жертвой пала инерция, но да и фиг с ней

## Почему это хорошо для игры
Можно вдвоём дрочить один монитор

## Изображения изменений

https://github.com/user-attachments/assets/98534a3e-c3e3-4af6-bdb9-a1b80e04a4d4


## Тестирование
Ага

## Changelog

:cl:
qol: Сидеть со своим романтическим интересом за одной консолью камер - стало удобнее! Теперь ваш партнёр будет наблюдать точно тоже самое что и вы
del: Удалена возможность включить иннерцию и перемещаться к выбранному элементу в наномапах. По техническим причинам.
/:cl:

## Обзор от Sourcery

Синхронизация позиции карты и уровня масштабирования между всеми пользователями интерфейса, гарантируя, что все видят одно и то же представление.

Улучшения:
- Улучшен пользовательский опыт за счет синхронизации позиции карты и уровня масштабирования между всеми пользователями.
- Удален эффект инерции при перемещении по карте для более прямого управления.
- Удалена опция отслеживания, что упрощает пользовательский интерфейс и фокусируется на синхронизированном просмотре карты.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Synchronize map position and zoom level between all users of the UI, ensuring everyone sees the same view.

Enhancements:
- Improve the user experience by synchronizing the map position and zoom level between all users.
- Remove the inertia effect from the map movement for a more direct control experience.
- Remove the tracking option, simplifying the UI and focusing on synchronized map viewing.

</details>