### PR TITLE
move non-prime stuff from prime module

### DIFF
--- a/modular_bandastation/modular_bandastation.dme
+++ b/modular_bandastation/modular_bandastation.dme
@@ -46,6 +46,7 @@
 #include "orderables/_orderables.dme"
 #include "outfits/_outfits.dme"
 #include "overrides/_overrides.dme"
+#include "paperwork/_paperwork.dme"
 #include "pixel_shift/_pixel_shift.dme"
 #include "preferences/_preferences.dme"
 #include "ru_jobs/_ru_jobs.dme"
@@ -72,8 +73,4 @@
 // Модпаки включены по умолчанию для запуска всех тестов и для этого кода тоже.
 #ifndef DISABLE_PRIME_MODPACKS
 #include "prime_only/_prime_only.dme"
-#include "storyteller/code/storytellers/storyteller_prime.dm"
-#include "storyteller/code/storytellers/storyteller_prime_moon.dm"
 #endif
-
-#include "paperwork/_paperwork.dme"

--- a/modular_bandastation/storyteller/_storyteller.dme
+++ b/modular_bandastation/storyteller/_storyteller.dme
@@ -51,6 +51,8 @@
 #include "code\storytellers\storyteller_operative.dm"
 #include "code\storytellers\storyteller_black_orbit.dm"
 #include "code\storytellers\storyteller_phantom.dm"
+#include "code\storytellers\storyteller_prime.dm"
+#include "code\storytellers\storyteller_prime_moon.dm"
 
 #include "code\dynamic_report.dm"
 #include "code\scheduled_event.dm"

--- a/modular_bandastation/storyteller/code/gamemode.dm
+++ b/modular_bandastation/storyteller/code/gamemode.dm
@@ -201,7 +201,6 @@ SUBSYSTEM_DEF(gamemode)
 		flags |= SS_NO_FIRE
 		return SS_INIT_NO_NEED
 
-	selected_storyteller = /datum/storyteller/angryverse
 	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/gamemode/fire(resumed = FALSE)


### PR DESCRIPTION
## Что этот PR делает

Исправляет ошибку компиляции

## Обзор от Sourcery

Улучшения:
- Удалено жестко заданное значение рассказчика по умолчанию для повышения гибкости при инициализации игрового режима.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Remove the hardcoded default storyteller to improve flexibility in gamemode initialization

</details>