### PR TITLE
Fix: Load from json

### DIFF
--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -502,10 +502,12 @@
 			backpack_contents[itype] = backpack[item]
 	var/list/beltpack = outfit_data["belt_contents"]
 	belt_contents = list()
-	for(var/item in beltpack)
-		var/itype = text2path(item)
-		if(itype)
-			belt_contents[itype] = belt[item]
+	for(var/itype in beltpack)
+		var/inum = beltpack[type_to_load]
+		if(!isnum(inum))
+			inum = 1
+		for(var/i in 1 to inum)
+			belt_contents += itype
 	box = text2path(outfit_data["box"])
 	var/list/impl = outfit_data["implants"]
 	implants = list()

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -503,7 +503,7 @@
 	var/list/beltpack = outfit_data["belt_contents"]
 	belt_contents = list()
 	for(var/itype in beltpack)
-		var/inum = beltpack[type_to_load]
+		var/inum = beltpack[itype]
 		if(!isnum(inum))
 			inum = 1
 		for(var/i in 1 to inum)

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -503,9 +503,7 @@
 	var/list/beltpack = outfit_data["belt_contents"]
 	belt_contents = list()
 	for(var/itype in beltpack)
-		var/inum = beltpack[itype]
-		if(!isnum(inum))
-			inum = 1
+		var/inum = beltpack[itype] || 1
 		for(var/i in 1 to inum)
 			belt_contents += itype
 	box = text2path(outfit_data["box"])


### PR DESCRIPTION

## Что этот PR делает
Чинит загрузку содержимого json файла для Select Equipment. Содержимое поясов теперь нормально загружается, как и должно list(item=count, other_item=count).
## Почему это хорошо для игры
Рабочий Select Equipment
## Изображения изменений
![image](https://github.com/user-attachments/assets/442185be-5a3c-452d-a59e-ff56a311c9ec)
## Тестирование
Лклк
## Changelog

:cl: Ez-Briz
fix: Select Equipment теперь корректно подгружает вещи в поясе из содержимого json файла.
/:cl:
