### PR TITLE
Baylike movement speed tweaks

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -123,9 +123,9 @@ DEFINE_BITFIELD(status_flags, list(
 #define BASE_GRAB_RESIST_CHANCE 60 //base chance for whether or not you can escape from a grab
 
 //slowdown when in softcrit. Note that crawling slowdown will also apply at the same time!
-#define SOFTCRIT_ADD_SLOWDOWN 2
+#define SOFTCRIT_ADD_SLOWDOWN 4
 //slowdown when crawling
-#define CRAWLING_ADD_SLOWDOWN 4
+#define CRAWLING_ADD_SLOWDOWN 6
 
 //Attack types for checking block reactions
 /// Attack was made with a melee weapon

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -101,7 +101,7 @@
 
 	//We are now going to move
 	var/add_delay = mob.cached_multiplicative_slowdown
-	var/new_glide_size = DELAY_TO_GLIDE_SIZE(add_delay * ( (NSCOMPONENT(direct) && EWCOMPONENT(direct)) ? sqrt(2) : 1 ) )
+	var/new_glide_size = DELAY_TO_GLIDE_SIZE(add_delay * ( (NSCOMPONENT(direct) && EWCOMPONENT(direct)) ? 2 : 1 ) )
 	mob.set_glide_size(new_glide_size) // set it now in case of pulled objects
 	//If the move was recent, count using old_move_delay
 	//We want fractional behavior and all
@@ -120,7 +120,7 @@
 	. = ..()
 
 	if((direct & (direct - 1)) && mob.loc == new_loc) //moved diagonally successfully
-		add_delay *= sqrt(2)
+		add_delay *= 2
 
 	var/after_glide = 0
 	if(visual_delay)

--- a/code/modules/mod/mod_ai.dm
+++ b/code/modules/mod/mod_ai.dm
@@ -139,7 +139,7 @@
 	var/datum/mod_part/legs_to_move = get_part_datum_from_slot(ITEM_SLOT_FEET)
 	if(wearer && (!legs_to_move || !legs_to_move.sealed))
 		return FALSE
-	var/timemodifier = MOVE_DELAY * (ISDIAGONALDIR(direction) ? sqrt(2) : 1) * (wearer ? WEARER_DELAY : LONE_DELAY)
+	var/timemodifier = MOVE_DELAY * (ISDIAGONALDIR(direction) ? 2 : 1) * (wearer ? WEARER_DELAY : LONE_DELAY)
 	if(wearer && !wearer.Process_Spacemove(direction))
 		return FALSE
 	else if(!wearer && (!has_gravity() || !isturf(loc)))


### PR DESCRIPTION
## Что этот PR делает

This PR makes some tweaks to movement slowing the game down significantly. Changes apply to diagonal movement and Crawling. Softcrit crawling has also been slowed down.


## Почему это хорошо для игры

Slowed down movement will force people to rely on considering the way they move, crawling changes are there because normal TG crawling is a little too fast Imo.
Slowed down movement will help roleplay? Probably?

## Тестирование

Запустил и поползал, ползается медленнее чем раньше. Победа? 

## Changelog

:cl:
balance: Изменение скорости перемещения ползком, и замедление диагонального перемещения
/:cl:

## Обзор от Sourcery

Изменение механики движения для значительного замедления движения игрока, особенно при диагональном движении и ползании.

Исправления ошибок:
- Скорректированы расчеты скорости движения для обеспечения более последовательных и преднамеренных штрафов к движению.

Улучшения:
- Увеличен множитель замедления для диагонального движения с sqrt(2) до 2, что эффективно снижает скорость диагонального движения.
- Увеличено замедление при ползании с 4 до 6, чтобы сделать ползание более обдуманным.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modify movement mechanics to significantly slow down player movement, particularly for diagonal movement and crawling

Bug Fixes:
- Adjust movement speed calculations to provide more consistent and intentional movement penalties

Enhancements:
- Increase slowdown multiplier for diagonal movement from sqrt(2) to 2, effectively reducing diagonal movement speed
- Increase crawling slowdown from 4 to 6 to make crawling more deliberate

</details>