### PR TITLE
eg-14 holdable by holsters again...

### DIFF
--- a/code/game/objects/items/storage/holsters.dm
+++ b/code/game/objects/items/storage/holsters.dm
@@ -32,6 +32,7 @@
 		/obj/item/gun/ballistic/rifle/boltaction, //fits if you make it an obrez
 		/obj/item/gun/energy/laser/captain,
 		/obj/item/gun/energy/e_gun/hos,
+		/obj/item/gun/energy/eg_14,
 	))
 	atom_storage.open_sound = 'sound/items/handling/holster_open.ogg'
 	atom_storage.open_sound_vary = TRUE
@@ -53,6 +54,7 @@
 		/obj/item/gun/energy/recharge/ebow,
 		/obj/item/gun/energy/laser/captain,
 		/obj/item/gun/energy/e_gun/hos,
+		/obj/item/gun/energy/eg_14,
 	))
 
 /obj/item/storage/belt/holster/energy/thermal
@@ -108,6 +110,7 @@
 		/obj/item/gun/energy/laser/thermal,
 		/obj/item/gun/energy/laser/captain,
 		/obj/item/gun/energy/e_gun/hos,
+		/obj/item/gun/energy/eg_14,
 		/obj/item/gun/ballistic/rifle/boltaction, //fits if you make it an obrez
 	))
 
@@ -162,6 +165,7 @@
 		/obj/item/gun/energy/dueling,
 		/obj/item/gun/energy/laser/captain,
 		/obj/item/gun/energy/e_gun/hos,
+		/obj/item/gun/energy/eg_14,
 	))
 
 	atom_storage.silent = TRUE


### PR DESCRIPTION
## Что этот PR делает

 eg-14 помещается в кобуру ОПЯТЬ

## Changelog

:cl:
fix: eg-14 помещается в кобуру ОПЯТЬ (я ненавижу рефакторы офов, которые потом еще и откатывают)
/:cl:

## Обзор от Sourcery

Исправления ошибок:
- Восстановлена возможность помещения энергетического пистолета eg-14 в различные типы кобур

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Restore the ability to place the eg-14 energy gun into different types of holsters

</details>