### PR TITLE
Podman eye fix

### DIFF
--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -1109,7 +1109,5 @@
 	name = "pod eyes"
 	desc = "Strangest salad you've ever seen."
 	icon_state = "eyes_pod"
-	eye_color_left = "#375846"
-	eye_color_right = "#375846"
 	iris_overlay = null
 	foodtype_flags = PODPERSON_ORGAN_FOODTYPES

--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -1109,5 +1109,9 @@
 	name = "pod eyes"
 	desc = "Strangest salad you've ever seen."
 	icon_state = "eyes_pod"
+	/// BANDASTATION REMOVAL START - Podman eye color fix
+	// eye_color_left = "#375846"
+	// eye_color_right = "#375846"
+	/// BANDASTATION REMOVAL END - Podman eye color fix
 	iris_overlay = null
 	foodtype_flags = PODPERSON_ORGAN_FOODTYPES


### PR DESCRIPTION
## Что этот PR делает

Возвращает возможность снова менять цвет глаз расы Подмен.

## Почему это хорошо для игры

Поскольку у нас данная раса доступна в редакторе персонажа с начала раунда, то для более удобного редактирования персонажа и большего разнообразия во внешнем виде, следует вернуть функцию изменения цвета глаз для этой расы.

## Тестирование

Проверено в редакторе персонажа и в раунде.

## Changelog

:cl:
add: Цвет глаз подманов теперь снова можно редактировать
/:cl:
