### PR TITLE
Fix title screen hrefs

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -136,7 +136,7 @@ window "mapwindow"
 		is-disabled = true
 		saved-params = ""
 		auto-format = false
-		style = ".center { text-align: center; } .maptext { font-family: 'Grand9K Pixel'; font-size: 6pt; -dm-text-outline: 1px black; color: white; line-height: 1.0; } .command_headset { font-weight: bold; } .context { font-family: 'Pix Cyrillic'; font-size: 12pt; -dm-text-outline: 1px black; }  .subcontext { font-family: 'TinyUnicode'; font-size: 12pt; line-height: 0.75; } .small { font-family: 'Spess Font'; font-size: 6pt; line-height: 1.4; } .big { font-family: 'Pix Cyrillic'; font-size: 12pt; } .reallybig { font-size: 12pt; } .extremelybig { font-size: 12pt; } .greentext { color: #00FF00; font-size: 6pt; } .redtext { color: #FF0000; font-size: 6pt; } .clown { color: #FF69BF; font-weight: bold; } .his_grace { color: #15D512; } .hypnophrase { color: #0d0d0d; font-weight: bold; } .yell { font-weight: bold; } .italics { font-family: 'Spess Font'; font-size: 6pt; line-height: 1.4; }"
+		background-color = #000000
 	elem "status_bar"
 		type = LABEL
 		pos = 0,464

--- a/modular_bandastation/title_screen/code/title_screen_html.dm
+++ b/modular_bandastation/title_screen/code/title_screen_html.dm
@@ -78,7 +78,7 @@
 			var/traitID = replacetext(replacetext("[trait.type]", "/datum/station_trait/job/", ""), "/", "-")
 			var/assigned = LAZYFIND(trait.lobby_candidates, player)
 			html += {"
-				<a id="lobby-trait-[number]" class="lobby_button lobby_element" href='byond://?src=[REF(user)];trait_signup=[trait.name];id=[number]'>
+				<a id="lobby-trait-[number]" class="lobby_button lobby_element" href='byond://?src=[REF(player)];trait_signup=[trait.name];id=[number]'>
 					<div class="toggle">
 						<img class="pixelated default indicator trait_active [assigned ? "" : "hidden"]" src="[SSassets.transport.get_asset_url(asset_name = "lobby_active.png")]">
 						<img class="pixelated default indicator trait_disabled [!assigned ? "" : "hidden"]" src="[SSassets.transport.get_asset_url(asset_name = "lobby_disabled.png")]">
@@ -112,10 +112,7 @@
 	html += {"
 		<script language="JavaScript">
 			function call_byond(href, value) {
-				const request = new XMLHttpRequest();
-				const url = "?src=[REF(player)];" + href + "=" + value;
-				request.open("GET", url);
-				request.send();
+				window.location = `byond://?src=[REF(player)];${href}=${value}`
 			}
 
 			let ready_int = 0;


### PR DESCRIPTION
## Что этот PR делает
Сэй теперь спокойно открывается в лобби, без предварительного клика в чат
Плюс админ кнопки должны снова появляться сразу

## Changelog

:cl:
fix: Сэй теперь должен снова нормально открываться в лобби, а админ кнопки должны появляться корректно
/:cl:

## Краткое описание от Sourcery

Исправлены атрибуты href на титульном экране, чтобы обеспечить корректную работу трейтов лобби и кнопок администратора путем ссылки на объект игрока и обновления метода вызова JavaScript.

Исправления ошибок:
- Исправлен атрибут href на титульном экране, чтобы правильно ссылаться на объект игрока вместо объекта пользователя, обеспечивая надлежащую функциональность ссылок на трейты лобби.
- Исправлена функция JavaScript для вызова URL-адресов BYOND для использования `window.location` вместо `XMLHttpRequest`, что решает проблемы с немедленным появлением кнопок администратора.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the title screen hrefs to ensure lobby traits and admin buttons function correctly by referencing the player object and updating the JavaScript call method.

Bug Fixes:
- Fix the href attribute in the title screen to correctly reference the player object instead of the user object, ensuring proper functionality of lobby trait links.
- Correct the JavaScript function for calling BYOND URLs to use window.location instead of XMLHttpRequest, resolving issues with admin buttons not appearing immediately.

</details>