### PR TITLE
remove `R_NONE` requirement from most of the admin verbs (except hideverbs/deadmin). It's not requires actual permissions

### DIFF
--- a/code/modules/admin/admin_investigate.dm
+++ b/code/modules/admin/admin_investigate.dm
@@ -12,7 +12,7 @@
 
 	WRITE_FILE(F, "[time_stamp(format = "YYYY-MM-DD hh:mm:ss")] [REF(src)] ([x],[y],[z]) || [source] [message]<br>")
 
-ADMIN_VERB(investigate_show, R_NONE, "Investigate", "Browse various detailed logs.", ADMIN_CATEGORY_GAME)
+ADMIN_VERB(investigate_show, R_ADMIN|R_DEBUG, "Investigate", "Browse various detailed logs.", ADMIN_CATEGORY_GAME)
 	var/static/list/investigates = list(
 		INVESTIGATE_ACCESSCHANGES,
 		INVESTIGATE_ATMOS,

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -13,7 +13,7 @@
 // We also make SURE to fail loud, IE: if something stops the message from reaching the recipient, the sender HAS to know
 // If you "refactor" this to make it "cleaner" I will send you to hell
 
-ADMIN_VERB_ONLY_CONTEXT_MENU(cmd_admin_pm_context, R_NONE, "Admin PM Mob", mob/target in world)
+ADMIN_VERB_ONLY_CONTEXT_MENU(cmd_admin_pm_context, R_ADMIN, "Admin PM Mob", mob/target in world)
 	if(!ismob(target))
 		to_chat(
 			src,
@@ -25,7 +25,7 @@ ADMIN_VERB_ONLY_CONTEXT_MENU(cmd_admin_pm_context, R_NONE, "Admin PM Mob", mob/t
 	user.cmd_admin_pm(target.client, null)
 	BLACKBOX_LOG_ADMIN_VERB("Admin PM Mob")
 
-ADMIN_VERB(cmd_admin_pm_panel, R_NONE, "Admin PM", "Show a list of clients to PM", ADMIN_CATEGORY_MAIN)
+ADMIN_VERB(cmd_admin_pm_panel, R_ADMIN, "Admin PM", "Show a list of clients to PM", ADMIN_CATEGORY_MAIN)
 	var/list/targets = list()
 	for(var/client/client in GLOB.clients)
 		var/nametag = ""

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -1,4 +1,4 @@
-ADMIN_VERB(cmd_admin_say, R_NONE, "ASay", "Send a message to other admins", ADMIN_CATEGORY_MAIN, message as text)
+ADMIN_VERB(cmd_admin_say, R_ADMIN, "ASay", "Send a message to other admins", ADMIN_CATEGORY_MAIN, message as text)
 	message = emoji_parse(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
 	if(!message)
 		return

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -1,5 +1,5 @@
 
-ADMIN_VERB(dsay, R_NONE, "DSay", "Speak to the dead.", ADMIN_CATEGORY_GAME, message as text)
+ADMIN_VERB(dsay, R_ADMIN, "DSay", "Speak to the dead.", ADMIN_CATEGORY_GAME, message as text)
 	if(user.prefs.muted & MUTE_DEADCHAT)
 		to_chat(user, span_danger("You cannot send DSAY messages (muted)."), confidential = TRUE)
 		return

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -61,7 +61,7 @@ ADMIN_VERB(radio_report, R_DEBUG, "Radio Report", "Shows a report of all radio d
 	browser.open()
 	BLACKBOX_LOG_ADMIN_VERB("Show Radio Report")
 
-ADMIN_VERB(reload_admins, R_SERVER|R_DEBUG, "Reload Admins", "Reloads all admins from the database.", ADMIN_CATEGORY_MAIN)
+ADMIN_VERB(reload_admins, R_PERMISSIONS, "Reload Admins", "Reloads all admins from the database.", ADMIN_CATEGORY_MAIN)
 	var/confirm = tgui_alert(user, "Are you sure you want to reload all admins?", "Confirm", list("Yes", "No"))
 	if(confirm != "Yes")
 		return

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -61,7 +61,7 @@ ADMIN_VERB(radio_report, R_DEBUG, "Radio Report", "Shows a report of all radio d
 	browser.open()
 	BLACKBOX_LOG_ADMIN_VERB("Show Radio Report")
 
-ADMIN_VERB(reload_admins, R_NONE, "Reload Admins", "Reloads all admins from the database.", ADMIN_CATEGORY_MAIN)
+ADMIN_VERB(reload_admins, R_SERVER|R_DEBUG, "Reload Admins", "Reloads all admins from the database.", ADMIN_CATEGORY_MAIN)
 	var/confirm = tgui_alert(user, "Are you sure you want to reload all admins?", "Confirm", list("Yes", "No"))
 	if(confirm != "Yes")
 		return

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -196,7 +196,7 @@ ADMIN_VERB(set_round_end_sound, R_SOUND, "Set Round End Sound", "Set the sound t
 	message_admins("[key_name_admin(user)] set the round end sound to [sound]")
 	BLACKBOX_LOG_ADMIN_VERB("Set Round End Sound")
 
-ADMIN_VERB(stop_sounds, R_NONE, "Stop All Playing Sounds", "Stops all playing sounds for EVERYONE.", ADMIN_CATEGORY_DEBUG)
+ADMIN_VERB(stop_sounds, R_SOUND, "Stop All Playing Sounds", "Stops all playing sounds for EVERYONE.", ADMIN_CATEGORY_DEBUG)
 	log_admin("[key_name(user)] stopped all currently playing sounds.")
 	message_admins("[key_name_admin(user)] stopped all currently playing sounds.")
 	for(var/mob/player as anything in GLOB.player_list)

--- a/code/modules/admin/verbs/reestablish_db_connection.dm
+++ b/code/modules/admin/verbs/reestablish_db_connection.dm
@@ -1,4 +1,4 @@
-ADMIN_VERB(reestablish_db_connection, R_NONE, "Reestablish DB Connection", "Attempts to (re)establish the DB Connection", ADMIN_CATEGORY_SERVER)
+ADMIN_VERB(reestablish_db_connection, R_DEBUG|R_SERVER, "Reestablish DB Connection", "Attempts to (re)establish the DB Connection", ADMIN_CATEGORY_SERVER)
 	if (!CONFIG_GET(flag/sql_enabled))
 		to_chat(user, span_adminnotice("The Database is not enabled!"), confidential = TRUE)
 		return

--- a/code/modules/admin/verbs/requests.dm
+++ b/code/modules/admin/verbs/requests.dm
@@ -1,4 +1,4 @@
 
-ADMIN_VERB(requests, R_NONE, "Requests Manager", "Open the request manager panel to view all requests during this round", ADMIN_CATEGORY_GAME)
+ADMIN_VERB(requests, R_ADMIN, "Requests Manager", "Open the request manager panel to view all requests during this round", ADMIN_CATEGORY_GAME)
 	GLOB.requests.ui_interact(usr)
 	BLACKBOX_LOG_ADMIN_VERB("Request Manager")

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -1,6 +1,6 @@
 GLOBAL_DATUM(everyone_an_antag, /datum/everyone_is_an_antag_controller)
 
-ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before with this handy dandy semi-misc stuff menu.", ADMIN_CATEGORY_GAME)
+ADMIN_VERB(secrets, R_DEBUG|R_FUN, "Secrets", "Abuse harder than you ever have before with this handy dandy semi-misc stuff menu.", ADMIN_CATEGORY_GAME)
 	var/datum/secrets_menu/tgui = new(user)
 	tgui.ui_interact(user.mob)
 	BLACKBOX_LOG_ADMIN_VERB("Secrets Panel")

--- a/code/modules/admin/view_variables/mark_datum.dm
+++ b/code/modules/admin/view_variables/mark_datum.dm
@@ -8,7 +8,7 @@
 	holder.RegisterSignal(holder.marked_datum, COMSIG_QDELETING, TYPE_PROC_REF(/datum/admins, handle_marked_del))
 	vv_update_display(D, "marked", VV_MSG_MARKED)
 
-ADMIN_VERB_ONLY_CONTEXT_MENU(mark_datum, R_NONE, "Mark Object", datum/target as mob|obj|turf|area in view())
+ADMIN_VERB_ONLY_CONTEXT_MENU(mark_datum, R_DEBUG, "Mark Object", datum/target as mob|obj|turf|area in view())
 	user.mark_datum(target)
 
 /datum/admins/proc/handle_marked_del(datum/source)

--- a/code/modules/admin/view_variables/tag_datum.dm
+++ b/code/modules/admin/view_variables/tag_datum.dm
@@ -12,5 +12,5 @@
 	else
 		holder.add_tagged_datum(target_datum)
 
-ADMIN_VERB_ONLY_CONTEXT_MENU(tag_datum, R_NONE, "Tag Datum", datum/target_datum as mob|obj|turf|area in view())
+ADMIN_VERB_ONLY_CONTEXT_MENU(tag_datum, R_DEBUG, "Tag Datum", datum/target_datum as mob|obj|turf|area in view())
 	user.tag_datum(target_datum)

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -1,7 +1,7 @@
 #define ICON_STATE_CHECKED 1 /// this dmi is checked. We don't check this one anymore.
 #define ICON_STATE_NULL 2 /// this dmi has null-named icon_state, allowing it to show a sprite on vv editor.
 
-ADMIN_VERB_AND_CONTEXT_MENU(debug_variables, R_NONE, "View Variables", "View the variables of a datum.", ADMIN_CATEGORY_DEBUG, datum/thing in world)
+ADMIN_VERB_AND_CONTEXT_MENU(debug_variables, R_DEBUG, "View Variables", "View the variables of a datum.", ADMIN_CATEGORY_DEBUG, datum/thing in world)
 	user.debug_variables(thing)
 // This is kept as a separate proc because admins are able to show VV to non-admins
 

--- a/modular_bandastation/ert/code/ert_manager.dm
+++ b/modular_bandastation/ert/code/ert_manager.dm
@@ -7,7 +7,7 @@
 GLOBAL_VAR_INIT(ert_request_answered, FALSE)
 GLOBAL_LIST_EMPTY(ert_request_messages)
 
-ADMIN_VERB(ert_manager, R_NONE, "ERT Manager", "Manage ERT reqests.", ADMIN_CATEGORY_GAME)
+ADMIN_VERB(ert_manager, R_ADMIN, "ERT Manager", "Manage ERT reqests.", ADMIN_CATEGORY_GAME)
 	var/datum/ert_manager/tgui = new(user)
 	tgui.ui_interact(user.mob)
 	BLACKBOX_LOG_ADMIN_VERB("ERT Manager")


### PR DESCRIPTION
## Что этот PR делает

Многие админские вербы которые должны были быть спрятаными за пермишенами, как например Админсей и тд теперь действительно требуют эти пермишены.

## Почему это хорошо для игры

Спрайтер больше не будет видеть админский чат :madge:

## Changelog

:cl:
fix: Многие админские вербы которые должны были быть спрятаными за пермишенами, как например Админсей и тд теперь действительно требуют эти пермишены
/:cl:

## Обзор от Sourcery

Удалено требование разрешения `R_NONE` из административных команд, заменено соответствующими конкретными административными разрешениями.

Исправления ошибок:
- Обеспечено, что административные команды должным образом защищены соответствующими уровнями разрешений.

Улучшения:
- Обновлены разрешения для административных команд, чтобы требовать определенные роли вместо использования разрешения `R_NONE` по умолчанию.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove `R_NONE` permission requirement from admin verbs, replacing it with appropriate specific admin permissions

Bug Fixes:
- Ensure admin verbs are properly gated behind appropriate permission levels

Enhancements:
- Update admin verb permissions to require specific roles instead of using the default `R_NONE` permission

</details>