### PR TITLE
stickers won't stick to mobs, all stickers now can be seen on `examine`

### DIFF
--- a/code/game/objects/items/stickers.dm
+++ b/code/game/objects/items/stickers.dm
@@ -66,8 +66,14 @@
  * picks random coordinates based on a `target`'s icon.
  */
 /obj/item/sticker/proc/attempt_attach(atom/target, mob/user, px, py)
+	/// BANDASTATION ADDITION - Stickers don't stick to mobs
+	if(ismob(target))
+		balloon_alert(user, "стикер не прилипает!")
+		return FALSE
+	/// BANDASTATION ADDITION - Stickers don't stick to mobs
+
 	if(COUNT_TRAIT_SOURCES(target, TRAIT_STICKERED) >= MAX_STICKER_COUNT)
-		balloon_alert_to_viewers("sticker won't stick!")
+		balloon_alert_to_viewers("слишком много стикеров!")
 		return FALSE
 
 	if(isnull(px) || isnull(py))
@@ -81,13 +87,16 @@
 
 	if(!isnull(user))
 		user.do_attack_animation(target, used_item = src)
-		target.balloon_alert(user, "sticker sticked")
-		var/mob/living/victim = target
-		if(istype(victim) && !isnull(victim.client))
-			user.log_message("stuck [src] to [key_name(victim)]", LOG_ATTACK)
-			victim.log_message("had [src] stuck to them by [key_name(user)]", LOG_ATTACK)
+		target.balloon_alert(user, "стикер прилеплен")
 
-	target.AddComponent(/datum/component/sticker, src, get_dir(target, src), px, py, null, null, examine_text)
+		/// BANDASTATION REMOVAL - Stickers don't stick to mobs
+		// var/mob/living/victim = target
+		// if(istype(victim) && !isnull(victim.client))
+		// 	user.log_message("stuck [src] to [key_name(victim)]", LOG_ATTACK)
+		// 	victim.log_message("had [src] stuck to them by [key_name(user)]", LOG_ATTACK)
+		/// BANDASTATION REMOVAL - Stickers don't stick to mobs
+
+	target.AddComponent(/datum/component/sticker, src, get_dir(target, src), px, py, null, null, examine_text || "Приклеен стикер [name]")
 	return TRUE
 
 #undef MAX_STICKER_COUNT


### PR DESCRIPTION
## Что этот PR делает

Стикеры больше не прилипают к мобам.
Всем стикерам добавлен текст по умолчанию, который виден при осмотре предмета, к которому стикер приклеен.

## Changelog

:cl:
add: Всем стикерам добавлен текст по умолчанию, который виден при осмотре предмета, к которому стикер приклеен
qol: Переведены baloon-алёрты для действия попытки приклеивания стикера
del: Стикеры больше не прилипают к мобам
/:cl:

## Краткое описание от Sourcery

Изменение механики стикеров для предотвращения приклеивания к мобам и добавление текста осмотра по умолчанию

Новые функции:
- Добавлен текст осмотра по умолчанию для всех стикеров при прикреплении к объекту

Исправления ошибок:
- Решена проблема с возможностью приклеивания стикеров к мобам

Улучшения:
- Предотвращено прикрепление стикеров к мобам
- Улучшена обратная связь с пользователем при попытке приклеить стикеры к недопустимым целям

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modify sticker mechanics to prevent sticking to mobs and add default examine text

New Features:
- Add default examine text for all stickers when attached to an object

Bug Fixes:
- Resolve issue with stickers being able to stick to mobs

Enhancements:
- Prevent stickers from being attached to mobs
- Improve user feedback when attempting to stick stickers to invalid targets

</details>