### PR TITLE
fix blueshield and ntr closets content population, let eg14 (blueshield pistol) to holsters

### DIFF
--- a/code/datums/storage/subtypes/holsters.dm
+++ b/code/datums/storage/subtypes/holsters.dm
@@ -20,6 +20,7 @@
 			/obj/item/gun/ballistic/rifle/boltaction, //fits if you make it an obrez
 			/obj/item/gun/energy/laser/captain,
 			/obj/item/gun/energy/e_gun/hos,
+			/obj/item/gun/energy/eg_14, /// BANDASTATION ADD
 		)
 
 	set_holdable(holdable_override)
@@ -38,6 +39,7 @@
 		/obj/item/gun/energy/recharge/ebow,
 		/obj/item/gun/energy/laser/captain,
 		/obj/item/gun/energy/e_gun/hos,
+		/obj/item/gun/energy/eg_14, /// BANDASTATION ADD
 	)
 
 	return ..()
@@ -67,6 +69,7 @@
 		/obj/item/gun/energy/laser/captain,
 		/obj/item/gun/energy/e_gun/hos,
 		/obj/item/gun/ballistic/rifle/boltaction, //fits if you make it an obrez
+		/obj/item/gun/energy/eg_14, /// BANDASTATION ADD
 	)
 
 	return ..()
@@ -95,6 +98,7 @@
 		/obj/item/gun/energy/dueling,
 		/obj/item/gun/energy/laser/captain,
 		/obj/item/gun/energy/e_gun/hos,
+		/obj/item/gun/energy/eg_14, /// BANDASTATION ADD
 	)
 
 	return ..()

--- a/modular_bandastation/objects/code/structures/crates_lockers/closets/secure/blueshield.dm
+++ b/modular_bandastation/objects/code/structures/crates_lockers/closets/secure/blueshield.dm
@@ -5,13 +5,14 @@
 	req_access = list(ACCESS_BLUESHIELD)
 
 /obj/structure/closet/secure_closet/blueshield/PopulateContents()
-	return list(
-		/obj/item/storage/briefcase/secure,
-		/obj/item/storage/medkit/advanced,
-		/obj/item/storage/belt/security/full,
-		/obj/item/storage/bag/garment/blueshield,
-		/obj/item/radio/headset/blueshield,
-		/obj/item/radio/headset/blueshield/alt,
-		/obj/item/sensor_device,
-		/obj/item/pinpointer/crew,
+	var/static/list/items_inside = list(
+		/obj/item/storage/briefcase/secure = 1,
+		/obj/item/storage/medkit/advanced = 1,
+		/obj/item/storage/belt/security/full = 1,
+		/obj/item/storage/bag/garment/blueshield = 1,
+		/obj/item/radio/headset/blueshield = 1,
+		/obj/item/radio/headset/blueshield/alt = 1,
+		/obj/item/sensor_device = 1,
+		/obj/item/pinpointer/crew = 1,
 	)
+	generate_items_inside(items_inside, src)

--- a/modular_bandastation/objects/code/structures/crates_lockers/closets/secure/nanotrasen_representative.dm
+++ b/modular_bandastation/objects/code/structures/crates_lockers/closets/secure/nanotrasen_representative.dm
@@ -5,13 +5,14 @@
 	req_access = list(ACCESS_NANOTRASEN_REPRESENTATIVE)
 
 /obj/structure/closet/secure_closet/nanotrasen_representative/PopulateContents()
-	return list(
-		/obj/item/storage/briefcase/secure,
-		/obj/item/radio/headset/heads/nanotrasen_representative,
-		/obj/item/pai_card,
-		/obj/item/assembly/flash/handheld,
-		/obj/item/taperecorder,
-		/obj/item/storage/box/tapes,
-		/obj/item/storage/bag/garment/nanotrasen_representative,
+	var/static/list/items_inside = list(
+		/obj/item/storage/briefcase/secure = 1,
+		/obj/item/radio/headset/heads/nanotrasen_representative = 1,
+		/obj/item/pai_card = 1,
+		/obj/item/assembly/flash/handheld = 1,
+		/obj/item/taperecorder = 1,
+		/obj/item/storage/box/tapes = 1,
+		/obj/item/storage/bag/garment/nanotrasen_representative = 1,
 	)
+	generate_items_inside(items_inside, src)
 


### PR DESCRIPTION
## Что этот PR делает

Исправляет баги после рефактора storage, который откатят скоро... но что поделать

## Changelog

:cl:
fix: eg14 (пистолет БЩ) снова лезет в кобуру
fix: шкафы НТРа и БЩ снова корректно заполняются содержимым
/:cl:

## Обзор от Sourcery

Исправление заполнения содержимого шкафов Blueshield и NTR и включение ношения пистолета EG14 в кобуре

Исправления ошибок:
- Исправлен механизм заполнения предметов для шкафов Blueshield и представителя Nanotrasen, чтобы обеспечить правильную генерацию содержимого.
- Добавлен EG14 (пистолет Blueshield) в различные типы кобур, чтобы обеспечить правильное хранение оружия.

Улучшения:
- Обновлен метод заполнения шкафа для использования функции `generate_items_inside()` для более надежного размещения предметов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix content population for Blueshield and NTR closets and enable EG14 pistol holstering

Bug Fixes:
- Corrected the item population mechanism for Blueshield and Nanotrasen Representative closets to ensure proper content generation
- Added EG14 (Blueshield pistol) to various holster types to allow proper weapon storage

Enhancements:
- Updated closet population method to use generate_items_inside() function for more reliable item placement

</details>