### PR TITLE
all slippery sources immobilize for 2 seconds by default

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
@@ -255,7 +255,7 @@
 /// from /mob/proc/change_mob_type_unchecked() : ()
 #define COMSIG_MOB_CHANGED_TYPE "mob_changed_type"
 
-/// from /mob/proc/slip(): (knockdown_amonut, obj/slipped_on, lube_flags [mobs.dm], paralyze, force_drop)
+/// from /mob/proc/slip(): (knockdown_amonut, obj/slipped_on, lube_flags [mobs.dm], paralyze, force_drop, immobilize)
 #define COMSIG_MOB_SLIPPED "mob_slipped"
 
 /// From the base of /datum/component/callouts/proc/callout_picker(mob/user, atom/clicked_atom): (datum/callout_option/callout, atom/target)

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -22,7 +22,13 @@
 	/// How long the slip keeps the crossing mob knocked over (they can still crawl and use weapons) for.
 	var/knockdown_time = 0
 	/// How long the slip paralyzes (prevents the crossing mob doing anything) for.
-	var/paralyze_time = 2 SECONDS
+	var/paralyze_time = 0
+
+	/// BANDASTATION ADDITION START - Immobilizing slippery
+	/// How long the slip immobilizes mob (prevents voluntary movement of the crossing mob)
+	var/immobilize_time = 2 SECONDS
+	/// BANDASTATION ADDITION END - Immobilizing slippery
+
 	/// How long the slip dazes (makes the crossing mob vulnerable to shove stuns) for.
 	var/daze_time = 3 SECONDS
 	/// Flags for how slippery the parent is. See [__DEFINES/mobs.dm]
@@ -59,16 +65,18 @@
  * * force_drop - should the crossing mob drop items in its hands or not
  * * slot_whitelist - flags controlling where on a mob this item can be equipped to make the parent mob slippery full list [here][ITEM_SLOT_OCLOTHING]
  * * datum/callback/on_slip_callback - Callback to add custom behaviours as the crossing mob is slipped
+ * * immobilize - ength of time to immobilize the crossing mob for (Deciseconds)
  */
 /datum/component/slippery/Initialize(
 	knockdown,
 	lube_flags = NONE,
 	datum/callback/on_slip_callback,
-	paralyze = 2 SECONDS,
+	paralyze,
 	daze = 3 SECONDS,
 	force_drop = FALSE,
 	slot_whitelist,
 	datum/callback/can_slip_callback,
+	immobilize = 2 SECONDS, /// BANDASTATION ADDITION - Immobilizing slippery
 )
 	src.knockdown_time = max(knockdown, 0)
 	src.paralyze_time = max(paralyze, 0)
@@ -77,6 +85,7 @@
 	src.lube_flags = lube_flags
 	src.can_slip_callback = can_slip_callback
 	src.on_slip_callback = on_slip_callback
+	src.immobilize_time = max(immobilize, 0) /// BANDASTATION ADDITION - Immobilizing slippery
 	if(slot_whitelist)
 		src.slot_whitelist = slot_whitelist
 
@@ -99,6 +108,7 @@
 /datum/component/slippery/proc/apply_fantasy_bonuses(obj/item/source, bonus)
 	SIGNAL_HANDLER
 	knockdown_time = source.modify_fantasy_variable("knockdown_time", knockdown_time, bonus)
+	immobilize_time = source.modify_fantasy_variable("immobilize_time", immobilize_time, bonus) /// BANDASTATION ADDITION - Immobilizing slippery
 	if(bonus >= 5)
 		paralyze_time = source.modify_fantasy_variable("paralyze_time", paralyze_time, bonus)
 		LAZYSET(source.fantasy_modifications, "lube_flags", lube_flags)
@@ -109,6 +119,7 @@
 /datum/component/slippery/proc/remove_fantasy_bonuses(obj/item/source, bonus)
 	SIGNAL_HANDLER
 	knockdown_time = source.reset_fantasy_variable("knockdown_time", knockdown_time)
