### PR TITLE
Fix: Central 'localka' runtimes

### DIFF
--- a/code/modules/admin/whitelist.dm
+++ b/code/modules/admin/whitelist.dm
@@ -19,6 +19,7 @@ GLOBAL_LIST(whitelist)
 	// BANDASTATION EDIT - SSCentral
 	if(!SScentral.active)
 		stack_trace("Using whitelist without SS Central is not supported")
+		return
 	return SScentral.is_player_whitelisted(ckey)
 
 #undef WHITELISTFILE

--- a/code/modules/admin/whitelist.dm
+++ b/code/modules/admin/whitelist.dm
@@ -17,6 +17,8 @@ GLOBAL_LIST(whitelist)
 
 /proc/check_whitelist(ckey)
 	// BANDASTATION EDIT - SSCentral
+	if(!SScentral.active)
+		stack_trace("Using whitelist without SS Central is not supported")
 	return SScentral.is_player_whitelisted(ckey)
 
 #undef WHITELISTFILE

--- a/modular_bandastation/metaserver/code/admin.dm
+++ b/modular_bandastation/metaserver/code/admin.dm
@@ -1,5 +1,11 @@
 ADMIN_VERB(wl_ban, R_BAN, "WL Ban", "Выписать игрока из вайтлиста.", ADMIN_CATEGORY_MAIN)
 	BLACKBOX_LOG_ADMIN_VERB("WL Ban")
+
+	if(!SScentral.active)
+		to_chat(user, span_bolddanger("Невозможно выписать игрока из вайтлиста. SS Central не настроен!"))
+		stack_trace("Using whitelist/whitelist bans without SS Central is not supported")
+		return
+
 	var/banned_ckey = input(user, "Укажите ckey игрока для выписки.", "Выписка", "") as text|null
 	banned_ckey = ckey(banned_ckey)
 	if(!banned_ckey)

--- a/modular_bandastation/metaserver/code/discord_link.dm
+++ b/modular_bandastation/metaserver/code/discord_link.dm
@@ -13,6 +13,8 @@
 
 /client/New()
 	. = ..()
+	if(!SScentral.active)
+		return
 	SScentral.get_player_discord_async(ckey)
 
 /mob/dead/new_player/register_for_interview()
@@ -24,7 +26,7 @@
 	set name = "Привязать Discord"
 	set desc = "Привязка аккаунта Discord к BYOND"
 
-	if(!SScentral.initialized)
+	if(!SScentral.active)
 		to_chat(src, span_warning("Привязка Discord сейчас недоступна."))
 		return
 

--- a/modular_bandastation/metaserver/code/donate.dm
+++ b/modular_bandastation/metaserver/code/donate.dm
@@ -1,3 +1,5 @@
 /client/New()
 	. = ..()
+	if(!SScentral.active)
+		return
 	SScentral.update_player_donate_tier_async(src)

--- a/modular_bandastation/metaserver/code/interview.dm
+++ b/modular_bandastation/metaserver/code/interview.dm
@@ -1,6 +1,9 @@
 /// Doesnt need the panic bunker to work
 /mob/dead/new_player/proc/check_whitelist_or_make_interviewee()
 	if(!CONFIG_GET(flag/panic_bunker_interview))
+		if(!SScentral.active)
+			stack_trace("Using whitelists and interviews without SS Central is not supported")
+			return
 		return
 	if(SScentral.is_player_whitelisted(ckey))
 		client.interviewee = FALSE

--- a/modular_bandastation/metaserver/code/ss_central.dm
+++ b/modular_bandastation/metaserver/code/ss_central.dm
@@ -13,6 +13,7 @@ SUBSYSTEM_DEF(central)
 	var/list/discord_links = list()
 	init_order = INIT_ORDER_DBCORE
 	flags = SS_NO_FIRE
+	var/active = FALSE
 
 /datum/controller/subsystem/central/vv_edit_var(var_name, var_value)
 	return FALSE
@@ -20,14 +21,21 @@ SUBSYSTEM_DEF(central)
 /datum/controller/subsystem/central/CanProcCall(procname)
 	return FALSE
 
+/datum/controller/subsystem/central/New()
+	. = ..()
+	active = can_run()
+
 /datum/controller/subsystem/central/Initialize()
-	if(!CONFIG_GET(string/ss_central_url) || !CONFIG_GET(string/ss_central_token))
+	if(!active)
 		return SS_INIT_NO_NEED
 	load_whitelist()
 	// TODO: preload links
 
+/datum/controller/subsystem/central/proc/can_run()
+	return CONFIG_GET(string/ss_central_url) && CONFIG_GET(string/ss_central_token)
+
 /datum/controller/subsystem/central/stat_entry(msg)
-	if(!initialized)
+	if(!initialized || !active)
 		msg = "OFFLINE"
 	else
 		msg = "WL: [CONFIG_GET(flag/usewhitelist)] [CONFIG_GET(string/server_type)]"

--- a/modular_bandastation/title_screen/code/new_player.dm
+++ b/modular_bandastation/title_screen/code/new_player.dm
@@ -14,6 +14,11 @@
 		return
 
 	if(CONFIG_GET(flag/force_discord_verification) && (href_list["toggle_ready"] || href_list["late_join"] || href_list["observe"]))
+		if(!SScentral.active)
+			to_chat(usr, "Система привязок дискорда не активна, но включен режим проверки привязки. Дальнейшая игра невозможна до исправления. Сообщите хосту об этом.")
+			stack_trace("Discord verification is enabled, but SS Central is not active.")
+			return
+
 		if(!SScentral.is_player_discord_linked(ckey))
 			to_chat(usr, PLAYER_REQUIRES_LINKED_DISCORD_CHAT_MESSAGE)
 			return FALSE


### PR DESCRIPTION
## Что этот PR делает
Добавляет везде проверки на то, что централ активен

## Тестирование
Мне лень
## Changelog

:cl:
fix: SSCentral больше не будет рантаймить на локалке
/:cl: