### PR TITLE
Fixes display of sec corporate uniform and skirt

### DIFF
--- a/modular_bandastation/objects/code/items/clothing/under/jobs/security.dm
+++ b/modular_bandastation/objects/code/items/clothing/under/jobs/security.dm
@@ -3,9 +3,11 @@
 	icon = 'modular_bandastation/objects/icons/obj/clothing/under/security.dmi'
 	worn_icon = 'modular_bandastation/objects/icons/mob/clothing/under/security.dmi'
 	icon_state = "sec_corporate"
+	can_adjust = FALSE
 
 /obj/item/clothing/under/rank/security/officer/skirt/corporate
 	name = "security corporate skirt"
 	icon = 'modular_bandastation/objects/icons/obj/clothing/under/security.dmi'
 	worn_icon = 'modular_bandastation/objects/icons/mob/clothing/under/security.dmi'
 	icon_state = "sec_corporate_skirt"
+	can_adjust = FALSE


### PR DESCRIPTION
## Что этот PR делает
Фиксит отображение корпоративной униформы СБ.
Fixes #1230

## Почему это хорошо для игры
Больше не будет чёрных квадратов на фиолетовом фоне вместо спрайтов.

## Тестирование
Компилил и пытался засучить рукава - не получилось.

## Changelog
:cl:
fix: Починено отображение корпоративной униформы и юбки СБ. Теперь их нельзя спустить до пояса.
/:cl:

## Обзор от Sourcery

Исправления ошибок:
- Устранены проблемы с отображением корпоративной униформы и юбки службы безопасности, предотвращающие появление черных квадратов на фиолетовом фоне.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolved display problems with security corporate uniform and skirt, preventing black squares on purple background

</details>