+	immobilize_time = source.reset_fantasy_variable("immobilize_time", immobilize_time) /// BANDASTATION ADDITION - Immobilizing slippery
 	paralyze_time = source.reset_fantasy_variable("paralyze_time", paralyze_time)
 	var/previous_lube_flags = LAZYACCESS(source.fantasy_modifications, "lube_flags")
 	LAZYREMOVE(source.fantasy_modifications, "lube_flags")
@@ -145,6 +156,7 @@
 		daze = component.daze_time
 		force_drop = component.force_drop_items
 		slot_whitelist = component.slot_whitelist
+		immobilize_time = component.immobilize_time /// BANDASTATION ADDITION - Immobilizing slippery
 
 	src.knockdown_time = max(knockdown, 0)
 	src.paralyze_time = max(paralyze, 0)
@@ -153,6 +165,7 @@
 	src.lube_flags = lube_flags
 	src.on_slip_callback = on_slip_callback
 	src.can_slip_callback = can_slip_callback
+	src.immobilize_time = immobilize_time  /// BANDASTATION ADDITION - Immobilizing slippery
 	if(slot_whitelist)
 		src.slot_whitelist = slot_whitelist
 /**
@@ -175,7 +188,7 @@
 		return
 	if(can_slip_callback && !can_slip_callback.Invoke(holder, victim))
 		return
-	if(victim.slip(knockdown_time, parent, lube_flags, paralyze_time, daze_time, force_drop_items))
+	if(victim.slip(knockdown_time, parent, lube_flags, paralyze_time, daze_time, force_drop_items, immobilize_time))  // BANDASTATION EDIT - Immobilizing slippery
 		on_slip_callback?.Invoke(victim)
 
 /**

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -22,7 +22,7 @@
 	/// How long the slip keeps the crossing mob knocked over (they can still crawl and use weapons) for.
 	var/knockdown_time = 0
 	/// How long the slip paralyzes (prevents the crossing mob doing anything) for.
-	var/paralyze_time = 0
+	var/paralyze_time = 2 SECONDS
 	/// How long the slip dazes (makes the crossing mob vulnerable to shove stuns) for.
 	var/daze_time = 3 SECONDS
 	/// Flags for how slippery the parent is. See [__DEFINES/mobs.dm]
@@ -64,7 +64,7 @@
 	knockdown,
 	lube_flags = NONE,
 	datum/callback/on_slip_callback,
-	paralyze,
+	paralyze = 2 SECONDS,
 	daze = 3 SECONDS,
 	force_drop = FALSE,
 	slot_whitelist,

--- a/code/game/atom/atom_act.dm
+++ b/code/game/atom/atom_act.dm
@@ -150,7 +150,7 @@
 		step(harmed_atom, REVERSE_DIR(harmed_atom.dir))
 
 ///Handle the atom being slipped over
-/atom/proc/handle_slip(mob/living/carbon/slipped_carbon, knockdown_amount, obj/slipping_object, lube, paralyze, daze, force_drop)
+/atom/proc/handle_slip(mob/living/carbon/slipped_carbon, knockdown_amount, obj/slipping_object, lube, paralyze, daze, force_drop, immobilize) /// BANDASTATION EDIT - Immobilizing slippery
 	return
 
 ///Used for making a sound when a mob involuntarily falls into the ground.

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -361,7 +361,7 @@
 	wash(CLEAN_WASH, TRUE)
 	return TRUE
 
-/turf/open/handle_slip(mob/living/slipper, knockdown_amount, obj/slippable, lube, paralyze_amount, daze_amount, force_drop)
+/turf/open/handle_slip(mob/living/slipper, knockdown_amount, obj/slippable, lube, paralyze_amount, daze_amount, force_drop, immobilize)  /// BANDASTATION EDIT - Immobilizing slippery
 	if(slipper.movement_type & MOVETYPES_NOT_TOUCHING_GROUND)
 		return FALSE
 	if(!has_gravity(src))
@@ -416,6 +416,7 @@
 	else
 		slipper.Paralyze(paralyze_amount)
 		slipper.Knockdown(knockdown_amount, daze_amount = daze_amount)
+		slipper.Immobilize(immobilize)  // BANDASTATION EDIT - Immobilizing slippery
 
 	if(!isnull(buckled_obj) && !ismob(buckled_obj))
 		buckled_obj.unbuckle_mob(slipper)

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -1,10 +1,10 @@
-/mob/living/carbon/slip(knockdown_amount, obj/slipped_on, lube_flags, paralyze, daze, force_drop = FALSE)
+/mob/living/carbon/slip(knockdown_amount, obj/slipped_on, lube_flags, paralyze, daze, force_drop = FALSE, immobilize)  /// BANDASTATION EDIT - Immobilizing slippery
 	if(movement_type & MOVETYPES_NOT_TOUCHING_GROUND)
 		return FALSE
 	if(!(lube_flags & SLIDE_ICE))
 		log_combat(src, (slipped_on || get_turf(src)), "slipped on the", null, ((lube_flags & SLIDE) ? "(SLIDING)" : null))
 	..()
-	return loc.handle_slip(src, knockdown_amount, slipped_on, lube_flags, paralyze, daze, force_drop)
+	return loc.handle_slip(src, knockdown_amount, slipped_on, lube_flags, paralyze, daze, force_drop, immobilize)  /// BANDASTATION EDIT - Immobilizing slippery
 
 /mob/living/carbon/Move(NewLoc, direct)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -9,7 +9,7 @@
 		return
 	return considering
 
-/mob/living/carbon/human/slip(knockdown_amount, obj/slipped_on, lube_flags, paralyze, daze, force_drop = FALSE)
+/mob/living/carbon/human/slip(knockdown_amount, obj/slipped_on, lube_flags, paralyze, daze, force_drop = FALSE, immobilize) /// BANDASTATION EDIT - Immobilizing slippery
 	if(HAS_TRAIT(src, TRAIT_NO_SLIP_ALL))
 		return FALSE
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -378,11 +378,12 @@
  * paralyze - time (in deciseconds) the slip leaves them paralyzed / unable to move
  * daze - time (in deciseconds) the slip leaves them vulnerable to shove stuns
  * force_drop = the slip forces them to drop held items
+ * immobilize = time (in deciseconds) the slip leaves them immobilized
  */
-/mob/proc/slip(knockdown_amount, obj/slipped_on, lube_flags, paralyze, daze, force_drop = FALSE)
+/mob/proc/slip(knockdown_amount, obj/slipped_on, lube_flags, paralyze, daze, force_drop = FALSE, immobilize) /// BANDASTATION EDIT - Immobilizing slippery
 	add_mob_memory(/datum/memory/was_slipped, antagonist = slipped_on)
 
-	SEND_SIGNAL(src, COMSIG_MOB_SLIPPED, knockdown_amount, slipped_on, lube_flags, paralyze, daze, force_drop)
+	SEND_SIGNAL(src, COMSIG_MOB_SLIPPED, knockdown_amount, slipped_on, lube_flags, paralyze, daze, force_drop, immobilize) /// BANDASTATION EDIT - Immobilizing slippery
 
 //bodypart selection verbs - Cyberboss
 //8: repeated presses toggles through head - eyes - mouth


### PR DESCRIPTION
## Что этот PR делает

Все скользкие поверхности (/datum/component/slippery) обездвиживают на 2 секунды по умолчанию

## Почему это хорошо для игры

Возможность сразу ползти после падения выглядит как минимум странно и убого - мне не нравится.

## Тестирование

Подскользнулся на банановой кожурке - лежу отдыхаю

## Changelog

:cl:
balance: Верховное правительство планеты клоунов изменила законы физики и теперь все источники скользкозти по умолчанию обездвиживают на 2 секунды. Сообщество ползунов негодует.
/:cl: