### PR TITLE
Cyberiad: external airlocks

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -1627,10 +1627,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "avD" = (
-/obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_exterior_1f_n3"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "avG" = (
@@ -3635,12 +3636,17 @@
 "aTm" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"aTq" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "airlock_exterior_1f_w1"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "aTr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -7759,6 +7765,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
+"bSF" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_exterior_2f_n1";
+	idSelf = "airlock_control_2f_n1";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_y = 5
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/solars/starboard/fore)
 "bSG" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/closet/secure_closet/freezer,
@@ -9830,6 +9846,16 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical/ghetto)
+"csm" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_exterior_2f_w2";
+	idSelf = "airlock_control_2f_w2";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = -5
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/solars/port/aft)
 "csp" = (
 /obj/item/clothing/shoes/magboots{
 	pixel_y = 6
@@ -10092,6 +10118,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"cvu" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_interior_1f_e3";
+	idSelf = "airlock_control_1f_e3";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = -4
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/starboard/aft)
 "cvB" = (
 /obj/effect/turf_decal/siding/wood/end,
 /obj/effect/turf_decal/siding/dark/corner{
@@ -10573,11 +10609,12 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/atmos)
 "cBx" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_exterior_2f_n3"
+	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "cBA" = (
@@ -10761,11 +10798,10 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "cDZ" = (
-/obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_interior_1f_n3"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
@@ -12418,9 +12454,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "cXa" = (
-/obj/structure/sign/warning/vacuum/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_interior_2f_w3";
+	idSelf = "airlock_control_2f_w3";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = 5
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/engine/atmos)
 "cXd" = (
 /obj/machinery/light/directional/north,
 /obj/effect/spawner/random/vending/colavend,
@@ -14406,13 +14448,12 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "dtU" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_exterior_2f_s2"
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "dtX" = (
@@ -17562,6 +17603,10 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"ejg" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port/aft)
 "ejh" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table,
@@ -17849,6 +17894,18 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/ghetto)
+"emT" = (
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "airlock_exterior_1f_n3";
+	idInterior = "airlock_interior_1f_n3";
+	idSelf = "airlock_control_1f_n3";
+	req_access = list("engineering");
+	name = "Airlock Access Controller";
+	interior_airlock = "airlock_control_1f_n3";
+	pixel_x = -4
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/fore/starboard)
 "emW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -18676,6 +18733,16 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/office)
+"ezY" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_interior_2f_s1";
+	idSelf = "airlock_control_2f_s1";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = -5
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/transit_tube)
 "eAc" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -18898,6 +18965,16 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
+"eCC" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_exterior_2f_n3";
+	idSelf = "airlock_control_2f_n3";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_y = 5
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/solars/port/fore)
 "eCM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18934,6 +19011,18 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/service/bar/atrium/ghetto)
+"eDh" = (
+/obj/machinery/door_buttons/airlock_controller{
+	pixel_x = -4;
+	idExterior = "airlock_exterior_2f_w1";
+	idInterior = "airlock_interior_2f_w1";
+	idSelf = "airlock_control_2f_w1";
+	req_access = list("engineering");
+	name = "Airlock Access Controller";
+	interior_airlock = "airlock_control_2f_w1"
+	},
+/turf/closed/wall,
+/area/station/maintenance/port/aft)
 "eDr" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 6
@@ -19321,6 +19410,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"eHT" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_interior_1f_w2";
+	idSelf = "airlock_control_1f_w2";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_y = 5
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/port/aft)
 "eHU" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -20529,6 +20628,16 @@
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
+"eXE" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_exterior_1f_s3";
+	idSelf = "airlock_control_1f_s3";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = -5
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/engine/ghetto)
 "eXQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -20664,6 +20773,14 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"eZN" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "airlock_interior_1f_w1"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "eZW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -21003,6 +21120,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/service)
+"feR" = (
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "airlock_exterior_2f_w2";
+	idInterior = "airlock_interior_2f_w2";
+	idSelf = "airlock_control_2f_w2";
+	req_access = list("engineering");
+	name = "Airlock Access Controller";
+	interior_airlock = "airlock_control_2f_w2";
+	pixel_y = -4
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/solars/port/aft)
 "feT" = (
 /obj/structure/bed/medical/emergency,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
@@ -21572,6 +21701,18 @@
 /obj/item/kirbyplants/random/dead,
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/department/security/ghetto)
+"fkY" = (
+/obj/machinery/door_buttons/airlock_controller{
+	pixel_x = -4;
+	idExterior = "airlock_exterior_1f_n1";
+	idInterior = "airlock_interior_1f_n1";
+	idSelf = "airlock_control_1f_n1";
+	req_access = list("engineering");
+	name = "Airlock Access Controller";
+	interior_airlock = "airlock_control_1f_n1"
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/port/greater)
 "flb" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -21971,6 +22112,16 @@
 /obj/machinery/meter,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
+"fqB" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_exterior_1f_n2";
+	idSelf = "airlock_control_1f_n2";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_y = 5
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/security/ghetto/fore)
 "fqE" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/airalarm/directional/west,
@@ -22577,6 +22728,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
+"fxx" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_exterior_1f_n3";
+	idSelf = "airlock_control_1f_n3";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_y = 5
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/fore/starboard)
 "fxy" = (
 /obj/machinery/vending/cola/space_up,
 /obj/effect/decal/cleanable/dirt,
@@ -23280,6 +23441,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/abandoned)
+"fFF" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_exterior_2f_s2";
+	idSelf = "airlock_control_2f_s2";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_y = -5
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/solars/starboard/aft)
 "fFP" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -23383,6 +23554,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"fGQ" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_interior_1f_e1";
+	idSelf = "airlock_control_1f_e1";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_y = 5
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/fore/starboard)
 "fGS" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/lawyer,
@@ -23596,6 +23777,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
+"fIZ" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_interior_1f_e3"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard/aft)
 "fJa" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/sign/warning/deathsposal/directional/east,
@@ -24154,6 +24343,16 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
+"fQh" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_exterior_1f_w2";
+	idSelf = "airlock_control_1f_w2";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = -5
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/port/aft)
 "fQm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25299,12 +25498,11 @@
 /turf/open/floor/wood,
 /area/station/service/library/ghetto)
 "ges" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_exterior_1f_w2"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
 "geu" = (
@@ -25479,6 +25677,18 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
+"ggm" = (
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "airlock_exterior_1f_w2";
+	idInterior = "airlock_interior_1f_w2";
+	idSelf = "airlock_control_1f_w2";
+	req_access = list("engineering");
+	name = "Airlock Access Controller";
+	interior_airlock = "airlock_control_1f_w2";
+	pixel_y = 4
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/ghetto/port/aft)
 "ggq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -25707,6 +25917,11 @@
 /obj/item/gun/ballistic/revolver/russian,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"giT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard/aft)
 "gjd" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -25755,6 +25970,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
+"gjX" = (
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "airlock_exterior_1f_e2";
+	idInterior = "airlock_interior_1f_e2";
+	idSelf = "airlock_control_1f_e2";
+	req_access = list("engineering");
+	name = "Airlock Access Controller";
+	interior_airlock = "airlock_control_1f_e2";
+	pixel_y = -4
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/starboard)
 "gjY" = (
 /obj/structure/railing/corner/end/flip{
 	dir = 4;
@@ -26887,6 +27114,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/service)
+"gAG" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_interior_1f_w1";
+	idSelf = "airlock_control_1f_w1";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = -5
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/port)
 "gAV" = (
 /obj/structure/railing{
 	dir = 8
@@ -27053,12 +27290,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "gCR" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_interior_2f_n2"
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "gDg" = (
@@ -27187,10 +27423,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "gFe" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_exterior_2f_n4"
+	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "gFq" = (
@@ -28617,6 +28854,16 @@
 "gVu" = (
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/abandoned_gambling_den)
+"gVz" = (
+/obj/machinery/door_buttons/access_button{
+	pixel_y = -5;
+	idDoor = "airlock_interior_1f_n3";
+	idSelf = "airlock_control_1f_n3";
+	req_access = list("engineering");
+	name = "Airlock Access Button"
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/fore/starboard)
 "gVD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/random,
@@ -29161,10 +29408,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port)
 "hbO" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_interior_2f_w1"
+	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "hcl" = (
@@ -29602,6 +29850,16 @@
 /obj/structure/chair,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"hhV" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_exterior_1f_s2";
+	idSelf = "airlock_control_1f_s2";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = -5
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/engine/ghetto)
 "hhW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -29628,6 +29886,18 @@
 /obj/item/defibrillator/loaded,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
+"hij" = (
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "airlock_exterior_2f_n2";
+	idInterior = "airlock_interior_2f_n2";
+	idSelf = "airlock_control_2f_n2";
+	req_access = list("engineering");
+	name = "Airlock Access Controller";
+	interior_airlock = "airlock_control_2f_n2";
+	pixel_y = 4
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/fore)
 "hiq" = (
 /obj/effect/turf_decal/trimline/dark/warning{
 	dir = 5
@@ -29694,6 +29964,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
+"hiE" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_interior_1f_s3";
+	idSelf = "airlock_control_1f_s3";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = 5
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/engine/ghetto)
 "hiG" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -30209,6 +30489,16 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
+"hoy" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_interior_2f_s2";
+	idSelf = "airlock_control_2f_s2";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_y = 5
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/solars/starboard/aft)
 "hoA" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/chair/wood,
@@ -30626,13 +30916,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "huw" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_exterior_2f_w2"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "hux" = (
@@ -33488,6 +33777,18 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"ieu" = (
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "airlock_exterior_1f_e1";
+	idInterior = "airlock_interior_1f_e1";
+	idSelf = "airlock_control_1f_e1";
+	req_access = list("engineering");
+	name = "Airlock Access Controller";
+	interior_airlock = "airlock_control_1f_e1";
+	pixel_y = 4
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/fore/starboard)
 "iex" = (
 /obj/structure/flora/bush/jungle/a/style_random,
 /obj/structure/flora/rock/style_2{
@@ -33495,6 +33796,16 @@
 	},
 /turf/open/misc/dirt/dark/station,
 /area/station/service/bar/atrium/ghetto)
+"ieD" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_interior_2f_w1";
+	idSelf = "airlock_control_2f_w1";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_y = 5
+	},
+/turf/closed/wall,
+/area/station/maintenance/port/aft)
 "ieH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33516,6 +33827,16 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
 /area/station/service/kitchen/abandoned)
+"ieQ" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_exterior_2f_e1";
+	idSelf = "airlock_control_2f_e1";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = 5
+	},
+/turf/closed/wall,
+/area/station/maintenance/starboard/aft)
 "ieW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34189,6 +34510,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"inM" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_exterior_1f_n1";
