### PR TITLE
Cyberiad: Various fixes in coffee shop, wiring on bridge and curtains in vip bar

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -25494,6 +25494,7 @@
 "ggv" = (
 /obj/structure/table/wood,
 /obj/item/hand_labeler,
+/obj/structure/cable,
 /turf/open/floor/carpet/black,
 /area/station/command/meeting_room)
 "ggA" = (
@@ -29343,6 +29344,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet/black,
 /area/station/command/meeting_room)
 "heR" = (
@@ -30875,6 +30877,13 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/maintenance/department/security/ghetto)
+"hxi" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/station/command/meeting_room)
 "hxl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31889,7 +31898,6 @@
 /obj/machinery/door/airlock/public{
 	id_tag = "vip_room2"
 	},
-/obj/structure/curtain/cloth/fancy,
 /turf/open/floor/iron/checker,
 /area/station/service/bar/atrium/ghetto)
 "hIA" = (
@@ -35739,6 +35747,7 @@
 	id = "heads_meeting_outer"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/meeting_room)
 "iIJ" = (
@@ -37969,9 +37978,9 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = "ChangBottom"
+	id = "JimNortonBottom"
 	},
-/obj/machinery/door/window/right/directional/north{
+/obj/machinery/door/window/right/directional/south{
 	name = "Jim Norton's Quebecois Coffee"
 	},
 /turf/open/floor/plating,
@@ -58787,17 +58796,27 @@
 /obj/structure/table/wood,
 /obj/machinery/coffeemaker/impressa,
 /obj/machinery/button/door/directional/south{
-	name = "Jim Norton's Quebecois Coffee Bottom Shutters Control";
-	id = "JimNortonBottom";
-	pixel_x = 6
+	name = "Jim Norton's Quebecois Coffee South Shutters Control";
+	id = "JimNortonBottom"
 	},
 /obj/machinery/button/door/directional/south{
 	id = "JimNortonKitchen";
-	name = "Jim Norton's Quebecois Coffee Shutters Control";
-	pixel_x = -6
+	name = "Jim Norton's Quebecois Coffee North Shutters Control";
+	pixel_x = -10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/button/door/directional/west{
+	id = "vip_room2";
+	name = "Door Control";
+	specialfunctions = 4;
+	normaldoorcontrol = 1
+	},
+/obj/machinery/button/door/directional/south{
+	id = "JimNortonDoor";
+	name = "Jim Norton's Quebecois Coffee Door Lock";
+	pixel_x = 10
+	},
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "olw" = (
@@ -67407,13 +67426,15 @@
 	normaldoorcontrol = 1;
 	pixel_x = -15;
 	specialfunctions = 4;
-	pixel_y = -2
+	pixel_y = -2;
+	req_access = list("psychology")
 	},
 /obj/machinery/button/door/directional/south{
 	id = "psychological_office_shutters";
 	name = "Psychological Office Shutters Control";
 	pixel_x = -15;
-	pixel_y = 8
+	pixel_y = 8;
+	req_access = list("psychology")
 	},
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
@@ -81074,6 +81095,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet/black,
 /area/station/command/meeting_room)
 "tId" = (
@@ -89544,14 +89566,12 @@
 "vMr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/public,
+/obj/machinery/door/airlock/public{
+	id_tag = "JimNortonDoor"
+	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/window/preopen{
-	dir = 4;
-	id = "JimNortonBottom"
-	},
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "vMy" = (
@@ -94102,7 +94122,6 @@
 "wUk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
@@ -98315,7 +98334,6 @@
 /obj/machinery/door/airlock/public{
 	id_tag = "vip_room1"
 	},
-/obj/structure/curtain/cloth/fancy,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/bar/atrium/ghetto)
 "xWE" = (
@@ -190632,7 +190650,7 @@ xUN
 eyM
 npS
 mCw
-eyM
+hxi
 xUN
 gzC
 urm


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Читать чейнджлог

## Changelog

:cl:
qol: Кибериада: В кофе-шопе было проведено несколько улучшений. Убрана лишняя декаль сайдинга, добавлена кнопка болтирования шлюза, убран шаттер с двери, исправлены наименования, стекло в нижнем окошке было повернуто, чтобы оно не сталкивалось с шаттером.
qol: Кибериада: Добавлена электризация окон на мостике в комнате переговоров.
qol: Кибериада: Убраны лишние шторы, которые мешали закрывать шлюзы в випке бара.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->

## Обзор от Sourcery

Улучшены различные детали и элементы для повышения удобства использования карты Cyberiad.

Улучшения:
- Удалена ненужная декаль обшивки в кофейне.
- Добавлена кнопка задвижки шлюза в кофейне.
- Повернуто стекло в нижнем окне для предотвращения столкновений.
- Добавлена электрическая проводка к окнам в комнате для совещаний на мосту.
- Удалены мешающие шторы в VIP-баре, чтобы можно было закрыть ворота.

<details>
<summary>Original summary in English</summary>

## Краткое описание от Sourcery

Улучшение удобства использования и удаление ненужных элементов на карте Cyberiad

Улучшения:
- Удалена ненужная декаль сайдинга в кофейне
- Добавлена кнопка-слайдер ворот в кофейне
- Повернуто стекло в нижнем окне для предотвращения столкновений
- Добавлена электрическая проводка к окнам в комнате для совещаний на мосту
- Удалены мешающие шторы в VIP-баре, чтобы можно было закрыть ворота

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve usability and remove unnecessary elements in the Cyberiad map

Enhancements:
- Remove unnecessary siding decal in the coffee shop
- Add gate slider button in the coffee shop
- Rotate glass in lower window to prevent collisions
- Add electrical wiring to windows in the bridge meeting room
- Remove obstructive curtains in VIP bar to allow gate closure

</details>

</details>