### PR TITLE
Match shutters and button id for magistrate office on metastation

### DIFF
--- a/_maps/bandastation/automapper/templates/metastation/metastation_magistrate_office.dmm
+++ b/_maps/bandastation/automapper/templates/metastation/metastation_magistrate_office.dmm
@@ -232,7 +232,7 @@
 	dir = 4
 	},
 /obj/machinery/button/door/directional/west{
-	id = "lawyer_shutters";
+	id = "magistrate_shutters";
 	name = "Privacy Shutters"
 	},
 /obj/effect/landmark/start/magistrate,


### PR DESCRIPTION
## Что этот PR делает
Фиксит айди кнопки и привязанных к ней створок на мете в кабинете магистрата.
Fixes #1258

## Почему это хорошо для игры
Створки магистрата теперь работают.

## Изображения изменений

https://github.com/user-attachments/assets/7ccf4b30-e11b-4bfe-9fd0-547422c14c96


## Тестирование
Компилил и кликал на кнопочку.

## Changelog
:cl:
fix: Створки в кабинете магистрата на Metastaion теперь вновь закрываются и открываются по нажатии на кнопку.
/:cl:

## Обзор от Sourcery

Исправления ошибок:
- Исправлено соответствие ID кнопок и жалюзи в офисе магистрата для восстановления правильного открытия и закрытия жалюзи.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Corrected the mapping of button and shutter IDs in the magistrate office to restore proper opening and closing of shutters

</details>