### PR TITLE
fix storages :madge:

### DIFF
--- a/modular_bandastation/objects/code/items/storage/garment.dm
+++ b/modular_bandastation/objects/code/items/storage/garment.dm
@@ -3,43 +3,45 @@
 	desc = "A bag for storing extra clothes and shoes. This one belongs to the blueshield."
 
 /obj/item/storage/bag/garment/blueshield/PopulateContents()
-	return list(
-		/obj/item/clothing/suit/hooded/wintercoat/blueshield,
-		/obj/item/clothing/suit/armor/vest/blueshield,
-		/obj/item/clothing/suit/armor/vest/blueshield_jacket,
-		/obj/item/clothing/head/beret/blueshield,
-		/obj/item/clothing/head/beret/blueshield/navy,
-		/obj/item/clothing/mask/gas/sechailer,
-		/obj/item/clothing/under/rank/blueshield,
-		/obj/item/clothing/under/rank/blueshield/skirt,
-		/obj/item/clothing/under/rank/blueshield/casual,
-		/obj/item/clothing/under/rank/blueshield/casual/skirt,
-		/obj/item/clothing/under/rank/blueshield/turtleneck,
-		/obj/item/clothing/under/rank/blueshield/turtleneck/skirt,
-		/obj/item/clothing/under/rank/blueshield/formal,
-		/obj/item/clothing/neck/cloak/blueshield,
-		/obj/item/clothing/glasses/sunglasses,
-		/obj/item/clothing/glasses/hud/health/sunglasses,
-		/obj/item/clothing/shoes/jackboots/sec,
-		/obj/item/clothing/shoes/laceup,
+	var/list/items_inside = list(
+		/obj/item/clothing/suit/hooded/wintercoat/blueshield = 1,
+		/obj/item/clothing/suit/armor/vest/blueshield = 1,
+		/obj/item/clothing/suit/armor/vest/blueshield_jacket = 1,
+		/obj/item/clothing/head/beret/blueshield = 1,
+		/obj/item/clothing/head/beret/blueshield/navy = 1,
+		/obj/item/clothing/mask/gas/sechailer = 1,
+		/obj/item/clothing/under/rank/blueshield = 1,
+		/obj/item/clothing/under/rank/blueshield/skirt = 1,
+		/obj/item/clothing/under/rank/blueshield/casual = 1,
+		/obj/item/clothing/under/rank/blueshield/casual/skirt = 1,
+		/obj/item/clothing/under/rank/blueshield/turtleneck = 1,
+		/obj/item/clothing/under/rank/blueshield/turtleneck/skirt = 1,
+		/obj/item/clothing/under/rank/blueshield/formal = 1,
+		/obj/item/clothing/neck/cloak/blueshield = 1,
+		/obj/item/clothing/glasses/sunglasses = 1,
+		/obj/item/clothing/glasses/hud/health/sunglasses = 1,
+		/obj/item/clothing/shoes/jackboots/sec = 1,
+		/obj/item/clothing/shoes/laceup = 1,
 	)
+	generate_items_inside(items_inside, src)
 
 /obj/item/storage/bag/garment/nanotrasen_representative
 	name = "nanotrasen representative's garment bag"
 	desc = "A bag for storing extra clothes and shoes. This one belongs to the nanotrasen representative."
 
 /obj/item/storage/bag/garment/nanotrasen_representative/PopulateContents()
-	return list(
-		/obj/item/clothing/glasses/hud/security/sunglasses,
-		/obj/item/clothing/glasses/sunglasses,
-		/obj/item/clothing/gloves/color/white,
-		/obj/item/clothing/shoes/laceup,
-		/obj/item/clothing/head/hats/nanotrasen_representative,
-		/obj/item/clothing/under/rank/nanotrasen_representative,
-		/obj/item/clothing/under/rank/nanotrasen_representative/skirt,
-		/obj/item/clothing/under/rank/nanotrasen_representative/formal,
-		/obj/item/clothing/under/suit/nanotrasen_representative_female_suit,
+	var/list/items_inside = list(
+		/obj/item/clothing/glasses/hud/security/sunglasses = 1,
+		/obj/item/clothing/glasses/sunglasses = 1,
+		/obj/item/clothing/gloves/color/white = 1,
+		/obj/item/clothing/shoes/laceup = 1,
+		/obj/item/clothing/head/hats/nanotrasen_representative = 1,
+		/obj/item/clothing/under/rank/nanotrasen_representative = 1,
+		/obj/item/clothing/under/rank/nanotrasen_representative/skirt = 1,
+		/obj/item/clothing/under/rank/nanotrasen_representative/formal = 1,
+		/obj/item/clothing/under/suit/nanotrasen_representative_female_suit = 1,
 	)
+	generate_items_inside(items_inside, src)
 
 
 /obj/item/storage/bag/garment/magistrate
@@ -47,12 +49,13 @@
 	desc = "A bag for storing extra clothes and shoes. This one belongs to the magistrate."
 
 /obj/item/storage/bag/garment/magistrate/PopulateContents()
-	return list(
-		/obj/item/clothing/under/rank/magistrate,
-		/obj/item/clothing/under/rank/magistrate/skirt,
-		/obj/item/clothing/under/rank/magistrate/formal,
-		/obj/item/clothing/suit/magirobe,
-		/obj/item/clothing/shoes/laceup,
-		/obj/item/clothing/glasses/sunglasses,
-		/obj/item/clothing/gloves/color/white,
+	var/list/items_inside = list(
+		/obj/item/clothing/under/rank/magistrate = 1,
+		/obj/item/clothing/under/rank/magistrate/skirt = 1,
+		/obj/item/clothing/under/rank/magistrate/formal = 1,
+		/obj/item/clothing/suit/magirobe = 1,
+		/obj/item/clothing/shoes/laceup = 1,
+		/obj/item/clothing/glasses/sunglasses = 1,
+		/obj/item/clothing/gloves/color/white = 1,
 	)
+	generate_items_inside(items_inside, src)

--- a/modular_bandastation/objects/code/items/storage/id_stickers_box.dm
+++ b/modular_bandastation/objects/code/items/storage/id_stickers_box.dm
@@ -6,7 +6,9 @@
 	illustration = "id_stickers_box_label"
 
 /obj/item/storage/box/id_stickers/PopulateContents()
-	var/list/insert = list()
+	var/static/list/id_sticker_subtypes = subtypesof(/obj/item/id_sticker)
+
+	var/list/items_inside = list()
 	for(var/i in 1 to 3)
-		insert += pick(subtypesof(/obj/item/id_sticker))
-	return insert
+		items_inside[pick(id_sticker_subtypes)] += 1
+	generate_items_inside(items_inside, src)

--- a/modular_bandastation/objects/code/items/weapons/melee/centcom/rapier.dm
+++ b/modular_bandastation/objects/code/items/weapons/melee/centcom/rapier.dm
@@ -73,7 +73,7 @@
 	return ..()
 
 /obj/item/storage/belt/centcom_sabre/PopulateContents()
-	return /obj/item/melee/sabre/centcom_sabre
+	new /obj/item/melee/sabre/centcom_sabre(src)
 
 /datum/storage/centcom_katana_belt
 	max_slots = 1
@@ -123,4 +123,4 @@
 	return ..()
 
 /obj/item/storage/belt/centcom_katana/PopulateContents()
-	return /obj/item/melee/sabre/centcom_katana
+	new /obj/item/melee/sabre/centcom_katana(src)


### PR DESCRIPTION
## Что этот PR делает

Чиним хранилища после отката рефактора :madge:


## Changelog

:cl:
fix: Рапира и сабля ЦК, сумки для одежды БЩ.НТРа и Магистрата снова содержат в себе предметы и другие сломанные стораджи
/:cl:

## Краткое описание от Sourcery

Исправление инициализации хранилища для различных сумок для одежды, коробок с ID-наклейками и оружейных поясов Центрального командования для обеспечения правильного заполнения предметов.

Исправления ошибок:
- Исправлено заполнение хранилища для сумок для одежды blueshield, представителя NanoTrasen и магистрата для правильного добавления предметов.
- Исправлена коробка с ID-наклейками для правильной генерации случайных наклеек.
- Исправлена инициализация хранилища поясов с саблей и катаной Центрального командования для правильного добавления предметов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix storage initialization for various garment bags, ID sticker boxes, and CentCom weapon belts to ensure items are correctly populated

Bug Fixes:
- Repair storage population for blueshield, NanoTrasen representative, and magistrate garment bags to correctly add items
- Fix ID sticker box to properly generate random stickers
- Correct CentCom sabre and katana belt storage initialization to add items correctly

</details>