### PR TITLE
Fix examine panel

### DIFF
--- a/modular_bandastation/examine_panel/code/examine_panel_component.dm
+++ b/modular_bandastation/examine_panel/code/examine_panel_component.dm
@@ -95,11 +95,9 @@
 
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		examine_panel_screen.display_to(user)
-		user.client.register_map_obj(examine_panel_screen)
 		ui = new(user, src, "ExaminePanel")
 		ui.open()
-
+		examine_panel_screen.display_to(user, ui.window)
 
 /datum/component/examine_panel/ui_data(mob/user)
 	var/list/data = list()

--- a/tgui/packages/tgui/interfaces/ExaminePanel.tsx
+++ b/tgui/packages/tgui/interfaces/ExaminePanel.tsx
@@ -16,10 +16,10 @@ export const ExaminePanel = (props) => {
   const { act, data } = useBackend<Data>();
   const { character_name, obscured, assigned_map, flavor_text } = data;
   return (
-    <Window title="Подробное описание" width={900} height={670} theme="admin">
+    <Window title="Подробное описание" width={600} height={350} theme="ntos">
       <Window.Content>
         <Stack fill>
-          <Stack.Item width="30%">
+          <Stack.Item>
             <Section fill title="Превью персонажа">
               {!obscured && (
                 <CharacterPreview id={assigned_map} height="100%" />


### PR DESCRIPTION
## Что этот PR делает
Пофиксил панель подробного осмотра
Ну и уменьшил её, так как она была комично большой

## Изображения изменений
![image](https://github.com/user-attachments/assets/57de9dc5-39d0-4818-877a-6db53bd5dc3b)

## Changelog

:cl:
fix: Панель подробного описания персонажа, теперь не имеет микрочела, а микрочел имеет её. Плюс она стала компактнее
/:cl:

## Обзор от Sourcery

Улучшение панели осмотра путем изменения размера и корректировки логики отображения

Исправления ошибок:
- Исправлен механизм отображения панели осмотра для корректного отображения предварительного просмотра персонажа

Улучшения:
- Уменьшен размер панели осмотра с 900x670 до 600x350
- Изменена тема панели с 'admin' на 'ntos'
- Упрощен процесс инициализации пользовательского интерфейса

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the examine panel by resizing and adjusting its display logic

Bug Fixes:
- Fixed the examine panel display mechanism to correctly show the character preview

Enhancements:
- Reduced the examine panel size from 900x670 to 600x350
- Changed the panel theme from 'admin' to 'ntos'
- Simplified the UI initialization process

</details>