### PR TITLE
remove gamma set on cult win

### DIFF
--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -262,7 +262,6 @@
 		title = "[command_name()]: Отдел паранормальных явлений",
 		sound = 'sound/announcer/alarm/airraid.ogg',
 	)
-	SSsecurity_level.set_level(SEC_LEVEL_GAMMA) /// BANDASTATION EDIT - Cult
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(narsie_end_second_check)), 50 SECONDS)
 
 ///Second crew last second win check and flufftext for [/proc/begin_the_end()]


### PR DESCRIPTION
## Что этот PR делает

remove gamma set on cult win

:cl:
del: Передумал и убрал Гамму при победе культа :ratge:
/:cl:

## Обзор от Sourcery

Исправления ошибок:
- Удалено автоматическое установление уровня безопасности гамма во время победы культа

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Removed automatic setting of gamma security level during cult victory

</details>