+	idSelf = "airlock_control_1f_n1";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_y = 5
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/port/greater)
 "inS" = (
 /obj/machinery/door/window/brigdoor/left/directional/north{
 	name = "Creature Pen";
@@ -35343,12 +35674,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "iDY" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_interior_1f_e1"
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "iEh" = (
@@ -36073,6 +36403,16 @@
 /obj/item/stock_parts/power_store/cell/high,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
+"iMx" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_interior_2f_e1";
+	idSelf = "airlock_control_2f_e1";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = -4
+	},
+/turf/closed/wall,
+/area/station/maintenance/starboard/aft)
 "iMy" = (
 /obj/machinery/light/small/directional/east{
 	name = "maintenance light";
@@ -40649,12 +40989,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "jUs" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_exterior_2f_w1"
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "jUu" = (
@@ -40733,6 +41072,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"jVh" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_interior_2f_n2";
+	idSelf = "airlock_control_2f_n2";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_y = 5
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/fore)
 "jVi" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -41333,6 +41682,15 @@
 /obj/structure/table/wood/fancy/blue,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"kbW" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_interior_1f_s3"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/engine/ghetto)
 "kco" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -41667,6 +42025,18 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"kgZ" = (
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "airlock_exterior_2f_s1";
+	idInterior = "airlock_interior_2f_s1";
+	idSelf = "airlock_control_2f_s1";
+	req_access = list("engineering");
+	name = "Airlock Access Controller";
+	interior_airlock = "airlock_control_2f_s1";
+	pixel_y = -4
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/transit_tube)
 "khb" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/effect/turf_decal/tile/purple/half,
@@ -41698,9 +42068,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "khr" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/port/aft)
+/obj/machinery/door_buttons/access_button{
+	pixel_y = -5;
+	idDoor = "airlock_interior_1f_n1";
+	idSelf = "airlock_control_1f_n1";
+	req_access = list("engineering");
+	name = "Airlock Access Button"
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/port/greater)
 "kht" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -41878,6 +42254,16 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"kjZ" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_exterior_1f_e2";
+	idSelf = "airlock_control_1f_e2";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = 5
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/starboard)
 "kka" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/effect/spawner/random/structure/crate,
@@ -42823,12 +43209,17 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "kvb" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "airlock_exterior_2f_w3";
+	idInterior = "airlock_interior_2f_w3";
+	idSelf = "airlock_control_2f_w3";
+	req_access = list("engineering");
+	name = "Airlock Access Controller";
+	interior_airlock = "airlock_control_2f_w3";
+	pixel_y = 4
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/engine/atmos)
 "kvh" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -42972,9 +43363,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "kwE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/transit_tube)
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "airlock_exterior_1f_s3";
+	idInterior = "airlock_interior_1f_s3";
+	idSelf = "airlock_control_1f_s3";
+	req_access = list("engineering");
+	name = "Airlock Access Controller";
+	interior_airlock = "airlock_control_1f_s3";
+	pixel_y = 4
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/engine/ghetto)
 "kwL" = (
 /obj/machinery/computer/mech_bay_power_console,
 /turf/open/floor/catwalk_floor,
@@ -43961,6 +44360,16 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
+"kIf" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_exterior_1f_e1";
+	idSelf = "airlock_control_1f_e1";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = 5
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/fore/starboard)
 "kIg" = (
 /obj/machinery/door/window/right/directional/north{
 	name = "Garden";
@@ -44854,14 +45263,14 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/aft)
 "kSu" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_exterior_1f_s3"
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard/aft)
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/engine/ghetto)
 "kSv" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -45168,12 +45577,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
 "kWY" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_interior_2f_s1"
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/engineering/transit_tube)
 "kWZ" = (
@@ -46585,13 +46993,12 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "lpy" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_interior_2f_e1"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "lpB" = (
@@ -46999,13 +47406,12 @@
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
 "lsX" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_exterior_2f_e1"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "lsZ" = (
@@ -47459,6 +47865,28 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"lzA" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_interior_2f_n1";
+	idSelf = "airlock_control_2f_n1";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_y = -5
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/solars/starboard/fore)
+"lzC" = (
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "airlock_exterior_1f_e3";
+	idInterior = "airlock_interior_1f_e3";
+	idSelf = "airlock_control_1f_e3";
+	req_access = list("engineering");
+	name = "Airlock Access Controller";
+	interior_airlock = "airlock_control_1f_e3";
+	pixel_y = 4
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/starboard/aft)
 "lzH" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -47716,6 +48144,16 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port/greater)
+"lCK" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_exterior_1f_w1";
+	idSelf = "airlock_control_1f_w1";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_y = -5
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/port)
 "lCL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -49328,12 +49766,11 @@
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/magistrate)
 "lWs" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_interior_1f_w2"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
 "lWz" = (
@@ -50188,6 +50625,18 @@
 	},
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
+"mhi" = (
+/obj/machinery/door_buttons/airlock_controller{
+	pixel_x = -4;
+	idExterior = "airlock_exterior_1f_w1";
+	idInterior = "airlock_interior_1f_w1";
+	idSelf = "airlock_control_1f_w1";
+	req_access = list("engineering");
+	name = "Airlock Access Controller";
+	interior_airlock = "airlock_control_1f_w1"
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/port)
 "mhl" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -50879,6 +51328,16 @@
 "mri" = (
 /turf/closed/wall/r_wall,
 /area/station/security/courtroom/holding)
+"mrk" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_exterior_1f_e3";
+	idSelf = "airlock_control_1f_e3";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = 5
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/starboard/aft)
 "mrl" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "robo2"
@@ -51016,12 +51475,11 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage)
 "msN" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_exterior_1f_e1"
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "msO" = (
@@ -51363,6 +51821,18 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
 /area/station/security/processing)
+"mxl" = (
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "airlock_exterior_1f_s1";
+	idInterior = "airlock_interior_1f_s1";
+	idSelf = "airlock_control_1f_s1";
+	req_access = list("engineering");
+	name = "Airlock Access Controller";
+	interior_airlock = "airlock_control_1f_s1";
+	pixel_y = 4
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/auxiliary)
 "mxm" = (
 /obj/machinery/telecomms/bus/preset_two,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
@@ -51903,11 +52373,10 @@
 /turf/open/floor/iron/kitchen,
 /area/station/maintenance/ghetto/bar)
 "mDW" = (
-/obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_interior_1f_n2"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/fore)
@@ -53174,11 +53643,14 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/ghetto)
 "mTa" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_exterior_1f_e4";
+	idSelf = "airlock_control_1f_e4";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = 5
+	},
+/turf/closed/wall,
 /area/station/maintenance/ghetto/starboard/aft)
 "mTb" = (
 /obj/structure/cable,
@@ -53540,13 +54012,12 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/cmo)
 "mYc" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_interior_2f_n1"
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "mYf" = (
@@ -53593,6 +54064,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/ce)
+"mYv" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_interior_2f_n4";
+	idSelf = "airlock_control_2f_n4";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_y = -5
+	},
+/turf/closed/wall,
+/area/station/maintenance/port/greater)
 "mYz" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -55555,9 +56036,16 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "nwo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "airlock_exterior_2f_n1";
+	idInterior = "airlock_interior_2f_n1";
+	idSelf = "airlock_control_2f_n1";
+	req_access = list("engineering");
+	name = "Airlock Access Controller";
+	interior_airlock = "airlock_control_2f_n1";
+	pixel_x = -4
+	},
+/turf/closed/wall/r_wall,
 /area/station/maintenance/solars/starboard/fore)
 "nwu" = (
 /obj/machinery/portable_atmospherics/pump,
@@ -55816,6 +56304,16 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/smooth,
 /area/station/medical/chemistry/ghetto)
+"nAc" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_interior_1f_s1";
+	idSelf = "airlock_control_1f_s1";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = 5
+	},
+/turf/closed/wall/rust,
+/area/station/maintenance/ghetto/auxiliary)
 "nAh" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -59464,12 +59962,11 @@
 /area/station/maintenance/ghetto/garden)
 "osL" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_interior_1f_s2"
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/ghetto)
 "osV" = (
@@ -59889,6 +60386,16 @@
 /obj/item/banner/command,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
+"oxM" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_interior_1f_e2";
+	idSelf = "airlock_control_1f_e2";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_y = -5
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/starboard)
 "oxN" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/stairs/left{
@@ -61127,6 +61634,16 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
+"oOl" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_interior_2f_w2";
+	idSelf = "airlock_control_2f_w2";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = 5
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/solars/port/aft)
 "oOo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -61225,7 +61742,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "oPo" = (
