### PR TITLE
Small hookah display text

### DIFF
--- a/modular_bandastation/bar_hookahs/code/bar_hookahs.dm
+++ b/modular_bandastation/bar_hookahs/code/bar_hookahs.dm
@@ -176,7 +176,11 @@
 		return
 
 	var/transferred = container.reagents.trans_to(src, container.amount_per_transfer_from_this)
-	user.visible_message(span_notice("[user] переливает что-то в [src.declent_ru(NOMINATIVE)]."), span_notice("Вы переливаете [transferred] единиц жидкости в [src.declent_ru(NOMINATIVE)]."))
+	if(transferred > 0)
+		user.visible_message(span_notice("[user] переливает что-то в [src.declent_ru(NOMINATIVE)]."),
+			span_notice("Вы переливаете [transferred] единиц жидкости в [src.declent_ru(NOMINATIVE)]."))
+	else
+		to_chat(user, span_warning("В [src.declent_ru(PREPOSITIONAL)] нет места!"))
 
 /obj/item/hookah/process()
 	if(!lit || !fuel)

--- a/modular_bandastation/bar_hookahs/code/bar_hookahs.dm
+++ b/modular_bandastation/bar_hookahs/code/bar_hookahs.dm
@@ -176,11 +176,14 @@
 		return
 
 	var/transferred = container.reagents.trans_to(src, container.amount_per_transfer_from_this)
-	if(transferred > 0)
-		user.visible_message(span_notice("[user] переливает что-то в [src.declent_ru(NOMINATIVE)]."),
-			span_notice("Вы переливаете [transferred] единиц жидкости в [src.declent_ru(NOMINATIVE)]."))
-	else
+	if(transferred <= 0)
 		to_chat(user, span_warning("В [src.declent_ru(PREPOSITIONAL)] нет места!"))
+		return
+		
+	user.visible_message(
+		span_notice("[user] переливает что-то в [src.declent_ru(NOMINATIVE)]."),
+		span_notice("Вы переливаете [transferred] единиц жидкости в [src.declent_ru(NOMINATIVE)].")
+	)
 
 /obj/item/hookah/process()
 	if(!lit || !fuel)


### PR DESCRIPTION
## Что этот PR делает

Исправляет вывод в чат если в кальяне нет места для жидкости

## Почему это хорошо для игры

Не будет писаться "вы переливаете 0 единиц"

## Тестирование

локалочка

## Changelog

:cl:
fix: Исправил вывод если ничего не было перелито в кальян
/:cl:

## Обзор от Sourcery

Исправления ошибок:
- Исправлено отображение сообщения при попытке перелить жидкость в кальян, в котором нет свободного места, что предотвращает сбивающие с толку сообщения о передаче нулевого количества единиц.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixed the display message when attempting to transfer liquid to a hookah with no available space, preventing confusing zero-unit transfer messages

</details>