### PR TITLE
Fix chat badges align

### DIFF
--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -24,7 +24,7 @@ img.icon {
   min-height: 16px;
   min-width: 16px;
   width: auto;
-  vertical-align: bottom;
+  vertical-align: middle;
 }
 
 a {


### PR DESCRIPTION
## Что этот PR делает
То что написано в тайтле
Я чёт забыл про то что можно высоту строки менять

## Изображения изменений
![image](https://github.com/user-attachments/assets/a33cfa6f-7741-4cb7-85e4-ca3acefae116)

## Changelog

:cl:
fix: Бэйджики в чате теперь правильно центрируются при кастомной высоте строки
/:cl:
