### PR TITLE
Should be announced option and announcements for ERT squad spawn

### DIFF
--- a/modular_bandastation/ert/code/ert_manager.dm
+++ b/modular_bandastation/ert/code/ert_manager.dm
@@ -218,6 +218,7 @@ ADMIN_VERB(ert_manager, R_NONE, "ERT Manager", "Manage ERT reqests.", ADMIN_CATE
 	ert_team.mission = missionobj
 
 	var/mob/dead/observer/earmarked_leader
+	var/leader_spawned = FALSE // just in case the earmarked leader disconnects or becomes unavailable, we can try giving leader to the last guy to get chosen
 
 	if(ertemplate.leader_experience)
 		var/list/candidate_living_exps = list()
@@ -261,9 +262,10 @@ ADMIN_VERB(ert_manager, R_NONE, "ERT Manager", "Manage ERT reqests.", ADMIN_CATE
 		//Give antag datum
 		var/datum/antagonist/ert/ert_antag
 
-		if(commander_slots > 0 && (chosen_candidate == earmarked_leader))
+		if((chosen_candidate == earmarked_leader) && (commander_slots > 0 && !leader_spawned))
 			ert_antag = new ertemplate.leader_role ()
 			earmarked_leader = null
+			leader_spawned = TRUE
 		else
 			ert_antag = ertemplate.roles[WRAP(numagents,1,length(ertemplate.roles) + 1)]
 			ert_antag = new ert_antag ()

--- a/modular_bandastation/ert/code/ert_manager.dm
+++ b/modular_bandastation/ert/code/ert_manager.dm
@@ -22,7 +22,7 @@ ADMIN_VERB(ert_manager, R_NONE, "ERT Manager", "Manage ERT reqests.", ADMIN_CATE
 	var/engineering_slots = 0
 	var/janitor_slots = 0
 	var/inquisitor_slots = 0
-	var/should_be_announced = FALSE
+	var/should_be_announced = TRUE
 
 /datum/ert_manager/ui_state(mob/user)
 	return ADMIN_STATE(R_ADMIN)

--- a/modular_bandastation/ert/code/ert_manager.dm
+++ b/modular_bandastation/ert/code/ert_manager.dm
@@ -92,6 +92,12 @@ ADMIN_VERB(ert_manager, R_NONE, "ERT Manager", "Manage ERT reqests.", ADMIN_CATE
 					to_chat(usr, "<span class='userdanger'>Invalid ERT type.</span>")
 					return
 
+			if((commander_slots + medical_slots + janitor_slots + inquisitor_slots + security_slots + engineering_slots) == 0)
+				message_admins("[key_name_admin(usr)] tried to create a [ert_type] ERT with zero slots available!")
+				log_admin("[key_name(usr)] tried to create a [ert_type] ERT with zero slots available.")
+				to_chat(usr, span_userdanger("ERT must have at least 1 slot available!"))
+				return
+
 			new_ert.teamsize = commander_slots + security_slots + medical_slots + engineering_slots + janitor_slots + inquisitor_slots
 			new_ert.roles = slots_to_roles(security_slots, medical_slots, engineering_slots, janitor_slots, inquisitor_slots, ert_type)
 

--- a/modular_bandastation/ert/code/ert_manager.dm
+++ b/modular_bandastation/ert/code/ert_manager.dm
@@ -22,6 +22,7 @@ ADMIN_VERB(ert_manager, R_NONE, "ERT Manager", "Manage ERT reqests.", ADMIN_CATE
 	var/engineering_slots = 0
 	var/janitor_slots = 0
 	var/inquisitor_slots = 0
+	var/should_be_announced = FALSE
 
 /datum/ert_manager/ui_state(mob/user)
 	return ADMIN_STATE(R_ADMIN)
@@ -48,6 +49,7 @@ ADMIN_VERB(ert_manager, R_NONE, "ERT Manager", "Manage ERT reqests.", ADMIN_CATE
 	data["inquisitorSlots"] = inquisitor_slots
 	data["totalSlots"] = commander_slots + security_slots + medical_slots + engineering_slots + janitor_slots + inquisitor_slots
 	data["ertSpawnpoints"] = length(GLOB.emergencyresponseteamspawn)
+	data["shouldBeAnnounced"] = should_be_announced
 
 	data["ertRequestMessages"] = GLOB.ert_request_messages
 	return data
@@ -65,6 +67,8 @@ ADMIN_VERB(ert_manager, R_NONE, "ERT Manager", "Manage ERT reqests.", ADMIN_CATE
 			admin_slots = admin_slots ? 0 : 1
 		// if("toggleCom")
 		// 	commander_slots = commander_slots ? 0 : 1	no can do sir, leader must be
+		if("toggleAnnounce")
+			should_be_announced = !should_be_announced
 		if("setSec")
 			security_slots = text2num(params["setSec"])
 		if("setMed")
@@ -109,7 +113,8 @@ ADMIN_VERB(ert_manager, R_NONE, "ERT Manager", "Manage ERT reqests.", ADMIN_CATE
 			var/slot_text = english_list(slots_list)
 			message_admins("[key_name_admin(usr)] dispatched a [ert_type] ERT. Slots: [slot_text]")
 			log_admin("[key_name(usr)] dispatched a [ert_type] ERT. Slots: [slot_text]")
-			priority_announce("Внимание, [station_name()]. Мы рассматриваем возможность отправки ОБР, ожидайте.", "Активирован протокол ОБР")
+			if(should_be_announced)
+				priority_announce("Внимание, [station_name()]. Мы рассматриваем возможность отправки ОБР, ожидайте.", "Активирован протокол ОБР")
 			makeERTFromSlots(new_ert, admin_slots, commander_slots, security_slots, medical_slots, engineering_slots, janitor_slots, inquisitor_slots)
 
 		if("view_player_panel")
@@ -182,6 +187,8 @@ ADMIN_VERB(ert_manager, R_NONE, "ERT Manager", "Manage ERT reqests.", ADMIN_CATE
 	var/obj/effect/landmark/ert_brief_spawn/brief_spawn = locate()
 
 	if(!length(candidates))
+		if(should_be_announced)
+			minor_announce("Внимание, [station_name()]. К сожалению, в настоящее время мы не можем направить к вам отряд быстрого реагирования.", "ОБР недоступен")
 		return FALSE
 
 	if(ertemplate.spawn_admin)
@@ -274,6 +281,14 @@ ADMIN_VERB(ert_manager, R_NONE, "ERT Manager", "Manage ERT reqests.", ADMIN_CATE
 
 	if (teamSpawned)
 		message_admins("[ertemplate.polldesc] has spawned with the mission: [ertemplate.mission]")
+		if(should_be_announced)
+			switch(ert_type)
+				if("Amber")
+					priority_announce("Внимание, [station_name()]. Мы направляем стандартный отряд быстрого реагирования кода «ЭМБЕР». Ожидайте.", "ОБР в пути")
+				if("Red")
+					priority_announce("Внимание, [station_name()]. Мы направляем стандартный отряд быстрого реагирования кода «РЭД». Ожидайте.", "ОБР в пути")
+				if("Gamma")
+					priority_announce("Внимание, [station_name()]. Мы направляем стандартный отряд быстрого реагирования кода «ГАММА». Ожидайте.", "ОБР в пути")
 
 	//Open the Armory doors
 	if(ertemplate.opendoors)

--- a/modular_bandastation/ert/code/ert_manager.dm
+++ b/modular_bandastation/ert/code/ert_manager.dm
@@ -65,8 +65,8 @@ ADMIN_VERB(ert_manager, R_NONE, "ERT Manager", "Manage ERT reqests.", ADMIN_CATE
 			ert_type = params["ertType"]
 		if("toggleAdmin")
 			admin_slots = admin_slots ? 0 : 1
-		// if("toggleCom")
-		// 	commander_slots = commander_slots ? 0 : 1	no can do sir, leader must be
+		if("toggleCom")
+			commander_slots = commander_slots ? 0 : 1
 		if("toggleAnnounce")
 			should_be_announced = !should_be_announced
 		if("setSec")
@@ -197,7 +197,7 @@ ADMIN_VERB(ert_manager, R_NONE, "ERT Manager", "Manage ERT reqests.", ADMIN_CATE
 			var/chosen_outfit = usr.client?.prefs?.read_preference(/datum/preference/choiced/brief_outfit)
 			usr.client.prefs.safe_transfer_prefs_to(admin_officer, is_antag = TRUE)
 			admin_officer.equipOutfit(chosen_outfit)
-			admin_officer.key = usr.key
+			admin_officer.PossessByPlayer(usr.key)
 		else
 			to_chat(usr, span_warning("Could not spawn you in as briefing officer as you are not a ghost!"))
 
@@ -218,7 +218,6 @@ ADMIN_VERB(ert_manager, R_NONE, "ERT Manager", "Manage ERT reqests.", ADMIN_CATE
 	ert_team.mission = missionobj
 
 	var/mob/dead/observer/earmarked_leader
-	var/leader_spawned = FALSE // just in case the earmarked leader disconnects or becomes unavailable, we can try giving leader to the last guy to get chosen
 
 	if(ertemplate.leader_experience)
 		var/list/candidate_living_exps = list()
@@ -254,7 +253,7 @@ ADMIN_VERB(ert_manager, R_NONE, "ERT Manager", "Manage ERT reqests.", ADMIN_CATE
 		else
 			ert_operative = new /mob/living/carbon/human(spawnloc)
 			chosen_candidate.client.prefs.safe_transfer_prefs_to(ert_operative, is_antag = TRUE)
-		ert_operative.key = chosen_candidate.key
+		ert_operative.PossessByPlayer(chosen_candidate.key)
 
 		if(ertemplate.enforce_human || !(ert_operative.dna.species.changesource_flags & ERT_SPAWN))
 			ert_operative.set_species(/datum/species/human)
@@ -262,10 +261,9 @@ ADMIN_VERB(ert_manager, R_NONE, "ERT Manager", "Manage ERT reqests.", ADMIN_CATE
 		//Give antag datum
 		var/datum/antagonist/ert/ert_antag
 
-		if((chosen_candidate == earmarked_leader) || (numagents == 1 && !leader_spawned))
+		if(commander_slots > 0 && (chosen_candidate == earmarked_leader))
 			ert_antag = new ertemplate.leader_role ()
 			earmarked_leader = null
-			leader_spawned = TRUE
 		else
 			ert_antag = ertemplate.roles[WRAP(numagents,1,length(ertemplate.roles) + 1)]
 			ert_antag = new ert_antag ()

--- a/tgui/packages/tgui/interfaces/ErtManager.tsx
+++ b/tgui/packages/tgui/interfaces/ErtManager.tsx
@@ -30,6 +30,7 @@ type Data = {
   totalSlots: number;
   ertSpawnpoints: number;
   ertRequestMessages: MessageType[];
+  shouldBeAnnounced: BooleanLike;
 };
 
 type MessageType = {
@@ -136,8 +137,14 @@ const ERTOverview = (props) => {
 
 const SendERT = (props) => {
   const { act, data } = useBackend<Data>();
-  const { ertType, adminSlots, commanderSlots, totalSlots, ertSpawnpoints } =
-    data;
+  const {
+    ertType,
+    adminSlots,
+    commanderSlots,
+    totalSlots,
+    ertSpawnpoints,
+    shouldBeAnnounced,
+  } = data;
 
   const ertNum = [0, 1, 2, 3, 4, 5];
   enum ERTJOB {
@@ -186,6 +193,16 @@ const SendERT = (props) => {
                   onClick={() => act('toggleAdmin')}
                 >
                   {adminSlots ? 'Yes' : 'No'}
+                </Button>
+              </LabeledList.Item>
+              <LabeledList.Item label="Should be announced?">
+                <Button
+                  icon={shouldBeAnnounced ? 'toggle-on' : 'toggle-off'}
+                  selected={shouldBeAnnounced}
+                  tooltip="Последует оповещение после отказа/одобрения запроса?"
+                  onClick={() => act('toggleAnnounce')}
+                >
+                  {shouldBeAnnounced ? 'Yes' : 'No'}
                 </Button>
               </LabeledList.Item>
               <LabeledList.Item label="Commander">

--- a/tgui/packages/tgui/interfaces/ErtManager.tsx
+++ b/tgui/packages/tgui/interfaces/ErtManager.tsx
@@ -209,7 +209,7 @@ const SendERT = (props) => {
                 <Button
                   icon={commanderSlots ? 'toggle-on' : 'toggle-off'}
                   selected={commanderSlots}
-                  tooltip="Лидер должен быть"
+                  tooltip="Будет лидер при создании отряда или нет?"
                   onClick={() => act('toggleCom')}
                 >
                   {commanderSlots ? 'Yes' : 'No'}

--- a/tgui/packages/tgui/interfaces/ErtManager.tsx
+++ b/tgui/packages/tgui/interfaces/ErtManager.tsx
@@ -199,7 +199,7 @@ const SendERT = (props) => {
                 <Button
                   icon={shouldBeAnnounced ? 'toggle-on' : 'toggle-off'}
                   selected={shouldBeAnnounced}
-                  tooltip="Последует оповещение после отказа/одобрения запроса?"
+                  tooltip="Последует ли оповещение после отказа/одобрения запроса?"
                   onClick={() => act('toggleAnnounce')}
                 >
                   {shouldBeAnnounced ? 'Yes' : 'No'}


### PR DESCRIPTION
## Что этот PR делает
Добавляет в ерт манагер возможность выбрать будет сделано оповещение после спавна отряда или нет.
Добавляет анонсы о том что отряд ЕРТ заспавнился и какого этот отряд типа.
Добавляет возможность в ерт манагер выбрать будет лидер при спавне отряда или нет.
Добавляет защиту от дурака при спавне ЕРТ с нулём доступных слотов.
Fixes #1259

## Почему это хорошо для игры
Больше возможностей для спавна ЕРТ и больше понимания игрокам что к ним выехало ЕРТ или нет.

## Изображения изменений
![image](https://github.com/user-attachments/assets/9c45309a-088d-4616-9fa4-9939dd63d52a)

## Тестирование
Компилил и спавнил ерт.

## Changelog
:cl:
add: Добавлены анонсы при спавне отряда ЕРТ и в случае, если отряд не смог заспавниться.
qol: Добавлена опция в ЕРТ менеджер для возможности убрать или оставить оповещение при создании ЕРТ.
qol: Добавлена опция в ЕРТ менеджер для возможности убрать или оставить лидера при создании ЕРТ.
qol: Добавлена защита от дурака при создании ЕРТ с нулём доступных слотов в ЕРТ менеджере.
/:cl:

## Обзор от Sourcery

Добавлена настраиваемая опция анонса для появления отряда ERT

Новые возможности:
- Добавлен переключатель для управления тем, следует ли объявлять о появлении отряда ERT.
- Добавлены конкретные объявления для различных типов ERT (Amber, Red, Gamma) при появлении.

Улучшения:
- Обеспечена большая гибкость в ERT manager, позволяя администраторам выбирать, делать ли объявления.
- Улучшено информирование игроков о статусе развертывания ERT.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable announcement option for ERT squad spawning

New Features:
- Introduce a toggle to control whether ERT squad spawning should be announced
- Add specific announcements for different ERT types (Amber, Red, Gamma) when spawned

Enhancements:
- Provide more flexibility in ERT manager by allowing admins to choose whether to make announcements
- Improve player communication about ERT deployment status

</details>