### PR TITLE
Loadout fixes

### DIFF
--- a/code/modules/loadout/loadout_menu.dm
+++ b/code/modules/loadout/loadout_menu.dm
@@ -101,7 +101,7 @@
 	/** BANDASTATION ADDITION - START */
 	data["loadout_leftpoints"] = preferences.loadout_points
 	data["loadout_maxpoints"] = preferences.get_loadout_points()
-	data["donator_level"] = preferences.parent.donator_level
+	data["donator_level"] = preferences.parent.get_donator_level()
 	/** BANDASTATION ADDITION - END */
 	return data
 

--- a/modular_bandastation/loadout/code/categories/heads.dm
+++ b/modular_bandastation/loadout/code/categories/heads.dm
@@ -1,7 +1,8 @@
-// MARK: Tier 0
+// MARK: Tier 1
 /datum/loadout_item/head/ratge_helmet
 	name = "Крысоголов"
 	item_path = /obj/item/clothing/head/ratge
+	donator_level = DONATOR_TIER_1
 
 // MARK: Tier 2
 /datum/loadout_item/head/biker_helmet

--- a/modular_bandastation/loadout/code/categories/masks.dm
+++ b/modular_bandastation/loadout/code/categories/masks.dm
@@ -12,21 +12,25 @@
 	outfit.mask = item_path
 
 // MARK: Tier 0
+/datum/loadout_item/masks/breathscarf
+	name = "Шарф с системой дыхания"
+	item_path = /obj/item/clothing/mask/breath/breathscarf
+
+// MARK: Tier 1
 /datum/loadout_item/masks/pig
 	name = "Маска свиньи"
 	item_path = /obj/item/clothing/mask/animal/pig
+	donator_level = DONATOR_TIER_1
 
 /datum/loadout_item/masks/horsehead
 	name = "Маска лошади"
 	item_path = /obj/item/clothing/mask/animal/horsehead
+	donator_level = DONATOR_TIER_1
 
 /datum/loadout_item/masks/raven
 	name = "Маска ворона"
 	item_path = /obj/item/clothing/mask/animal/small/raven
-
-/datum/loadout_item/masks/breathscarf
-	name = "Шарф с системой дыхания"
-	item_path = /obj/item/clothing/mask/breath/breathscarf
+	donator_level = DONATOR_TIER_1
 
 // MARK: Tier 2
 /datum/loadout_item/masks/red_gas

--- a/modular_bandastation/loadout/code/categories/masks.dm
+++ b/modular_bandastation/loadout/code/categories/masks.dm
@@ -11,12 +11,12 @@
 		LAZYADD(outfit.backpack_contents, outfit.mask)
 	outfit.mask = item_path
 
-// MARK: Tier 0
+// MARK: Tier 1
 /datum/loadout_item/masks/breathscarf
 	name = "Шарф с системой дыхания"
 	item_path = /obj/item/clothing/mask/breath/breathscarf
+	donator_level = DONATOR_TIER_1
 
-// MARK: Tier 1
 /datum/loadout_item/masks/pig
 	name = "Маска свиньи"
 	item_path = /obj/item/clothing/mask/animal/pig


### PR DESCRIPTION
## Что этот PR делает
Поднял тир необходимый для масок зверей с 0 до 1
И тир необходимый для шляпы крысы с 0 до 1

А так же админы и разрыбы теперь получают тир

## Почему это хорошо для игры
Работягам нужна бесплатная подписка

## Changelog

:cl:
fix: Админы и разрабы снова получают тир подписки в лодауте
fix: Поднят необходимый тир подписки с 0 до 1 для следующих предметов: Шлем в виде головы крысы, маски из Hotline Miami
/:cl:
