### PR TITLE
pies only stun when fired from pneumatic cannon

### DIFF
--- a/code/datums/components/splat.dm
+++ b/code/datums/components/splat.dm
@@ -57,9 +57,9 @@
 	SIGNAL_HANDLER
 	if(caught) //someone caught us!
 		return
-	splat(source, hit_atom)
+	splat(source, hit_atom, throwing_datum)
 
-/datum/component/splat/proc/splat(atom/movable/source, atom/hit_atom)
+/datum/component/splat/proc/splat(atom/movable/source, atom/hit_atom, datum/thrownthing/throwing_datum)
 	var/turf/hit_turf = get_turf(hit_atom)
 	new smudge_type(hit_turf)
 	var/can_splat_on = TRUE
@@ -67,7 +67,7 @@
 		var/mob/living/living_target_getting_hit = hit_atom
 		if(iscarbon(living_target_getting_hit))
 			can_splat_on = !!(living_target_getting_hit.get_bodypart(BODY_ZONE_HEAD))
-		hit_callback?.Invoke(living_target_getting_hit, can_splat_on)
+		hit_callback?.Invoke(living_target_getting_hit, can_splat_on, throwing_datum)
 	if(can_splat_on && is_type_in_typecache(hit_atom, GLOB.splattable))
 		hit_atom.AddComponent(/datum/component/face_decal/splat, icon_state, layer, splat_color || source.color, memory_type, moodlet_type)
 	SEND_SIGNAL(source, COMSIG_MOVABLE_SPLAT, hit_atom)

--- a/code/game/objects/items/food/pie.dm
+++ b/code/game/objects/items/food/pie.dm
@@ -75,8 +75,8 @@
 	. = ..()
 	AddComponent(/datum/component/splat, hit_callback = CALLBACK(src, PROC_REF(stun_and_blur)))
 
-/obj/item/food/pie/cream/proc/stun_and_blur(mob/living/victim, can_splat_on)
-	if(stunning)
+/obj/item/food/pie/cream/proc/stun_and_blur(mob/living/victim, can_splat_on, datum/thrownthing/throwing_datum)
+	if(stunning && throwing_datum && (throwing_datum.force >= (victim.move_resist * MOVE_FORCE_FORCEPUSH_RATIO)))
 		victim.Paralyze(2 SECONDS) //splat!
 	if(can_splat_on)
 		victim.adjust_eye_blur(2 SECONDS)

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -238,7 +238,7 @@
 	else
 		loadedWeightClass--
 	AM.forceMove(get_turf(src))
-	AM.throw_at(target, pressure_setting * 10 * range_multiplier, pressure_setting * 2, user, spin_item)
+	AM.throw_at(target, pressure_setting * 10 * range_multiplier, pressure_setting * 2, user, spin_item, force = MOVE_FORCE_STRONG)
 	return TRUE
 
 /obj/item/pneumatic_cannon/proc/get_target(turf/target, turf/starting)


### PR DESCRIPTION
## Что этот PR делает

Даёт предметам запущеным из пневматической пушки force MOVE_FORCE_STRONG.
Пироги теперь станят только если их кинули с достаточной силой - то есть пирог кинутый рукой обычного члена экипажа не застанит, но при выстрели из пневматической пушки - застанит.

## Почему это хорошо для игры

Человек не способен кидать пироги с такой силой, чтобы от него упали

## Тестирование

Протестировал - при выстреле из пушки стан есть, при броске - нет

## Changelog

:cl:
balance: даёт предметам запущеным из пневматической пушки force MOVE_FORCE_STRONG
balance: чтобы пирог застанил, он должен быть брошен с достаточной силой больше чем (move_resist * MOVE_FORCE_FORCEPUSH_RATIO). То есть пирог запущенный из пушки будет станить среднестатистического члена экипажа, а кинутый рукой - нет. 
/:cl:
