### PR TITLE
Title Screen image improvements

### DIFF
--- a/modular_bandastation/title_screen/code/title_screen_html.dm
+++ b/modular_bandastation/title_screen/code/title_screen_html.dm
@@ -25,6 +25,7 @@
 	"}
 
 	if(screen_image_url)
+		html += {"<img id="screen_blur" class="bg bg-blur" src="[screen_image_url]" alt="Загрузка..." onerror="fix_image()">"}
 		html += {"<img id="screen_image" class="bg" src="[screen_image_url]" alt="Загрузка..." onerror="fix_image()">"}
 
 	html += {"<input type="checkbox" id="hide_menu">"}
@@ -207,9 +208,11 @@
 
 			let image_src;
 			const image_container = document.getElementById("screen_image");
+			const image_blur_container = document.getElementById("screen_blur");
 			function update_image(image) {
 				image_src = image;
 				image_container.src = image_src;
+				image_blur_container.src = image_src;
 			}
 
 			let attempts = 0;

--- a/modular_bandastation/title_screen/html/title_screen_default.css
+++ b/modular_bandastation/title_screen/html/title_screen_default.css
@@ -172,12 +172,13 @@ input,
     inset: 0;
     width: 100vw;
     height: 100vh;
+	filter: drop-shadow(0 0 1em hsla(0, 0%, 0%, 0.33));
     z-index: 0;
 }
 
 .bg-blur {
 	transform: scale(2);
-    filter: blur(2.5rem);
+    filter: blur(2.5rem) brightness(0.75);
 }
 
 #container_notice {

--- a/modular_bandastation/title_screen/html/title_screen_default.css
+++ b/modular_bandastation/title_screen/html/title_screen_default.css
@@ -131,7 +131,6 @@ html {
 	font-size: 15px;
 	overflow: hidden;
 	text-align: center;
-	-ms-user-select: none;
 	user-select: none;
 	cursor: default;
 	position: static;
@@ -164,20 +163,21 @@ input,
 }
 
 .pixelated {
-	-ms-interpolation-mode: nearest-neighbor;
 	image-rendering: pixelated;
 }
 
 .bg {
+    object-fit: contain;
 	position: absolute;
-	width: auto;
-	height: 100vmin;
-	min-width: 100vmin;
-	min-height: 100vmin;
-	top: 50%;
-	left: 50%;
-	transform: translate(-50%, -50%);
-	z-index: 0;
+    inset: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 0;
+}
+
+.bg-blur {
+	transform: scale(2);
+    filter: blur(2.5rem);
 }
 
 #container_notice {


### PR DESCRIPTION
## Что этот PR делает
Слегка привёл пикчи в лобби к более современному подходу, благодаря чему они больше не кропятся

## Почему это хорошо для игры
Картинки и гифки не обрезаются, а вместо пустоты заблюренная копия под оригиналом

## Изображения изменений

https://github.com/user-attachments/assets/14114ce7-e9a5-4440-b220-eb8c26231ef8

## Changelog

:cl:
qol: Картинки в лобби больше не обрезаются, какую бы картинку не поставили - её будет видно полностью
/:cl:

## Обзор от Sourcery

Улучшение отображения изображения на титульном экране путем добавления размытого фона и обеспечения полной видимости изображения

Новые возможности:
- Реализован эффект размытого фона для изображений на титульном экране

Улучшения:
- Изменен CSS для отображения полных изображений без обрезки на титульном экране
- Добавлена версия изображения титульного экрана с размытым фоном

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve title screen image display by adding a blurred background and ensuring full image visibility

New Features:
- Implement a blurred background effect for title screen images

Enhancements:
- Modify CSS to display full images without cropping in the title screen
- Add a blurred background version of the title screen image

</details>