-/obj/structure/sign/warning/vacuum/external/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "oPp" = (
@@ -64005,12 +64521,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/lower)
 "pxB" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_interior_2f_n4"
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "pxH" = (
@@ -65133,12 +65648,11 @@
 /area/station/science/research)
 "pKB" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_exterior_1f_s2"
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/ghetto)
 "pKC" = (
@@ -65567,12 +66081,11 @@
 /area/station/maintenance/ghetto/auxiliary)
 "pPR" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_interior_2f_w3"
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "pQe" = (
@@ -65668,12 +66181,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "pRu" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_interior_1f_e4"
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
 "pRx" = (
@@ -66640,12 +67152,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
 "qeb" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_exterior_1f_n2"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/fore)
 "qed" = (
@@ -66885,6 +67396,13 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/ghetto/starboard)
+"qhU" = (
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/engine/ghetto)
 "qia" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/plating,
@@ -66976,12 +67494,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "qjk" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_exterior_2f_s1"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/engineering/transit_tube)
 "qjt" = (
@@ -67915,6 +68432,7 @@
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/structure/sign/warning/vacuum/external/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "qws" = (
@@ -68691,6 +69209,16 @@
 	},
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
+"qGe" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_interior_1f_s2";
+	idSelf = "airlock_control_1f_s2";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = 5
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/engine/ghetto)
 "qGg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -70598,12 +71126,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "rep" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_exterior_1f_e2"
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "rez" = (
@@ -70844,10 +71371,11 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "rhm" = (
-/obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_exterior_1f_n1"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "rhq" = (
@@ -70910,6 +71438,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"rhL" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_exterior_2f_n4";
+	idSelf = "airlock_control_2f_n4";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_y = 5
+	},
+/turf/closed/wall,
+/area/station/maintenance/port/greater)
 "rhY" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/generic,
@@ -71588,12 +72126,11 @@
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
 "rpR" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_exterior_2f_n2"
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "rpV" = (
@@ -71953,6 +72490,16 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
+"ruc" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_exterior_2f_n2";
+	idSelf = "airlock_control_2f_n2";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = 5
+	},
+/turf/closed/wall,
+/area/station/maintenance/fore)
 "ruf" = (
 /turf/open/openspace,
 /area/station/science/ordnance/office)
@@ -74354,6 +74901,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"rZs" = (
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "airlock_exterior_2f_s2";
+	idInterior = "airlock_interior_2f_s2";
+	idSelf = "airlock_control_2f_s2";
+	req_access = list("engineering");
+	name = "Airlock Access Controller";
+	interior_airlock = "airlock_control_2f_s2";
+	pixel_x = -4
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/solars/starboard/aft)
 "rZB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -75729,12 +76288,11 @@
 /area/station/maintenance/starboard/upper)
 "spM" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_exterior_2f_w3"
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "spQ" = (
@@ -76479,6 +77037,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"szJ" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_exterior_2f_w3";
+	idSelf = "airlock_control_2f_w3";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = -5
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/engine/atmos)
 "szL" = (
 /obj/item/reagent_containers/cup/glass/shaker,
 /obj/structure/table,
@@ -78299,12 +78867,11 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "sYo" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "airlock_interior_1f_s1"
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "sYw" = (
@@ -78412,12 +78979,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "taj" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_interior_1f_e2"
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "tay" = (
@@ -78444,6 +79010,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"tbc" = (
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "airlock_exterior_1f_s2";
+	idInterior = "airlock_interior_1f_s2";
+	idSelf = "airlock_control_1f_s2";
+	req_access = list("engineering");
+	name = "Airlock Access Controller";
+	interior_airlock = "airlock_control_1f_s2";
+	pixel_y = -4
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/engine/ghetto)
 "tbe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
@@ -79760,6 +80338,18 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"trc" = (
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "airlock_exterior_1f_n2";
+	idInterior = "airlock_interior_1f_n2";
+	idSelf = "airlock_control_1f_n2";
+	req_access = list("engineering");
+	name = "Airlock Access Controller";
+	interior_airlock = "airlock_control_1f_n2";
+	pixel_y = 4
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/security/ghetto/fore)
 "trg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -83955,11 +84545,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "utK" = (
-/obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_interior_1f_n1"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
@@ -85298,12 +85887,11 @@
 /turf/open/floor/plating,
 /area/station/service/chapel/monastery)
 "uMd" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "airlock_exterior_1f_s1"
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "uMf" = (
@@ -86039,6 +86627,16 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
+"uVQ" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_interior_1f_n2";
+	idSelf = "airlock_control_1f_n2";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = -5
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/security/ghetto/fore)
 "uVU" = (
 /obj/effect/landmark/start/cook,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -86174,6 +86772,18 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/kitchen)
+"uYn" = (
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "airlock_exterior_1f_e4";
+	idInterior = "airlock_interior_1f_e4";
+	idSelf = "airlock_control_1f_e4";
+	req_access = list("engineering");
+	name = "Airlock Access Controller";
+	interior_airlock = "airlock_control_1f_e4";
+	pixel_y = -4
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/starboard/aft)
 "uYv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -86248,12 +86858,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "uYW" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_exterior_1f_e4"
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
 "uYX" = (
@@ -86857,6 +87466,16 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"vhx" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_exterior_1f_s1";
+	idSelf = "airlock_control_1f_s1";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = -5
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/auxiliary)
 "vhz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -89254,6 +89873,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"vIT" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_interior_2f_n3";
+	idSelf = "airlock_control_2f_n3";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_y = -5
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/solars/port/fore)
 "vIX" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plating,
@@ -90778,6 +91407,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
+"wdA" = (
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/sign/warning/vacuum/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/engine/ghetto)
 "wdB" = (
 /obj/structure/chair/stool{
 	dir = 4
@@ -90978,13 +91615,12 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "wha" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_interior_2f_w2"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "whg" = (
@@ -91391,6 +92027,16 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/fore)
+"wkZ" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_exterior_2f_w1";
+	idSelf = "airlock_control_2f_w1";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = -5
+	},
+/turf/closed/wall,
+/area/station/maintenance/port/aft)
 "wlt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
@@ -93233,6 +93879,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
+"wIU" = (
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "airlock_exterior_2f_e1";
+	idInterior = "airlock_interior_2f_e1";
+	idSelf = "airlock_control_2f_e1";
+	req_access = list("engineering");
+	name = "Airlock Access Controller";
+	interior_airlock = "airlock_control_2f_e1";
+	pixel_y = -4
+	},
+/turf/closed/wall,
+/area/station/maintenance/starboard/aft)
 "wJo" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -94529,6 +95187,14 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/station/commons/storage/emergency)
+"xaS" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_exterior_1f_e3"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard/aft)
 "xaT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -94844,6 +95510,18 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
+"xeb" = (
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "airlock_exterior_2f_n3";
+	idInterior = "airlock_interior_2f_n3";
+	idSelf = "airlock_control_2f_n3";
+	req_access = list("engineering");
+	name = "Airlock Access Controller";
+	interior_airlock = "airlock_control_2f_n3";
+	pixel_x = -4
+	},
+/turf/closed/wall/r_wall,
+/area/station/maintenance/solars/port/fore)
 "xeg" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -95335,6 +96013,16 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"xjr" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_interior_1f_e4";
+	idSelf = "airlock_control_1f_e4";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = -5
+	},
+/turf/closed/wall,
+/area/station/maintenance/ghetto/starboard/aft)
 "xju" = (
 /obj/machinery/atmospherics/components/binary/valve/on{
 	dir = 4
@@ -95778,6 +96466,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"xoG" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "airlock_exterior_2f_s1";
+	idSelf = "airlock_control_2f_s1";
+	req_access = list("engineering");
+	name = "Airlock Access Button";
+	pixel_x = 5
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/transit_tube)
 "xoI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -96290,11 +96988,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "xwf" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_interior_2f_s2"
+	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "xwi" = (
@@ -97086,11 +97785,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "xGB" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_exterior_2f_n1"
+	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "xGF" = (
@@ -97829,6 +98529,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lower)
+"xPS" = (
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "airlock_exterior_2f_n4";
+	idInterior = "airlock_interior_2f_n4";
+	idSelf = "airlock_control_2f_n4";
+	req_access = list("engineering");
+	name = "Airlock Access Controller";
+	interior_airlock = "airlock_control_2f_n4";
+	pixel_x = 4
+	},
+/turf/closed/wall,
+/area/station/maintenance/port/greater)
 "xPT" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -99049,13 +99761,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "ygO" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/machinery/door/airlock/external{
+	id_tag = "airlock_interior_2f_n3"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "ygR" = (
@@ -111955,8 +112666,8 @@ doz
 doz
 doz
 iEV
-iEV
-iEV
+tbM
+tbM
 iEV
 cVi
 cVi
@@ -113236,9 +113947,9 @@ doz
 doz
 doz
 doz
-tbM
-tbM
-tbM
+iEV
+iEV
+iEV
 oXT
 lCE
 gPX
@@ -113750,9 +114461,9 @@ doz
 doz
 doz
 doz
-tbM
-tbM
-tbM
+inM
+fkY
+khr
 xyL
 dyB
 ivV
@@ -114818,9 +115529,9 @@ mQU
 mQU
 mQU
 mQU
-eHR
+eZN
 mQU
-aoJ
+aTq
 jEk
 doz
 doz
@@ -115074,10 +115785,10 @@ mQU
 pLM
 mLL
 tWQ
+gAG
 tWQ
-tWQ
-tWQ
-tWQ
+mhi
+lCK
 ceC
 doz
 doz
@@ -118456,7 +119167,7 @@ doz
 rmU
 ges
 ges
-rmU
+fQh
 doz
 ceC
 oVL
@@ -118967,10 +119678,10 @@ doz
 doz
 doz
 doz
-weS
-khr
-aec
 mBX
+aec
+ejg
+ggm
 ceC
 oVL
 oVL
@@ -119484,7 +120195,7 @@ ceC
 rmU
 nbK
 aec
-rmU
+eHT
 doz
 oVL
 doz
@@ -122572,8 +123283,8 @@ rmU
 doz
 dKo
 dKo
-pKB
-dKo
+kSu
+eXE
 job
 doz
 doz
@@ -122589,7 +123300,7 @@ doz
 doz
 doz
 ccJ
-dKo
+hhV
 pKB
 dKo
 cKv
@@ -123087,7 +123798,7 @@ doz
 dKo
 lcw
 inV
-dKo
+kwE
 ctJ
 fSc
 fSc
@@ -123103,7 +123814,7 @@ fSc
 fSc
 fSc
 fND
-dKo
+tbc
 tFN
 pMA
 obg
@@ -123343,8 +124054,8 @@ rmU
 eIA
 dKo
 dKo
-osL
-dKo
+kbW
+hiE
 ifG
 ifG
 ifG
@@ -123360,7 +124071,7 @@ ifG
 aRR
 aRR
 ifG
-dKo
+qGe
 osL
 dKo
 cKv
@@ -123617,8 +124328,8 @@ ese
 hir
 tSC
 exc
-jpa
-kpt
+qhU
+wdA
 dKo
 dKo
 dKo
@@ -126324,7 +127035,7 @@ doz
 yjB
 ugr
 mDW
-yjB
+uVQ
 oLS
 jxu
 jxu
@@ -126581,7 +127292,7 @@ doz
 ceC
 yjB
 aQY
-yjB
+trc
 oLS
 jxu
 xaY
@@ -127095,7 +127806,7 @@ doz
 ceC
 job
 job
-yjB
+fqB
 ovd
 jxu
 xaY
@@ -131581,7 +132292,7 @@ wcM
 doz
 uPA
 uMd
-uPA
+vhx
 doz
 doz
 doz
@@ -131838,7 +132549,7 @@ wcM
 doz
 uPA
 pZA
-uPA
+mxl
 doz
 doz
 doz
@@ -132095,7 +132806,7 @@ mDY
 uPA
 uPA
 sYo
-xfI
+nAc
 xfI
 xfI
 uPA
@@ -141496,9 +142207,9 @@ doz
 doz
 doz
 doz
-qqz
-qqz
-qqz
+pNZ
+pNZ
+pNZ
 eJq
 tbQ
 pNZ
@@ -142010,9 +142721,9 @@ doz
 doz
 doz
 doz
-qqz
-qqz
-qqz
+fxx
+emT
+gVz
 fZE
 tbQ
 vpn
@@ -147947,7 +148658,7 @@ ezB
 vpn
 sNB
 vpn
-pNZ
+fGQ
 doz
 nSN
 xAl
@@ -148461,7 +149172,7 @@ uyS
 gPs
 pNZ
 vpn
-pNZ
+ieu
 doz
 doz
 doz
@@ -148718,7 +149429,7 @@ alI
 gHs
 pNZ
 msN
-pNZ
+kIf
 doz
 doz
 doz
@@ -148995,7 +149706,7 @@ ceC
 hUE
 ceC
 ceC
-ipz
+oxM
 qTP
 fqF
 ghW
@@ -149509,7 +150220,7 @@ doz
 ceC
 doz
 doz
-ipz
+gjX
 qTP
 ipz
 doz
@@ -149766,7 +150477,7 @@ doz
 ceC
 doz
 doz
-ipz
+kjZ
 rep
 ipz
 vbK
@@ -149829,9 +150540,9 @@ iYR
 iYR
 iYR
 iYR
-cXa
+fKk
 iYR
-iYR
+doz
 doz
 doz
 doz
@@ -150084,13 +150795,13 @@ ssd
 iYR
 yaj
 kpd
-ifu
+giT
 fuc
 fKk
-lFh
-hzG
-hzG
-hzG
+iYR
+doz
+doz
+doz
 doz
 doz
 doz
@@ -150344,10 +151055,10 @@ fKk
 ifu
 ifu
 ifu
-fKk
-mTa
-fKk
-kSu
+iYR
+doz
+doz
+doz
 doz
 doz
 doz
@@ -150601,10 +151312,10 @@ fKk
 fKk
 fdb
 fKk
-vSA
-hzG
-hzG
-hzG
+iYR
+doz
+doz
+doz
 doz
 doz
 doz
@@ -150859,7 +151570,7 @@ iYR
 iYR
 iYR
 iYR
-iYR
+doz
 doz
 doz
 doz
@@ -154936,8 +155647,8 @@ doz
 doz
 iYR
 iYR
-pRu
-iYR
+fIZ
+cvu
 iYR
 doz
 doz
@@ -154962,7 +155673,7 @@ doz
 doz
 doz
 iYR
-iYR
+xjr
 pRu
 iYR
 iYR
@@ -155194,7 +155905,7 @@ doz
 doz
 iYR
 fKk
-iYR
+lzC
 doz
 doz
 doz
@@ -155219,7 +155930,7 @@ doz
 doz
 doz
 doz
-iYR
+uYn
 fKk
 iYR
 doz
@@ -155450,8 +156161,8 @@ doz
 doz
 doz
 iYR
-uYW
-iYR
+xaS
+mrk
 ceC
 ceC
 doz
@@ -155476,7 +156187,7 @@ doz
 doz
 doz
 doz
-iYR
+mTa
 uYW
 iYR
 doz
@@ -176720,10 +177431,10 @@ tYD
 tYD
 trM
 vrm
-rvO
-rvO
-rvO
-rvO
+rhL
+oBy
+xPS
+mYv
 wuv
 bix
 gsR
@@ -179282,9 +179993,9 @@ tYD
 aIv
 tYD
 tYD
-sDZ
-sDZ
-sDZ
+eCC
+xeb
+vIT
 pEG
 gBo
 iRa
@@ -179345,10 +180056,10 @@ fCJ
 coz
 xOp
 qfY
+ieD
+eDh
 oXc
-oXc
-oXc
-oXc
+wkZ
 oXc
 oXc
 tYD
@@ -179541,7 +180252,7 @@ nGS
 tYD
 kJd
 tYD
-sDZ
+eKq
 eKq
 eKq
 eKq
@@ -182884,7 +183595,7 @@ tYD
 tYD
 tYD
 tYD
-kvb
+aTm
 wNd
 wNd
 aTm
@@ -183141,7 +183852,7 @@ tYD
 tYD
 tYD
 tYD
-kvb
+aTm
 eyH
 wNd
 aTm
@@ -183989,7 +184700,7 @@ wRD
 sZW
 kJd
 kJd
-hWR
+csm
 huw
 hWR
 xRt
@@ -184246,7 +184957,7 @@ coz
 coz
 coz
 tYD
-hWR
+feR
 fFP
 hWR
 xRt
@@ -184502,8 +185213,8 @@ pVS
 oXc
 kAy
 coz
-spZ
-hWR
+coz
+oOl
 wha
 hWR
 hWR
@@ -187362,7 +188073,7 @@ tYD
 kJd
 iMe
 spM
-iMe
+szJ
 trM
 tYD
 tYD
@@ -187619,7 +188330,7 @@ kJd
 kJd
 iMe
 aWy
-iMe
+kvb
 trM
 trM
 tYD
@@ -187876,8 +188587,8 @@ xRt
 iMe
 iMe
 pPR
-iMe
-iMe
+cXa
+rgH
 trM
 tYD
 tYD
@@ -203948,7 +204659,7 @@ xLF
 xLF
 cTF
 xLF
-mZY
+jVh
 raF
 pOX
 pOX
@@ -204308,8 +205019,8 @@ qyb
 vTH
 ygf
 xFx
-kwE
 xFx
+ezY
 kWY
 xFx
 omY
@@ -204462,7 +205173,7 @@ fgy
 mZY
 mZY
 brR
-mZY
+hij
 tYD
 cdD
 tYD
@@ -204566,7 +205277,7 @@ dRA
 dRA
 hpN
 job
-xFx
+kgZ
 cZt
 xFx
 eaC
@@ -204719,7 +205430,7 @@ tYD
 tYD
 fgy
 rpR
-fgy
+ruc
 tYD
 tYD
 tYD
@@ -204823,7 +205534,7 @@ dRA
 fzd
 hpN
 job
-xFx
+xoG
 qjk
 xFx
 nGB
@@ -207543,9 +208254,9 @@ sJu
 sJu
 kJd
 kJd
-xeX
+bSF
 nwo
-xeX
+lzA
 xCx
 mzJ
 xgU
@@ -207802,7 +208513,7 @@ kJd
 kJd
 kJd
 kJd
-xeX
+lyf
 lyf
 lyf
 lyf
@@ -216142,9 +216853,9 @@ fOt
 pqA
 hGd
 dCU
-hdu
-hdu
-hdu
+hoy
+rZs
+fFF
 tYD
 tYD
 kJd
@@ -216399,7 +217110,7 @@ fOt
 fOt
 fOt
 fOt
-hdu
+fOt
 gJs
 gJs
 gJs
@@ -218672,8 +219383,8 @@ tfm
 vLK
 xRt
 bTH
-qWL
-qWL
+bTH
+iMx
 lpy
 qWL
 bTH
@@ -218930,7 +219641,7 @@ vLK
 xRt
 xRt
 xRt
-qWL
+wIU
 sZD
 qWL
 bTH
@@ -219187,7 +219898,7 @@ vLK
 aut
 xRt
 aut
-qWL
+ieQ
 lsX
 qWL
 bTH


### PR DESCRIPTION
## Что этот PR делает

На карте Кибериада добавляет болты на внешние аирлоки, те, что ведут в космос за пределы станции, и кнопки под доступом инженеров.

## Почему это хорошо для игры

Наверное есть? Запрос старшей разработки.

## Изображения

Пример
![StrongDMM-2025-04-04 00 01 56](https://github.com/user-attachments/assets/28424803-d7ac-4390-8ee2-9fa5221e12df)

## Тестирование

Локалка

## Changelog

:cl:
map: Кибериада: внешние аирлоки, ведущих в космос за переделы станции, заболтированы и у них появились кнопки с доступом инженеров.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
