### PR TITLE
fix tajaran mutation toxic recipe

### DIFF
--- a/modular_bandastation/species/code/reagents/mutation.dm
+++ b/modular_bandastation/species/code/reagents/mutation.dm
@@ -21,5 +21,5 @@
 
 /datum/chemical_reaction/slime/slimetajaran
 	results = list(/datum/reagent/mutationtoxin/tajaran = 1)
-	required_reagents = list(/datum/reagent/milk = 5)
+	required_reagents = list(/datum/reagent/consumable/milk = 5)
 	required_container = /obj/item/slime_extract/green


### PR DESCRIPTION
## Что этот PR делает

closes https://github.com/ss220club/BandaStation/issues/1265

## Тестирование

Рецепт работает

## Changelog

:cl:
fix: таяровский мутационный токсин теперь имеет рабочий рецепт (зеленый слайм + 5 юнитов молока)
/:cl:

## Обзор от Sourcery

Исправления ошибок:
- Исправлена химическая реакция для таджаранского мутагенного токсина путем использования правильного типа молочного реагента, что обеспечивает корректную работу рецепта.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Corrected the chemical reaction for Tajaran mutation toxin by using the correct milk reagent type, ensuring the recipe now works correctly

</details>