### PR TITLE
Fix typo in announce

### DIFF
--- a/modular_bandastation/ert/code/ert_manager.dm
+++ b/modular_bandastation/ert/code/ert_manager.dm
@@ -292,9 +292,9 @@ ADMIN_VERB(ert_manager, R_NONE, "ERT Manager", "Manage ERT reqests.", ADMIN_CATE
 				if("Amber")
 					priority_announce("Внимание, [station_name()]. Мы направляем стандартный отряд быстрого реагирования кода «ЭМБЕР». Ожидайте.", "ОБР в пути")
 				if("Red")
-					priority_announce("Внимание, [station_name()]. Мы направляем стандартный отряд быстрого реагирования кода «РЭД». Ожидайте.", "ОБР в пути")
+					priority_announce("Внимание, [station_name()]. Мы направляем усиленный отряд быстрого реагирования кода «РЭД». Ожидайте.", "ОБР в пути")
 				if("Gamma")
-					priority_announce("Внимание, [station_name()]. Мы направляем стандартный отряд быстрого реагирования кода «ГАММА». Ожидайте.", "ОБР в пути")
+					priority_announce("Внимание, [station_name()]. Мы направляем элитный отряд быстрого реагирования кода «ГАММА». Ожидайте.", "ОБР в пути")
 
 	//Open the Armory doors
 	if(ertemplate.opendoors)


### PR DESCRIPTION
## Что этот PR делает
Не увидел что на парадизе в анонсе при вызове различных отрядов отличался их тип и теперь все отряды стали стандартными.

## Почему это хорошо для игры
Меньше очепяток.

## Тестирование
Прокомпилил и анонсы вызвал.

## Changelog
:cl:
typo: При удачном вызове ЕРТ через ЕРТ менеджер в анонсе станции отображаются правильные типы отрядов.
/:cl:

## Обзор от Sourcery

Исправления ошибок:
- Исправлен текст объявления, чтобы точно отражать тип группы экстренного реагирования (ERT), развертываемой для уровней кода Red и Gamma.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Corrected the announcement text to accurately reflect the type of emergency response team (ERT) being deployed for Red and Gamma code levels

</details>