### PR TITLE
disable spawn for some station traits, nerf blackout chance on this station trait from 60 to 30 percent

### DIFF
--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -106,7 +106,7 @@
 /datum/station_trait/blackout/on_round_start()
 	. = ..()
 	for(var/obj/machinery/power/apc/apc as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/power/apc))
-		if(is_station_level(apc.z) && prob(60))
+		if(is_station_level(apc.z) && prob(30)) /// BANDASTATION EDIT: original prob(60) - Station traits
 			apc.overload_lighting()
 
 /datum/station_trait/empty_maint

--- a/modular_bandastation/balance/code/station_traits.dm
+++ b/modular_bandastation/balance/code/station_traits.dm
@@ -16,12 +16,5 @@
 
 /datum/station_trait/random_spawns
 	weight = 0
-
-/datum/station_trait/announcement_intern
-	weight = 0
-
-/datum/station_trait/announcement_medbot
-	weight = 0
-
 /datum/station_trait/colored_assistants
 	weight = 0

--- a/modular_bandastation/balance/code/station_traits.dm
+++ b/modular_bandastation/balance/code/station_traits.dm
@@ -13,3 +13,15 @@
 
 /datum/station_trait/pet_day
 	weight = 0
+
+/datum/station_trait/random_spawns
+	weight = 0
+
+/datum/station_trait/announcement_intern
+	weight = 0
+
+/datum/station_trait/announcement_medbot
+	weight = 0
+
+/datum/station_trait/colored_assistants
+	weight = 0

--- a/modular_bandastation/balance/code/station_traits.dm
+++ b/modular_bandastation/balance/code/station_traits.dm
@@ -16,5 +16,6 @@
 
 /datum/station_trait/random_spawns
 	weight = 0
+
 /datum/station_trait/colored_assistants
 	weight = 0


### PR DESCRIPTION
## Что этот PR делает

Отключает такие трейты станции:
- random_spawns
- colored_assistants

Снижает шанс блекаута зоны при трейте блекаута с 60% до 30%

:cl:
del: Отключает такие трейты станции:
- random_spawns
- colored_assistants
balance: Снизил шанс блекаута зоны при трейте блекаута с 60% до 30%
/:cl: