### PR TITLE
Cyberiad: remap Med (and RND) [1/2]

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -100,14 +100,9 @@
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/backroom/ghetto)
 "abw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "abz" = (
 /obj/structure/flora/bush/jungle/b/style_random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -210,10 +205,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "adh" = (
-/obj/machinery/suit_storage_unit/medical,
+/obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/bot_white{
 	color = "#52B4E9"
 	},
+/obj/machinery/suit_storage_unit/medical,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "adk" = (
@@ -248,14 +244,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "adz" = (
-/obj/machinery/door/airlock/psych,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/medical/medbay/central)
 "adA" = (
 /turf/closed/wall,
 /area/station/medical/cryo)
@@ -272,6 +271,7 @@
 "adQ" = (
 /obj/structure/sign/poster/contraband/random/directional/east,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/starboard)
 "aec" = (
@@ -316,7 +316,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "aeX" = (
-/obj/effect/spawner/structure/window,
+/obj/structure/sign/departments/exam_room,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/treatment_center)
 "afw" = (
@@ -510,11 +511,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "ahj" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/bed/medical/anchored{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "ahp" = (
@@ -558,12 +559,8 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
 "ahI" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/white,
+/obj/structure/sign/warning/no_smoking/circle,
+/turf/closed/wall,
 /area/station/medical/medbay/lobby)
 "ahK" = (
 /obj/effect/turf_decal/tile/purple,
@@ -905,21 +902,24 @@
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
 "alU" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
 	},
-/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "alX" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/grunge{
+	name = "Morgue"
 	},
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "amc" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -955,13 +955,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "amp" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "amF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -999,11 +999,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "amN" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/maintenance/three,
+/obj/structure/closet/crate/medical,
+/turf/open/floor/plating,
+/area/station/medical/abandoned)
 "amQ" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/tile/neutral/anticorner{
@@ -1051,20 +1053,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port)
 "anJ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/door/airlock/medical/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/sign/departments/medbay/alt,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
@@ -1072,7 +1062,7 @@
 	name = "Quarantine Lockdown";
 	opacity = 0
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/plating,
 /area/station/medical/medbay/aft)
 "anM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/general{
@@ -1192,10 +1182,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "apz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/sign/warning/bodysposal/directional/east,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/area/station/maintenance/ghetto/starboard)
 "apA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1465,15 +1457,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "atx" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+/obj/machinery/light_switch/directional/west,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
 	},
-/obj/item/radio/intercom/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/storage)
 "atB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1609,18 +1599,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "avs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/mob/living/carbon/human/species/monkey,
+/obj/structure/flora/bush/jungle/b/style_random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "avu" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -1664,8 +1647,10 @@
 /turf/open/floor/carpet/black,
 /area/station/maintenance/starboard/fore)
 "awe" = (
-/obj/machinery/atmospherics/components/binary/valve/on,
 /obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/simple{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "awk" = (
@@ -1754,11 +1739,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "axs" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
+/area/station/maintenance/aft)
 "axt" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/old,
@@ -1769,6 +1753,15 @@
 /obj/item/clothing/mask/gas/clown_hat,
 /turf/open/floor/plating,
 /area/station/security/interrogation/ghetto)
+"axu" = (
+/obj/machinery/light/directional/north,
+/obj/structure/table/wood,
+/obj/machinery/microwave{
+	pixel_x = -1;
+	pixel_y = 6
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/medical/break_room)
 "axy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2640,10 +2633,13 @@
 /turf/open/water,
 /area/station/maintenance/ghetto/garden)
 "aHf" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/defibrillator_mount,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_y = 4;
+	pixel_x = -6
 	},
-/obj/machinery/stasis,
+/obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "aHh" = (
@@ -2740,16 +2736,15 @@
 /area/station/cargo/storage)
 "aIh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/toy/cards/deck/cas/black{
-	pixel_x = -7
-	},
-/obj/item/toy/cards/deck/cas{
-	pixel_x = 5;
-	pixel_y = 10
-	},
+/obj/structure/safe,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/area/station/maintenance/aft)
 "aIl" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
@@ -2806,20 +2801,9 @@
 	},
 /area/station/hallway/secondary/entry)
 "aIW" = (
-/obj/item/reagent_containers/chem_pack,
-/obj/item/reagent_containers/chem_pack,
-/obj/item/reagent_containers/chem_pack,
-/obj/item/reagent_containers/chem_pack,
-/obj/item/reagent_containers/chem_pack,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "aJk" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
@@ -2840,12 +2824,12 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
 "aJA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/obj/machinery/stasis{
-	dir = 4
+/obj/effect/turf_decal/tile/blue/full,
+/obj/structure/table/reinforced,
+/obj/machinery/defibrillator_mount,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_y = 4;
+	pixel_x = 7
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
@@ -2871,13 +2855,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "aJW" = (
-/obj/structure/window/spawner/directional/south,
-/obj/structure/table/reinforced,
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/obj/item/poster/random_contraband,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron,
 /area/station/maintenance/aft)
 "aKb" = (
 /obj/effect/turf_decal/stripes/line,
@@ -2911,20 +2891,21 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "aKH" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
+/obj/structure/table/glass,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/maintenance/department/medical/morgue)
 "aKM" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
 	},
+/obj/machinery/camera/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/maintenance/department/medical/morgue)
 "aKX" = (
 /obj/machinery/smartfridge/food,
 /obj/machinery/button/door/directional/east{
@@ -3039,14 +3020,13 @@
 /turf/closed/wall,
 /area/station/service/theater)
 "aMv" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
 	},
-/obj/structure/chair/comfy/teal{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/theatre)
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "aMD" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -3106,8 +3086,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "aNh" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
@@ -3385,25 +3366,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "aQK" = (
+/obj/effect/landmark/start/paramedic,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "aQL" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id = "quarantine";
-	name = "Quarantine Lockdown";
-	opacity = 0
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayEntrance"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/chemistry)
 "aQP" = (
 /obj/structure/railing{
 	dir = 1
@@ -3929,28 +3904,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "aWA" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/syringes{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/item/storage/box/gloves{
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/obj/item/storage/box/masks{
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/medical/abandoned)
 "aWB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/safe/floor,
@@ -4073,7 +4030,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "aXV" = (
-/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "aXW" = (
@@ -4131,9 +4091,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
 "aYv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/area/station/maintenance/department/medical/morgue)
 "aYy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -4150,11 +4111,14 @@
 "aYE" = (
 /obj/structure/table/glass,
 /obj/machinery/firealarm/directional/east,
-/obj/item/computer_disk/medical,
-/obj/item/computer_disk/medical,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
+/obj/item/storage/medkit/regular{
+	pixel_y = 6
+	},
+/obj/item/computer_disk/medical,
+/obj/item/computer_disk/medical,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "aYN" = (
@@ -4416,12 +4380,9 @@
 /turf/open/misc/grass,
 /area/station/security/prison/garden)
 "bcI" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "bcK" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -4465,24 +4426,31 @@
 /area/station/construction/mining/aux_base)
 "bdn" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/medical/medbay/central)
 "bdx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/table/reinforced,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/pillbottles,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/plating,
+/area/station/medical/abandoned)
 "bdy" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -4528,6 +4496,15 @@
 /obj/effect/landmark/start/chief_medical_officer,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
+"bee" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "beh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -4568,15 +4545,13 @@
 /turf/closed/wall,
 /area/station/cargo/warehouse)
 "beN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/turf/open/floor/iron/white,
-/area/station/medical/paramedic)
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/structure/bodycontainer/morgue{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "beQ" = (
 /obj/item/wrench,
 /obj/effect/decal/cleanable/blood/old,
@@ -4643,22 +4618,9 @@
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/ghetto/fore/starboard)
 "bfK" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/security/cell/right/directional/north{
-	name = "Isolator";
-	req_access = list("medical")
-	},
-/obj/machinery/door/poddoor/shutters/window/preopen{
-	dir = 1;
-	id = "durka2"
-	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/door/window/brigdoor/security/cell/left/directional/south{
-	name = "Isolator"
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/medical/medbay/lobby)
 "bfN" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -4693,6 +4655,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
+"bgr" = (
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "bgA" = (
 /obj/effect/spawner/random/medical/injector,
 /turf/open/floor/plating,
@@ -4782,11 +4747,14 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
 "bhy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/machinery/light/small/directional/south{
+	name = "maintenance light";
+	nightshift_allowed = 0;
+	nightshift_enabled = 1
 	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/morgue)
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "bhz" = (
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
@@ -4825,11 +4793,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bhZ" = (
+/obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/chem_dispenser,
-/obj/machinery/status_display/evac/directional/west,
+/obj/effect/landmark/start/chemist,
+/obj/structure/chair/stool{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/station/medical/pharmacy)
 "bic" = (
@@ -4967,18 +4938,20 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "bjo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil{
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil,
+/obj/item/multitool,
+/turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
+/area/station/medical/chemistry)
 "bjq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5068,12 +5041,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "bkn" = (
-/obj/structure/chair,
-/obj/effect/spawner/random/trash/graffiti{
-	spawn_loot_chance = 50
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/effect/turf_decal/stripes,
+/obj/item/kirbyplants/random,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/medical/chemistry)
 "bko" = (
 /obj/machinery/atmospherics/components/binary/pump/layer2{
 	name = "Exfiltrate to Waste"
@@ -5093,6 +5065,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
+"bkF" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "bkP" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
@@ -5149,13 +5129,12 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "blx" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green/fourcorners,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/chem_storage)
 "blA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -5203,17 +5182,15 @@
 /turf/open/floor/iron/herringbone,
 /area/station/maintenance/aft)
 "blT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
-	dir = 8
-	},
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "bmd" = (
@@ -5271,11 +5248,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "bnm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/mess,
-/obj/structure/frame/machine/secured,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "bnr" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "testlab";
@@ -5418,17 +5396,11 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/station/engineering/gravity_generator)
 "bpx" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Virology - Airlock";
-	network = list("ss13","medbay")
+/obj/structure/toilet{
+	pixel_y = 12
 	},
-/obj/structure/sink/directional/west,
-/obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/floor/iron/freezer,
+/area/station/medical/break_room)
 "bpy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5585,13 +5557,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/ghetto)
 "bri" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/window/right/directional/north{
-	name = "Body Disposal"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/morgue)
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "brl" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -5604,11 +5574,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "brn" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/structure/railing,
-/turf/open/floor/iron/white,
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/bush/grassy,
+/obj/structure/flora/bush/flowers_pp,
+/turf/open/floor/grass,
 /area/station/medical/treatment_center)
 "brr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5673,11 +5642,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/sink/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/medical/medbay/aft)
 "brP" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -5839,10 +5805,11 @@
 "bui" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/medical,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "bup" = (
@@ -5868,13 +5835,23 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "buy" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/medical/patients_rooms)
 "buC" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/engineering_guide{
@@ -6127,6 +6104,29 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
+"bxD" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/paper{
+	pixel_y = 4
+	},
+/obj/item/pen/red{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/hand_labeler{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "bxI" = (
 /obj/structure/closet/crate,
 /obj/item/toy/dodgeball,
@@ -6195,7 +6195,6 @@
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "byf" = (
@@ -6214,10 +6213,10 @@
 	},
 /area/station/hallway/secondary/entry)
 "byg" = (
-/obj/structure/closet/crate/freezer,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/light/small/directional/east,
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "byv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6285,13 +6284,17 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "bzn" = (
-/obj/effect/decal/cleanable/vomit,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/medical{
+	dir = 4
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "bzp" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron,
@@ -6325,13 +6328,10 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "bzO" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/theatre)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/freezer/food,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "bzP" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/dark,
@@ -6411,11 +6411,12 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/ghetto/central)
 "bBw" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 10
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "bBN" = (
 /obj/effect/spawner/random/trash/bin,
 /turf/open/floor/iron,
@@ -6540,15 +6541,8 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "bCK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "bCN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6591,13 +6585,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "bDp" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/sign/warning/no_smoking/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/turf/closed/wall,
+/area/station/maintenance/department/medical/morgue)
 "bDu" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -6846,9 +6835,9 @@
 /turf/closed/wall,
 /area/station/commons/storage/primary)
 "bGl" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard)
 "bGo" = (
 /obj/item/radio/intercom/directional/north,
 /obj/structure/closet/secure_closet/atmospherics,
@@ -6924,8 +6913,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "bIa" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
@@ -7331,6 +7321,15 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/engineering/atmos)
+"bMO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "bMV" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -7480,12 +7479,12 @@
 /turf/open/floor/plating,
 /area/station/security/interrogation/ghetto)
 "bON" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
 /area/station/medical/treatment_center)
 "bOO" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -7495,11 +7494,12 @@
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "bOW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sink/kitchen/directional/south,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron/cafeteria,
+/area/station/medical/break_room)
 "bPa" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -7556,12 +7556,11 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/qm)
 "bPQ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/medical/chemistry/ghetto)
+/turf/closed/wall,
+/area/station/maintenance/department/medical/morgue)
 "bPR" = (
 /obj/structure/table,
 /obj/item/radio/intercom/prison/directional/north,
@@ -7778,9 +7777,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/storage)
 "bRT" = (
-/obj/machinery/cryo_cell,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
@@ -7918,14 +7917,14 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "bUL" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/obj/effect/turf_decal/tile/neutral/anticorner,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "bUT" = (
 /obj/structure/toilet{
 	pixel_y = -4;
@@ -7988,12 +7987,20 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/ghetto/starboard/aft)
 "bVS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 10
+/obj/item/reagent_containers/chem_pack,
+/obj/item/reagent_containers/chem_pack,
+/obj/item/reagent_containers/chem_pack,
+/obj/item/reagent_containers/chem_pack,
+/obj/item/reagent_containers/chem_pack,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/structure/closet/crate/freezer/blood,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "bVV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/brown/half/contrasted,
@@ -8099,24 +8106,25 @@
 /turf/open/floor/iron/stairs/medium,
 /area/station/hallway/primary/central/fore)
 "bXj" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/obj/machinery/door/airlock/atmos,
+/obj/effect/mapping_helpers/airlock/access/all/engineering,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "bXn" = (
 /turf/closed/wall,
 /area/station/cargo/drone_bay/ghetto)
 "bXw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "bXy" = (
@@ -8481,30 +8489,23 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "cbm" = (
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_exterior"
+/obj/machinery/door/airlock{
+	name = "Private Restroom"
 	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/effect/turf_decal/tile/green/fourcorners,
+/obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable,
-/obj/machinery/door_buttons/access_button{
-	idDoor = "virology_airlock_exterior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_y = 24;
-	req_access = list("virology")
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/turf/open/floor/iron/freezer,
+/area/station/medical/break_room)
 "cbo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8522,12 +8523,14 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/central)
 "cbw" = (
-/obj/machinery/door/poddoor/shutters/window{
-	id = "chemistry_access_shutters"
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
+/area/station/medical/psychology)
 "cby" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres{
@@ -8696,12 +8699,11 @@
 /turf/closed/wall,
 /area/station/security/lockers)
 "cdC" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/structure/railing/corner{
+/obj/structure/railing{
 	dir = 8
 	},
+/obj/structure/bed/medical/anchored,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "cdD" = (
@@ -8731,15 +8733,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "ces" = (
-/obj/machinery/door/window/right/directional/east{
-	name = "Coroner"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/small,
-/area/station/medical/morgue)
+/obj/structure/chair/comfy/teal{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "cex" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/medkit/regular{
@@ -8988,12 +8990,21 @@
 	},
 /area/station/service/hydroponics)
 "chY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/bar/fourcorners,
-/obj/effect/spawner/random/trash/mess,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/obj/structure/sign/warning/biohazard/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "cic" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9123,8 +9134,11 @@
 	},
 /obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "cjn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9430,10 +9444,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "clY" = (
-/obj/structure/sink/directional/south,
-/obj/structure/mirror/directional/north,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "cmg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9464,22 +9478,26 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "cmQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
 /obj/machinery/door/airlock/medical/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
 	id = "quarantine";
 	name = "Quarantine Lockdown";
 	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
@@ -9535,8 +9553,12 @@
 /turf/open/floor/iron/herringbone,
 /area/station/maintenance/aft)
 "cnG" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/table/reinforced,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/item/poster/random_contraband,
+/obj/structure/window/spawner/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "cnI" = (
@@ -9638,11 +9660,12 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port/aft)
 "coB" = (
-/obj/structure/table/reinforced,
-/obj/item/trash/tray,
-/obj/effect/spawner/random/food_or_drink/pizzaparty,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/morgue)
 "coR" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor2-old"
@@ -9710,10 +9733,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "cqc" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/station/medical/paramedic)
+/area/station/medical/cryo)
 "cqd" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
@@ -9772,11 +9801,14 @@
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
 "cqM" = (
-/obj/machinery/light/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/random/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/white,
+/area/station/medical/psychology)
 "cqN" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical{
@@ -9815,11 +9847,10 @@
 /turf/open/floor/carpet,
 /area/station/service/library/ghetto)
 "crq" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain,
+/turf/open/floor/plating,
+/area/station/medical/patients_rooms)
 "crv" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -9827,13 +9858,23 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
+"crw" = (
+/obj/machinery/light_switch/directional/north,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/iron/smooth,
+/area/station/medical/chemistry)
 "crB" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
 	},
-/obj/machinery/light/directional/north,
+/obj/structure/table/glass,
+/obj/item/folder/white{
+	pixel_y = 4
+	},
+/obj/item/book/manual/wiki/infections,
+/obj/machinery/camera/directional/north,
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/medical/virology)
 "crG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -9849,13 +9890,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "crH" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/turf/open/floor/iron/cafeteria,
+/area/station/medical/break_room)
 "crJ" = (
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/abandoned_gambling_den)
@@ -9937,10 +9976,11 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "csD" = (
+/obj/machinery/duct,
+/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "csF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10024,7 +10064,11 @@
 "ctR" = (
 /obj/structure/window/spawner/directional/west,
 /obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_y = 4
+	},
 /obj/effect/spawner/random/maintenance,
+/obj/structure/window/spawner/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "ctY" = (
@@ -10085,21 +10129,18 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/central)
 "cuC" = (
-/obj/machinery/vending/wardrobe/chem_wardrobe,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "cuJ" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id = "quarantine";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/medical/pharmacy)
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/central)
 "cuT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -10361,9 +10402,14 @@
 /turf/open/space/openspace,
 /area/space/nearstation)
 "cye" = (
-/obj/machinery/chem_heater/withbuffer,
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/chemistry/ghetto)
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "cyl" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -10377,9 +10423,11 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "cys" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/kitchen)
+/mob/living/carbon/human/species/monkey,
+/obj/structure/flora/bush/lavendergrass/style_3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "cyw" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -10389,11 +10437,10 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/checkpoint/medical)
 "cyz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry/ghetto)
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/aft)
 "cyA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/garbage,
@@ -10623,6 +10670,15 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
+"cBr" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "cBt" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/holopad,
@@ -10664,11 +10720,18 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "cBQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/west,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/chair/office/light{
+	dir = 1;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/chemistry)
 "cBU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -10750,9 +10813,16 @@
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/office)
 "cCS" = (
-/obj/machinery/smartfridge/organ,
-/turf/open/floor/iron/dark/small,
-/area/station/medical/morgue)
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "cDj" = (
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 4
@@ -10787,7 +10857,6 @@
 	dir = 2
 	},
 /obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/structure/sign/departments/psychology/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "cDB" = (
@@ -11001,6 +11070,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"cFZ" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "cGg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11059,6 +11134,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
+"cGK" = (
+/obj/structure/marker_beacon/indigo,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "cGR" = (
 /obj/structure/table/wood,
 /obj/machinery/requests_console/directional/south{
@@ -11149,23 +11231,16 @@
 /turf/open/floor/cult,
 /area/station/maintenance/starboard/fore)
 "cHV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
-	},
-/obj/structure/table/optable,
-/obj/effect/spawner/random/medical/surgery_tool,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "cHW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11409,15 +11484,22 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/ghetto)
 "cKC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes,
-/turf/open/floor/iron/smooth,
-/area/station/medical/chemistry/ghetto)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "cKE" = (
-/obj/machinery/vending/boozeomat,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/structure/table/reinforced,
+/obj/item/surgery_tray/full/morgue,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "cKJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/sink/directional/east,
@@ -11454,9 +11536,11 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "cLk" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/chemistry)
 "cLp" = (
 /obj/item/clothing/mask/balaclava,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -11538,11 +11622,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/machinery/holopad,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "cMm" = (
 /obj/structure/cable,
 /mob/living/basic/crab{
@@ -11578,9 +11660,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "cMI" = (
@@ -11678,17 +11757,24 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "cNQ" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 2
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/morgue)
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "cNR" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"cNT" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 6
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "cNW" = (
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /obj/machinery/photobooth/security,
@@ -11911,20 +11997,26 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "cQO" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/psych{
+	id_tag = "psych_office"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
+/area/station/medical/psychology)
 "cRd" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/sign/warning/no_smoking/circle,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/medical/surgery/theatre)
+/area/station/maintenance/starboard/upper)
 "cRf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -11967,9 +12059,7 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "cRy" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/large,
 /area/station/service/bar/atrium/ghetto)
 "cRA" = (
@@ -12085,12 +12175,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "cTa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/mess,
+/obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
 "cTb" = (
 /obj/structure/reagent_dispensers/wall/peppertank/directional/north,
@@ -12189,7 +12278,10 @@
 /turf/open/floor/iron,
 /area/station/command/teleporter)
 "cUf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "cUg" = (
@@ -12208,12 +12300,16 @@
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/disposal)
 "cUp" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+/obj/structure/table,
+/obj/item/clothing/gloves/latex/nitrile{
+	pixel_y = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/theatre)
+/obj/item/folder/white,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/psychology)
 "cUs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -12418,15 +12514,14 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "cVX" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/trunk/multiz/down{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "cWl" = (
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
@@ -12454,6 +12549,13 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
+"cWF" = (
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "cWQ" = (
 /obj/machinery/computer/prisoner/gulag_teleporter_computer,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -12488,13 +12590,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "cXl" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "cXq" = (
@@ -12600,13 +12704,14 @@
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hop)
 "cYo" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "cYp" = (
@@ -12793,13 +12898,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "cZU" = (
-/obj/structure/table/optable{
-	desc = "A cold, hard place for your final rest.";
-	name = "Morgue Slab"
+/obj/effect/spawner/random/vending/colavend,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/obj/item/surgery_tray/full/morgue,
-/turf/open/floor/iron/dark/small,
-/area/station/medical/morgue)
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "cZW" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -12888,16 +12992,10 @@
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "dba" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/floor/iron/freezer,
+/area/station/medical/break_room)
 "dbc" = (
 /obj/structure/chair/sofa/bench{
 	dir = 4
@@ -12956,13 +13054,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/storage)
 "dbP" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "dbS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -13031,10 +13127,9 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "dcV" = (
-/obj/structure/barricade/wooden/crude,
-/obj/structure/barricade/wooden,
+/obj/structure/falsewall,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
+/area/station/maintenance/department/medical/morgue)
 "dcX" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/structure/closet/emcloset,
@@ -13077,13 +13172,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "ddK" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/structure/curtain,
+/obj/machinery/shower/directional/north,
+/turf/open/floor/iron/freezer,
+/area/station/medical/break_room)
 "ddN" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "eng_vaul_maint";
@@ -13201,12 +13293,15 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "dfK" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/dark,
+/area/station/medical/surgery/theatre)
 "dfL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13391,12 +13486,16 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/security/ghetto)
 "dic" = (
-/obj/machinery/washing_machine,
-/obj/machinery/light/small/directional/north,
-/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "dii" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13432,6 +13531,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/effect/turf_decal/tile/red/full,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/checkpoint/medical)
 "div" = (
@@ -13522,9 +13622,6 @@
 /obj/item/pen{
 	pixel_y = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "djm" = (
@@ -13907,17 +14004,13 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "dmG" = (
-/obj/structure/table,
-/obj/item/gun/syringe{
-	pixel_x = -12;
-	pixel_y = 6
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/gun/syringe{
-	pixel_x = -12
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "dmU" = (
 /obj/effect/turf_decal/box/corners,
 /obj/effect/turf_decal/box/corners{
@@ -13956,17 +14049,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "dnz" = (
-/obj/effect/turf_decal/tile/blue/full,
-/obj/structure/table/reinforced,
-/obj/machinery/defibrillator_mount,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_y = 4;
-	pixel_x = -6
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_y = 4;
+/obj/structure/table/reinforced/rglass,
+/obj/item/stack/medical/gauze{
 	pixel_x = 7
 	},
+/obj/item/stack/medical/mesh{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/item/stack/medical/suture,
+/obj/effect/turf_decal/tile/blue/full,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "dnB" = (
@@ -14111,8 +14205,6 @@
 	nightshift_enabled = 1;
 	nightshift_light_power = 0.4
 	},
-/obj/structure/table/wood,
-/obj/item/trash/candle,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "dpb" = (
@@ -14153,12 +14245,9 @@
 /turf/open/floor/wood,
 /area/station/security/prison/mess)
 "dpz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
+/area/station/maintenance/starboard/upper)
 "dpE" = (
 /obj/machinery/light/small/directional/south{
 	name = "maintenance light";
@@ -14367,17 +14456,12 @@
 /turf/open/floor/carpet/green,
 /area/station/commons/dorms/apartment1)
 "dsq" = (
-/obj/structure/sign/warning/deathsposal/directional/north,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/machinery/light/directional/north,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/floor/plating,
+/area/station/medical/abandoned)
 "dsu" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -14516,10 +14600,17 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
 "dun" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/medical/virology)
 "duo" = (
 /obj/structure/ladder,
 /obj/effect/turf_decal/stripes/box,
@@ -14609,16 +14700,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
 "dvk" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "ghetto_medical_storage"
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
 	},
-/obj/machinery/button/door/directional/south{
-	id = "ghetto_medical_storage";
-	name = "Shutters Control"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "dvm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14806,20 +14893,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "dxK" = (
-/obj/structure/sign/poster/official/safety_eye_protection/directional/north,
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
-	color = "#ff0000";
-	name = "Scrubbers multi deck pipe adapter"
-	},
-/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
-	color = "#0000ff";
-	name = "Supply multi deck pipe adapter"
-	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/floor/iron/smooth,
-/area/station/medical/chemistry/ghetto)
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "dxQ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -14873,27 +14951,44 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "dyq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/effect/spawner/random/maintenance/two,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/railing/corner,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "dyr" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "dys" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/light/directional/east,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/book/manual/wiki/plumbing{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/book/manual/wiki/chemistry{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/book/manual/wiki/grenades,
+/obj/item/storage/box/syringes,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/dark,
+/area/station/medical/chemistry)
 "dyy" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -15069,6 +15164,10 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"dAX" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "dAY" = (
 /obj/machinery/button/door/directional/south{
 	id = "ghetto_storage_loading"
@@ -15125,13 +15224,8 @@
 /turf/open/floor/iron/recharge_floor,
 /area/station/security/mechbay)
 "dBA" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/chair/stool{
-	dir = 1
-	},
-/obj/effect/landmark/start/chemist,
-/turf/open/floor/engine,
-/area/station/medical/pharmacy)
+/turf/closed/wall/r_wall,
+/area/station/medical/treatment_center)
 "dBC" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 9
@@ -15161,7 +15255,7 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "dBT" = (
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "dCm" = (
@@ -15237,12 +15331,9 @@
 /turf/closed/wall,
 /area/station/security/checkpoint/engineering)
 "dCQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/floor,
-/obj/effect/mapping_helpers/dead_body_placer,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/medical/patients_rooms)
 "dCU" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -15274,12 +15365,12 @@
 /turf/open/floor/iron/chapel,
 /area/station/maintenance/starboard/fore)
 "dDI" = (
-/obj/machinery/vending/coffee,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10
+/obj/machinery/plumbing/sender,
+/obj/effect/turf_decal/siding/yellow/end{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/turf/open/floor/plating,
+/area/station/medical/chemistry)
 "dDJ" = (
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
@@ -15650,16 +15741,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "dIb" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/barricade/wooden/crude,
+/obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/medical/surgery/theatre)
 "dId" = (
 /obj/structure/closet/emcloset{
 	contents_initialized = 1;
@@ -15755,8 +15847,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "dJE" = (
-/obj/structure/cable,
-/obj/structure/chair/wood,
+/obj/structure/table/wood,
+/obj/item/trash/candle,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "dJF" = (
@@ -15792,11 +15884,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay/ghetto)
 "dKd" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/bodycontainer/morgue{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "dKj" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -15808,17 +15899,21 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "dKk" = (
-/obj/structure/table,
-/obj/machinery/computer/records/medical/laptop{
-	dir = 1;
-	pixel_y = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/airlock/grunge{
+	name = "Morgue"
 	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 8;
-	pixel_y = 12
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron/dark/small,
-/area/station/medical/morgue)
+/obj/machinery/duct,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "dKo" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/engine/ghetto)
@@ -15962,7 +16057,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
 "dLq" = (
-/obj/effect/turf_decal/tile/green/fourcorners,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
+/obj/structure/sink/directional/west,
+/obj/machinery/camera/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "dLz" = (
@@ -16023,6 +16123,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"dMF" = (
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "dMR" = (
 /turf/closed/wall,
 /area/station/cargo/storage)
@@ -16080,6 +16184,7 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "dNF" = (
+/obj/structure/cable,
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
@@ -16091,21 +16196,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
 "dNO" = (
-/obj/structure/table/glass,
-/obj/item/storage/belt/medical,
-/obj/item/healthanalyzer{
-	pixel_x = 2;
-	pixel_y = 10
-	},
-/obj/item/clothing/glasses/hud/health{
-	pixel_y = 6
-	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/east,
+/obj/effect/spawner/random/trash/cigbutt,
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/chem_storage)
 "dNY" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plating,
@@ -16408,17 +16503,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "dSO" = (
-/obj/structure/table,
-/obj/item/knife/plastic{
-	pixel_x = 8
-	},
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/medical/chemistry)
 "dSW" = (
 /obj/item/hfr_box/body/waste_output,
 /obj/item/hfr_box/body/moderator_input,
@@ -16435,11 +16526,21 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "dTr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/machinery/oven/range,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/mapping_helpers/requests_console/ore_update,
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
+/obj/machinery/smartfridge/chemistry/virology/preloaded,
+/obj/machinery/requests_console/directional/north{
+	department = "Virology";
+	name = "Virology Requests Console"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "dTt" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -16750,14 +16851,31 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
-"dXq" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
+"dXp" = (
+/obj/structure/table/optable{
+	desc = "A cold, hard place for your final rest.";
+	name = "Morgue Slab"
 	},
-/obj/machinery/vending/wallmed/directional/north,
-/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
+"dXq" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/structure/table/glass,
+/obj/item/radio/headset/headset_med{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/soap{
+	pixel_y = 8
+	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/virology)
 "dXr" = (
 /obj/machinery/conveyor{
 	dir = 10;
@@ -16777,12 +16895,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "dXD" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/holopad,
-/obj/effect/turf_decal/box/white{
-	color = "#52B4E9"
-	},
-/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "dXQ" = (
@@ -17377,13 +17492,13 @@
 "eeX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=HOP";
 	location = "CHE"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
@@ -17558,6 +17673,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
+"eit" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "eiu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -17572,11 +17692,41 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "eiG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 1
 	},
-/obj/machinery/chem_master,
-/turf/open/floor/engine,
+/obj/structure/table/reinforced/rglass,
+/obj/item/assembly/igniter{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/assembly/igniter{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/assembly/igniter{
+	pixel_x = -6
+	},
+/obj/item/assembly/igniter{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/obj/item/assembly/timer{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/assembly/timer{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/item/assembly/timer{
+	pixel_x = 8
+	},
+/obj/item/assembly/timer{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "eiH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -17585,14 +17735,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "eiK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/obj/effect/spawner/random/maintenance/two,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central)
 "eiM" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/dirt,
@@ -17722,6 +17868,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"ejY" = (
+/obj/effect/spawner/random/structure/table_or_rack,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "ejZ" = (
 /obj/effect/spawner/structure/electrified_grille,
 /turf/open/floor/plating,
@@ -17807,11 +17957,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "elG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/machinery/modular_computer/preset/cargochat/medical{
+	dir = 8
 	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry/ghetto)
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "elH" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
@@ -18556,10 +18707,10 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
 "ewZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/railing{
-	dir = 1
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
 	},
+/obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "exb" = (
@@ -18810,13 +18961,17 @@
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "eAC" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 4
 	},
-/obj/structure/closet/secure_closet/chemical,
-/obj/item/construction/plumbing,
-/obj/item/radio/headset/headset_med,
-/obj/item/radio/headset/headset_med,
+/obj/structure/table/reinforced/rglass,
+/obj/item/hand_labeler{
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/stack/package_wrap,
+/obj/item/toy/figure/chemist,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "eAG" = (
@@ -18934,11 +19089,25 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/gravity_generator)
 "eBS" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
-/obj/item/restraints/handcuffs/cable/pink,
-/obj/item/melee/chainofcommand,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/machinery/airalarm/directional/north,
+/obj/structure/table/wood,
+/obj/machinery/coffeemaker/impressa{
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/cup/bottle/syrup_bottle/liqueur{
+	pixel_x = 13;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/cup/bottle/syrup_bottle/korta_nectar{
+	pixel_x = 13;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/cup/bottle/syrup_bottle/caramel{
+	pixel_x = 13;
+	pixel_y = 1
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/medical/break_room)
 "eCg" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -19070,7 +19239,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/chemistry)
 "eEa" = (
 /obj/structure/railing{
 	dir = 4
@@ -19089,15 +19258,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "eEz" = (
-/obj/structure/bed{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/mob/living/carbon/human/species/monkey,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
-	},
+/obj/structure/closet/crate/medical,
+/obj/structure/sign/poster/official/help_others/directional/north,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/treatment_center)
 "eEC" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/mapping_helpers/broken_floor,
@@ -19175,13 +19342,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
 "eFQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
+/obj/machinery/light/small/directional/west,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/area/station/maintenance/ghetto/aft)
 "eGb" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/lighter,
@@ -19214,15 +19378,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "eGp" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/modular_computer/preset/cargochat/medical{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/brown/filled/end{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
+/obj/effect/turf_decal/stripes,
+/obj/machinery/status_display/ai/directional/north,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/smooth,
+/area/station/medical/chemistry)
 "eGx" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
@@ -19459,12 +19619,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/bar/atrium/ghetto)
 "eIq" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "eIw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2,
@@ -19922,11 +20081,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "eOq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "eOu" = (
 /obj/machinery/door/airlock/wood/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -19986,13 +20148,13 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
 "ePA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "ePB" = (
@@ -20026,11 +20188,9 @@
 /turf/open/floor/carpet/green,
 /area/station/commons/dorms/apartment1)
 "eQb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "eQc" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red{
@@ -20138,6 +20298,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"eRN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "eRT" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -20223,14 +20388,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "eSO" = (
+/obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+	dir = 5
 	},
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/theatre)
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "eSR" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 8
@@ -20252,9 +20415,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "eTo" = (
-/obj/effect/turf_decal/siding/wood/corner,
-/turf/open/floor/wood/large,
-/area/station/service/bar/atrium/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "eTt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -20500,11 +20665,16 @@
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "eWD" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/dark,
+/area/station/medical/surgery/theatre)
 "eWG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -20530,17 +20700,12 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/ghetto/fore/starboard)
 "eWU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "eWX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20567,10 +20732,8 @@
 /turf/open/floor/wood,
 /area/station/maintenance/aft)
 "eXr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/dim/directional/east,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/central)
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "eXt" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -20619,10 +20782,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "eXQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+/obj/structure/railing{
+	dir = 4
 	},
-/obj/structure/railing/corner,
+/obj/structure/bed/medical/anchored{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "eXR" = (
@@ -20765,6 +20931,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
+"fac" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "faf" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron/grimy,
@@ -20870,14 +21043,9 @@
 /turf/open/floor/wood/parquet,
 /area/station/security/courtroom)
 "fbN" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/obj/effect/landmark/start/coroner,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "fbS" = (
 /obj/item/kirbyplants/random/dead,
 /obj/effect/spawner/random/maintenance,
@@ -20888,9 +21056,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "fbX" = (
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/engine,
 /area/station/medical/pharmacy)
 "fca" = (
@@ -20901,13 +21071,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "fcd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/machinery/light/small/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
+/obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "fcg" = (
@@ -20917,13 +21081,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "fcj" = (
-/obj/structure/closet/secure_closet/personal/patient,
+/obj/structure/closet/secure_closet/medical1,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "fcz" = (
@@ -20977,17 +21139,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
 "fdc" = (
-/obj/structure/table,
-/obj/item/kitchen/spoon/plastic,
-/obj/item/kitchen/fork/plastic,
-/obj/item/knife/plastic{
-	pixel_x = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/obj/item/food/grown/banana,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "fdy" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "MiniSat Teleporter";
@@ -21194,14 +21352,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
 "fgl" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/half,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "fgq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21212,13 +21371,11 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "fgr" = (
+/obj/structure/cable,
+/obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "fgw" = (
@@ -21378,6 +21535,9 @@
 	pixel_x = 8;
 	pixel_y = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "fif" = (
@@ -21448,8 +21608,12 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "fiK" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
-/turf/closed/wall/r_wall,
+/obj/machinery/portable_atmospherics/canister/air{
+	anchored = 1
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "fiO" = (
 /obj/machinery/door/window/brigdoor/left/directional/north{
@@ -21486,9 +21650,11 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "fiY" = (
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table_frame,
+/obj/effect/spawner/random/trash/soap,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
+/area/station/maintenance/aft)
 "fiZ" = (
 /obj/effect/turf_decal/trimline/yellow/line,
 /turf/open/floor/iron,
@@ -21538,12 +21704,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/ghetto)
 "fjz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/central)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "fjA" = (
 /obj/structure/firelock_frame{
 	anchored = 1
@@ -21724,26 +21888,27 @@
 "flO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "flP" = (
 /turf/open/floor/wood,
 /area/station/service/kitchen/abandoned)
 "flS" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
 	},
-/obj/structure/chair/comfy/teal{
-	dir = 4
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/turf/open/floor/plating,
+/area/station/medical/virology)
 "flT" = (
 /obj/structure/railing{
 	dir = 10
@@ -21928,10 +22093,8 @@
 "fof" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/sign/warning/vacuum/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "fog" = (
 /obj/effect/turf_decal/siding/wideplating_new/light{
 	dir = 6
@@ -22003,11 +22166,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "fpz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
 "fpA" = (
@@ -22079,12 +22244,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "fqT" = (
-/obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/delivery/white{
-	color = "#52B4E9"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/virology)
 "fqU" = (
 /obj/structure/railing{
 	dir = 1;
@@ -22332,19 +22499,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "ftE" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
 /obj/machinery/light/small/directional/north,
 /obj/machinery/camera/directional/north{
-	c_tag = "Medbay - Hallway North";
+	c_tag = "Medbay - Hallway - North";
 	network = list("ss13","medbay")
 	},
-/obj/structure/sign/departments/morgue/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "ftL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22570,16 +22734,13 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/ghetto/port)
 "fwl" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "fwx" = (
@@ -22593,10 +22754,19 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "fwy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/machinery/light/small/directional/east{
+	name = "maintenance light";
+	nightshift_allowed = 0;
+	nightshift_enabled = 1;
+	nightshift_light_power = 0.4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/item/reagent_containers/spray/cleaner,
+/obj/structure/table/glass,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "fwF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22640,13 +22810,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "fxe" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/obj/structure/sink/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "fxi" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/light/small/directional/south,
@@ -22755,12 +22921,10 @@
 /area/station/security/courtroom/holding)
 "fys" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/cafeteria,
+/area/station/medical/break_room)
 "fyz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22838,8 +23002,9 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "fzv" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "fzC" = (
@@ -22880,10 +23045,8 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "fAb" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/turf/closed/wall/r_wall,
+/area/station/medical/chemistry)
 "fAr" = (
 /obj/structure/reflector/box,
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -23072,14 +23235,18 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port)
 "fCK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/machinery/camera{
+	c_tag = "Medbay Hallway Center";
 	dir = 8
 	},
-/obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "fCN" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
@@ -23224,15 +23391,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "fEy" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "fED" = (
@@ -23471,12 +23633,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "fGO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/chem_master,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/sign/warning/no_smoking/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/medical/chemistry)
 "fGS" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/lawyer,
@@ -23555,6 +23717,20 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
+"fHo" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "fHt" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -23654,9 +23830,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "fIE" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -23738,12 +23911,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "fJB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "fJD" = (
@@ -23793,10 +23961,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
 "fKm" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/medical/break_room)
 "fKw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23926,23 +24096,23 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/theater)
 "fLX" = (
-/obj/effect/turf_decal/tile/green/fourcorners,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/floor/plating,
+/area/station/medical/abandoned)
 "fMi" = (
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/wood,
 /area/station/service/library)
 "fMo" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
 	},
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/medical/chemistry)
 "fMy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -23961,16 +24131,14 @@
 /turf/open/floor/stone,
 /area/station/service/hydroponics/ghetto)
 "fMF" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/spawner/random/structure/barricade,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/area/station/maintenance/ghetto/aft)
 "fMH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -24167,12 +24335,11 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "fOE" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "fOG" = (
@@ -24186,9 +24353,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "fOH" = (
-/obj/item/storage/box/bodybags,
+/obj/structure/chair/wood,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/area/station/maintenance/aft)
 "fOS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24378,6 +24545,13 @@
 /obj/machinery/oven/range,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"fRZ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/structure/sink/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/psychology)
 "fSb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/smooth,
@@ -24651,6 +24825,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/north,
+/obj/machinery/power/apc/worn_out/directional/west,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "fVs" = (
@@ -24686,37 +24863,12 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "fVL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder{
-	pixel_x = -1;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_x = 3;
-	pixel_y = -8
-	},
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_x = -3;
-	pixel_y = -8
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	pixel_y = -6
-	},
-/obj/item/reagent_containers/dropper{
-	pixel_y = -7
-	},
-/obj/structure/sign/warning/no_smoking/directional/north,
-/obj/machinery/camera/directional/north{
-	c_tag = "Medbay - Chemistry Lab East";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/station/medical/chemistry/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "fVV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -24756,20 +24908,14 @@
 /turf/open/floor/carpet,
 /area/station/service/library)
 "fWo" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/door/window/right/directional/north{
-	req_access = list("medical")
-	},
-/obj/effect/turf_decal/box/white{
-	color = "#52B4E9"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/landmark/navigate_destination/chemfactory,
 /turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/area/station/medical/chemistry)
 "fWu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24807,12 +24953,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "fWP" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "fWR" = (
@@ -24888,20 +25031,21 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "fYg" = (
-/obj/machinery/button/door/directional{
-	id = "viroshutters";
-	pixel_x = 24
+/obj/structure/table/reinforced,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags{
+	pixel_x = -6;
+	pixel_y = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
+/obj/item/reagent_containers/cup/bottle/formaldehyde{
+	pixel_x = 8;
+	pixel_y = 6
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/sign/warning/vacuum/directional/south,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "fYh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -25164,11 +25308,14 @@
 	},
 /area/station/commons/lounge)
 "gbq" = (
-/obj/structure/chair/comfy/teal{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "gbs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25241,9 +25388,9 @@
 /turf/open/floor/wood/large,
 /area/station/service/theater)
 "gbZ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/table,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/area/station/maintenance/ghetto/starboard)
 "gcr" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -25820,6 +25967,15 @@
 /obj/item/gun/ballistic/revolver/russian,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"giT" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "gjd" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -25991,11 +26147,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "glK" = (
-/obj/item/instrument/recorder,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "glP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -26020,6 +26174,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"gmq" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/reagent_containers/cup/beaker,
+/obj/item/reagent_containers/dropper,
+/obj/structure/sign/warning/electric_shock/directional/west,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "gmr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -26072,14 +26233,9 @@
 /turf/open/floor/eighties/red,
 /area/station/maintenance/port/aft)
 "gmX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "gnb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table/wood,
@@ -26270,9 +26426,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "goV" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/obj/structure/chair/comfy/teal,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/maintenance/department/medical/morgue)
 "gpb" = (
 /turf/open/floor/iron,
 /area/station/maintenance/port)
@@ -26299,10 +26458,15 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "gpy" = (
-/obj/machinery/door/airlock/maintenance,
+/obj/machinery/duct,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/maintenance{
+	name = "Virology Service Room"
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
+/area/station/maintenance/department/medical/morgue)
 "gpE" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/random/maintenance/two,
@@ -26383,10 +26547,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
 "gqS" = (
-/obj/machinery/light/small/directional/east,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/medical/surgery/theatre)
 "gqT" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -26441,15 +26607,24 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "grZ" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id = "quarantine";
-	name = "Quarantine Lockdown";
-	opacity = 0
+/obj/structure/table/glass,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_y = 10
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/item/storage/belt/medical{
+	pixel_y = 6
+	},
+/obj/item/clothing/glasses/hud/health{
+	pixel_y = -2
+	},
+/obj/structure/cable,
+/obj/item/storage/belt/medical{
+	pixel_y = 6
+	},
+/obj/item/clothing/glasses/hud/health{
+	pixel_y = -2
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "gsa" = (
 /obj/item/radio/intercom/directional/north,
@@ -26538,20 +26713,23 @@
 /turf/open/floor/wood/parquet,
 /area/station/hallway/secondary/service)
 "gto" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
+/obj/structure/table/glass,
+/obj/item/storage/box/syringes{
+	pixel_x = -4;
+	pixel_y = 5
 	},
-/obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/button/door/directional/west{
-	id = "chemistry_access_shutters";
-	name = "Chemistry Access Shutter Control";
-	req_access = list("medical");
-	pixel_x = 0;
-	pixel_y = -24
+/obj/item/storage/box/beakers{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_y = -4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
+/area/station/medical/virology)
 "gtv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26691,7 +26869,7 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "gwp" = (
-/obj/machinery/photocopier/prebuilt,
+/obj/machinery/photocopier,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/starboard)
@@ -26978,6 +27156,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "gAg" = (
@@ -27113,9 +27298,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "gCn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/medical/medbay)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/station/medical/break_room)
 "gCq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/status_display/door_timer{
@@ -27233,26 +27428,24 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "gDC" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
 /obj/item/radio/intercom/directional/east,
-/obj/machinery/light/directional/east,
+/obj/machinery/door/window/left/directional/west{
+	name = "Chemistry Lab Access Hatch";
+	req_access = list("plumbing")
+	},
+/obj/effect/turf_decal/stripes/box,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/structure/ladder{
+	name = "chemistry lab access"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "gDI" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/machinery/light_switch/directional/east{
-	pixel_x = 23
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/virology)
 "gDU" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/rack,
@@ -27265,15 +27458,24 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay/ghetto)
 "gEj" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "gEm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/frame/computer,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/west,
+/obj/item/radio/intercom/directional/west,
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "gEo" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/camera/directional/north{
@@ -27643,9 +27845,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
 "gIs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "gIx" = (
@@ -27683,10 +27886,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
 "gIU" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/wooden,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/medical/virology)
 "gIV" = (
 /obj/effect/spawner/random/structure/chair_maintenance{
 	dir = 8
@@ -27854,8 +28056,11 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark/small,
-/area/station/medical/morgue)
+/area/station/medical/patients_rooms)
 "gLj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -27929,10 +28134,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "gLB" = (
-/obj/structure/bed{
-	color = "#8C3E00"
-	},
-/obj/machinery/newscaster/directional/east,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "gLG" = (
@@ -27987,12 +28189,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "gMr" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 5
-	},
-/obj/effect/landmark/event_spawn,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/virology,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/maintenance/department/medical/morgue)
 "gMH" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -28017,10 +28223,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "gMN" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "gMS" = (
@@ -28125,17 +28330,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gNQ" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/door/window/right/directional/north{
-	req_access = list("medical")
-	},
-/obj/effect/turf_decal/box/white{
-	color = "#52B4E9"
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
@@ -28148,19 +28345,19 @@
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/magistrate)
 "gNY" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "gNZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/flowers_pp,
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "gOb" = (
 /obj/structure/table/wood,
 /obj/item/modular_computer/laptop,
@@ -28376,13 +28573,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "gPC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/effect/spawner/random/trash/crushed_can{
-	pixel_y = 10
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "gPI" = (
 /obj/machinery/holopad/secure,
 /obj/machinery/ai_slipper,
@@ -28542,6 +28739,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
+"gRJ" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/morgue)
 "gRK" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -28618,10 +28825,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "gTc" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/bed/medical/anchored,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "gTj" = (
@@ -28639,11 +28844,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "gTy" = (
-/obj/effect/turf_decal/tile/green/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/abandoned)
 "gTC" = (
 /obj/effect/turf_decal/trimline/tram/mid_joiner{
 	dir = 8
@@ -28708,15 +28912,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "gUF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/medical/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "gUI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -28767,10 +28966,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/abandoned_gambling_den)
 "gVD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "gVF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28793,6 +28992,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "gVU" = (
@@ -28938,8 +29140,11 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "gXi" = (
 /obj/structure/stairs/west,
 /turf/open/floor/plating,
@@ -29007,11 +29212,14 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
 "gXP" = (
-/obj/structure/table/glass,
+/obj/structure/chair/comfy/teal{
+	dir = 4
+	},
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron/cafeteria,
+/area/station/medical/break_room)
 "gXV" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -29056,15 +29264,14 @@
 /turf/open/floor/wood,
 /area/station/maintenance/aft)
 "gYx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/central)
 "gYA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -29194,13 +29401,16 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/ghetto/port)
 "hag" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/medical/surgery/theatre)
 "hah" = (
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
@@ -29218,14 +29428,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "haT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/medical/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/firedoor,
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/item/clothing/suit/jacket/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
+/area/station/medical/psychology)
 "haV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29395,6 +29605,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "hdl" = (
@@ -29596,12 +29809,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "hfU" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "hfV" = (
 /obj/machinery/status_display/supply,
 /turf/closed/wall,
@@ -29654,8 +29864,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "hgF" = (
-/obj/item/radio/intercom/directional/west,
-/obj/machinery/photocopier/prebuilt,
+/obj/machinery/photocopier,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "hgJ" = (
@@ -29736,6 +29946,11 @@
 	dir = 8
 	},
 /area/station/engineering/transit_tube)
+"hhC" = (
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "hhF" = (
 /obj/item/vending_refill/cigarette,
 /obj/structure/sign/poster/contraband/rebels_unite/directional/south,
@@ -29878,14 +30093,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "hjg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "hjn" = (
 /obj/machinery/atmospherics/components/unary/passive_vent/layer2{
 	dir = 8
@@ -30109,16 +30323,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard/west)
 "hmg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/obj/structure/table/wood,
-/obj/item/food/canned/peaches/maint,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/mob/living/carbon/human/species/monkey,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "hmi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/grille,
@@ -30307,13 +30515,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "hnY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/half,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "hnZ" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -30405,6 +30614,11 @@
 	dir = 4
 	},
 /area/station/maintenance/starboard/fore)
+"hoX" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "hoZ" = (
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/carpet/royalblack,
@@ -30448,6 +30662,11 @@
 	dir = 1
 	},
 /area/station/science/xenobiology)
+"hpv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "hpw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30544,24 +30763,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hqD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table_frame,
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/obj/machinery/processor,
-/obj/item/clothing/suit/apron/chef,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/spawner/random/trash/graffiti,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "hqJ" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/flora/bush/lavendergrass,
@@ -30585,10 +30790,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "hrb" = (
-/obj/structure/chair,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "hri" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30832,11 +31039,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "huF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "huO" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/effect/turf_decal/bot,
@@ -31263,14 +31474,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
 "hzQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
+/obj/effect/turf_decal/delivery,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/door/window/left/directional/north{
+	name = "Medbay Delivery";
+	req_access = list("medical")
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "hzV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -31528,17 +31739,15 @@
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "hDp" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/donkpockets,
-/obj/machinery/camera/directional/east{
-	c_tag = "Virology - Break Room";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/machinery/airalarm/directional/east,
+/obj/item/reagent_containers/applicator/pill/maintenance,
+/obj/item/reagent_containers/applicator/pill/maintenance,
+/obj/item/storage/box/gum,
+/obj/item/toy/cattoy,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/abandoned)
 "hDv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
@@ -31781,22 +31990,27 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/abandoned_gambling_den)
 "hFx" = (
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
+	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "hFE" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/vending/coffee,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/theatre)
+/obj/structure/disposaloutlet,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
 "hFK" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -31825,11 +32039,11 @@
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/starboard/aft)
 "hFR" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/virology)
 "hFT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -31917,12 +32131,12 @@
 /turf/open/floor/grass,
 /area/station/maintenance/ghetto/garden)
 "hGP" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "hGS" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -32066,24 +32280,18 @@
 /turf/open/floor/iron/checker,
 /area/station/service/bar/atrium/ghetto)
 "hIA" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
 /obj/structure/cable,
-/obj/machinery/door_buttons/airlock_controller{
-	idExterior = "virology_airlock_exterior";
-	idInterior = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Console";
-	pixel_y = -25;
-	req_access = list("virology")
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/machinery/light/directional/south,
+/obj/structure/rack,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/cup/glass/bottle/vodka,
+/turf/open/floor/plating,
+/area/station/medical/abandoned)
 "hIG" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
+	dir = 8
 	},
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/machinery/light_switch/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "hIL" = (
@@ -32115,18 +32323,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "hJh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
+/obj/structure/rack,
+/obj/item/wrench/medical,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/area/station/maintenance/aft)
 "hJi" = (
 /obj/machinery/igniter/incinerator_atmos{
 	id = "waste_incinerator_igniter"
@@ -32310,15 +32510,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/aft)
 "hLw" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/chemistry)
 "hLA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -32402,14 +32601,21 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
 "hMV" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/closed/wall/r_wall,
+/obj/machinery/portable_atmospherics/canister{
+	anchored = 1
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "hMX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/railing/corner{
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -32593,9 +32799,15 @@
 /turf/open/floor/plating,
 /area/station/tcommsat/server)
 "hPk" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "hPv" = (
 /obj/structure/railing{
 	dir = 8
@@ -32620,25 +32832,10 @@
 /turf/closed/wall,
 /area/station/cargo/sorting)
 "hPQ" = (
-/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
-	color = "#0000ff";
-	name = "Supply multi deck pipe adapter";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
-	color = "#ff0000";
-	dir = 1;
-	name = "Scrubbers multi deck pipe adapter"
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow/fourcorners,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/landmark/start/psychologist,
+/obj/structure/chair/office/light,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
+/area/station/medical/psychology)
 "hPR" = (
 /obj/effect/turf_decal/bot/left,
 /turf/open/floor/iron/dark/textured_large,
@@ -32797,16 +32994,33 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "hSo" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
+/obj/machinery/duct,
+/obj/structure/table/glass,
+/obj/item/storage/box/gloves{
+	pixel_x = -4;
+	pixel_y = 6
 	},
-/obj/machinery/newscaster/directional/north,
+/obj/item/storage/box/masks{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/virology)
 "hSq" = (
-/obj/structure/closet/wardrobe/black,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "hSt" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
@@ -33069,13 +33283,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/prison/ghetto)
 "hVC" = (
-/obj/structure/safe,
-/obj/item/poster/random_contraband,
-/obj/item/poster/random_contraband,
-/obj/item/poster/random_contraband,
-/obj/item/poster/random_contraband,
-/obj/item/poster/random_contraband,
-/obj/effect/spawner/random/maintenance,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "hVK" = (
@@ -33252,11 +33463,13 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "hYw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/west,
-/obj/structure/table/wood,
-/turf/open/floor/stone,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/light/small/directional/west{
+	name = "maintenance light";
+	nightshift_allowed = 0;
+	nightshift_enabled = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard)
 "hYK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -33409,14 +33622,17 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "hZO" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
 	},
-/obj/structure/chair/comfy/teal{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/medical/paramedic)
 "hZY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
@@ -33433,12 +33649,15 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/aft)
 "iax" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/landmark/start/chemist,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/turf/open/floor/engine,
 /area/station/medical/pharmacy)
 "iay" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -33607,13 +33826,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "idc" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Medbay - Chemistry Lab North";
-	network = list("ss13","medbay")
-	},
-/obj/machinery/chem_master,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/medical/chemistry/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction/flip,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "idm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33912,6 +34131,16 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
+"ihG" = (
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/dark,
+/area/station/medical/surgery/theatre)
 "ihI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -33939,20 +34168,20 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/camera/directional/east{
-	c_tag = "Medbay - Hallway South";
-	network = list("ss13","medbay")
+/obj/machinery/camera{
+	c_tag = "Medbay Hallway South";
+	dir = 4
 	},
 /obj/machinery/duct,
+/obj/machinery/firealarm/directional/east,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "ihX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
+	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/landmark/start/hangover,
-/obj/structure/bed/medical/anchored{
+/obj/machinery/stasis{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -34016,27 +34245,24 @@
 /turf/open/floor/plating,
 /area/station/security/checkpoint/arrivals)
 "iiS" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light/small/directional/east,
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/upper)
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "iiT" = (
 /obj/item/flashlight/lantern,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "ije" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
+/obj/structure/disposalpipe/trunk/multiz/down{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/light/warm/no_nightlight/directional/east,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "ijf" = (
@@ -34124,10 +34350,11 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
 "ijK" = (
-/obj/machinery/holopad,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "ijO" = (
@@ -34192,23 +34419,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "ikV" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/table,
-/obj/item/clothing/glasses/hud/health{
-	pixel_y = 10
-	},
-/obj/item/clothing/glasses/hud/health{
-	pixel_y = 6
-	},
-/obj/item/clothing/glasses/hud/health{
-	pixel_y = 2
-	},
-/obj/item/clothing/glasses/hud/health{
-	pixel_y = -2
-	},
-/obj/item/radio/intercom/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/storage)
+/area/station/medical/chemistry)
 "ikW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 8
@@ -34256,6 +34471,23 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
+"ilE" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/obj/machinery/vending/wardrobe/viro_wardrobe,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
+"ilG" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
+/obj/structure/rack,
+/obj/item/crowbar/red,
+/obj/item/wrench,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "ilI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34442,11 +34674,14 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "iov" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "iox" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -34469,24 +34704,19 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
 "ioA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table,
+/obj/item/storage/box/cups{
+	pixel_y = 6
 	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id = "quarantine";
-	name = "Quarantine Lockdown";
-	opacity = 0
+/obj/item/storage/box/cups{
+	pixel_y = 2
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/medical/break_room)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/psychology)
 "ioD" = (
 /obj/machinery/door/airlock,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -34611,10 +34841,9 @@
 /turf/open/floor/iron/stairs/right,
 /area/station/security/holding_cell)
 "iqs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/white,
+/area/station/maintenance/aft)
 "iqu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -34662,6 +34891,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
@@ -34700,13 +34930,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "irP" = (
+/obj/machinery/cryo_cell,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
+	dir = 5
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/structure/bed/medical/anchored,
+/obj/structure/sign/warning/bodysposal/directional/east,
 /turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/area/station/medical/cryo)
 "irW" = (
 /obj/structure/railing/corner/end{
 	dir = 8
@@ -34786,17 +35016,12 @@
 /turf/open/floor/wood,
 /area/station/service/kitchen/abandoned)
 "isI" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/duct,
+/obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "isK" = (
@@ -34820,16 +35045,16 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
 "itj" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table,
+/obj/item/emergency_bed,
+/obj/item/emergency_bed{
+	pixel_y = 3
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/theatre)
+/obj/item/emergency_bed{
+	pixel_y = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "itk" = (
 /obj/machinery/chem_master/condimaster{
 	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
@@ -35072,12 +35297,9 @@
 /area/station/science/research)
 "iwo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/structure/desk_bell{
-	pixel_x = -3
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "iwq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35157,6 +35379,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"ixC" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "ixF" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small/directional/south,
@@ -35197,14 +35426,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/duct,
+/obj/structure/sign/departments/restroom/directional/east,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "iyN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/spawner/random/structure/grille,
@@ -35294,11 +35521,10 @@
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
 "iAq" = (
-/obj/effect/landmark/start/hangover,
-/obj/structure/railing{
-	dir = 8
+/obj/structure/railing/corner{
+	dir = 1
 	},
-/obj/structure/bed/medical/anchored,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "iAD" = (
@@ -35308,9 +35534,8 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "iAJ" = (
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/medical/chemistry/ghetto)
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "iAQ" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -35366,19 +35591,25 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/garden)
 "iBx" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 6
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/obj/item/pen{
-	pixel_x = -5;
-	pixel_y = 8
-	},
-/obj/structure/table/reinforced/rglass,
-/obj/item/toy/figure/chemist,
-/turf/open/floor/iron/white,
+/obj/machinery/chem_heater/withbuffer,
+/turf/open/floor/engine,
 /area/station/medical/pharmacy)
+"iBz" = (
+/obj/machinery/button/elevator/directional/east{
+	id = "morgue_elevator"
+	},
+/obj/machinery/lift_indicator/directional/east{
+	linked_elevator_id = "morgue_elevator"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "iBB" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -35437,12 +35668,13 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "iCv" = (
-/obj/machinery/computer/pandemic,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/clothing/glasses/science,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/chem_storage)
 "iCy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
@@ -35505,11 +35737,12 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/atmos/hfr_room)
 "iDh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "iDn" = (
 /obj/machinery/atmospherics/components/binary/valve/on{
 	dir = 4
@@ -35567,7 +35800,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "iEl" = (
-/obj/machinery/holopad,
+/obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "iEn" = (
@@ -35660,13 +35893,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/lower)
 "iFy" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "iFA" = (
@@ -35825,12 +36058,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "iHs" = (
-/obj/structure/closet/crate,
 /obj/item/poster/random_contraband,
-/obj/item/poster/random_contraband,
-/obj/item/poster/random_contraband,
-/obj/item/coin/silver,
-/obj/effect/spawner/random/maintenance/two,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "iHv" = (
@@ -36065,12 +36295,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "iJZ" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 4
 	},
-/obj/machinery/disposal/bin,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/dark/small,
+/obj/effect/mapping_helpers/dead_body_placer,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "iKc" = (
 /obj/machinery/button/door/directional/north{
@@ -36102,11 +36331,15 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "iKn" = (
-/obj/structure/chair/comfy/teal,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/landmark/start/medical_doctor,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "iKu" = (
@@ -36397,11 +36630,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/dronefabricator)
 "iNF" = (
-/obj/machinery/computer/operating{
-	dir = 4
+/obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/turf/open/floor/iron/dark/small,
-/area/station/medical/morgue)
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "iNG" = (
 /obj/item/seeds/apple,
 /obj/item/seeds/banana,
@@ -36522,15 +36756,16 @@
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "iPv" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light/directional/west,
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/theatre)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "iPy" = (
 /obj/effect/turf_decal/tile/green,
 /obj/machinery/cryopod{
@@ -36544,29 +36779,23 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "iPC" = (
-/obj/structure/table/glass,
-/obj/machinery/camera/directional/north{
-	c_tag = "Virology - Workspace";
-	network = list("ss13","medbay")
+/obj/structure/rack,
+/obj/item/reagent_containers/cup/bottle/fluorine{
+	pixel_x = 7;
+	pixel_y = 3
 	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 8;
-	pixel_y = 12
+/obj/item/reagent_containers/cup/bottle/epinephrine{
+	pixel_x = -5;
+	pixel_y = 3
 	},
-/obj/machinery/requests_console/directional/north{
-	department = "Virology";
-	name = "Virology Requests Console"
+/obj/item/reagent_containers/cup/bottle/iodine{
+	pixel_x = 1
 	},
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/effect/mapping_helpers/requests_console/ore_update,
-/obj/effect/mapping_helpers/requests_console/supplies,
-/obj/effect/mapping_helpers/requests_console/announcement,
-/obj/effect/mapping_helpers/requests_console/information,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/chem_storage)
 "iPQ" = (
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
@@ -36662,6 +36891,9 @@
 /turf/open/openspace,
 /area/station/security/prison)
 "iRy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /obj/structure/bed/dogbed{
 	anchored = 1;
 	name = "Tom's bed"
@@ -36925,13 +37157,20 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "iUw" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/right/directional/north{
-	req_access = list("medical")
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
 	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	location = "Medbay"
+	},
+/turf/open/floor/plating,
+/area/station/medical/medbay/central)
 "iUI" = (
 /mob/living/carbon/human/species/monkey,
 /obj/structure/sink/directional/east,
@@ -37384,6 +37623,25 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
+"iZR" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/item/storage/medkit/brute{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/medkit/regular,
+/obj/item/storage/medkit/brute{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/left/directional/south{
+	req_access = list("medical")
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "iZV" = (
 /obj/structure/railing/corner/end/flip{
 	dir = 4
@@ -37432,13 +37690,25 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "jar" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/door/airlock/maintenance{
+	name = "Chemistry Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/chemist,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
+/area/station/medical/chemistry)
 "jaB" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -37607,14 +37877,16 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "jdd" = (
-/obj/machinery/requests_console/directional/east{
-	department = "Medbay";
-	name = "Medbay Requests Console"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera{
+	c_tag = "Medbay Lobby Reception";
+	dir = 4
 	},
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/machinery/light/directional/east,
-/obj/structure/filingcabinet/chestdrawer,
-/obj/item/folder/white,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "jdk" = (
@@ -37695,10 +37967,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "jed" = (
@@ -37797,17 +38069,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard/aft)
 "jfx" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/virology/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/closed/wall,
+/area/station/medical/chem_storage)
 "jfC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37927,6 +38190,7 @@
 /obj/item/trash/pistachios,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "jgF" = (
@@ -38333,8 +38597,11 @@
 	dir = 4
 	},
 /obj/machinery/duct,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "jmE" = (
 /obj/machinery/computer/monitor,
 /obj/structure/cable,
@@ -38399,19 +38666,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "jnm" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 1
+	},
 /obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/iron/dark,
-/area/station/medical/surgery/theatre)
+/area/station/medical/morgue)
 "jnB" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/effect/turf_decal/stripes/corner{
@@ -38533,13 +38795,11 @@
 /turf/closed/wall/rust,
 /area/station/maintenance/starboard/fore)
 "jpT" = (
-/obj/structure/closet/l3closet/virology,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/structure/curtain,
+/obj/machinery/shower/directional/north,
+/obj/item/soap/deluxe,
+/turf/open/floor/iron/freezer,
+/area/station/medical/break_room)
 "jpV" = (
 /obj/structure/chair/sofa/right{
 	color = "#85130b";
@@ -38566,7 +38826,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/structure/sign/poster/random/directional/east,
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -38689,6 +38948,31 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"jrM" = (
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/effect/turf_decal/tile/green/fourcorners,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_interior";
+	name = "Virology Interior Airlock"
+	},
+/obj/machinery/door_buttons/access_button{
+	idDoor = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	req_access = list("virology");
+	pixel_y = -24
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "jrR" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -38936,6 +39220,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"juA" = (
+/obj/structure/sign/warning/gas_mask/directional/west,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/obj/structure/closet/l3closet/virology,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "juX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38980,16 +39272,11 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "jvL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id = "quarantine";
-	name = "Quarantine Lockdown";
-	opacity = 0
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/station/medical/paramedic)
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "jvO" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
@@ -38998,10 +39285,9 @@
 /area/station/command/heads_quarters/cmo)
 "jvS" = (
 /obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "jvU" = (
@@ -39075,6 +39361,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/railing,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
@@ -39212,11 +39499,28 @@
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "jyF" = (
+/obj/machinery/door/airlock/medical/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/aft)
 "jyH" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/structure/sign/departments/psychology/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "jyQ" = (
@@ -39387,12 +39691,14 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/prison/ghetto)
 "jAR" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/virology)
 "jAW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/structure/girder,
@@ -39540,27 +39846,26 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage)
 "jDR" = (
-/obj/effect/spawner/structure/window,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/cryo)
 "jDU" = (
-/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = 2;
-	pixel_y = 4
+/obj/item/clothing/glasses/hud/health{
+	pixel_y = -2
 	},
-/obj/item/pen{
-	pixel_x = 2;
-	pixel_y = 4
+/obj/item/clothing/glasses/hud/health{
+	pixel_y = 2
 	},
-/obj/item/camera{
-	pixel_y = 4;
-	pixel_x = -14
+/obj/item/clothing/glasses/hud/health{
+	pixel_y = 6
 	},
-/obj/item/toy/figure/coroner,
-/turf/open/floor/iron/dark/small,
-/area/station/medical/morgue)
+/obj/item/clothing/glasses/hud/health{
+	pixel_y = 10
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "jDW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -39664,16 +39969,9 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/aft)
 "jEU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/item/kitchen/rollingpin,
-/obj/item/reagent_containers/condiment/sugar,
-/obj/item/reagent_containers/condiment/enzyme,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "jFb" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
@@ -39859,6 +40157,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/light/small/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "jGT" = (
@@ -39913,12 +40214,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "jHx" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
+/obj/structure/chair/comfy/teal{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/theatre)
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/morgue)
 "jHz" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -40052,10 +40355,12 @@
 /turf/closed/wall/rust,
 /area/station/service/hydroponics/ghetto)
 "jJh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/chair/wood,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/obj/structure/bed/medical/emergency,
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "jJp" = (
 /obj/structure/table/wood,
 /obj/item/megaphone{
@@ -40231,15 +40536,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "jLm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/directional/west,
-/turf/open/floor/iron,
+/obj/structure/sign/warning/gas_mask/directional/south,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "jLr" = (
 /obj/structure/chair{
@@ -40388,9 +40686,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "jMQ" = (
-/obj/machinery/holopad,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "jMT" = (
 /obj/structure/cable,
 /obj/machinery/power/solar{
@@ -40677,15 +40977,22 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
 "jRz" = (
-/obj/machinery/plumbing/receiver{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/landmark/event_spawn,
+/obj/machinery/button/door/directional/south{
+	id = "durka1";
+	name = "Isolator 1 Shutter Control";
+	pixel_x = -6
 	},
-/obj/effect/turf_decal/siding/yellow/end{
-	dir = 4
+/obj/machinery/button/door/directional/south{
+	id = "durka2";
+	name = "Isolator 2 Shutter Control";
+	pixel_x = 6
 	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/plating,
-/area/station/medical/medbay/aft)
+/turf/open/floor/iron/white,
+/area/station/medical/psychology)
 "jRH" = (
 /obj/structure/bed,
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
@@ -40737,6 +41044,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "psychological_office_shutters"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
 	},
 /turf/open/floor/plating,
 /area/station/medical/psychology)
@@ -40803,6 +41117,7 @@
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
 	},
+/obj/effect/landmark/navigate_destination/med,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "jTF" = (
@@ -40892,11 +41207,17 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "jUv" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/door/airlock/virology/glass{
+	name = "Isolation A"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/area/station/medical/virology)
 "jUz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/departments/medbay/alt,
@@ -40990,11 +41311,11 @@
 /turf/open/floor/carpet/black,
 /area/station/commons/lounge)
 "jVq" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table_frame,
+/obj/item/wheelchair,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "jVy" = (
 /obj/structure/chair{
 	dir = 1
@@ -41149,9 +41470,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "jXc" = (
-/obj/machinery/photocopier/prebuilt,
-/turf/open/floor/iron/dark/small,
-/area/station/medical/morgue)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "jXg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -41210,16 +41537,12 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
 "jYl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/machinery/duct,
-/obj/structure/sign/departments/virology/directional/east,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/lobby)
 "jYn" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
@@ -41339,13 +41662,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
 "jZz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/stack/medical/mesh,
-/obj/machinery/defibrillator_mount/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "jZG" = (
@@ -41397,6 +41718,11 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"jZU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "jZW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/holosign/barrier/engineering,
@@ -41423,12 +41749,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "kae" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
 	},
-/obj/effect/landmark/start/chemist,
-/turf/open/floor/iron/dark,
-/area/station/medical/chemistry/ghetto)
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "kak" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
@@ -41576,12 +41901,10 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "kcM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
 "kcN" = (
@@ -41613,14 +41936,8 @@
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/command/nuke_storage)
 "kdc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/obj/structure/table_frame,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "kdj" = (
 /obj/structure/table,
 /obj/item/flatpack{
@@ -41648,15 +41965,19 @@
 /turf/open/floor/iron/white/diagonal,
 /area/station/maintenance/ghetto/starboard/aft)
 "kds" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "kdz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/machinery/holopad,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "kdD" = (
@@ -41678,11 +41999,13 @@
 "kdU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 8
 	},
-/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "kdW" = (
@@ -41691,13 +42014,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "kea" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/maintenance/department/medical/morgue)
 "kej" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/food_or_drink,
@@ -41718,10 +42038,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "ker" = (
-/obj/structure/closet/emcloset,
-/obj/structure/sign/warning/vacuum/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
+/area/station/maintenance/starboard/upper)
 "key" = (
 /obj/structure/closet/wardrobe/botanist,
 /obj/effect/decal/cleanable/dirt,
@@ -41846,6 +42168,15 @@
 "kgb" = (
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
+"kgd" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/camera/directional/east,
+/obj/machinery/light_switch/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "kgs" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -41911,6 +42242,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/lockers)
+"khh" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "khi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42007,14 +42343,8 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "kiz" = (
-/obj/machinery/plumbing/receiver{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/yellow/end{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/medical/medbay/aft)
+/turf/open/floor/iron/white,
+/area/station/medical/psychology)
 "kiD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -42062,10 +42392,16 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "kjg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "kjo" = (
 /obj/structure/rack,
 /obj/item/restraints/legcuffs/beartrap{
@@ -42129,12 +42465,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard/west)
 "kko" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/structure/closet/l3closet/virology,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "kkq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -42180,6 +42517,14 @@
 /obj/machinery/light/directional/south,
 /turf/open/misc/grass,
 /area/station/security/prison/garden)
+"kkO" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "kkP" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
@@ -42369,12 +42714,15 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "kmU" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/area/station/medical/surgery/theatre)
 "kna" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
@@ -42489,29 +42837,24 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "kos" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/computer/pandemic,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/machinery/camera/directional/north,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/virology)
 "kot" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/aft)
 "koA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
 	},
-/obj/structure/table,
-/obj/item/storage/box/cups{
-	pixel_y = 6
-	},
-/obj/item/storage/box/cups{
-	pixel_y = 2
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/structure/closet/l3closet/virology,
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/medical/virology)
 "koD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42669,6 +43012,13 @@
 	},
 /turf/open/floor/carpet/green,
 /area/station/command/bridge)
+"kpY" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "kqa" = (
 /obj/structure/chair/plastic{
 	dir = 1
@@ -42695,13 +43045,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "kqJ" = (
-/obj/structure/table/wood,
-/obj/structure/bedsheetbin{
-	pixel_y = -2
+/obj/structure/chair/office/light{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "kqR" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron/dark/smooth_large,
@@ -42756,7 +43104,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "krL" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "Waste to Canister";
@@ -42817,12 +43165,11 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel/monastery)
 "ksr" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "kst" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42941,8 +43288,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/chem_heater/withbuffer,
-/obj/structure/window/reinforced/spawner/directional/north,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/engine,
 /area/station/medical/pharmacy)
 "ktC" = (
@@ -43063,12 +43418,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "kvh" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "kvl" = (
@@ -43371,12 +43723,12 @@
 "kzH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/camera/directional/east{
-	c_tag = "Medbay - Lobby Reception";
-	network = list("ss13","medbay")
+/obj/machinery/requests_console/directional/east{
+	department = "Medbay";
+	name = "Medbay Requests Console"
 	},
-/obj/structure/cable,
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "kzI" = (
@@ -43401,11 +43753,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "kzZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
+/obj/machinery/holopad,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "kAc" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 1
@@ -43647,6 +43997,21 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/glass/reinforced,
 /area/station/hallway/secondary/dock)
+"kCr" = (
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/door/window/right/directional/north{
+	req_access = list("medical")
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "kCs" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -43790,21 +44155,18 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "kEb" = (
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "kEh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "kEl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible,
 /obj/effect/turf_decal/trimline/dark_green/line{
@@ -43845,23 +44207,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "kEz" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/abandoned)
 "kEA" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/structure/closet/toolcloset,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "kEC" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/decal/cleanable/dirt,
@@ -43931,13 +44288,13 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "kFp" = (
-/obj/machinery/door/airlock/virology/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/showcase/machinery/cloning_pod{
+	desc = "An old decommissioned scanner, permanently scuttled.";
+	icon_state = "scanner";
+	name = "decommissioned cloning scanner"
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/abandoned)
 "kFt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -43987,13 +44344,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "kFF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "kFH" = (
 /obj/structure/table,
 /obj/item/folder{
@@ -44366,11 +44720,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "kJW" = (
-/obj/item/kirbyplants/random,
 /obj/structure/sign/poster/official/fruit_bowl/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "kJY" = (
@@ -44395,31 +44746,24 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/storage)
 "kKc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id = "quarantine";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/machinery/door/airlock/grunge,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "kKh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/light/directional/north,
-/obj/machinery/chem_heater/withbuffer,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/obj/structure/table/reinforced/rglass,
+/obj/machinery/reagentgrinder{
+	pixel_x = -2;
+	pixel_y = 12
+	},
+/obj/item/stack/sheet/mineral/plasma,
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "kKi" = (
 /obj/structure/disposalpipe/segment,
@@ -44726,15 +45070,9 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/abandoned_gambling_den)
 "kNW" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "kOg" = (
@@ -44779,6 +45117,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "kOJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "kOO" = (
@@ -44809,11 +45150,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "kPk" = (
-/obj/effect/turf_decal/tile/bar/half{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
 	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "kPl" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -44934,25 +45276,22 @@
 /turf/open/floor/wood,
 /area/station/service/library/ghetto)
 "kQI" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/station/medical/pharmacy)
 "kQM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/duct,
+/obj/structure/table/reinforced/rglass,
+/obj/item/reagent_containers/cup/beaker,
+/obj/item/reagent_containers/dropper,
+/obj/structure/sign/warning/electric_shock/directional/east,
 /turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/area/station/medical/virology)
 "kQP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -44996,9 +45335,7 @@
 /area/station/engineering/storage/tech)
 "kRj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "kRp" = (
@@ -45305,14 +45642,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "kVP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/structure/mirror/directional/north,
+/obj/structure/sink/directional/south,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "kVS" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/vault,
@@ -45521,6 +45857,14 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/wood,
 /area/station/service/library)
+"kYm" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/vending/wardrobe/chem_wardrobe,
+/turf/open/floor/iron/dark,
+/area/station/medical/chemistry)
 "kYn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -45609,13 +45953,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "kZe" = (
-/obj/machinery/plumbing/sender,
-/obj/effect/turf_decal/siding/yellow/end{
-	dir = 8
+/obj/machinery/vending/wardrobe/coroner_wardrobe,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/tile/dark_blue/anticorner{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
-/area/station/medical/chemistry/ghetto)
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "kZm" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -45687,10 +46031,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "kZZ" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/sign/departments/exam_room,
-/turf/open/floor/plating,
-/area/station/medical/treatment_center)
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/smartfridge/organ,
+/obj/effect/turf_decal/tile/neutral/anticorner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "las" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -45719,6 +46066,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
+"laO" = (
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central)
 "laX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45844,8 +46195,8 @@
 	},
 /area/station/hallway/secondary/entry)
 "lci" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "lck" = (
@@ -45855,9 +46206,17 @@
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/atmos/project)
 "lcn" = (
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/obj/structure/table/wood,
+/obj/structure/bedsheetbin{
+	pixel_y = -2
+	},
+/obj/machinery/camera{
+	c_tag = "Virology Workspace";
+	dir = 1
+	},
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/iron/cafeteria,
+/area/station/medical/break_room)
 "lcq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/machinery/duct,
@@ -46034,24 +46393,21 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/ghetto/central/aft)
 "lfw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/mess,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/landmark/start/psychologist,
+/turf/open/floor/carpet,
+/area/station/medical/psychology)
 "lfL" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood/parquet,
 /area/station/security/courtroom)
 "lfM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/structure/table/reinforced/rglass,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "lfP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46136,17 +46492,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "lgR" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id = "quarantine";
-	name = "Quarantine Lockdown";
-	opacity = 0
+/obj/effect/landmark/start/medical_doctor,
+/obj/structure/chair/comfy/teal,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/no_smoking/circle,
-/turf/open/floor/plating,
-/area/station/medical/medbay/lobby)
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "lha" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -46220,12 +46572,10 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "lhZ" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/bodycontainer/morgue{
+/obj/effect/turf_decal/trimline/neutral/end{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "lic" = (
 /obj/effect/decal/cleanable/dirt,
@@ -46332,9 +46682,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "lju" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/departments/exam_room,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/landmark/start/medical_doctor,
+/obj/structure/chair,
+/turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "ljw" = (
 /obj/effect/spawner/random/vending/snackvend,
@@ -46352,23 +46705,15 @@
 /turf/open/floor/grass,
 /area/station/maintenance/starboard/upper)
 "ljF" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/table/reinforced,
-/obj/item/radio/intercom/directional/east,
-/obj/item/stack/cable_coil{
-	pixel_y = 3
-	},
-/obj/item/stack/cable_coil,
-/obj/item/multitool,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/station/medical/chemistry/ghetto)
-"ljJ" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/curtain,
 /turf/open/floor/plating,
-/area/station/medical/virology)
+/area/station/medical/treatment_center)
+"ljJ" = (
+/obj/machinery/atmospherics/pipe/smart/simple{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "ljR" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/trimline/dark_blue/line{
@@ -46429,17 +46774,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/storage)
 "lkX" = (
-/obj/structure/ladder,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/door/window/left/directional/north{
-	name = "Chemistry Lab Access Hatch";
-	req_access = list("plumbing")
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/box,
-/obj/structure/sign/departments/chemistry/directional/south,
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
+/area/station/medical/psychology)
 "lla" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/storage/briefcase,
@@ -46531,18 +46870,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "lmq" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/storage/toolbox/emergency{
-	pixel_y = 4
-	},
-/obj/item/wrench/medical,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/item/radio/intercom/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "lmt" = (
@@ -46707,11 +47039,11 @@
 /turf/open/floor/iron/checker,
 /area/station/service/bar/atrium/ghetto)
 "lnZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "lob" = (
@@ -46901,7 +47233,6 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/obj/effect/landmark/start/psychologist,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "lpU" = (
@@ -47018,9 +47349,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "lqQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "lqR" = (
@@ -47062,14 +47391,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "lrj" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/machinery/computer/operating{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/dark_blue/anticorner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "lrk" = (
 /obj/structure/cable,
 /obj/machinery/holopad/secure,
@@ -47425,15 +47754,12 @@
 /turf/open/floor/stone,
 /area/station/service/hydroponics/ghetto)
 "luY" = (
-/obj/structure/disposaloutlet{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/morgue)
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "lvg" = (
 /obj/machinery/light/directional/east,
 /obj/structure/sign/poster/official/random/directional/east,
@@ -47519,6 +47845,11 @@
 /obj/item/stack/sheet/mineral/plasma/five,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/dronefabricator)
+"lwy" = (
+/obj/effect/turf_decal/stripes/box,
+/obj/structure/ladder,
+/turf/open/floor/iron/smooth,
+/area/station/medical/chemistry)
 "lwA" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/iron,
@@ -47583,13 +47914,14 @@
 /turf/open/floor/carpet/black,
 /area/station/command/meeting_room)
 "lxE" = (
-/obj/effect/spawner/random/engineering/atmospherics_portable,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
-/turf/open/floor/iron/large,
-/area/station/maintenance/ghetto/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "lxI" = (
 /obj/machinery/power/turbine/turbine_outlet,
 /turf/open/floor/engine,
@@ -47653,9 +47985,7 @@
 	},
 /obj/machinery/newscaster/directional/north,
 /obj/structure/table/glass,
-/obj/item/storage/box/cups{
-	pixel_y = 2
-	},
+/obj/item/reagent_containers/cup/glass/mug,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "lyL" = (
@@ -47775,13 +48105,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "lAc" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "lAn" = (
@@ -47892,9 +48222,14 @@
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/service)
 "lBE" = (
-/obj/effect/turf_decal/stripes,
-/turf/open/floor/iron/smooth,
-/area/station/medical/chemistry/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central)
 "lBH" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "53453545"
@@ -48439,9 +48774,13 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/department/security/ghetto)
 "lJc" = (
-/obj/effect/landmark/start/coroner,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/structure/bed,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/item/toy/plush/hampter,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "lJi" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -48529,14 +48868,11 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage)
 "lKe" = (
-/obj/structure/table/glass,
-/obj/machinery/microwave,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/storage/fancy/candle_box,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/abandoned)
 "lKf" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -48577,24 +48913,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "lKp" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/table/reinforced/rglass,
-/obj/machinery/light/directional/south,
-/obj/machinery/airalarm/directional/south,
-/obj/item/storage/pill_bottle/penacid{
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/cup/bottle/morphine{
-	pixel_x = 2;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/cup/bottle/epinephrine{
-	pixel_x = 14;
-	pixel_y = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium/ghetto)
 "lKu" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
 	color = "#ff0000";
@@ -48769,12 +49091,9 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "lMr" = (
-/obj/structure/chair/comfy/teal{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/iron/smooth,
+/area/station/medical/chemistry)
 "lMu" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -48917,12 +49236,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/fore)
 "lOk" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
+/obj/machinery/airalarm/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/half,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "lOl" = (
 /obj/structure/chair/wood,
 /turf/open/floor/plating,
@@ -48976,13 +49299,23 @@
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/port)
 "lOV" = (
-/obj/machinery/door/airlock/atmos,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/upper)
+/obj/machinery/camera/directional/south{
+	c_tag = "Medbay - Cryogenics"
+	},
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/door/window/right/directional/north{
+	req_access = list("medical")
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "lOX" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/item/phone{
@@ -49203,9 +49536,11 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/holopad,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "lQV" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
@@ -49263,10 +49598,17 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "lSt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "lSv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -49489,14 +49831,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "lVp" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/theatre)
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "lVu" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/break_room)
@@ -49623,23 +49963,8 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "lWD" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/item/storage/medkit/brute{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/storage/medkit/regular,
-/obj/item/storage/medkit/brute{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
+/turf/closed/wall/rust,
+/area/station/medical/psychology)
 "lWI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49851,6 +50176,16 @@
 /obj/effect/landmark/start/head_of_security,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
+"lZv" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/machinery/camera/directional/east,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "lZy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49955,11 +50290,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "maI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/obj/structure/cable,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "maN" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/spacecash/c10,
@@ -50211,9 +50548,9 @@
 /area/station/hallway/secondary/service)
 "mdI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/iron/white,
-/area/station/maintenance/aft)
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "mdS" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -50268,9 +50605,23 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "meC" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/obj/machinery/door/airlock/maintenance{
+	name = "Morgue Maintenance"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "meG" = (
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/iron,
@@ -50513,15 +50864,11 @@
 /turf/open/floor/iron/grimy,
 /area/station/hallway/secondary/entry)
 "mia" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/theatre)
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "mie" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -50550,6 +50897,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
+"miu" = (
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/obj/machinery/duct,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/surgery/theatre)
 "mix" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
@@ -50922,12 +51283,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/fore)
 "moo" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/closet/secure_closet/personal/patient,
-/obj/item/clothing/suit/jacket/straight_jacket,
-/obj/item/clothing/mask/muzzle,
+/obj/machinery/light/directional/west,
+/obj/machinery/rnd/production/techfab/department/medical,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/bot_white{
+	color = "#52B4E9"
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/medical/storage)
 "mow" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -50997,12 +51360,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "mpF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/door/airlock/atmos,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/effect/mapping_helpers/airlock/access/all/engineering,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
 "mpV" = (
@@ -51377,11 +51742,13 @@
 /turf/open/floor/carpet/orange,
 /area/station/maintenance/starboard/fore)
 "mtX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/effect/spawner/random/maintenance/four,
-/turf/open/floor/stone,
-/area/station/maintenance/ghetto/bar)
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "mtY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -51401,13 +51768,12 @@
 /turf/open/floor/circuit/green,
 /area/station/science/xenobiology)
 "muc" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/effect/turf_decal/delivery,
-/obj/item/knife/kitchen,
-/obj/item/storage/box/donkpockets,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "mul" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/kitchen/small,
@@ -51515,10 +51881,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/abandoned)
 "mvr" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "mvt" = (
@@ -51695,6 +52058,10 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/science/ordnance/office)
+"myh" = (
+/obj/structure/sign/warning/biohazard/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/medical/surgery/theatre)
 "myi" = (
 /obj/structure/railing{
 	dir = 8
@@ -51834,10 +52201,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "mzO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/aft)
+/area/station/maintenance/starboard/upper)
 "mzP" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -52175,11 +52544,11 @@
 /turf/open/floor/pod,
 /area/station/maintenance/ghetto/storage)
 "mDR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/clothing/under/suit/waiter,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "mDW" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -52457,18 +52826,12 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "mGN" = (
-/obj/machinery/light/small/directional/south{
-	name = "maintenance light";
-	nightshift_allowed = 0;
-	nightshift_enabled = 1
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Medbay - Morgue South"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/area/station/medical/chemistry)
 "mGR" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -52513,11 +52876,10 @@
 /turf/open/floor/iron/smooth,
 /area/station/commons/toilet/restrooms)
 "mHs" = (
-/obj/machinery/firealarm/directional/east,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/dark,
-/area/station/medical/chemistry/ghetto)
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "mHA" = (
 /obj/structure/frame,
 /turf/open/floor/iron/dark,
@@ -52589,36 +52951,17 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "mIn" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 1
-	},
-/obj/structure/table/reinforced/rglass,
-/obj/item/screwdriver{
-	pixel_x = 2;
-	pixel_y = 11
-	},
-/obj/item/grenade/chem_grenade{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/grenade/chem_grenade{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/grenade/chem_grenade{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/grenade/chem_grenade{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/stack/cable_coil{
-	pixel_x = 6
-	},
 /obj/structure/sign/poster/official/science/directional/west,
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron/white,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/effect/turf_decal/siding/yellow/end{
+	dir = 8
+	},
+/obj/machinery/plumbing/receiver{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "mIo" = (
 /obj/structure/cable,
@@ -52626,6 +52969,7 @@
 /area/station/maintenance/ghetto/port)
 "mIp" = (
 /obj/structure/table/wood,
+/obj/structure/sign/poster/official/random/directional/west,
 /obj/item/cane{
 	pixel_x = 2;
 	pixel_y = 4
@@ -52633,9 +52977,8 @@
 /obj/item/flashlight/lamp/green{
 	pixel_y = 14
 	},
-/obj/structure/sign/poster/official/random/directional/west,
-/obj/machinery/light/warm/no_nightlight/directional/west,
 /obj/item/toy/figure/psychologist,
+/obj/machinery/light/warm/no_nightlight/directional/west,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "mIr" = (
@@ -52939,6 +53282,13 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/dark/small,
 /area/station/commons/vacant_room/commissary)
+"mLP" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "mLR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -52974,19 +53324,31 @@
 /turf/open/floor/wood/large,
 /area/station/service/bar/atrium/ghetto)
 "mMF" = (
+/obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/chem_mass_spec,
-/obj/machinery/light_switch/directional/east,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/light/directional/east,
+/obj/structure/table/reinforced/rglass,
+/obj/item/book/manual/wiki/chemistry{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/book/manual/wiki/grenades,
+/obj/item/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'";
+	name = "Chemistry Cleaner"
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'";
+	name = "Chemistry Cleaner"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "mMK" = (
-/obj/structure/cable/multilayer/multiz,
 /obj/machinery/light/directional/west,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "mMO" = (
@@ -53063,23 +53425,21 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "mNQ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/turf/open/floor/plating,
+/area/station/medical/chemistry)
 "mOh" = (
 /obj/machinery/light_switch/directional/west,
-/obj/effect/landmark/start/paramedic,
 /obj/structure/chair/office/light{
 	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
@@ -53119,11 +53479,11 @@
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/port/aft)
 "mOE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/trimline/neutral/end{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "mOF" = (
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 4
@@ -53131,6 +53491,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"mOH" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/machinery/stasis,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "mOI" = (
 /turf/closed/wall,
 /area/station/maintenance/ghetto/central)
@@ -53212,7 +53580,8 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/holopad,
+/obj/machinery/medical_kiosk,
+/obj/structure/railing,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
@@ -53228,9 +53597,11 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "mPJ" = (
-/obj/structure/bodycontainer/morgue,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/morgue)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "mPO" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/grimy,
@@ -53289,11 +53660,14 @@
 /turf/open/floor/wood,
 /area/station/maintenance/aft)
 "mQp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/morgue)
+/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/morgue)
 "mQq" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/circuit,
@@ -53434,11 +53808,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "mSM" = (
@@ -53495,13 +53866,13 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/ghetto/starboard/aft)
 "mTq" = (
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/mask/muzzle,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/effect/turf_decal/tile/bar,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "mTu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table/wood,
@@ -53512,11 +53883,13 @@
 /turf/open/floor/carpet/black,
 /area/station/command/meeting_room)
 "mTv" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/theatre)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/item/coin/silver,
+/obj/effect/spawner/random/maintenance/two,
+/obj/item/poster/random_contraband,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "mTx" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
@@ -53703,12 +54076,9 @@
 /turf/open/floor/wood/large,
 /area/station/service/bar/atrium/ghetto)
 "mWk" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/obj/structure/flora/rock/pile/jungle/style_random,
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "mWm" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -53761,6 +54131,10 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/grass,
 /area/station/maintenance/ghetto/garden)
+"mWS" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "mWZ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -53771,16 +54145,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "mXp" = (
-/obj/effect/turf_decal/tile/green/fourcorners,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/floor/iron/freezer,
+/area/station/medical/break_room)
 "mXy" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -53935,6 +54303,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"mYN" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/camera/directional/east,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/head/utility/welding,
+/turf/open/floor/iron/dark,
+/area/station/medical/chemistry)
 "mYO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -53945,6 +54325,11 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library/ghetto)
+"mYQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "mYT" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/machinery/computer/crew{
@@ -53965,12 +54350,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/prison)
 "mZd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/airalarm/directional/north,
+/obj/structure/reagent_dispensers/plumbed,
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "mZo" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -54002,13 +54388,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/abandoned_gambling_den)
 "mZE" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/effect/landmark/event_spawn,
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "mZH" = (
 /obj/machinery/suit_storage_unit/rd,
 /obj/effect/turf_decal/tile/purple/anticorner{
@@ -54350,6 +54737,12 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
+"ner" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "nex" = (
 /obj/machinery/computer/records/security,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -54371,41 +54764,10 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "neD" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/obj/structure/table/glass,
-/obj/machinery/camera/directional/south{
-	c_tag = "Medbay - Cryogenics";
-	network = list("ss13","medbay")
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/storage/pill_bottle/mannitol,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/machinery/requests_console/directional/south{
-	department = "Medbay";
-	name = "Medbay Requests Console"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/obj/effect/turf_decal/stripes,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/medical/chemistry)
 "neK" = (
 /obj/item/cultivator,
 /turf/open/floor/plating,
@@ -54434,12 +54796,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "nfs" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/iv_drip,
-/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/turf/open/floor/plating,
+/area/station/medical/virology)
 "nfA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -54456,14 +54816,28 @@
 /area/station/maintenance/ghetto/fore/starboard)
 "nfS" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/item/paper_bin{
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_y = 6
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "nfX" = (
 /obj/structure/window/spawner/directional/west,
+/obj/effect/spawner/random/maintenance,
 /obj/structure/table/reinforced,
-/obj/item/folder,
-/obj/effect/spawner/random/maintenance/two,
-/obj/structure/window/spawner/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "nga" = (
@@ -54477,6 +54851,9 @@
 /area/station/maintenance/ghetto/sorting)
 "ngd" = (
 /obj/effect/spawner/random/trash/garbage,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "ngq" = (
@@ -54624,15 +55001,11 @@
 /turf/open/floor/carpet,
 /area/station/service/library/ghetto)
 "nhZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/morgue)
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "nib" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -54868,11 +55241,15 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "nkU" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/item/clothing/suit/jacket/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/structure/sign/poster/official/nanotrasen_logo/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/psychology)
 "nkY" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -55182,17 +55559,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "noj" = (
+/obj/machinery/light/small/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/table/glass,
-/obj/item/soap/nanotrasen{
-	pixel_y = 2
+/obj/structure/chair/comfy/teal{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "nol" = (
@@ -55274,6 +55649,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
+"noU" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/camera/directional/south,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "npf" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -55283,14 +55666,9 @@
 /area/station/science/lower)
 "npt" = (
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/machinery/duct,
+/turf/open/floor/iron/freezer,
+/area/station/medical/break_room)
 "npE" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -55609,9 +55987,20 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "ntv" = (
-/obj/effect/spawner/random/structure/barricade,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/table/reinforced/rglass,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/clothing/neck/stethoscope{
+	pixel_y = 8
+	},
+/obj/item/clothing/neck/stethoscope{
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "ntK" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -55876,13 +56265,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "nwH" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/medical/treatment_center)
 "nwJ" = (
 /turf/closed/wall,
 /area/station/security/checkpoint/arrivals)
@@ -55945,43 +56333,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "nxv" = (
-/obj/item/assembly/timer{
-	pixel_x = 8;
-	pixel_y = 6
+/obj/machinery/camera{
+	c_tag = "Medbay Chemistry";
+	dir = 8
 	},
-/obj/item/assembly/timer{
-	pixel_x = 8;
-	pixel_y = 3
-	},
-/obj/item/assembly/timer{
-	pixel_x = 8
-	},
-/obj/item/assembly/timer{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/item/assembly/igniter{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/assembly/igniter{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/item/assembly/igniter{
-	pixel_x = -6
-	},
-/obj/item/assembly/igniter{
-	pixel_x = -6;
-	pixel_y = -3
-	},
-/obj/structure/table/reinforced/rglass,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Medbay - Chemistry";
-	network = list("ss13","medbay")
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
@@ -56024,11 +56381,17 @@
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "nyB" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/storage/fancy/cigarettes/cigpack_robust{
+	pixel_x = 6
+	},
+/obj/item/lighter{
+	pixel_x = -6
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
 "nyL" = (
@@ -56096,17 +56459,18 @@
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "nAb" = (
-/obj/structure/ladder,
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/iron/smooth,
-/area/station/medical/chemistry/ghetto)
-"nAh" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/railing,
-/obj/machinery/medical_kiosk,
 /turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/morgue)
+"nAh" = (
+/obj/structure/flora/grass/jungle,
+/obj/structure/flora/bush/flowers_yw,
+/obj/structure/flora/bush/sunny,
+/obj/machinery/light/floor,
+/turf/open/floor/grass,
 /area/station/medical/treatment_center)
 "nAl" = (
 /obj/effect/turf_decal/tile/dark{
@@ -56225,12 +56589,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/prison)
 "nBq" = (
-/obj/machinery/vending/medical,
-/obj/machinery/light/directional/north,
-/obj/structure/sign/poster/official/help_others/directional/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "nBr" = (
@@ -56292,10 +56651,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "nBO" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes,
-/turf/open/floor/iron/dark,
-/area/station/medical/chemistry/ghetto)
+/obj/structure/flora/bush/large/style_random{
+	pixel_y = 0
+	},
+/obj/structure/water_source/puddle,
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "nBR" = (
 /obj/effect/spawner/random/structure/chair_maintenance{
 	dir = 1
@@ -56411,11 +56772,10 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "nDg" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/rnd/production/techfab/department/medical,
 /obj/effect/turf_decal/bot_white{
 	color = "#52B4E9"
 	},
+/obj/machinery/suit_storage_unit/medical,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "nDm" = (
@@ -56541,10 +56901,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/chair/stool{
-	dir = 8
-	},
-/obj/effect/landmark/start/chemist,
 /turf/open/floor/engine,
 /area/station/medical/pharmacy)
 "nFd" = (
@@ -56585,12 +56941,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "nFH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/coroner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "nFI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -56624,14 +56983,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "nGp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "nGs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/trimline/dark_blue/corner{
@@ -56698,9 +57054,9 @@
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/port/fore)
 "nHf" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/warning/no_smoking/circle,
+/turf/open/floor/plating,
 /area/station/medical/treatment_center)
 "nHh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56752,6 +57108,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/range)
+"nHH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "nHI" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/mass_driver/chapelgun{
@@ -56807,10 +57171,10 @@
 /turf/open/floor/plating,
 /area/station/commons/storage/emergency)
 "nIk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "nIl" = (
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -57153,13 +57517,15 @@
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "nNt" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/light/directional/south,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "nNA" = (
@@ -57242,14 +57608,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nOm" = (
-/obj/machinery/door/window/right/directional/east{
-	name = "Coroner"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/turf/closed/wall,
+/area/station/medical/patients_rooms)
 "nOp" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -57296,14 +57656,10 @@
 "nPb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "nPg" = (
 /obj/structure/chair/wood,
 /obj/effect/mapping_helpers/broken_floor,
@@ -57510,6 +57866,15 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"nRH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "nRP" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/structure/closet/crate/goldcrate,
@@ -57618,13 +57983,9 @@
 /turf/open/floor/wood/large,
 /area/station/service/bar/atrium/ghetto)
 "nTm" = (
-/obj/machinery/recharge_station,
-/obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chemistry)
 "nTn" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -57712,12 +58073,11 @@
 /turf/open/floor/plating,
 /area/station/security/prison/ghetto)
 "nUh" = (
-/obj/structure/chair/comfy/teal{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/obj/structure/table/wood,
+/obj/item/storage/fancy/donut_box,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/cafeteria,
+/area/station/medical/break_room)
 "nUk" = (
 /turf/open/openspace,
 /area/station/security/prison)
@@ -57890,14 +58250,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical/ghetto)
 "nWA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/corner{
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
+/area/station/medical/virology)
 "nWC" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/random/trash/garbage{
@@ -57953,6 +58314,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/prison)
+"nXL" = (
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/door/airlock/virology/glass{
+	name = "Isolation B"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "nXM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -58083,6 +58456,12 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
+"nYZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "nZg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
@@ -58166,6 +58545,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
+"oae" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/closet/crate/freezer/organ,
+/turf/open/floor/iron/white,
+/area/station/maintenance/aft)
 "oah" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/dock)
@@ -58212,11 +58596,11 @@
 /area/station/maintenance/department/security/ghetto/fore)
 "oaU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "oaV" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -58329,12 +58713,16 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
 "obP" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/box/white{
-	color = "#52B4E9"
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
 	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry/ghetto)
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/sign/warning/deathsposal/directional/west,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "obV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58425,12 +58813,15 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "ocH" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/railing/corner{
-	dir = 4
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard)
 "ocK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -58535,10 +58926,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "odT" = (
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "odU" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/maintenance,
@@ -58566,9 +58957,9 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/spawner/random/structure/barricade,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/area/station/maintenance/ghetto/starboard)
 "oek" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/steam_vent,
@@ -58597,12 +58988,18 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "oew" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
+"oez" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/theatre)
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "oeQ" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/cult,
@@ -58630,24 +59027,22 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "ofC" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = -8
+/obj/structure/rack,
+/obj/item/reagent_containers/cup/bottle/lithium{
+	pixel_x = 7;
+	pixel_y = 3
 	},
-/obj/item/storage/box/syringes{
-	pixel_x = 2;
-	pixel_y = 4
+/obj/item/reagent_containers/cup/bottle/iron{
+	pixel_x = -5;
+	pixel_y = 3
 	},
-/obj/item/stack/sheet/mineral/plasma{
-	pixel_x = -2;
-	pixel_y = 6
+/obj/item/reagent_containers/cup/bottle/multiver{
+	pixel_x = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/chem_storage)
 "ofE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/cable,
@@ -58903,17 +59298,12 @@
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
 "oiR" = (
-/obj/structure/table/reinforced/rglass,
-/obj/item/food/grown/banana,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/graffiti{
+	spawn_loot_chance = 50
 	},
-/obj/machinery/light/small/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "oja" = (
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -59018,6 +59408,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"ojL" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/machinery/light/directional/north,
+/obj/machinery/vending/medical,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "ojU" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/machinery/newscaster/directional/east,
@@ -59033,11 +59431,15 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "okh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/dinnerware,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Chemistry Lab Exit"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
+/area/station/medical/chemistry)
 "okj" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -59529,6 +59931,9 @@
 "opS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "opW" = (
@@ -59556,12 +59961,8 @@
 /turf/open/floor/carpet/red,
 /area/station/service/bar/atrium/ghetto)
 "oqa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "oqb" = (
@@ -59712,15 +60113,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "orz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron/dark,
+/area/station/medical/surgery/theatre)
 "orS" = (
 /obj/structure/table,
 /obj/item/melee/baton/security/cattleprod,
@@ -60100,14 +60499,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "owG" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/trimline/green/filled/line{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/obj/machinery/duct,
+/turf/open/floor/iron/cafeteria,
+/area/station/medical/break_room)
 "owL" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -60365,11 +60765,8 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "oAw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/random/structure/table,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "oAz" = (
@@ -60442,8 +60839,9 @@
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/port/greater)
 "oBv" = (
-/turf/open/floor/plating,
-/area/station/medical/morgue)
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "oBx" = (
 /obj/structure/closet/emcloset,
 /obj/effect/landmark/start/hangover/closet,
@@ -60516,8 +60914,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "oCm" = (
-/obj/structure/table/glass,
-/obj/item/storage/medkit/emergency,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "oCs" = (
@@ -60525,13 +60922,12 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "oCy" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/cryo_cell,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/cryo)
 "oCD" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/carpet,
@@ -60649,10 +61045,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "oDP" = (
-/obj/effect/spawner/random/structure/tank_holder,
-/obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
+/area/station/maintenance/department/medical/morgue)
 "oDR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -60815,24 +61210,29 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "oFy" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
-	},
-/obj/machinery/button/door/directional/east{
-	id = "chemistry_access_shutters";
-	name = "Chemistry Access Shutter Control";
-	req_access = list("medical");
-	pixel_x = 0;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
+/area/station/medical/psychology)
+"oFB" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/gloves{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/assembly/igniter{
+	pixel_y = -3
+	},
+/obj/structure/sign/warning/chem_diamond/directional/south,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/station/medical/chem_storage)
 "oFI" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -60959,7 +61359,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "oHZ" = (
-/obj/machinery/light_switch/directional/west,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "oId" = (
@@ -61014,9 +61414,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/garden)
 "oIA" = (
-/obj/machinery/iv_drip,
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/area/station/medical/cryo)
 "oID" = (
 /obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
 /obj/effect/turf_decal/siding/thinplating_new/light/end{
@@ -61099,16 +61504,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port/aft)
 "oJD" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/disposalpipe/segment{
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/filingcabinet/chestdrawer,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/theatre)
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "oJH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/garbage,
@@ -61124,11 +61526,20 @@
 /area/station/hallway/primary/aft)
 "oJQ" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/landmark/event_spawn,
+/obj/machinery/duct,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/light/directional/south,
+/obj/machinery/camera/directional/south{
+	c_tag = "Medbay - Surgery Observation";
+	network = list("ss13","medbay")
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "oJR" = (
@@ -61156,6 +61567,7 @@
 /obj/machinery/light/small/directional/west,
 /obj/structure/sign/departments/engineering/directional/west,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "oKr" = (
@@ -61267,12 +61679,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/duct,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/theatre)
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "oLo" = (
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron,
@@ -61356,9 +61768,7 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "oMC" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "oMD" = (
@@ -61441,6 +61851,15 @@
 /obj/structure/sign/directions/arrival/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
+"oNZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/dark,
+/area/station/medical/surgery/theatre)
 "oOa" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/structure/closet/crate,
@@ -61506,13 +61925,14 @@
 	},
 /area/station/commons/dorms)
 "oOE" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "oOF" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/holopad/secure,
@@ -61544,17 +61964,14 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "oPj" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+/obj/structure/table/reinforced/rglass,
+/obj/item/folder/white{
+	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
+/obj/item/pen/red,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/virology)
 "oPo" = (
 /obj/structure/sign/warning/vacuum/external/directional/east,
 /turf/open/floor/iron/dark,
@@ -61736,7 +62153,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "oRT" = (
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/fore)
@@ -61830,12 +62247,10 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "oSQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "oSR" = (
@@ -61913,14 +62328,12 @@
 /turf/open/misc/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "oTG" = (
-/obj/structure/table/glass,
-/obj/item/hand_labeler{
-	pixel_x = 2;
-	pixel_y = 2
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 9
 	},
-/obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/structure/bodycontainer/morgue,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "oTM" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -61945,13 +62358,15 @@
 /turf/open/misc/dirt/dark/station,
 /area/station/service/bar/atrium/ghetto)
 "oUd" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"oUI" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/upper)
 "oUL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -62116,8 +62531,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "oWu" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "oWy" = (
@@ -62132,12 +62549,13 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "oWz" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/structure/closet/secure_closet/medical1,
+/obj/machinery/camera/directional/south,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "oWA" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
@@ -62312,14 +62730,18 @@
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "oZf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/item/bedsheet{
+	dir = 4
+	},
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/white,
+/area/station/medical/psychology)
 "oZm" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -62515,9 +62937,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
 "pbQ" = (
-/obj/structure/sign/poster/official/walk,
-/turf/closed/wall,
-/area/station/medical/medbay/lobby)
+/obj/machinery/light/directional/north,
+/obj/machinery/vending/drugs,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "pbS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
 	dir = 5
@@ -62634,17 +63060,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "pdc" = (
-/obj/machinery/light/small/directional/east{
-	name = "maintenance light";
-	nightshift_allowed = 0;
-	nightshift_enabled = 1;
-	nightshift_light_power = 0.4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "pdl" = (
 /obj/item/stack/rods,
 /turf/open/space/openspace,
@@ -62780,12 +63202,7 @@
 /turf/open/floor/iron/white/diagonal,
 /area/station/maintenance/ghetto/starboard/aft)
 "peT" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
+/turf/open/openspace,
 /area/station/medical/cryo)
 "peV" = (
 /obj/structure/railing,
@@ -62912,14 +63329,10 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "pgN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/trimline/dark_blue/line,
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 1
-	},
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/small,
-/area/station/maintenance/ghetto/central)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "pgR" = (
 /obj/machinery/camera/motion/directional/east{
 	c_tag = "Bridge - AI Upload - East";
@@ -63122,19 +63535,17 @@
 /turf/open/floor/carpet/black,
 /area/station/command/meeting_room)
 "pjb" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
+/obj/item/restraints/handcuffs/cable/pink,
+/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/item/melee/chainofcommand,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
+"pjd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
-"pjd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
+/area/station/medical/psychology)
 "pje" = (
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
@@ -63177,10 +63588,7 @@
 /turf/open/floor/carpet,
 /area/station/service/library)
 "pjT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "pjU" = (
@@ -63208,6 +63616,14 @@
 /area/station/maintenance/starboard/fore)
 "pki" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "pkk" = (
@@ -63536,12 +63952,32 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/ghetto)
 "pnT" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/bush/grassy,
-/obj/structure/flora/bush/sunny,
-/obj/structure/flora/bush/flowers_pp,
-/obj/machinery/light/floor,
-/turf/open/floor/grass,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/table/reinforced/rglass,
+/obj/item/reagent_containers/cup/bottle/epinephrine{
+	pixel_x = 14;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/cup/bottle/morphine{
+	pixel_x = 2;
+	pixel_y = 8
+	},
+/obj/item/storage/pill_bottle/penacid{
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/syringe/antiviral{
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/syringe/epinephrine,
+/obj/item/reagent_containers/syringe{
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "pnV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -63751,11 +64187,12 @@
 /area/station/maintenance/starboard/fore)
 "pqx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/bar/half{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/rack,
+/obj/item/wrench,
+/obj/item/crowbar/red,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "pqy" = (
 /obj/structure/spacevine{
 	can_spread = 0;
@@ -63900,10 +64337,18 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "psB" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/security/cell/right/directional/north{
+	name = "Isolator";
+	req_access = list("medical")
 	},
-/obj/structure/table,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	dir = 1;
+	id = "durka2"
+	},
+/obj/machinery/door/window/brigdoor/security/cell/left/directional/south{
+	name = "Isolator"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "psF" = (
@@ -64064,6 +64509,27 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/command/teleporter)
+"puw" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/medical/cryo)
 "puC" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 5
@@ -64092,12 +64558,9 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
 "puQ" = (
-/obj/machinery/vending/wardrobe/viro_wardrobe,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/medical/abandoned)
 "puT" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/material_cheap,
@@ -64159,21 +64622,23 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "pvv" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/vending/drugs,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "pvD" = (
 /turf/closed/wall/r_wall,
 /area/station/science/breakroom)
 "pvJ" = (
+/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
-/obj/structure/cable,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
 /turf/open/floor/plating,
 /area/station/medical/psychology)
 "pvN" = (
@@ -64263,14 +64728,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "pwF" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/abandoned)
 "pwP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -64292,6 +64753,9 @@
 	},
 /obj/item/pen{
 	pixel_y = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
@@ -64400,29 +64864,33 @@
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "pyi" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/iron/dark/small,
-/area/station/medical/morgue)
+/obj/machinery/camera{
+	c_tag = "Medbay Morgue South"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/structure/chair/comfy/teal{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "pyk" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "pyo" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave/engineering/cell_included,
+/obj/machinery/light/small/directional/south{
+	name = "maintenance light";
+	nightshift_allowed = 0;
+	nightshift_enabled = 1
+	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/table/reinforced/rglass,
-/obj/machinery/light/directional/south,
-/obj/item/reagent_containers/syringe/epinephrine,
-/obj/item/reagent_containers/syringe/antiviral{
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/syringe/calomel{
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/syringe{
-	pixel_y = 12
-	},
 /turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/area/station/medical/patients_rooms)
 "pyp" = (
 /obj/effect/spawner/random/structure/closet_empty,
 /obj/effect/spawner/random/maintenance,
@@ -64444,10 +64912,17 @@
 /area/station/service/bar/backroom/ghetto)
 "pyz" = (
 /obj/machinery/light/directional/north,
+/obj/structure/table/glass,
+/obj/item/flashlight/pen/paramedic,
+/obj/item/paper_bin,
 /obj/machinery/airalarm/directional/north,
+/obj/item/toy/figure/paramedic,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "pyM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /obj/machinery/vending/coffee,
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
@@ -64634,35 +65109,19 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
 "pBD" = (
-/obj/item/book/manual/wiki/plumbing{
-	pixel_x = 4;
-	pixel_y = -4
-	},
-/obj/item/book/manual/wiki/grenades,
-/obj/item/book/manual/wiki/chemistry{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/obj/machinery/status_display/evac/directional/east,
-/obj/structure/table/reinforced,
-/obj/item/storage/box/syringes,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/station/medical/chemistry/ghetto)
-"pBE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/small,
-/area/station/medical/morgue)
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
+"pBE" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "pBF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64820,9 +65279,25 @@
 /turf/open/floor/wood/large,
 /area/station/service/bar/atrium/ghetto)
 "pCC" = (
-/obj/effect/spawner/random/structure/barricade,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayEntrance"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "pCG" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
@@ -64847,10 +65322,15 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "pCP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/departments/chemistry,
-/turf/open/floor/plating,
-/area/station/medical/pharmacy)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/airlock/medical,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/station/medical/paramedic)
 "pCT" = (
 /obj/structure/flora/bush/jungle/b/style_random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -65019,6 +65499,15 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
+"pEJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/aft)
 "pEQ" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 4
@@ -65058,9 +65547,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
 "pEZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/start/chemist,
+/turf/open/floor/iron/dark,
+/area/station/medical/chemistry)
 "pFd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/decal/cleanable/dirt,
@@ -65071,11 +65564,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
 "pFq" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "pFr" = (
@@ -65102,16 +65592,20 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "pFE" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/virology/glass{
+	name = "Containment Cells"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/virology)
 "pFT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -65444,22 +65938,26 @@
 /area/station/maintenance/starboard/aft)
 "pJY" = (
 /obj/structure/cable,
-/obj/effect/landmark/start/coroner,
-/turf/open/floor/iron/dark/small,
-/area/station/medical/morgue)
-"pKc" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
-"pKo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
+"pKc" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/morgue)
+"pKo" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "pKp" = (
 /turf/closed/wall,
 /area/station/security/execution)
@@ -65480,9 +65978,13 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/ghetto)
 "pKC" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/dark/small,
-/area/station/medical/morgue)
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/chair/comfy/teal{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "pKF" = (
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/iron,
@@ -65532,16 +66034,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "pLp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/structure/sign/warning/biohazard/directional/south,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/morgue)
 "pLr" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
@@ -65629,9 +66125,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "pMa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/structure/sign/warning/cold_temp/directional/east,
 /turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/area/station/medical/medbay/central)
 "pMn" = (
 /obj/structure/chair/pew/right,
 /turf/open/floor/wood/large,
@@ -65777,38 +66280,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "pOi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/effect/turf_decal/siding/yellow/end{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/obj/machinery/plumbing/receiver{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/medical/pharmacy)
 "pOm" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id = "quarantine";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/right/directional/west{
-	name = "Medbay Reception";
-	req_access = list("medical")
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/button/door/directional{
-	id = "MedbayEntrance";
-	name = "Medbay Doors Control";
-	normaldoorcontrol = 1;
-	req_access = list("medical")
-	},
-/obj/item/storage/box/rxglasses{
-	pixel_y = 14
+/obj/structure/chair/office/light{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
@@ -65827,9 +66311,17 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage)
 "pOC" = (
-/obj/effect/spawner/random/structure/tank_holder,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/mod/module/plasma_stabilizer,
+/obj/item/mod/module/thermal_regulator,
+/obj/item/mod/module/signlang_radio,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "pOI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65941,9 +66433,22 @@
 /turf/open/floor/carpet,
 /area/station/maintenance/starboard/aft)
 "pQC" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/stack/medical/gauze{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/stack/medical/mesh{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/item/stack/medical/suture{
+	pixel_x = -9;
+	pixel_y = 4
+	},
 /obj/effect/turf_decal/tile/blue/full,
-/obj/structure/table/reinforced,
-/obj/machinery/defibrillator_mount,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "pQP" = (
@@ -66050,6 +66555,16 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/port/fore)
+"pRG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "pRT" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -66199,11 +66714,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "pTn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/closet/crate/freezer/donk,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "pTr" = (
 /obj/machinery/light_switch/directional/west,
 /obj/machinery/camera/directional/south{
@@ -66224,12 +66738,11 @@
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "pTw" = (
-/obj/structure/closet/l3closet/virology,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/structure/curtain,
+/obj/item/bikehorn/rubberducky,
+/obj/machinery/shower/directional/north,
+/turf/open/floor/iron/freezer,
+/area/station/medical/break_room)
 "pTN" = (
 /obj/machinery/modular_computer/preset/cargochat/engineering{
 	dir = 4
@@ -66259,7 +66772,7 @@
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "pTY" = (
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/structure/sign/clock/directional/north,
+/obj/effect/decal/cleanable/ash/large,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "pTZ" = (
@@ -66299,9 +66812,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "pUM" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/stone,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/psychology)
 "pUU" = (
 /obj/item/reagent_containers/spray/plantbgone,
 /obj/item/reagent_containers/spray/pestspray{
@@ -66722,14 +67237,15 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "qak" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/east,
+/mob/living/carbon/human/species/monkey,
+/obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/cable,
-/obj/effect/spawner/random/trash/graffiti{
-	spawn_loot_chance = 50
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "qal" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66787,9 +67303,25 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
 "qaT" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayEntrance"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "qaY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66838,8 +67370,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "qbQ" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "qbT" = (
 /obj/structure/chair/stool{
 	dir = 4
@@ -67097,6 +67632,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"qfV" = (
+/obj/structure/sign/departments/restroom,
+/turf/closed/wall,
+/area/station/medical/patients_rooms)
 "qfX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/tank/plasma,
@@ -67114,13 +67653,12 @@
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison)
 "qgk" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/office{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/central)
+/obj/machinery/vending/wallmed/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/medical/surgery/theatre)
 "qgo" = (
 /obj/machinery/door/airlock/research/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -67234,18 +67772,8 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "qix" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/table/reinforced/rglass,
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_y = 6
-	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_y = 6
-	},
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "qiz" = (
 /obj/machinery/mech_bay_recharge_port{
@@ -67710,10 +68238,17 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "qof" = (
-/obj/machinery/vending/snack,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/bodycontainer/morgue{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
+"qol" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "qow" = (
 /obj/structure/easel,
 /obj/effect/decal/cleanable/dirt,
@@ -67732,8 +68267,11 @@
 /obj/machinery/computer/records/medical/laptop{
 	pixel_y = 2
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/machinery/button/door/directional/south{
+	id = "psychological_office_shutters";
+	name = "Psychological Office Shutters Control";
+	pixel_x = -15;
+	pixel_y = 8
 	},
 /obj/machinery/button/door/directional/south{
 	id = "psych_office";
@@ -67741,15 +68279,7 @@
 	normaldoorcontrol = 1;
 	pixel_x = -15;
 	specialfunctions = 4;
-	pixel_y = -2;
-	req_access = list("psychology")
-	},
-/obj/machinery/button/door/directional/south{
-	id = "psychological_office_shutters";
-	name = "Psychological Office Shutters Control";
-	pixel_x = -15;
-	pixel_y = 8;
-	req_access = list("psychology")
+	pixel_y = -2
 	},
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
@@ -67838,17 +68368,25 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/starboard/fore)
 "qpJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/obj/structure/bed,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/item/toy/plush/beeplushie,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "qpO" = (
 /obj/machinery/light/directional/north,
-/obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/dark/small,
-/area/station/medical/morgue)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "qpQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/camera/directional/north{
@@ -67877,13 +68415,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/medical,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/treatment_center)
 "qql" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron/dark,
@@ -67926,14 +68462,11 @@
 /turf/open/floor/iron/white/herringbone,
 /area/station/maintenance/ghetto/starboard/aft)
 "qqM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "qqN" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/ghetto/starboard/aft)
@@ -68038,39 +68571,38 @@
 "qtp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
+"qtw" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/medical/morgue)
-"qtw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/area/station/medical/surgery/theatre)
 "qtA" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
-"qtE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
 	},
 /obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/medical/chemistry)
+"qtE" = (
+/obj/machinery/camera/directional/west,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/area/station/medical/chemistry)
 "qtM" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/decal/cleanable/dirt,
@@ -68137,17 +68669,14 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "quL" = (
-/obj/item/storage/box/monkeycubes{
-	pixel_y = 3
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/maintenance/two,
+/obj/effect/spawner/random/trash/box,
+/obj/item/toy/plush/lizard_plushie/green{
+	name = "Tends-the-Wounds"
 	},
-/obj/structure/table/glass,
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10
-	},
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/abandoned)
 "quX" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/iron/fifty{
@@ -68196,12 +68725,21 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "qvy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark/small,
-/area/station/medical/morgue)
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "qvB" = (
 /obj/structure/stairs/east{
 	dir = 8
@@ -68236,6 +68774,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
+"qvR" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/surgery/theatre)
 "qwo" = (
 /obj/structure/table,
 /obj/item/clipboard{
@@ -68257,6 +68803,10 @@
 /obj/effect/spawner/random/trash/box,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
+"qwB" = (
+/obj/structure/sign/departments/chemistry,
+/turf/closed/wall/r_wall,
+/area/station/medical/pharmacy)
 "qwC" = (
 /obj/effect/turf_decal/trimline/white/warning{
 	dir = 1
@@ -68397,30 +68947,15 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "qxT" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_interior"
+/obj/machinery/door/airlock/medical{
+	name = "Unfinished Room"
 	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
-/obj/effect/turf_decal/tile/green/fourcorners,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/cable,
-/obj/machinery/door_buttons/access_button{
-	idDoor = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_x = -24;
-	req_access = list("virology")
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/abandoned)
 "qyb" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -68474,11 +69009,11 @@
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/starboard)
 "qze" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/morgue)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "qzl" = (
 /obj/structure/railing{
 	dir = 8
@@ -68676,11 +69211,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "qBf" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/photocopier,
+/obj/effect/turf_decal/tile/dark_blue/anticorner,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "qBh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
@@ -68902,6 +69438,14 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/stairs/right,
 /area/station/security/holding_cell)
+"qED" = (
+/obj/machinery/light/small/directional/west,
+/obj/structure/chair/office/light,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "qEI" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
@@ -68913,8 +69457,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "qEP" = (
-/turf/closed/wall/rust,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "qEY" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/dark,
@@ -68953,16 +69501,20 @@
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
 "qFE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/central)
 "qFH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/structure/transport/linear/public,
+/obj/effect/landmark/transport/transport_id{
+	specific_transport_id = "morgue_elevator"
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/obj/effect/abstract/elevator_music_zone{
+	linked_elevator_id = "aft_vator";
+	range = 2
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/station/medical/morgue)
 "qFQ" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -69363,15 +69915,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto)
 "qKG" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
+/area/station/maintenance/starboard/upper)
 "qKH" = (
 /obj/machinery/computer/upload/borg{
 	dir = 1
@@ -69621,20 +70170,10 @@
 /area/station/security/prison/ghetto)
 "qNJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "qNK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard,
@@ -69652,11 +70191,17 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
 "qNP" = (
-/obj/machinery/light/small/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/turf/open/floor/plating,
+/area/station/medical/virology)
 "qNX" = (
 /obj/structure/sign/poster/contraband/random/directional/north,
 /obj/machinery/light/small/broken/directional/north,
@@ -69664,9 +70209,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port)
 "qNY" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
@@ -69783,11 +70325,9 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "qPF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/stone,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard)
 "qPH" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -69795,17 +70335,9 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "qQb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/obj/item/chair/plastic,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/sign/warning/biohazard/directional/north,
+/turf/open/openspace,
+/area/station/medical/cryo)
 "qQf" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
@@ -69970,6 +70502,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
+"qSs" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "qSz" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow,
@@ -70109,7 +70651,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "qTS" = (
-/obj/machinery/photocopier/prebuilt,
+/obj/machinery/photocopier,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "qTY" = (
@@ -70179,8 +70721,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "qVj" = (
-/turf/closed/wall,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/flora/bush/sunny/style_random,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "qVo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70214,12 +70760,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "qVM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/cable_coil,
-/obj/structure/frame/computer,
-/obj/machinery/light/small/directional/north,
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/area/station/medical/virology)
 "qVO" = (
 /obj/structure/chair/office,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
@@ -70300,22 +70852,14 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "qWx" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/structure/closet,
+/obj/item/surgicaldrill,
+/turf/open/floor/plating,
+/area/station/medical/abandoned)
 "qWz" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -70442,9 +70986,14 @@
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison)
 "qXM" = (
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/obj/item/kirbyplants/random,
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/light_switch/directional/south,
+/obj/effect/turf_decal/tile/neutral/anticorner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "qXN" = (
 /obj/machinery/mecha_part_fabricator/maint,
 /turf/open/floor/plating,
@@ -70488,10 +71037,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "qYS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "qYT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -70508,12 +71056,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "qZe" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/virology)
 "qZi" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -70824,26 +71369,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "rcZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id = "quarantine";
-	name = "Quarantine Lockdown";
-	opacity = 0
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
 	},
-/obj/structure/cable,
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayEntrance"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/firedoor,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/chemistry)
 "rdd" = (
 /obj/item/paper_bin{
 	pixel_x = -4
@@ -70918,7 +71450,14 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "rdT" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "reb" = (
@@ -70939,6 +71478,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "reo" = (
@@ -71056,13 +71596,11 @@
 /turf/open/floor/iron,
 /area/station/science/lobby)
 "rfx" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 1
-	},
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/morgue)
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/public/glass,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "rfD" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin{
@@ -71308,15 +71846,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "rik" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "rip" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/red{
@@ -71751,6 +72293,17 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/structure/desk_bell{
+	pixel_x = 7
+	},
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/item/pen{
+	pixel_x = -5;
+	pixel_y = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "rnj" = (
@@ -71789,6 +72342,11 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/engineering/storage)
+"rnC" = (
+/obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "rnD" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
@@ -71802,11 +72360,7 @@
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/starboard/aft)
 "rnF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
-/obj/machinery/door/airlock/atmos,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering,
-/obj/effect/mapping_helpers/airlock/unres{
+/obj/machinery/atmospherics/components/binary/valve/on{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -71820,13 +72374,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "rnL" = (
-/obj/effect/landmark/start/hangover,
-/obj/structure/railing{
+/obj/structure/railing/corner{
 	dir = 4
 	},
-/obj/structure/bed/medical/anchored{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "roi" = (
@@ -71838,15 +72389,17 @@
 /turf/open/floor/wood,
 /area/station/service/library/ghetto)
 "rok" = (
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+	dir = 9
 	},
-/obj/structure/table/reinforced,
-/obj/item/mod/module/plasma_stabilizer,
-/obj/item/mod/module/thermal_regulator,
-/obj/item/mod/module/signlang_radio,
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
+/obj/structure/cable,
+/obj/machinery/door/window/left/directional/west{
+	name = "Medbay Lower Floor";
+	req_access = list("medical")
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/surgery/theatre)
 "ror" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Chapel - West"
@@ -72039,9 +72592,10 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "rqA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/bar/fourcorners,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "rqF" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -72050,10 +72604,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "rqK" = (
-/obj/effect/turf_decal/tile/green/fourcorners,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/treatment_center)
 "rqO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -72107,6 +72662,21 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
+"rrl" = (
+/obj/structure/table/glass,
+/obj/structure/reagent_dispensers/wall/virusfood/directional/north,
+/obj/item/storage/belt/medical,
+/obj/item/clothing/gloves/latex,
+/obj/item/healthanalyzer,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/science{
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "rrp" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -72342,6 +72912,11 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
+"rua" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/box,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "ruf" = (
 /turf/open/openspace,
 /area/station/science/ordnance/office)
@@ -72439,16 +73014,9 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "ruV" = (
-/obj/structure/chair/comfy/teal{
-	dir = 4
-	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Virology - Lobby";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/cafeteria,
+/area/station/medical/break_room)
 "ruY" = (
 /obj/structure/chair{
 	name = "Engineering Station"
@@ -72513,14 +73081,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "rwq" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/obj/machinery/vending/wallmed/directional/west,
-/obj/structure/chair/comfy/teal{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
+/turf/open/openspace,
 /area/station/medical/surgery/theatre)
 "rws" = (
 /obj/effect/decal/cleanable/dirt,
@@ -72528,10 +73089,14 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/ghetto/starboard/aft)
 "rwC" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/basic/goose/vomit,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/door/airlock/psych{
+	id_tag = "psych_office"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/station/medical/psychology)
 "rwD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -72697,10 +73262,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "rAh" = (
-/obj/machinery/light/directional/north,
-/obj/effect/landmark/navigate_destination/chemfactory,
-/turf/open/floor/iron/smooth,
-/area/station/medical/chemistry/ghetto)
+/obj/machinery/camera/directional/south{
+	c_tag = "Medbay Chemistry Lab - South";
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "rAk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
@@ -72914,11 +73482,15 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/break_room)
 "rCF" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
+/obj/structure/table/reinforced,
+/obj/item/cigbutt/cigarbutt,
+/obj/item/storage/fancy/cigarettes/cigpack_uplift,
+/obj/item/storage/box/matches{
+	pixel_x = 1;
+	pixel_y = -1
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/floor/plating,
+/area/station/medical/abandoned)
 "rCL" = (
 /obj/machinery/light/directional/west,
 /obj/structure/closet/emcloset,
@@ -72948,12 +73520,18 @@
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/security/lockers)
 "rDd" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/bodycontainer/morgue{
-	dir = 2
+/obj/machinery/duct,
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "virology_airlock_exterior";
+	idInterior = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Console";
+	pixel_y = -25;
+	req_access = list("virology")
 	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/morgue)
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "rDh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -72991,14 +73569,12 @@
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "rEd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/vending/wardrobe/chem_wardrobe,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/station/medical/chemistry/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "rEh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -73079,26 +73655,16 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "rFm" = (
-/obj/structure/table/glass,
-/obj/machinery/computer/records/medical/laptop{
-	dir = 8;
-	pixel_x = -2
-	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/abandoned)
 "rFp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/hallway/primary/starboard/west)
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "rFs" = (
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood/tile,
@@ -73378,12 +73944,15 @@
 /turf/open/floor/plating,
 /area/station/security/interrogation)
 "rJA" = (
-/obj/structure/window/spawner/directional/south,
-/obj/structure/table/reinforced,
-/obj/item/mop,
-/obj/structure/window/spawner/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "rJS" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/airalarm/directional/south,
@@ -73433,13 +74002,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "rKi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light/small/directional/south{
+	name = "maintenance light";
+	nightshift_allowed = 0;
+	nightshift_enabled = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/area/station/maintenance/department/medical/morgue)
 "rKx" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
@@ -73463,6 +74033,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"rKJ" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "rKL" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -73597,9 +74171,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "rMa" = (
@@ -73615,12 +74186,30 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "rMh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/iv_drip,
-/obj/item/wheelchair,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "rMk" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Central Hallway - South-West";
@@ -73862,12 +74451,15 @@
 	name = "Quarantine Lockdown";
 	opacity = 0
 	},
-/obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/duct,
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "rPa" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -73889,6 +74481,9 @@
 /turf/open/floor/plating/reinforced,
 /area/station/cargo/storage)
 "rPE" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /obj/machinery/light/floor,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
@@ -74026,14 +74621,14 @@
 /turf/open/floor/iron/stairs/left,
 /area/station/command/bridge)
 "rRN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
+	dir = 10
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "rRO" = (
 /obj/structure/cable,
 /turf/open/floor/circuit,
@@ -74130,7 +74725,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
@@ -74142,6 +74737,20 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/checkpoint/customs)
+"rTo" = (
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/surgery/theatre)
 "rTp" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
@@ -74156,17 +74765,12 @@
 /area/station/hallway/secondary/dock)
 "rTs" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
+	dir = 5
 	},
-/obj/machinery/light/directional/west,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/recharge_station,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
+/area/station/medical/treatment_center)
 "rTt" = (
 /obj/structure/sign/departments/telecomms/directional/north,
 /obj/machinery/camera/directional/north{
@@ -74421,19 +75025,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "rWq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/machinery/light/small/directional/east,
+/obj/structure/chair/office/light,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "rWy" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/cleanable/dirt,
@@ -74661,11 +75259,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "rYl" = (
-/obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
 "rYm" = (
@@ -74767,12 +75369,35 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "rZO" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/chem_dispenser,
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/engine,
+/obj/item/screwdriver{
+	pixel_x = 2;
+	pixel_y = 11
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 6
+	},
+/obj/structure/table/reinforced/rglass,
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "rZR" = (
 /obj/effect/turf_decal/bot,
@@ -74783,6 +75408,13 @@
 /obj/structure/chair,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
+"rZW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/morgue)
 "saa" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -74858,13 +75490,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "sbf" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/closed/wall,
+/area/station/medical/abandoned)
 "sbn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/unres{
@@ -74905,12 +75535,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "sbF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/engineering/flashlight,
+/obj/structure/sign/warning/bodysposal/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "sbI" = (
 /obj/machinery/computer/records/security{
 	dir = 4
@@ -75021,6 +75650,12 @@
 /obj/item/clothing/suit/apron/chef,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"scC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "scS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -75155,10 +75790,11 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
 "sdK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/virology)
 "sdN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
@@ -75234,18 +75870,10 @@
 /turf/open/floor/iron,
 /area/station/security/range)
 "sfe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
+/obj/structure/sign/poster/random/directional/north,
+/obj/machinery/light/directional/north,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/area/station/maintenance/aft)
 "sfs" = (
 /obj/structure/table/wood,
 /obj/item/book/bible,
@@ -75277,13 +75905,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "sfM" = (
-/obj/structure/table/glass,
-/obj/item/paper{
-	pixel_y = 4
+/obj/machinery/light/directional/north,
+/obj/structure/table/reinforced,
+/obj/machinery/computer/records/medical/laptop,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "sfS" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
@@ -75447,6 +76076,12 @@
 	dir = 1
 	},
 /area/station/commons/storage/primary)
+"shR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chemistry)
 "shW" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Starboard Primary Hallway 5"
@@ -75477,6 +76112,15 @@
 	},
 /turf/open/space/openspace,
 /area/space/nearstation)
+"siy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 2
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "siF" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -75503,8 +76147,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "siJ" = (
-/turf/closed/wall,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/door/poddoor/preopen{
+	elevator_mode = 1;
+	transport_linked_id = "morgue_elevator"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "siL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -75546,12 +76195,10 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/ghetto)
 "sjf" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/effect/spawner/random/maintenance,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "sjj" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4,
@@ -75941,8 +76588,12 @@
 /area/station/maintenance/starboard/aft)
 "snz" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "snB" = (
@@ -76178,13 +76829,17 @@
 /turf/open/floor/wood,
 /area/station/security/prison)
 "sqv" = (
+/obj/structure/table,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/gun/syringe{
+	pixel_x = -12
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/theatre)
+/obj/item/gun/syringe{
+	pixel_x = -12;
+	pixel_y = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "sqw" = (
 /turf/open/floor/iron/edge{
 	dir = 4
@@ -76203,8 +76858,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "sqI" = (
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
@@ -76214,15 +76870,22 @@
 /turf/open/floor/wood/tile,
 /area/station/service/lawoffice)
 "sqQ" = (
+/obj/machinery/requests_console/directional/south{
+	department = "Medbay";
+	name = "Medbay Requests Console"
+	},
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/structure/table/glass,
+/obj/item/storage/toolbox/emergency{
+	pixel_y = 4
+	},
+/obj/item/wrench/medical,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
+	dir = 10
 	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Medbay - Lobby";
-	network = list("ss13","medbay")
-	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/cryo)
 "sqT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -76439,16 +77102,17 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/bar/backroom/ghetto)
 "stV" = (
-/obj/structure/table/wood,
-/obj/machinery/light/directional/south,
-/obj/machinery/microwave/engineering/cell_included,
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/camera/directional/south{
-	c_tag = "Medbay - Break Room";
-	network = list("ss13","medbay")
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "stY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -76496,8 +77160,15 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "sux" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/virology)
 "suy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -76672,13 +77343,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto/central)
 "swA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/structure/closet/secure_closet/personal/patient,
-/obj/item/clothing/suit/jacket/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "swB" = (
@@ -76819,13 +77486,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "syU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/structure/transport/linear/public,
+/turf/open/floor/plating/elevatorshaft,
+/area/station/medical/morgue)
 "syV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -77103,20 +77766,12 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "sDc" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id = "quarantine";
-	name = "Quarantine Lockdown";
-	opacity = 0
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/plating,
-/area/station/medical/medbay)
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "sDf" = (
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/starboard/aft)
@@ -77277,11 +77932,25 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
 "sEm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/smooth,
+/area/station/medical/chemistry)
 "sEn" = (
+/obj/machinery/door/window/right/directional/west{
+	name = "Medbay Reception";
+	req_access = list("medical")
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/item/storage/box/rxglasses{
+	pixel_y = 14
+	},
+/obj/machinery/button/door/directional{
+	id = "MedbayEntrance";
+	name = "Medbay Doors Control";
+	normaldoorcontrol = 1;
+	req_access = list("medical")
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
@@ -77289,13 +77958,8 @@
 	name = "Quarantine Lockdown";
 	opacity = 0
 	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=1";
-	location = "Medbay"
-	},
-/obj/structure/plasticflaps/opaque,
-/turf/open/floor/plating,
-/area/station/maintenance/aft)
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "sEo" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
@@ -77405,27 +78069,28 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "sFs" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/structure/table/wood/fancy/red,
-/obj/item/plate/small{
-	color = "#454545";
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/cigarette/cigar{
-	pixel_y = 10;
-	pixel_x = -3
-	},
-/turf/open/floor/wood/large,
-/area/station/service/bar/atrium/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "sFx" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"sFC" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "sFG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -77453,9 +78118,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "sGh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "sGr" = (
 /obj/machinery/door/airlock/public,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -77553,22 +78223,17 @@
 /area/station/engineering/hallway)
 "sHx" = (
 /obj/machinery/firealarm/directional/west,
-/obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/item/flashlight/pen/paramedic,
-/obj/item/toy/figure/paramedic,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "sHy" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/valve/on{
+	dir = 4
 	},
-/obj/machinery/status_display/evac/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "sHE" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/table/optable,
@@ -77700,10 +78365,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "sJc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/stone,
-/area/station/maintenance/ghetto/bar)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "sJo" = (
 /obj/machinery/firealarm/directional/south,
 /obj/structure/table,
@@ -77880,10 +78546,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "sLQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/treatment_center)
 "sLZ" = (
 /obj/machinery/door/airlock/corporate,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -77953,6 +78621,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
+"sNp" = (
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/iron/dark,
+/area/station/medical/surgery/theatre)
 "sNA" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -77970,12 +78647,9 @@
 /turf/closed/wall/r_wall,
 /area/station/medical/surgery/fore)
 "sNS" = (
-/obj/structure/closet/crate/medical,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "sOa" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -78209,6 +78883,26 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/security/courtroom)
+"sRi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/reagent_containers/cup/bottle/potassium{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/cup/bottle/phosphorus{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/cup/bottle/sodium{
+	pixel_x = 1
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/station/medical/chem_storage)
 "sRo" = (
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
@@ -78227,13 +78921,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/sorting)
 "sRz" = (
-/obj/structure/bed,
-/mob/living/carbon/human/species/monkey,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "sRE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -78371,15 +79065,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "sTP" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/closed/wall,
+/area/station/medical/abandoned)
 "sTU" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -78517,11 +79204,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
 "sVt" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/maintenance/department/medical/morgue)
 "sVv" = (
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/light/directional/south,
@@ -78553,9 +79241,12 @@
 /turf/open/floor/iron/small,
 /area/station/maintenance/ghetto/central)
 "sVE" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/medical/morgue)
+/obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "sVT" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -78693,7 +79384,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "sXY" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
+	},
+/obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "sYa" = (
@@ -78729,6 +79423,18 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/maintenance/ghetto/central)
+"sYG" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "sYI" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/chem_master,
@@ -78778,9 +79484,6 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "sZA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -78801,11 +79504,20 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "sZN" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
+/area/station/maintenance/ghetto/aft)
+"sZR" = (
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/obj/machinery/vending/medical,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "sZT" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/line,
@@ -78993,19 +79705,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "tdr" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/construction/plumbing,
-/obj/item/construction/plumbing{
-	pixel_y = -5
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/station/medical/chemistry/ghetto)
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "tdD" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/legcuffs/beartrap,
@@ -79046,9 +79750,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "teg" = (
-/obj/structure/sign/warning/electric_shock/directional/north,
-/turf/open/floor/iron/smooth,
-/area/station/medical/chemistry/ghetto)
+/obj/structure/stairs/north,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "tem" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -79117,6 +79821,26 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
+"tfh" = (
+/obj/item/plunger{
+	pixel_x = 3
+	},
+/obj/item/plunger{
+	pixel_x = -3
+	},
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/evac/directional/north,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/dark,
+/area/station/medical/chemistry)
 "tfm" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/plating,
@@ -79186,6 +79910,9 @@
 /area/station/medical/surgery/aft)
 "tgC" = (
 /obj/structure/chair/office/light,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "tgE" = (
@@ -79246,13 +79973,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
 "thB" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "medical_break"
-	},
-/turf/open/floor/plating,
-/area/station/medical/break_room)
+/obj/machinery/light/small/directional/east,
+/turf/open/openspace,
+/area/station/medical/cryo)
 "thD" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/maintenance,
@@ -79284,10 +80007,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "til" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "tin" = (
@@ -79306,11 +80028,12 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/fore)
 "tiu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/maintenance/department/medical/morgue)
 "tiz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/mapping_helpers/broken_floor,
@@ -79557,6 +80280,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"tlp" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "tls" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -79577,8 +80306,14 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "tlu" = (
-/turf/closed/wall/rust,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "tlA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -79662,9 +80397,12 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
-/obj/structure/chair/comfy/teal,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
+/obj/structure/table/glass,
+/obj/item/soap/nanotrasen{
+	pixel_y = 2
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "tmK" = (
@@ -79672,34 +80410,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "tmL" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/table/reinforced/rglass,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/mesh{
-	pixel_x = -8;
-	pixel_y = -5
-	},
-/obj/item/stack/medical/mesh{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/obj/item/stack/medical/gauze{
-	pixel_x = 7
-	},
-/obj/item/stack/medical/gauze{
-	pixel_x = 7;
-	pixel_y = 6
-	},
-/obj/item/stack/medical/suture{
-	pixel_x = -9;
-	pixel_y = -7
-	},
-/obj/item/stack/medical/suture{
-	pixel_x = -9;
-	pixel_y = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/obj/effect/spawner/random/structure/tank_holder,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "tmN" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -79789,23 +80502,8 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
-/obj/item/storage/box/syringes{
-	pixel_y = 16
-	},
-/obj/structure/table/reinforced/rglass,
-/obj/item/storage/box/beakers{
-	pixel_y = 6;
-	pixel_x = -8
-	},
-/obj/item/storage/box/beakers{
-	pixel_y = 6;
-	pixel_x = 8
-	},
 /obj/machinery/firealarm/directional/east,
-/obj/item/hand_labeler{
-	pixel_x = -8;
-	pixel_y = 2
-	},
+/obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "tnC" = (
@@ -79914,13 +80612,7 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical/ghetto/morgue)
 "toL" = (
-/obj/structure/window/spawner/directional/south,
-/obj/structure/window/spawner/directional/west,
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_y = 4
-	},
-/obj/effect/spawner/random/maintenance,
+/obj/structure/chair,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "toP" = (
@@ -79936,18 +80628,13 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "toV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/light_switch/directional/north,
 /obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/treatment_center)
 "toY" = (
 /obj/machinery/button/door/directional/west{
 	id = "Toilet4";
@@ -79986,13 +80673,15 @@
 /turf/open/floor/iron/stairs/left,
 /area/station/security/holding_cell)
 "tpq" = (
-/obj/machinery/status_display/ai/directional/north,
-/obj/machinery/plumbing/sender,
-/obj/effect/turf_decal/siding/yellow/end{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table,
+/obj/item/knife/plastic{
+	pixel_x = 8
 	},
-/turf/open/floor/plating,
-/area/station/medical/chemistry/ghetto)
+/obj/item/kitchen/spoon/plastic,
+/obj/item/kitchen/fork/plastic,
+/turf/open/floor/iron/white,
+/area/station/medical/psychology)
 "tpu" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 1
@@ -80000,23 +80689,12 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "tpv" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id = "quarantine";
-	name = "Quarantine Lockdown";
-	opacity = 0
+/obj/machinery/fax{
+	fax_name = "Medical";
+	name = "Medical Fax Machine"
 	},
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/item/paper_bin{
-	pixel_y = 4
-	},
-/obj/item/pen{
-	pixel_y = 6
-	},
-/obj/item/toy/figure/md,
+/obj/structure/table/glass,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "tpx" = (
@@ -80111,13 +80789,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "tqC" = (
-/obj/machinery/atmospherics/components/binary/valve/on{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/valve/on,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
 "tqG" = (
@@ -80207,8 +80883,14 @@
 /area/station/maintenance/aft)
 "trI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/hallway/primary/starboard)
 "trL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -80272,11 +80954,14 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/gravity_generator)
 "tsA" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan{
+	dir = 8
+	},
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
 "tsD" = (
@@ -80330,12 +81015,17 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "ttv" = (
-/obj/structure/cable/multilayer/multiz,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/floor/plating,
-/area/station/medical/chemistry/ghetto)
+/obj/machinery/door/window/right/directional/east{
+	name = "Coroner"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "ttw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/port_gen/pacman,
@@ -80424,8 +81114,7 @@
 "tue" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/east,
-/obj/structure/cable,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "tuh" = (
@@ -80464,21 +81153,12 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "tuq" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags{
-	pixel_x = -6;
-	pixel_y = -6
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
-/obj/item/storage/box/bodybags{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/cup/bottle/formaldehyde{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/medical/morgue)
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "tuv" = (
 /obj/structure/cable,
 /obj/structure/table/reinforced,
@@ -80617,15 +81297,17 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/central/aft)
 "tvQ" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/door/airlock/research{
+	name = "Chemical Storage"
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/textured,
+/area/station/medical/chem_storage)
 "tvU" = (
 /obj/effect/spawner/random/structure/furniture_parts,
 /turf/open/floor/iron,
@@ -80696,11 +81378,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "twY" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced/plasma,
@@ -80834,15 +81513,8 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/checkpoint/medical)
 "tzr" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/machinery/camera/directional/west{
-	c_tag = "Medbay - Hallway Center";
-	network = list("ss13","medbay")
-	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "tzu" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/ghetto/fore/starboard)
@@ -81027,18 +81699,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "tCm" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/structure/table/wood/fancy/red,
-/obj/item/flashlight/lamp/green{
-	pixel_y = 14
-	},
-/obj/item/stack/spacecash/c100{
-	pixel_y = 2
-	},
-/turf/open/floor/wood/large,
-/area/station/service/bar/atrium/ghetto)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/chem_heater/withbuffer,
+/turf/open/floor/iron/dark,
+/area/station/medical/chemistry)
 "tCo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office{
@@ -81130,14 +81798,11 @@
 /area/station/engineering/atmos/mix/ghetto)
 "tDs" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+	dir = 10
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/vending/coffee,
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/medical/medbay/aft)
 "tDu" = (
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
@@ -81160,15 +81825,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "tDV" = (
-/obj/effect/turf_decal/tile/green/fourcorners,
-/obj/structure/disposalpipe/junction{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/medical/abandoned)
 "tEa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -81271,11 +81930,11 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/chemistry)
 "tEX" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -81679,6 +82338,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/kirbyplants/random,
+/obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "tKf" = (
@@ -81719,21 +82380,21 @@
 /turf/open/floor/carpet/royalblack,
 /area/station/maintenance/port/aft)
 "tKt" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "tKx" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "tKy" = (
@@ -82060,9 +82721,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "tOz" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/small,
-/area/station/medical/morgue)
+/obj/structure/sign/warning/electric_shock/directional/west,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/iron/smooth,
+/area/station/medical/chemistry)
 "tOL" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Holodeck - North"
@@ -82239,9 +82902,6 @@
 	},
 /obj/effect/mapping_helpers/mail_sorting/medbay/general,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "tRx" = (
@@ -82280,11 +82940,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
 "tSk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
+/turf/open/floor/iron/dark,
+/area/station/medical/treatment_center)
 "tSn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/right/directional/north{
@@ -82307,11 +82968,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
 "tSq" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 5
+/obj/machinery/vending/wallmed/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/medbay/central)
 "tSu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -82386,13 +83049,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "tUe" = (
-/obj/effect/spawner/random/engineering/atmospherics_portable,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
-/turf/open/floor/iron/large,
-/area/station/maintenance/ghetto/central)
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "tUn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/siding/thinplating_new{
@@ -82425,12 +83089,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "tUK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central)
 "tUP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,
@@ -82540,10 +83210,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "tVB" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
@@ -82555,12 +83224,13 @@
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/hos)
 "tVF" = (
-/obj/structure/sink/directional/east,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/maintenance,
+/obj/structure/rack,
+/obj/item/emergency_bed,
+/obj/item/tank/internals/anesthetic,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/abandoned)
 "tVG" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical,
@@ -82599,13 +83269,11 @@
 /turf/open/floor/iron/herringbone,
 /area/station/maintenance/aft)
 "tWi" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "tWj" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -82943,14 +83611,16 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/electrical/ghetto)
 "tZP" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/camera/directional/south{
-	c_tag = "Medbay - Chemistry Lab South";
-	network = list("ss13","medbay")
+/obj/machinery/shower/directional/west,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/virology)
 "tZV" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -83000,13 +83670,13 @@
 /turf/open/floor/carpet,
 /area/station/service/library/ghetto)
 "uaw" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/light{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/floor/plating,
+/area/station/medical/abandoned)
 "uax" = (
 /obj/machinery/computer/order_console/cook,
 /obj/machinery/light/warm/directional/north,
@@ -83075,26 +83745,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "uaZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
 	},
-/obj/structure/table/reinforced,
-/obj/item/plunger{
-	pixel_x = 3
-	},
-/obj/item/plunger{
-	pixel_x = -3
-	},
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/turf/open/floor/iron/dark,
-/area/station/medical/chemistry/ghetto)
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/morgue)
 "ubf" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/conveyor{
@@ -83123,21 +83779,40 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "ubr" = (
-/obj/effect/turf_decal/tile/green/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/machinery/camera{
+	c_tag = "Virology Lobby"
+	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_y = -4
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/station/medical/chem_storage)
 "ubt" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
+/obj/structure/rack,
+/obj/item/reagent_containers/cup/bottle/nitrogen{
+	pixel_x = 7;
+	pixel_y = 3
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/item/reagent_containers/cup/bottle/mercury{
+	pixel_x = -5;
+	pixel_y = 3
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/item/reagent_containers/cup/bottle/oxygen{
+	pixel_x = 1
+	},
+/obj/structure/sign/warning/no_smoking/circle/directional/south,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/station/medical/chem_storage)
 "ubx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -83171,11 +83846,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "ucd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/coroner,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/structure/table/reinforced/rglass,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "ucj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -83189,12 +83865,16 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "uco" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/mess,
-/obj/machinery/light/small/dim/directional/east,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/central)
+/obj/structure/closet{
+	name = "janitorial supplies"
+	},
+/obj/item/pushbroom,
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/neutral/anticorner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "ucp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -83244,6 +83924,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
+"udw" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "udD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -83392,12 +84081,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "ueU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "viroshutters"
+/obj/structure/table/wood,
+/obj/item/storage/box/donkpockets{
+	pixel_y = 5
 	},
-/turf/open/floor/plating,
-/area/station/medical/virology)
+/obj/item/storage/box/donkpockets/donkpocketberry,
+/turf/open/floor/iron/cafeteria,
+/area/station/medical/break_room)
 "ueW" = (
 /turf/open/floor/wood,
 /area/station/service/library/ghetto)
@@ -83414,10 +84104,11 @@
 /turf/open/space/openspace,
 /area/space/nearstation)
 "ufh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/flowers_br,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "ufk" = (
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
@@ -83567,14 +84258,13 @@
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom/ghetto)
 "ugS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/structure/sign/warning/gas_mask/directional/south,
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/area/station/maintenance/ghetto/aft)
 "ugU" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow{
@@ -83586,11 +84276,16 @@
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "ugX" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/food_or_drink/cake_ingredients,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/camera/directional/south{
+	c_tag = "Medbay Chemistry Lab - South";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "uhc" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -83599,10 +84294,12 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
 "uhf" = (
-/obj/structure/cable,
-/obj/structure/girder,
+/obj/machinery/plumbing/sender,
+/obj/effect/turf_decal/siding/yellow/end{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/aft)
+/area/station/medical/chemistry)
 "uhq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -83679,14 +84376,10 @@
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "uix" = (
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/medical/chemistry)
 "uiy" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Research - Xenobiology Secure Cell Interior";
@@ -83797,12 +84490,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
 "ujG" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/sign/warning/vacuum/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/obj/machinery/door/window/right/directional/south{
+	name = "Coroner"
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "ujN" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "warehouse_shutters";
@@ -83812,10 +84507,34 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "ujO" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/bush/grassy,
-/obj/structure/flora/bush/flowers_yw,
-/turf/open/floor/grass,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/table/reinforced/rglass,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/item/reagent_containers/applicator/patch/libital{
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/applicator/patch/aiuri{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/applicator/patch/libital{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/applicator/patch/aiuri{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/applicator/patch/libital{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/applicator/patch/aiuri{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "ujP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
@@ -83949,8 +84668,9 @@
 /turf/open/floor/iron,
 /area/station/science/lobby)
 "ulS" = (
-/obj/machinery/computer/crew,
-/obj/structure/sign/poster/official/random/directional/north,
+/obj/machinery/light_switch/directional/north,
+/obj/structure/filingcabinet/chestdrawer,
+/obj/item/folder/white,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "ulV" = (
@@ -83970,13 +84690,10 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "umf" = (
-/obj/effect/turf_decal/tile/green/fourcorners,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/iv_drip,
+/turf/open/floor/plating,
+/area/station/medical/abandoned)
 "umj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/dark_green{
@@ -84175,8 +84892,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "upw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -84233,12 +84951,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "uqs" = (
-/obj/effect/turf_decal/tile/green/fourcorners,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/medical/patient_stretcher,
+/obj/item/food/pizzaslice/moldy/bacteria,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating,
+/area/station/medical/abandoned)
 "uqu" = (
 /obj/machinery/grill{
 	pixel_y = 8
@@ -84273,6 +84991,9 @@
 /area/station/maintenance/ghetto/fore/starboard)
 "urf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "url" = (
@@ -84351,9 +85072,12 @@
 /turf/closed/wall/rust,
 /area/station/maintenance/ghetto/garden)
 "uta" = (
-/obj/structure/disposalpipe/trunk/multiz/down{
-	dir = 2
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "utg" = (
@@ -84423,13 +85147,12 @@
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
 "uub" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/mess,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard)
 "uuc" = (
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/carpet/green,
@@ -84445,7 +85168,7 @@
 /area/station/security/range)
 "uuk" = (
 /obj/effect/decal/cleanable/blood,
-/obj/structure/sign/warning/gas_mask/directional/north,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "uum" = (
@@ -84521,11 +85244,13 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/mechbay)
 "uvq" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "uvI" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -84718,13 +85443,15 @@
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "uxN" = (
-/obj/structure/table,
-/obj/item/soap{
-	pixel_y = 8
-	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10
+	dir = 1
 	},
+/obj/structure/table/glass,
+/obj/machinery/microwave{
+	pixel_x = -1;
+	pixel_y = 6
+	},
+/obj/item/storage/box/donkpockets,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "uxX" = (
@@ -84952,6 +85679,7 @@
 "uBe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "uBk" = (
@@ -85115,9 +85843,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "uDD" = (
-/obj/structure/chair/sofa/right/maroon,
-/turf/open/floor/wood/large,
-/area/station/service/bar/atrium/ghetto)
+/obj/structure/mannequin/skeleton,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/camera/directional/north,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "uDH" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -85138,11 +85870,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "uEt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 9
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/machinery/vending/cola/blue,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/aft)
 "uEL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -85308,21 +86041,11 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "uGN" = (
-/obj/structure/table/reinforced/rglass,
-/obj/item/food/grown/banana,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple{
+	dir = 5
 	},
-/obj/machinery/light/small/directional/west,
-/obj/machinery/camera/directional/west{
-	c_tag = "Virology - Observation";
-	network = list("ss13","medbay")
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "uGO" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/trash/cigbutt,
@@ -85371,16 +86094,12 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "uHq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 1
-	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
+/area/station/medical/medbay/lobby)
 "uHz" = (
 /obj/structure/statue/station_map/cyberiad/north,
 /turf/open/floor/iron,
@@ -85393,11 +86112,8 @@
 /turf/closed/wall/r_wall,
 /area/station/security/interrogation/ghetto)
 "uHT" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/air{
-	anchored = 1
-	},
-/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "uHW" = (
@@ -85464,18 +86180,10 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "uIF" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/pen/red{
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "uIH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -85578,9 +86286,7 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "uJF" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "uJH" = (
@@ -85590,10 +86296,11 @@
 /turf/open/floor/iron/kitchen/small,
 /area/station/maintenance/starboard/fore)
 "uJP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "uJS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -85817,6 +86524,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
+"uMI" = (
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "uMM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/maintenance,
@@ -85842,16 +86553,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "uMQ" = (
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/structure/table/reinforced/rglass,
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_y = 6
-	},
+/obj/machinery/chem_dispenser,
 /turf/open/floor/engine,
 /area/station/medical/pharmacy)
 "uMR" = (
@@ -86065,8 +86771,17 @@
 "uPs" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
+"uPt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/maintenance/two,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "uPu" = (
 /obj/structure/spacevine{
 	can_spread = 0;
@@ -86099,10 +86814,26 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "uQa" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/effect/turf_decal/tile/green/fourcorners,
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_exterior";
+	name = "Virology Exterior Airlock"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door_buttons/access_button{
+	idDoor = "virology_airlock_exterior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = -24;
+	req_access = list("virology")
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "uQg" = (
@@ -86257,10 +86988,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "uSk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/area/station/maintenance/ghetto/aft)
 "uSA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -86271,15 +87003,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "uSG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "uST" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/effect/decal/cleanable/dirt,
@@ -86358,22 +87087,11 @@
 /turf/open/water,
 /area/station/maintenance/ghetto/garden)
 "uTL" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/security/cell/left/directional/north{
-	name = "Isolator";
-	req_access = list("medical")
-	},
-/obj/machinery/door/poddoor/shutters/window/preopen{
-	dir = 1;
-	id = "durka1"
-	},
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/door/window/brigdoor/security/cell/left/directional/south{
-	name = "Isolator"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/iron/cafeteria,
+/area/station/medical/break_room)
 "uTO" = (
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/iron,
@@ -86627,10 +87345,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "uYk" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "uYv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -86643,17 +87363,13 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/fore)
 "uYE" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/obj/machinery/button/door/directional/south{
-	id = "Psychological office";
-	name = "Medical Break Room Shutters Control";
-	normaldoorcontrol = 1;
-	specialfunctions = 4;
-	pixel_y = 24
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/flowers_yw,
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "uYI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -86679,19 +87395,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/prison)
 "uYN" = (
-/obj/item/storage/backpack/duffelbag/clown/cream_pie,
-/turf/open/floor/plating,
-/area/station/medical/morgue)
-"uYQ" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder{
-	pixel_y = 8
+/obj/structure/bed{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/green/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/item/toy/plush/shark,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/patients_rooms)
+"uYQ" = (
+/obj/effect/spawner/random/medical/patient_stretcher,
+/turf/open/floor/plating,
+/area/station/medical/abandoned)
 "uYT" = (
 /obj/structure/chair/stool{
 	dir = 4
@@ -86812,12 +87528,15 @@
 /turf/open/openspace,
 /area/station/science/xenobiology)
 "vaB" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/food_or_drink/cake_ingredients,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance"
+	},
+/turf/open/floor/plating,
+/area/station/medical/abandoned)
 "vaF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -86911,12 +87630,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "vbM" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "vbZ" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -87068,10 +87785,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "vey" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table,
+/obj/item/kitchen/spoon/plastic,
+/obj/item/knife/plastic{
+	pixel_x = 8
+	},
+/obj/item/kitchen/fork/plastic,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "veB" = (
@@ -87203,9 +87923,14 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/fore)
 "vga" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/machinery/camera{
+	c_tag = "Medbay Lobby";
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "vgg" = (
@@ -87245,6 +87970,26 @@
 /obj/effect/spawner/random/medical/minor_healing,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical/ghetto/morgue)
+"vgu" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/machinery/computer/records/medical/laptop{
+	pixel_y = 2;
+	dir = 4
+	},
+/obj/item/clipboard{
+	pixel_y = 3
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "vgG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -87325,13 +88070,23 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/ghetto)
 "vhF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
 	},
-/turf/open/floor/engine,
+/obj/structure/table/reinforced/rglass,
+/obj/item/clothing/glasses/science{
+	pixel_y = 10
+	},
+/obj/item/clothing/glasses/science{
+	pixel_y = 4
+	},
+/obj/item/clothing/glasses/science{
+	pixel_y = -2
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "vhH" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -87390,11 +88145,12 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "viK" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 2
+/obj/structure/table/reinforced/rglass,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/morgue)
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "viO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -87466,12 +88222,11 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "vjG" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/light/directional/south,
-/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "vjI" = (
@@ -87548,31 +88303,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "vkj" = (
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/o_plus{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/blood/o_minus,
-/obj/item/reagent_containers/blood/b_plus,
-/obj/item/reagent_containers/blood/b_minus,
-/obj/item/reagent_containers/blood/a_plus,
-/obj/item/reagent_containers/blood/a_minus,
-/obj/item/reagent_containers/blood/lizard,
-/obj/item/reagent_containers/blood/lizard,
-/obj/item/reagent_containers/blood/ethereal,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/freezer,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/effect/spawner/random/medical/memeorgans,
+/turf/open/floor/plating,
+/area/station/medical/abandoned)
 "vkn" = (
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/iron,
@@ -87596,13 +88331,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "vky" = (
-/obj/effect/turf_decal/tile/neutral/half,
-/obj/effect/turf_decal/tile/neutral/half,
-/obj/effect/turf_decal/tile/neutral/half,
-/obj/effect/turf_decal/tile/neutral/half,
-/obj/structure/sink/kitchen/directional/south,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "vkz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -87945,13 +88676,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "voi" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/obj/structure/table,
-/obj/item/folder/white,
-/obj/item/clothing/gloves/latex/nitrile{
-	pixel_y = 14
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
@@ -88033,10 +88759,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "vpo" = (
-/obj/effect/spawner/random/structure/grille,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/table/glass,
+/obj/item/stack/medical/mesh,
+/obj/item/stack/medical/suture,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "vpp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -88072,12 +88802,12 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/ghetto)
 "vpM" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
+/obj/machinery/chem_dispenser,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/obj/structure/cable,
-/obj/machinery/vending/drugs,
-/turf/open/floor/iron/white,
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/engine,
 /area/station/medical/pharmacy)
 "vpN" = (
 /obj/effect/turf_decal/tile/blue{
@@ -88318,6 +89048,7 @@
 /area/station/science/xenobiology)
 "vrL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "vrO" = (
@@ -88386,21 +89117,11 @@
 	},
 /area/station/commons/dorms)
 "vsB" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/structure/chair/office/light,
-/obj/machinery/button/door/directional/south{
-	id = "durka1";
-	name = "Isolator 1 Shutter Control";
-	pixel_x = -6
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/button/door/directional/south{
-	id = "durka2";
-	name = "Isolator 2 Shutter Control";
-	pixel_x = 6
-	},
-/obj/effect/landmark/start/psychologist,
-/turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/aft)
 "vsC" = (
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 4
@@ -88635,31 +89356,9 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "vuy" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/table/reinforced/rglass,
-/obj/item/reagent_containers/applicator/patch/aiuri{
-	pixel_x = 6
-	},
-/obj/item/reagent_containers/applicator/patch/aiuri{
-	pixel_x = 6;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/applicator/patch/aiuri{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/applicator/patch/libital{
-	pixel_x = -6
-	},
-/obj/item/reagent_containers/applicator/patch/libital{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/applicator/patch/libital{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/turf/open/floor/iron/white,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/departments/exam_room,
+/turf/open/floor/plating,
 /area/station/medical/treatment_center)
 "vuF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -88965,15 +89664,17 @@
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/starboard/fore)
 "vzt" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+/obj/machinery/lift_indicator/directional/north{
+	linked_elevator_id = "morgue_elevator"
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
+/obj/machinery/button/elevator/directional/north{
+	id = "morgue_elevator"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
+/area/station/medical/cryo)
 "vzv" = (
 /obj/structure/sign/warning/secure_area,
 /turf/closed/wall/r_wall,
@@ -89018,8 +89719,9 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "vzJ" = (
-/turf/closed/wall/r_wall,
-/area/station/medical/chemistry/ghetto)
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "vzM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -89301,17 +90003,17 @@
 /area/station/maintenance/starboard/fore)
 "vDy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "vDC" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -89499,10 +90201,11 @@
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
 "vGl" = (
-/obj/effect/turf_decal/tile/green/fourcorners,
-/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/chem_storage)
 "vGv" = (
 /obj/effect/spawner/structure/window,
 /obj/effect/mapping_helpers/damaged_window,
@@ -89523,13 +90226,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "vGD" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "vGI" = (
@@ -89564,17 +90263,17 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/checkpoint/customs)
 "vHh" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/sign/poster/official/safety_eye_protection/directional/north,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron/smooth,
+/area/station/medical/chemistry)
 "vHk" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red/fourcorners,
@@ -89585,22 +90284,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "vHl" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/light/directional/south,
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/south,
-/obj/machinery/camera/directional/south{
-	c_tag = "Medbay - Surgery Observation";
-	network = list("ss13","medbay")
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/duct,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/theatre)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "vHq" = (
 /obj/structure/broken_flooring/corner/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -89698,10 +90387,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/firealarm/directional/east,
 /obj/machinery/duct,
+/obj/machinery/airalarm/directional/east,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "vIG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -89927,9 +90617,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "vLb" = (
@@ -90147,6 +90834,9 @@
 /area/station/maintenance/starboard/aft)
 "vOU" = (
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "vPa" = (
@@ -90311,14 +91001,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "vRI" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/medical/morgue)
 "vRP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -90520,6 +91204,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
+"vUk" = (
+/obj/effect/landmark/start/chemist,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "vUs" = (
 /obj/machinery/vending/cola/blue,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -90537,17 +91225,12 @@
 /turf/open/floor/iron/white/corner,
 /area/station/service/kitchen/kitchen_backroom/ghetto)
 "vUI" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
-/obj/item/book/manual/wiki/grenades,
-/obj/item/book/manual/wiki/plumbing{
-	pixel_x = 5
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/obj/item/book/manual/wiki/chemistry{
-	pixel_x = 8
-	},
-/obj/structure/table,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
+/area/station/medical/psychology)
 "vVf" = (
 /obj/effect/turf_decal/box/red,
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -90557,7 +91240,7 @@
 /turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "vVi" = (
-/obj/machinery/photocopier/prebuilt,
+/obj/machinery/photocopier,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
@@ -90924,11 +91607,8 @@
 /turf/open/floor/engine/cult,
 /area/station/service/library)
 "vZT" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "vZV" = (
@@ -91027,6 +91707,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay/ghetto)
+"waQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chemistry)
 "wba" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -91385,6 +92069,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/commons/storage/primary)
+"wgx" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chemistry)
 "wgD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -91485,14 +92175,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "whx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
+/obj/effect/spawner/random/structure/chair_flipped{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard)
 "whz" = (
 /obj/machinery/door/window/right/directional/west{
 	name = "ChangKitchen"
@@ -91758,11 +92445,11 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "wjM" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance,
-/obj/effect/spawner/random/bureaucracy/pen,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/central)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "wka" = (
 /obj/structure/table/wood,
 /obj/item/book/random,
@@ -91871,10 +92558,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "wlQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
+/turf/open/floor/iron/white,
+/area/station/maintenance/aft)
 "wlR" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
@@ -91911,7 +92596,7 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/area/station/medical/medbay/central)
 "wmw" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
@@ -91969,16 +92654,21 @@
 /area/station/cargo/drone_bay/ghetto)
 "wnr" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "wnx" = (
-/obj/structure/chair/comfy/teal{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "wnH" = (
 /obj/machinery/mecha_part_fabricator,
 /turf/open/floor/iron/dark,
@@ -91995,15 +92685,8 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "wob" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/head/utility/welding,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/station/medical/chemistry/ghetto)
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "woc" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/spawner/random/structure/closet_maintenance,
@@ -92057,6 +92740,33 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/red,
 /area/station/commons/dorms/apartment1)
+"woV" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/obj/item/camera{
+	pixel_y = 4;
+	pixel_x = -3
+	},
+/obj/effect/turf_decal/tile/dark_blue/anticorner{
+	dir = 8
+	},
+/obj/item/toy/figure/coroner{
+	pixel_y = -3
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "woY" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
@@ -92085,8 +92795,11 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "wpy" = (
-/obj/effect/decal/cleanable/ash/large,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/table/reinforced,
+/obj/item/mop,
+/obj/structure/window/spawner/directional/south,
+/obj/structure/window/spawner/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "wpG" = (
@@ -92114,19 +92827,39 @@
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "wqe" = (
-/obj/machinery/atmospherics/components/binary/valve/on,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table,
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/psychology)
 "wqi" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/pill_bottle/mannitol,
+/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "wqj" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
@@ -92139,17 +92872,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/locker)
 "wqA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/poddoor{
+	elevator_mode = 1;
+	transport_linked_id = "morgue_elevator"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/break_room)
+/area/station/medical/cryo)
 "wqI" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -92174,12 +92902,12 @@
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "wrk" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "wrm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -92189,20 +92917,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "wro" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/obj/structure/table/glass,
-/obj/item/clothing/glasses/hud/health{
-	pixel_y = -2
-	},
-/obj/item/storage/belt/medical{
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_y = 10
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/paramedic)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/spawner/directional/west,
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/maintenance/two,
+/obj/item/folder,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "wrs" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/light/small/directional/south,
@@ -92285,6 +93006,21 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/break_room)
+"wsm" = (
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/virology,
+/obj/structure/cable,
+/obj/machinery/door/airlock/virology/glass{
+	name = "Test Subject Cell"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "wsn" = (
 /turf/open/floor/iron/stairs/right{
 	dir = 1
@@ -92352,17 +93088,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wtl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
+/obj/machinery/camera{
+	c_tag = "Virology Airlock";
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/flora/bush/sunny/style_random,
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "wtn" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/closet{
@@ -92388,7 +93120,10 @@
 /area/station/security/lockers)
 "wtF" = (
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
 /area/station/medical/pharmacy)
 "wtQ" = (
 /obj/structure/cable,
@@ -92424,20 +93159,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "wuA" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 4
+/obj/machinery/chem_master,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/obj/item/clothing/glasses/science{
-	pixel_y = -2
-	},
-/obj/item/clothing/glasses/science{
-	pixel_y = 4
-	},
-/obj/item/clothing/glasses/science{
-	pixel_y = 10
-	},
-/obj/structure/table/reinforced/rglass,
-/turf/open/floor/iron/white,
+/turf/open/floor/engine,
 /area/station/medical/pharmacy)
 "wuK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -92560,14 +93286,30 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/aft)
 "wvS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/firealarm/directional/west,
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/blood/o_plus{
+	pixel_x = -2;
+	pixel_y = -1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/reagent_containers/blood/o_minus,
+/obj/item/reagent_containers/blood/b_plus,
+/obj/item/reagent_containers/blood/b_minus,
+/obj/item/reagent_containers/blood/a_plus,
+/obj/item/reagent_containers/blood/a_minus,
+/obj/item/reagent_containers/blood/lizard,
+/obj/item/reagent_containers/blood/lizard,
+/obj/item/reagent_containers/blood/ethereal,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "wvT" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -92682,20 +93424,7 @@
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/department/security/ghetto)
 "wxM" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id = "quarantine";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/door/firedoor,
-/obj/machinery/computer/records/medical/laptop{
-	pixel_y = 2;
-	dir = 4
-	},
+/obj/machinery/computer/crew,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "wxY" = (
@@ -92927,12 +93656,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "wAw" = (
-/obj/machinery/shower/directional/east,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/structure/sink/directional/south,
+/obj/structure/mirror/directional/north,
+/turf/open/floor/iron/freezer,
+/area/station/medical/break_room)
 "wAG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -93088,12 +93815,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "wCb" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/vending/wardrobe/coroner_wardrobe,
-/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/small,
-/area/station/medical/morgue)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "wCj" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -93181,12 +93912,9 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "wCT" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "wCV" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
@@ -93398,11 +94126,17 @@
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
 "wFa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/bar/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/color/blue{
+	desc = "An old pair of nitrile gloves, with no sterile properties.";
+	name = "old nitrile gloves"
+	},
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/suit/apron/surgical,
+/obj/item/surgicaldrill,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/abandoned)
 "wFf" = (
 /obj/structure/chair/sofa/right/maroon{
 	dir = 4
@@ -93970,6 +94704,11 @@
 /obj/structure/chair/office,
 /turf/open/floor/wood,
 /area/station/service/library)
+"wMB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/medical,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "wMW" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/generic,
@@ -94379,11 +95118,9 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "wRS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/medical/chemistry/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "wRV" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 4;
@@ -94520,12 +95257,14 @@
 	},
 /area/station/engineering/atmos)
 "wTr" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/delivery/white{
-	color = "#52B4E9"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/storage)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "wTB" = (
 /obj/effect/decal/cleanable/crayon/rune4,
 /turf/open/floor/wood,
@@ -94592,8 +95331,13 @@
 /turf/open/floor/plating,
 /area/station/security/checkpoint/customs)
 "wUC" = (
-/turf/closed/wall,
-/area/station/medical/virology)
+/obj/machinery/iv_drip,
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "wUL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -94893,13 +95637,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "wYT" = (
-/obj/structure/cable,
-/obj/structure/table,
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "wYX" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -95153,12 +95896,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/aft)
 "xck" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 5
-	},
-/obj/machinery/requests_console/auto_name/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/virology)
 "xcl" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 8
@@ -95218,14 +95958,18 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "xdh" = (
-/obj/machinery/door/window/right/directional/west{
-	name = "Coroner"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "xdk" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -95247,15 +95991,22 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "xdt" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/structure/filingcabinet/chestdrawer,
+/obj/structure/bed{
+	color = "#8C3E00"
+	},
+/obj/item/toy/plush/moth{
+	name = "Dr. Moff"
+	},
+/obj/machinery/light/warm/no_nightlight/directional/east,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "xdu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/structure/bodycontainer/morgue,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "xdz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -95314,33 +96065,32 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "xeg" = (
-/obj/machinery/smartfridge/chemistry/virology/preloaded,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/light_switch/directional/north,
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/station/medical/chem_storage)
 "xeh" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 1
-	},
-/obj/item/reagent_containers/dropper{
-	pixel_y = -5
-	},
-/obj/item/reagent_containers/dropper{
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/dropper{
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/dropper{
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/dropper{
-	pixel_y = 11
-	},
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
 /obj/structure/table/reinforced/rglass,
+/obj/item/storage/bag/chemistry,
+/obj/item/storage/bag/chemistry,
+/obj/item/radio/headset/headset_med,
+/obj/item/radio/headset/headset_med,
+/obj/item/clothing/mask/gas{
+	pixel_y = 6
+	},
+/obj/item/clothing/mask/gas{
+	pixel_y = 6
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "xem" = (
@@ -95390,6 +96140,17 @@
 /obj/item/wrench,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/garden)
+"xeT" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/effect/spawner/random/trash/soap,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "xeU" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -95483,17 +96244,12 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/fore)
 "xfD" = (
+/obj/machinery/airalarm/directional/east,
+/obj/structure/closet/secure_closet/chemical,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'";
-	name = "Chemistry Cleaner";
-	pixel_y = 14
-	},
-/obj/structure/table/reinforced/rglass,
-/obj/machinery/airalarm/directional/east,
+/obj/item/construction/plumbing,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "xfI" = (
@@ -95727,18 +96483,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "xii" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "xim" = (
-/obj/machinery/vending/cola,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "xiu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -95907,13 +96662,29 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"xkj" = (
+"xkg" = (
 /obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/turf/open/floor/plating,
+/area/station/medical/virology)
+"xkj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes,
-/turf/open/floor/iron/smooth,
-/area/station/medical/chemistry/ghetto)
+/obj/structure/cable,
+/obj/machinery/light/small/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central)
 "xkk" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
@@ -96032,19 +96803,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "xmg" = (
-/obj/structure/table/glass,
-/obj/item/clipboard{
-	pixel_y = 3
-	},
-/obj/item/clothing/neck/stethoscope,
-/obj/item/clothing/neck/stethoscope{
-	pixel_y = 4
-	},
-/obj/item/clothing/neck/stethoscope{
-	pixel_y = 8
-	},
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron/white,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/poster/official/walk,
+/turf/open/floor/plating,
 /area/station/medical/medbay/lobby)
 "xmh" = (
 /obj/effect/spawner/structure/window,
@@ -96099,11 +96860,24 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "xmJ" = (
-/obj/structure/chair/office/light,
-/obj/effect/turf_decal/tile/green/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/machinery/light/directional/south,
+/obj/machinery/airalarm/directional/south,
+/obj/structure/rack,
+/obj/item/reagent_containers/cup/bottle/basic_buffer{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/cup/bottle/formaldehyde{
+	pixel_x = 1
+	},
+/obj/item/reagent_containers/cup/bottle/acidic_buffer{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/station/medical/chem_storage)
 "xmL" = (
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
@@ -96140,10 +96914,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "xnz" = (
@@ -96186,12 +96956,16 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "xnK" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
+/obj/structure/table,
+/obj/item/wheelchair{
+	pixel_y = -3
 	},
-/obj/item/kirbyplants/random,
+/obj/item/wheelchair,
+/obj/item/wheelchair{
+	pixel_y = 3
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/storage)
 "xnP" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -96326,9 +97100,15 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/fore)
 "xpY" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/showcase/machinery/oldpod{
+	desc = "An old NT branded sleeper, decommissioned after the lead acetate incident. None of the functional machinery remains inside.";
+	name = "decommissioned sleeper"
+	},
+/obj/effect/spawner/random/decoration/glowstick,
+/obj/effect/decal/cleanable/greenglow,
+/obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/plating,
-/area/station/medical/virology)
+/area/station/medical/abandoned)
 "xqb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -96585,6 +97365,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/sign/departments/xenobio/alt/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "xtG" = (
@@ -96679,9 +97462,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "xun" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 5
-	},
+/obj/effect/spawner/random/trash/soap,
+/obj/effect/spawner/random/structure/table_or_rack,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "xur" = (
@@ -96753,10 +97535,15 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/ghetto)
 "xvz" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/medical/chemistry/ghetto)
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "xvV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -97052,16 +97839,13 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "xyV" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/event_spawn,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/obj/machinery/holopad,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "xyZ" = (
 /obj/structure/bed/dogbed/runtime,
 /mob/living/basic/pet/cat/runtime,
@@ -97096,14 +97880,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "xzZ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 5
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
+/area/station/medical/psychology)
 "xAa" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -97118,10 +97900,7 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "xAi" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/turf/open/floor/engine,
 /area/station/medical/pharmacy)
 "xAl" = (
 /obj/structure/stairs/north,
@@ -97308,13 +98087,18 @@
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/department/security/ghetto)
 "xDo" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/security/cell/left/directional/north{
+	name = "Isolator";
+	req_access = list("medical")
 	},
-/obj/machinery/light_switch/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	dir = 1;
+	id = "durka1"
+	},
+/obj/machinery/door/window/brigdoor/security/cell/left/directional/south{
+	name = "Isolator"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "xDs" = (
@@ -97345,6 +98129,16 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"xDW" = (
+/obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "xEa" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/tram/warning{
@@ -97359,16 +98153,12 @@
 	},
 /area/station/service/bar/backroom/ghetto)
 "xEg" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/obj/machinery/vending/coffee,
 /obj/machinery/camera/directional/north{
 	c_tag = "Medbay - Waiting Room";
 	network = list("ss13","medbay")
 	},
-/obj/machinery/light_switch/directional/east{
-	pixel_x = 24
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
@@ -97462,15 +98252,11 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/transit_tube)
 "xFy" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/obj/structure/sign/poster/official/nanotrasen_logo/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/iron/smooth,
+/area/station/medical/chemistry)
 "xFz" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -97521,21 +98307,23 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "xGa" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/dropper{
-	pixel_y = -4
+/obj/item/reagent_containers/cup/bottle/carbon{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/cup/bottle/ethanol{
+	pixel_x = -5;
+	pixel_y = 3
 	},
 /obj/machinery/light/directional/north,
-/obj/item/reagent_containers/dropper,
-/obj/item/clothing/glasses/science{
-	pixel_y = 8
+/obj/structure/rack,
+/obj/item/reagent_containers/cup/bottle/chlorine{
+	pixel_x = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
 	},
-/obj/structure/reagent_dispensers/wall/virusfood/directional/north,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/chem_storage)
 "xGc" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron/dark/smooth_large,
@@ -97579,11 +98367,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "xGF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/stone,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/dark,
+/area/station/medical/surgery/theatre)
 "xGR" = (
 /obj/structure/sign/departments/medbay/alt/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -97601,6 +98393,11 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
+"xHd" = (
+/obj/item/storage/medkit/emergency,
+/obj/structure/table/glass,
+/turf/open/floor/iron/white,
+/area/station/medical/paramedic)
 "xHf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -97669,16 +98466,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "xIi" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/duct,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
-/area/station/medical/virology)
+/area/station/medical/chemistry)
 "xIm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -97742,11 +98533,13 @@
 /turf/open/openspace,
 /area/station/science/xenobiology)
 "xJl" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/structure/sink/directional/east,
+/obj/structure/mirror/directional/west,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/virology)
 "xJn" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/box/white/corners{
@@ -97774,9 +98567,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
 "xJM" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/small,
-/area/station/medical/morgue)
+/obj/structure/chair/comfy/teal{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/patients_rooms)
 "xJQ" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
@@ -97914,12 +98709,11 @@
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "xLq" = (
+/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit,
-/obj/effect/turf_decal/tile/bar/fourcorners,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "xLv" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 8
@@ -98008,11 +98802,8 @@
 /turf/open/floor/iron,
 /area/station/science/genetics)
 "xMB" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/turf/closed/wall,
+/area/station/medical/medbay/central)
 "xME" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/railing{
@@ -98145,11 +98936,10 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "xNK" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron/cafeteria,
+/area/station/medical/break_room)
 "xNQ" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/clothing/costume,
@@ -98333,16 +99123,31 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/abandoned)
 "xQn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder{
+	pixel_x = -1;
+	pixel_y = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = 3;
+	pixel_y = -8
 	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = -3;
+	pixel_y = -8
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_y = -6
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_y = -7
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/chemistry)
 "xQu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/cable,
@@ -98462,12 +99267,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "xRz" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/obj/machinery/washing_machine,
+/turf/open/floor/iron/cafeteria,
+/area/station/medical/break_room)
 "xRD" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -98556,10 +99358,15 @@
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/department/security/ghetto)
 "xTi" = (
-/obj/machinery/status_display/evac/directional/north,
-/obj/machinery/chem_dispenser,
-/turf/open/floor/iron/dark,
-/area/station/medical/chemistry/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "xTn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -98701,16 +99508,10 @@
 /turf/open/openspace,
 /area/station/science/xenobiology)
 "xUX" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/turf/open/floor/iron/cafeteria,
+/area/station/medical/break_room)
 "xVd" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
@@ -98770,14 +99571,21 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
 "xWl" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/storage/box/beakers{
+	pixel_y = 6;
+	pixel_x = -8
+	},
+/obj/item/storage/box/beakers{
+	pixel_y = 6;
+	pixel_x = 8
+	},
+/obj/item/storage/box/syringes{
+	pixel_y = -4
+	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/reagentgrinder{
-	pixel_x = -2;
-	pixel_y = 12
-	},
-/obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "xWm" = (
@@ -98795,6 +99603,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"xWq" = (
+/obj/machinery/door/airlock/medical/glass,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/storage)
 "xWy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -98871,8 +99689,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/item/reagent_containers/cup/glass/mug,
 /obj/machinery/light_switch/directional/north,
+/obj/item/storage/box/cups{
+	pixel_y = 2
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "xXN" = (
@@ -98906,10 +99726,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "xXW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/structure/transport/linear/public,
+/obj/machinery/elevator_control_panel/directional/west{
+	linked_elevator_id = "morgue_elevator";
+	preset_destination_names = list("2"="Morgue                                Deck", "3"="Cryo                                Deck")
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/station/medical/morgue)
 "xYb" = (
 /obj/structure/table/wood,
 /obj/item/phone{
@@ -98953,12 +99776,15 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
 "xYF" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+/obj/structure/light_construct/directional/north,
+/obj/structure/showcase/machinery/cloning_pod{
+	desc = "An old prototype cloning pod, permanently decommissioned following the incident.";
+	name = "decommissioned cloner"
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/theatre)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating,
+/area/station/medical/abandoned)
 "xYK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -99037,12 +99863,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "xZI" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/obj/structure/sign/warning/no_smoking/circle,
+/turf/closed/wall,
+/area/station/medical/paramedic)
 "xZM" = (
 /obj/effect/turf_decal/siding/thinplating_new/corner{
 	dir = 1
@@ -99063,12 +99886,12 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "xZX" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister{
-	anchored = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "xZZ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Port to Fuel Pipe";
@@ -99148,18 +99971,12 @@
 /turf/open/floor/eighties/red,
 /area/station/maintenance/port/aft)
 "yaU" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
 	},
-/obj/item/lighter{
-	pixel_x = -6
-	},
-/obj/item/storage/fancy/cigarettes/cigpack_robust{
-	pixel_x = 6
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/upper)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "ybc" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/iron/dark,
@@ -99196,6 +100013,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
+"ybK" = (
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/turf/open/floor/plating,
+/area/station/maintenance/aft)
 "ybN" = (
 /obj/machinery/atmospherics/components/tank/air,
 /turf/open/floor/plating,
@@ -99224,14 +100045,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "ycf" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/reagentgrinder{
-	pixel_x = -2;
-	pixel_y = 12
-	},
-/obj/structure/table/reinforced/rglass,
+/obj/machinery/chem_mass_spec,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "ycr" = (
@@ -99470,13 +100287,12 @@
 /turf/open/floor/plating,
 /area/station/security/warden)
 "yfI" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/structure/chair,
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/theatre)
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "yfK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
@@ -99544,6 +100360,21 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
+"ygQ" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/construction/plumbing{
+	pixel_y = -5
+	},
+/obj/item/construction/plumbing,
+/obj/machinery/camera/directional/north{
+	c_tag = "Medbay Chemistry Lab - North";
+	network = list("ss13","medbay")
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/medical/chemistry)
 "ygR" = (
 /obj/structure/sign/poster/contraband/random/directional/east,
 /turf/open/floor/plating,
@@ -99592,11 +100423,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "yhl" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/spawner/random/structure/table_or_rack,
 /turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/area/station/maintenance/aft)
 "yhq" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -99677,17 +100507,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "yiF" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/chem_dispenser,
+/obj/machinery/requests_console/auto_name/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/medical/chemistry)
 "yiG" = (
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
@@ -99720,18 +100543,29 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"yiT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/aft)
 "yiU" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/item/storage/bag/chemistry,
-/obj/item/storage/bag/chemistry,
-/obj/item/clothing/mask/gas{
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/item/reagent_containers/cup/beaker/large{
 	pixel_y = 6
 	},
-/obj/item/clothing/mask/gas{
+/obj/item/reagent_containers/cup/beaker/large{
 	pixel_y = 6
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_y = -1
 	},
 /obj/structure/table/reinforced/rglass,
-/turf/open/floor/iron/white,
+/turf/open/floor/engine,
 /area/station/medical/pharmacy)
 "yjk" = (
 /obj/structure/rack,
@@ -99810,11 +100644,7 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "ykl" = (
-/obj/structure/table/glass,
-/obj/machinery/fax{
-	fax_name = "Medical";
-	name = "Medical Fax Machine"
-	},
+/obj/machinery/computer/records/medical,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "ykp" = (
@@ -99827,7 +100657,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/effect/landmark/navigate_destination/med,
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayEntrance"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "ykC" = (
@@ -99923,13 +100766,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "ylp" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/curtain,
+/turf/open/floor/plating,
+/area/station/medical/virology)
 "ylv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -99954,22 +100795,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "ylP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/radio{
-	desc = "An old handheld radio. You could use it, if you really wanted to.";
-	icon_state = "radio";
-	name = "old radio";
-	pixel_y = 15
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = 3
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/kitchen)
+/turf/open/floor/grass,
+/area/station/medical/virology)
 "ylQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -131511,14 +132341,14 @@ mOI
 kMs
 gjQ
 mOI
+gNv
+tVi
+mOI
+fEd
+bCP
 jkS
-bcI
-lkr
-pgN
-dGY
-wjM
-qgk
-qUM
+rFd
+mOI
 vbK
 dIW
 fsE
@@ -131768,14 +132598,14 @@ mOI
 ebN
 fOS
 mOI
-gNv
-tVi
-mOI
-fEd
-bCP
-jkS
-rFd
-mOI
+hKj
+aFl
+cQG
+nGs
+ezI
+fkv
+hgA
+qUM
 vbK
 dIW
 baR
@@ -132008,31 +132838,31 @@ guN
 guN
 mOI
 mOI
-doz
-doz
-ceC
-doz
-doz
-doz
-doz
-ceC
-doz
-doz
+mOI
+mOI
+mOI
+mOI
+mOI
+mOI
+mOI
 ceC
 ceC
 ceC
+ceC
+doz
+doz
 mOI
 isK
-fOS
+wQH
 mOI
-hKj
-aFl
-cQG
-nGs
-ezI
-fkv
-hgA
-qUM
+fOx
+maq
+mOI
+jyX
+sxp
+rsJ
+qIs
+mOI
 ceC
 dIW
 fsE
@@ -132264,32 +133094,32 @@ liU
 eVb
 rqb
 bCC
-mOI
-mOI
-mOI
-mOI
-mOI
-mOI
-mOI
+bBe
+dEJ
+bBe
+bBe
+rqb
+mdv
+dlM
 mOI
 ceC
 vbK
 jEk
 vbK
 ceC
-vbK
+ceC
 mOI
-isK
-qak
+qFE
+dlM
 mOI
-fOx
-maq
-mOI
-jyX
-sxp
-rsJ
-qIs
-mOI
+gPR
+dGY
+lkr
+hgA
+kpJ
+cPv
+oWP
+qUM
 vbK
 dIW
 dIW
@@ -132521,32 +133351,32 @@ guN
 guN
 guN
 gJQ
-bBe
-dEJ
-bBe
-bBe
-rqb
-mdv
+pkq
+tXJ
+cbv
+naU
+mOI
+mOI
 dlM
 mOI
-doz
+ceC
 mOI
 jGX
 mOI
-doz
+ceC
 vbK
 mOI
-dGY
+eiK
 dlM
 mOI
-gPR
-dGY
-lkr
-hgA
-kpJ
-cPv
-oWP
-qUM
+ydo
+maq
+mOI
+lHm
+hPz
+gid
+gqN
+mOI
 vbK
 doz
 doz
@@ -132778,31 +133608,31 @@ doz
 doz
 guN
 mOI
-pkq
-tXJ
-cbv
-naU
 mOI
 mOI
-dlM
+mOI
+mOI
+mOI
+hzl
+tZn
 mOI
 doz
 mOI
 dGY
 mOI
-doz
+vbK
 vbK
 mOI
-cKf
-dlM
 mOI
-ydo
-maq
+tUK
 mOI
-lHm
-hPz
-gid
-gqN
+mOI
+mOI
+mOI
+mOI
+onS
+onS
+mOI
 mOI
 vbK
 doz
@@ -133034,14 +133864,14 @@ ceC
 ceC
 ceC
 ceC
+ceC
+ceC
+ceC
+ceC
+ceC
 mOI
-mOI
-mOI
-mOI
-mOI
-mOI
-hzl
-tZn
+laO
+dlM
 mOI
 mOI
 mOI
@@ -133050,16 +133880,16 @@ mOI
 mOI
 mOI
 mOI
-mOI
-sfe
-mOI
-mOI
-mOI
-mOI
-mOI
-onS
-onS
-mOI
+dGY
+dGY
+dGY
+dGY
+dGY
+fRL
+qAb
+fRL
+eiK
+nPs
 mOI
 ceC
 doz
@@ -133295,11 +134125,11 @@ doz
 doz
 doz
 doz
-doz
+ceC
 mOI
-qXM
+dGY
 cTa
-fjz
+jKW
 dlM
 dlM
 dlM
@@ -133309,12 +134139,12 @@ dlM
 dlM
 nWv
 gjQ
-isK
-nPs
-fRL
-qAb
-fRL
-cKf
+cuJ
+dlM
+jKW
+jKW
+dGY
+dGY
 dGY
 duo
 mOI
@@ -133544,32 +134374,32 @@ guN
 raA
 raA
 raA
-raA
-raA
-raA
 iZA
 iZA
+iZA
+iZA
+iZA
 doz
 doz
 doz
-doz
-mOI
 fAb
-uco
-mOI
-dvk
-mOI
-mOI
-mOI
-jKW
-kMs
-kMs
-kMs
-dGY
-kMs
+fAb
+fAb
+fAb
+fAb
+fAb
+fAb
+fAb
+fAb
+fAb
+fAb
+jar
+fAb
+fAb
+fAb
 dGY
 dVc
-isK
+gYx
 dGY
 dGY
 dGY
@@ -133809,37 +134639,37 @@ gnI
 iZA
 iZA
 doz
-doz
-mOI
-mOI
-mOI
-mOI
-dGY
-nPs
-pOC
-mOI
-jKW
+fAb
+tOz
+dDI
+mLP
+iPv
+qtE
+tEW
+lxE
+giT
+xDW
 hPk
 lxE
 tUe
+fMo
+fAb
 mOI
 mOI
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
+lBE
+mOI
+mOI
+mOI
+mOI
+mOI
+mOI
+mOI
+mOI
+fif
+fif
+fif
+fif
+fif
 rQp
 nBf
 fif
@@ -134066,37 +134896,37 @@ wFf
 mca
 iZA
 doz
-doz
-ceC
-ceC
-ceC
-mOI
-eXr
-pCC
-rMh
-mOI
-hJh
-mOI
-mOI
-mOI
-mOI
-doz
-vzJ
-kZe
-lBE
-oPj
-tEW
-tEW
-tEW
-tEW
-cVX
-atx
-hLw
 mNQ
-sHy
-hag
-gNY
-vzJ
+lMr
+uhf
+cFZ
+ikV
+eXr
+eXr
+eXr
+eXr
+eXr
+eXr
+eXr
+uix
+rAh
+fAb
+doz
+qUM
+lBE
+qUM
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
+doz
+doz
+doz
+fif
 xXv
 wfp
 fif
@@ -134322,38 +135152,38 @@ lJm
 uFT
 kDA
 iZA
-iZA
-ceC
-ceC
 doz
-ceC
-mOI
-mOI
-mOI
-mOI
-mOI
-jKW
-mOI
-ceC
+qtA
+neD
+aMv
+hLw
+ikV
+eXr
+eXr
+eXr
+vUk
+eXr
+eXr
+eXr
+uix
+xIi
+fAb
 doz
-hUE
-doz
-vzJ
-tpq
+qUM
 lBE
-whx
-wRS
-sux
-sux
-sux
-sux
-sux
-sux
-sux
-cyz
-sdK
-ttv
-vzJ
+qUM
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
+doz
+doz
+doz
+fif
 cmE
 bBN
 fif
@@ -134578,39 +135408,39 @@ qST
 nTj
 lPa
 cRy
-sFs
 iZA
 doz
-ceC
+fAb
+eGp
+dSO
+kEb
+shR
+eXr
+eXr
+eXr
+eXr
+eXr
+eXr
+waQ
+uix
+bcI
+fAb
 doz
-ceC
-doz
-doz
-doz
-doz
-mOI
-jKW
-mOI
-ceC
-doz
-hUE
-doz
-vzJ
-dxK
+qUM
 xkj
-eiK
-lcn
-sux
-sux
-sux
-sux
-sux
-sux
-sux
-sux
-kos
-cLk
-vzJ
+qUM
+ceC
+ceC
+ceC
+ceC
+ceC
+doz
+doz
+ceC
+doz
+doz
+doz
+fif
 xXv
 rQp
 fif
@@ -134834,40 +135664,40 @@ wjd
 pIw
 kTA
 kTA
-kTA
-uDD
+cRy
 iZA
-ceC
-ceC
 doz
-ceC
-ceC
-ceC
-ceC
-ceC
-mOI
-jKW
-mOI
-ceC
+fAb
+lwy
+fWo
+eXr
+eXr
+eXr
+eXr
+eXr
+eXr
+eXr
+eXr
+eXr
+kEb
+bcI
+fAb
 doz
-hUE
-doz
-vzJ
-nAb
-cKC
-sbF
-goV
+bDp
+rMh
 vRI
-eDZ
-eDZ
-eDZ
-eDZ
-eDZ
-eDZ
-eWD
-kos
-tZP
-vzJ
+vRI
+vRI
+vRI
+vRI
+ceC
+ceC
+ceC
+ceC
+doz
+doz
+doz
+fif
 xXv
 rQp
 fzk
@@ -135091,40 +135921,40 @@ wjd
 ckY
 kTA
 kTA
-eZs
-nTj
+lKp
 iZA
-ceC
-vbK
-vbK
-vbK
-vbK
-vbK
-mOI
-mOI
-mOI
-jKW
-mOI
-ceC
 doz
-hUE
-doz
-vzJ
-rAh
+fAb
+xFy
+dSO
+eXr
+eXr
+eXr
+eXr
+eXr
+rFp
+eDZ
+ixC
+eXr
+kEb
+bcI
+fAb
+bDp
+bDp
 cKC
-sbF
+vRI
 goV
 aKH
-aKH
-aKH
-bUL
-aKH
-aKH
-aKH
-xJl
-kos
-cLk
-vzJ
+jHx
+vRI
+aDt
+aDt
+aDt
+aDt
+doz
+doz
+doz
+fif
 xXv
 xXv
 fzk
@@ -135348,40 +136178,40 @@ eGy
 oqM
 cSk
 oRu
-eTo
-tCm
+cRy
 iZA
 doz
-job
-doz
-doz
-doz
-jEk
+fAb
+crw
+dSO
+eXr
+uMI
+abw
 ksr
-dGY
-fbN
-jKW
-qUM
-ceC
-vbK
-hUE
-ceC
-vzJ
+jvL
+qYS
+qYS
+lVp
+eXr
+kEb
+bcI
+fAb
 teg
-cKC
-sbF
+teg
+xdh
+vRI
 aKM
-sux
-sux
-sux
-sux
-sux
-sux
-sux
-sux
-kos
-cLk
-vzJ
+kea
+nAb
+vRI
+juA
+gEm
+kko
+aDt
+doz
+doz
+doz
+fif
 kPe
 vIH
 fzk
@@ -135607,38 +136437,38 @@ kOU
 iOg
 kDA
 iZA
-iZA
-ceC
-vbK
-vbK
-vbK
-vbK
-vbK
-mOI
-mOI
-mOI
-fof
-mOI
-ceC
-vbK
-ceC
-ceC
-vzJ
+doz
+mNQ
+bkn
+dSO
+rnC
+mWS
+eXr
+eXr
+eXr
+qYS
+qYS
+lVp
+eXr
+kEb
+bcI
+fAb
+xeT
 cye
-nBO
+cKC
 wCT
 tiu
-sux
-sux
-sux
-sux
-sux
-sux
-sux
-elG
-kos
-cLk
-vzJ
+rZW
+mQp
+uQa
+mHs
+mHs
+rDd
+aDt
+ceC
+doz
+doz
+fif
 xXv
 xXv
 fzk
@@ -135865,37 +136695,37 @@ gsW
 eIx
 iZA
 doz
-doz
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-mOI
-jKW
-mOI
-ceC
-vbK
-doz
-doz
-vzJ
+qtA
+sEm
+dSO
+eXr
+cLk
+jvL
+mia
+abw
+qYS
+qYS
+lVp
+eXr
+kEb
+yfI
+okh
+gUF
 idc
 xvz
 gMr
-hFR
+gRJ
 sVt
+pLp
+vRI
+dLq
 sux
-sux
-sux
-sux
-sux
-sux
-kos
-kos
-cLk
-vzJ
+tZP
+aDt
+ceC
+ceC
+ceC
+fif
 xXv
 xXv
 fif
@@ -136122,37 +136952,37 @@ iZA
 iZA
 iZA
 doz
-doz
-ceC
-doz
-doz
-doz
-doz
-doz
-doz
-mOI
-jKW
-mOI
-ceC
-vbK
-doz
-doz
-vzJ
+fAb
+sEm
+aQL
+eXr
+eXr
+eXr
+eXr
+eXr
+sDc
+oez
+udw
+eXr
+kEb
+xZX
+fAb
+wob
 xTi
-bPQ
-kae
+vky
+wCT
 uaZ
 pKc
-sux
-sux
-sux
-sux
-sux
-sux
-sux
-sux
-fKm
-vzJ
+coB
+vRI
+aDt
+jrM
+aDt
+aDt
+aDt
+ceC
+ceC
+fif
 fuD
 ooa
 fif
@@ -136371,45 +137201,45 @@ aPM
 cfm
 ejC
 raA
-raA
-raA
-raA
 iZA
 iZA
+iZA
+iZA
+iZA
 doz
 doz
-doz
-doz
-ceC
-doz
-doz
-doz
-doz
-doz
-doz
-mOI
-jKW
-mOI
-ceC
-vbK
-vbK
-doz
-vzJ
-mHs
+fAb
+fAb
+vHh
+aQL
+eXr
+eXr
+eXr
+eXr
+eXr
+eXr
+eXr
+eXr
+eXr
+kEb
+xZX
+fAb
+odT
+xTi
 wob
-tdr
-ljF
-tSq
-sVt
-sux
-sux
-sux
-sux
-sux
-sux
-sux
-cLk
-vzJ
+aDt
+aDt
+aDt
+aDt
+aDt
+xJl
+pRG
+sTU
+wvS
+aDt
+doz
+doz
+fif
 rQp
 wfp
 fif
@@ -136635,38 +137465,38 @@ doz
 doz
 doz
 doz
-doz
-doz
-ceC
-doz
-doz
-doz
-ceC
-ceC
-ceC
-qUM
-jKW
-mOI
-mOI
-mOI
-vbK
-doz
+fAb
+tfh
+bjo
+dSO
+wRS
+wgx
+eXr
+eXr
+eXr
+eXr
+eXr
+eXr
+nTm
+kEb
+amp
+fAb
 vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
+xTi
+tmL
+aDt
+chY
+gto
 hSo
 obP
-sux
-sux
-sux
-sux
-sux
-sux
-cLk
-vzJ
+oUd
+hFR
+dAX
+sFC
+flS
+vbK
+doz
+fif
 xXv
 pHj
 fif
@@ -136892,38 +137722,38 @@ ceC
 ceC
 ceC
 ceC
-ceC
-ceC
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-qUM
-jKW
-ksr
-dGY
-fbN
-jEk
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-vzJ
+fAb
+ygQ
+mGN
+bnm
+eXr
+eXr
+eXr
+eXr
+eXr
+eXr
+eXr
+eXr
+eXr
+eXr
+kpY
+fAb
+bDp
+dKk
+bDp
+aDt
+rrl
+kqJ
 xck
 jAR
 hFR
 hFR
 gDI
 qZe
-hFR
-mWk
-xnK
-vzJ
+flS
+vbK
+doz
+fif
 xXv
 tmK
 fif
@@ -137149,38 +137979,38 @@ doz
 doz
 doz
 doz
-ceC
-doz
-doz
-doz
-ceC
-doz
-doz
-doz
-doz
-qUM
-ujG
-mOI
-mOI
-mOI
-vbK
-doz
-doz
-doz
-doz
-doz
-doz
-vzJ
+fAb
+yiF
+pEZ
+yaU
+tWi
+tWi
+tWi
+tWi
+tlp
+eXr
+eXr
+eXr
+eXr
+eXr
+ugX
+fAb
+uPt
+xTi
+sbF
+aDt
+kos
+fqT
 fVL
 pBD
 iAJ
-rEd
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
+iAJ
+iAJ
+qZe
+flS
+vbK
+doz
+fif
 rQp
 wfp
 fif
@@ -137406,37 +138236,37 @@ ceC
 ceC
 ceC
 ceC
+fAb
+fGO
+cBQ
+tCm
+xQn
+dys
+mYN
+kYm
+rcZ
+kKc
+kKc
+mtX
+kKc
+kKc
+rJA
+fAb
+vky
+xTi
+wob
+aDt
+dTr
+dun
+xim
+bxD
+ilE
+koA
+fcj
+oWz
+aDt
 ceC
 doz
-doz
-doz
-ceC
-doz
-doz
-doz
-doz
-mOI
-jKW
-mOI
-ceC
-vbK
-vbK
-doz
-doz
-doz
-doz
-doz
-ceC
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vbK
-vbK
-ceC
-ceC
 fif
 xXv
 xXv
@@ -137661,38 +138491,38 @@ ceC
 ceC
 doz
 doz
-doz
-doz
 ceC
 doz
-doz
-doz
+fAb
+fAb
+mNQ
+mNQ
+mNQ
+fAb
+fAb
+fAb
+fAb
+fAb
+fAb
+fAb
+fAb
+fAb
+fAb
+fAb
+wob
+kjg
+glK
+aDt
+aDt
+pFE
+aDt
+aDt
+aDt
+aDt
+aDt
+aDt
+aDt
 ceC
-doz
-doz
-doz
-ceC
-mOI
-jKW
-mOI
-ceC
-vbK
-vbK
-vbK
-ceC
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-ceC
-doz
 doz
 fif
 cmE
@@ -137918,38 +138748,38 @@ ceC
 ceC
 doz
 doz
-doz
-doz
 ceC
 doz
 doz
 doz
+doz
+doz
+doz
+bDp
+wMB
+vky
+vky
+vky
+scC
+vky
+mdI
+vky
+vky
+fHo
+vky
+kjg
+rKi
+aDt
+sZR
+sYG
+nWA
+kae
+nfs
+bzn
+qED
+gmq
+qNP
 ceC
-doz
-doz
-doz
-ceC
-mOI
-jKW
-mOI
-ceC
-vbK
-doz
-doz
-ceC
-doz
-job
-doz
-doz
-job
-doz
-doz
-job
-doz
-doz
-vbK
-job
-job
 doz
 fif
 wfp
@@ -138175,38 +139005,38 @@ ceC
 vbK
 doz
 doz
-doz
-doz
-ceC
-doz
-doz
-doz
 ceC
 doz
 doz
 doz
 doz
-mOI
-jKW
-mOI
-ceC
-ceC
-vbK
-vbK
-ceC
-ceC
-ceC
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-ceC
 doz
+doz
+wCT
+vky
+lCk
+lCk
+lCk
+lCk
+lCk
+lCk
+lCk
+lCk
+lCk
+glK
+xTi
+wob
+aDt
+uxN
+jAR
+hFR
+rEd
+jUv
+hFR
+clY
+oPj
+qNP
+ceC
 doz
 fif
 wfp
@@ -138431,40 +139261,40 @@ vbK
 ceC
 vbK
 vbK
-vbK
-vbK
-vbK
-ceC
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-mOI
-mOI
-mOI
-jKW
-qUM
 ceC
 ceC
 doz
-qVj
-qVj
-qVj
-qVj
-qVj
+doz
+doz
+doz
+doz
+doz
+wCT
+vky
+lCk
+lrj
+dXp
+fYg
+woV
+uco
+wUC
+qXM
+lCk
+vky
+xTi
+vky
+aDt
+dXq
+tKx
+iAJ
+qZe
+ylp
+ylp
+ylp
+ylp
+aDt
 ceC
 doz
-doz
-doz
-doz
-doz
-ceC
-vbK
-vbK
-vbK
-vbK
 fif
 fif
 eNr
@@ -138689,40 +139519,40 @@ jEk
 vbK
 doz
 doz
-doz
-doz
 ceC
 doz
 doz
 doz
 doz
 doz
-jEk
-ksr
-dGY
+doz
+bDp
+eRN
+lCk
+cKE
 fbN
-jKW
-mOI
-ceC
-ceC
-ceC
-qVj
+uJP
+pgN
+jJh
+bgr
+fgl
+alX
 mTq
 cHV
 jEU
-qVj
+aDt
+crB
+jAR
+hFR
+rEd
+nXL
+hFR
+mYQ
+oPj
+flS
 ceC
 doz
-doz
-doz
-doz
-doz
 ceC
-ceC
-doz
-doz
-vbK
-doz
 fif
 xXv
 vIH
@@ -138945,41 +139775,41 @@ doz
 ceC
 vbK
 vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-mOI
-mOI
-mOI
+ceC
+ceC
+doz
+doz
+doz
+doz
+doz
+bDp
+bDp
+aYv
+lCk
+sfM
+sNS
 fof
-mOI
-ceC
-vbK
-ceC
-qVj
+ujG
+sRz
+jZU
+lOk
+lCk
 vky
 rqA
 hqD
-qVj
+aDt
+ilG
+dun
+bMO
+sdK
+nfs
+gPC
+rWq
+kQM
+flS
 ceC
-doz
-doz
-doz
-doz
-doz
 ceC
 ceC
-ceC
-doz
-vbK
-doz
 fif
 xXv
 ooa
@@ -139203,39 +140033,39 @@ ceC
 vbK
 doz
 doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-mOI
-jKW
-mOI
 ceC
-vbK
-ceC
-qVj
+doz
+doz
+doz
+bDp
+bDp
+bDp
+oew
+vky
+lCk
+uDD
+tdr
+hiQ
+uIF
+dbP
+sFs
+hnY
+lCk
 byg
-csD
+hhC
 nIk
-qVj
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-vbK
+aDt
+nfs
+wsm
+nfs
+aDt
+aDt
+aDt
+aDt
+aDt
+aDt
+doz
+doz
 ceC
 fif
 xXv
@@ -139453,46 +140283,46 @@ iaz
 aOR
 vwk
 bti
-doz
-doz
+ceC
+ceC
 vbK
 ceC
 vbK
 vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-mOI
-jKW
-qUM
 ceC
-vbK
-doz
-qVj
-qVj
+ceC
+ceC
+ceC
+ceC
+bDp
+dMF
+dcV
+oDP
+lCk
+lCk
+kZe
+hSq
+oJD
+qBf
+kZZ
+ttv
+bUL
+lCk
+bDp
 gpy
-qVj
-qVj
-qVj
+bPQ
+aDt
+mWk
 sGh
-sGh
-qVj
-qVj
+ufh
+hmg
+uYE
+aDt
+vbK
 vbK
 doz
 doz
 doz
-ceC
-ceC
 ceC
 fif
 fuD
@@ -139715,41 +140545,41 @@ doz
 doz
 ceC
 txs
-siJ
-siJ
-siJ
-siJ
-siJ
-siJ
-siJ
-siJ
-siJ
-siJ
-siJ
-siJ
-siJ
-siJ
-jKW
-mOI
-ceC
-vbK
 doz
-qVj
+doz
+ipz
+ipz
+ipz
+ipz
+ipz
+ipz
+ipz
+ocH
+lCk
+oTG
+xdu
+xdu
+xdu
+xdu
+xdu
+bee
+bBw
+lCk
 mZd
 csD
-pqx
-qVj
+sHy
+aDt
 kdc
-xii
-xii
+fdc
+hpv
 gVD
-qVj
+dmG
+qVM
+qqM
+vbK
+vbK
 vbK
 doz
-doz
-doz
-vbK
-ceC
 doz
 fif
 rQp
@@ -139763,19 +140593,19 @@ rQp
 tGu
 khQ
 gYJ
-opS
-xXv
-xXv
-xXv
+nHH
+gmX
+gmX
+gmX
 oKn
-xXv
-xXv
-xXv
-xXv
-xXv
-neY
-fif
-doz
+gmX
+gmX
+gmX
+gmX
+gmX
+eFQ
+fjz
+hFE
 doz
 doz
 doz
@@ -139972,39 +140802,39 @@ doz
 doz
 ceC
 vbK
-siJ
-uJP
+doz
+doz
+ipz
 gbZ
-gbZ
-mtX
+qTP
 hYw
 qPF
-uSk
+qTP
 bGl
-sEm
-cBQ
+qTP
+lCk
 huF
 mDR
-siJ
-jKW
-mOI
-ceC
-vbK
-doz
-qVj
+mDR
+iJZ
+mDR
+rik
+jnm
+noU
+lCk
 muc
 xLq
 qNJ
 gIU
 avs
 xii
-xii
+nBO
 cys
 qVj
-vbK
-doz
-doz
-doz
+xkg
+bPs
+bPs
+nYZ
 vbK
 doz
 fif
@@ -140229,39 +141059,39 @@ doz
 vbK
 ceC
 vbK
-siJ
-qVM
-qFE
-bGl
-odT
-eQb
-sJc
-lSt
-sLQ
+doz
+doz
+hRA
+whx
+cwi
+cwi
+cwi
+cwi
+cwi
 apz
 meC
-meC
-gEj
+cBr
 tlu
-jKW
-mOI
-ceC
-cfT
-ceC
-qVj
-bOW
+tlu
+nFH
+eTo
+eTo
+lhZ
+beN
+lCk
+nGp
 nGp
 pqx
-coB
+aDt
 wtl
-xii
+qak
 gNZ
 ylP
-qVj
+mWk
+aDt
 vbK
-doz
-doz
 vbK
+sJc
 fif
 fif
 fif
@@ -140288,7 +141118,7 @@ tLJ
 etx
 etx
 xXv
-fif
+fzk
 doz
 doz
 doz
@@ -140486,44 +141316,44 @@ doz
 vbK
 ceC
 vbK
-siJ
-gEm
-gbZ
-gbZ
-gbZ
-xGF
-uSk
-uSk
-xdu
-xdu
-gbZ
-meC
-cKE
-siJ
-jKW
-qUM
-ceC
-vbK
-ceC
-qVj
-dTr
-wFa
+doz
+doz
+hRA
+qTP
+cwi
+ipz
+ipz
+ipz
+ipz
+ipz
+lCk
+lCk
+lCk
+lCk
+gEj
+vbM
+ner
+lhZ
+qof
+lCk
 bDp
-qVj
-yiF
-xQn
-xii
+bDp
+bDp
+aDt
+aDt
 qNP
-qVj
+qNP
+qNP
+aDt
+aDt
+ceC
 vbK
-doz
-doz
-jEk
-gJc
-xXv
-bRL
-xXv
-xXv
+cGK
+ugS
+gmX
+qSs
+gmX
+yiT
 vkn
 fif
 wfp
@@ -140743,44 +141573,44 @@ ceC
 ceC
 ceC
 vbK
-siJ
-bnm
-bGl
-gbZ
-pUM
-qpJ
-sJc
-maI
-lSt
-iwo
-rwC
+doz
+doz
+hRA
+qTP
+cwi
+ipz
+ceC
+ceC
+ceC
+ceC
+lCk
 xXW
-hnY
+syU
 siJ
-jKW
-mOI
+dKd
+mOE
+mOE
+lhZ
+qof
+lCk
+ceC
+ceC
+ceC
+ceC
 ceC
 vbK
-doz
-qVj
-vaB
-dys
-kPk
-uYk
-pLp
-lfw
-xii
-gVD
-qVj
 vbK
-doz
-doz
+vbK
+ceC
+ceC
+ceC
+vbK
 vbK
 fif
 fif
 fif
 wch
-rQp
+vsB
 rQp
 fif
 fif
@@ -141000,36 +141830,36 @@ oFI
 ipz
 ceC
 vbK
-siJ
-dyq
-gbZ
-gbZ
+doz
+doz
+ipz
+brP
 uub
-gbZ
-bzn
-bGl
-odT
-gPC
-meC
-meC
+ipz
+ceC
+ceC
+doz
+doz
+lCk
+qFH
 syU
 siJ
-jKW
-mOI
+iBz
+iiS
+lZv
+fVJ
+cNT
+lCk
 ceC
-vbK
 doz
-qVj
-ugX
-chY
-pEZ
-uYk
-qQb
-hjg
-xii
-xim
-qVj
-vbK
+doz
+ceC
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -141037,7 +141867,7 @@ ceC
 ceC
 fif
 fif
-xXv
+uSk
 xXv
 fif
 vXi
@@ -141256,45 +142086,45 @@ ipz
 qTP
 ipz
 ceC
-doz
-siJ
-aIh
-jJh
-wqi
-qtw
-qYS
-ufh
-gbZ
-iqs
-glK
-meC
-meC
-sEm
-siJ
-jKW
-mOI
-ceC
-ipz
-ipz
-qVj
-wYT
-sZN
-okh
-qVj
-hmg
-hjg
-gmX
-qof
-qVj
-vbK
-vbK
-vbK
-ceC
-ceC
 ceC
 doz
+doz
+ipz
+xmv
+cwi
+ipz
+ceC
+doz
+doz
+doz
+lCk
+lCk
+lCk
+lCk
+lCk
+lCk
+lCk
+lCk
+lCk
+lCk
+ceC
+doz
+doz
+ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
+ceC
+ceC
 fif
-rQp
+vsB
 wfp
 fif
 pmr
@@ -141305,7 +142135,7 @@ kDW
 wiD
 ocX
 fif
-dLc
+nRH
 etx
 bZr
 bZr
@@ -141513,45 +142343,45 @@ ipz
 fHl
 ipz
 ipz
-doz
-siJ
-tlu
-tlu
-siJ
+ceC
+ceC
+hRA
+hRA
+ipz
 oef
-siJ
-fMF
-tlu
-tlu
-siJ
-ntv
-siJ
-siJ
-siJ
-toV
 ipz
-ipz
-ipz
-dcV
-qVj
-qVj
-dIb
-qEP
-qVj
-qVj
-qKG
-wlQ
-qVj
-qVj
-iYR
-iYR
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 vbK
-job
+vbK
+vbK
+vbK
+ceC
+ceC
+ceC
+ceC
+doz
 doz
 ceC
 doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
 fif
-cmE
+sZN
 vIH
 wJT
 hpg
@@ -141561,8 +142391,8 @@ iuG
 gyV
 kwo
 ocX
-dLc
-dLc
+gNY
+fMF
 etx
 jNy
 jyC
@@ -141776,33 +142606,33 @@ vIX
 dmA
 wBP
 cwi
-cwi
-cwi
-cwi
-cwi
-ayj
-cwi
-qTP
 ipz
-qTP
-rik
-cwi
-bjo
-cwi
-cwi
-cwi
-cwi
-cwi
-cwi
-cwi
-cSQ
-cSQ
-cSQ
-cSQ
-cSQ
-cSQ
-iYR
-vbK
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 ceC
@@ -142033,39 +142863,39 @@ jrb
 qTP
 qTP
 cwi
-kEb
 ipz
-ipz
-ipz
-ipz
-cwi
-cwi
-gYx
-dpz
-cwi
-qTP
-ipz
-ipz
-ipz
-ipz
-oDP
-qTP
-ker
-ipz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
+doz
 iYR
 iYR
 iYR
 iYR
 iYR
-cSQ
 iYR
-vbK
+doz
 doz
 doz
 ceC
 doz
 fif
-rQp
+vsB
 kPe
 fif
 tNY
@@ -142075,7 +142905,7 @@ rvu
 lBj
 eZq
 fif
-dLc
+wTr
 etx
 ksf
 bDa
@@ -142291,30 +143121,30 @@ adQ
 woL
 cwi
 ipz
-hUE
 doz
 doz
-ipz
-ipz
-ipz
-ipz
-ipz
-ipz
-ipz
-ipz
+doz
+doz
+doz
+doz
+doz
 doz
 ceC
-ipz
-ipz
-oFI
-ipz
-ipz
+ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
 doz
 iYR
 lMT
 tNT
 qqN
-cSQ
+fKk
 iYR
 ceC
 ceC
@@ -142554,24 +143384,24 @@ doz
 doz
 doz
 doz
-vbK
-vbK
-vbK
-vbK
 doz
 doz
 ceC
+ceC
 doz
-ipz
-qTP
-ipz
+doz
+doz
+doz
+doz
+doz
+doz
 ceC
 doz
 iYR
 key
 gdj
 ktZ
-cSQ
+fKk
 iYR
 fif
 fif
@@ -142815,13 +143645,13 @@ doz
 doz
 ceC
 ceC
-doz
-doz
-vbK
-doz
-ipz
-fHl
-ipz
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
 ceC
 ceC
 iYR
@@ -143062,6 +143892,12 @@ jwl
 gEZ
 qVL
 ipz
+ceC
+ceC
+ceC
+ceC
+ceC
+doz
 doz
 doz
 ceC
@@ -143070,15 +143906,9 @@ ceC
 doz
 doz
 doz
-ceC
-ceC
-ceC
 doz
 doz
 doz
-vbK
-jEk
-vbK
 doz
 doz
 iYR
@@ -197559,13 +198389,13 @@ oBG
 smv
 rTb
 htt
-dRA
-dRA
-dRA
-dRA
-dRA
-dRA
-dRA
+vsP
+vsP
+vsP
+vsP
+vsP
+vsP
+vsP
 rIR
 lXF
 kot
@@ -197822,7 +198652,7 @@ dBT
 mIp
 oHZ
 hgF
-dRA
+vsP
 rIR
 aua
 kot
@@ -198079,7 +198909,7 @@ tgC
 qoy
 lpS
 cJV
-dRA
+vsP
 rIR
 uUr
 uUr
@@ -198334,9 +199164,9 @@ gAd
 hFx
 jvS
 djk
-gIs
+lfw
 kJW
-dRA
+vsP
 jct
 hXT
 hXT
@@ -198584,15 +199414,15 @@ whC
 fKw
 fKw
 fKw
-fKw
+siy
 eeX
 uAy
 jSn
 iRy
 kOJ
-trI
 fNX
-gIs
+fNX
+fNX
 pvJ
 jct
 iVN
@@ -198841,8 +199671,8 @@ qoM
 smv
 oje
 oje
+lSt
 oje
-bdx
 jyH
 vsP
 pyM
@@ -198850,7 +199680,7 @@ gLB
 ije
 xdt
 gIs
-dRA
+vsP
 pob
 dGv
 jct
@@ -199096,27 +199926,27 @@ awq
 awq
 awq
 dVg
-dVg
 jUz
+jyF
 cmQ
 anJ
-jUz
+dVg
+vsP
+vsP
+rwC
 vsP
 vsP
 vsP
 vsP
 vsP
-adz
-dRA
-dRA
+lWD
 kot
-kot
-dRA
+hfU
 dRA
 dRA
 dRA
 nVk
-qyb
+hXT
 psY
 hXT
 iCA
@@ -199353,26 +200183,26 @@ bhZ
 evE
 awq
 tmG
-rTs
+dbo
 vGD
 cXl
 fEy
-dbo
-gto
-dVg
+tDs
+vsP
+ioA
 oFy
 vUI
-dVg
+fRZ
 xDo
 swA
+oZf
 vsP
-crB
 jVq
-uTL
-mtY
-uix
+htZ
+axs
 dRA
 hzY
+fOH
 dJE
 dpa
 hXT
@@ -199600,37 +200430,37 @@ nke
 xhv
 awq
 rZO
-dBA
-axs
-iEl
 vSF
+vSF
+iEl
 sgT
+pOi
 fbX
 nFc
 uMQ
-pCP
+awq
 noj
 kNW
 oMC
-ezv
+pEJ
 tKt
-aXV
-vzt
-cbw
-jar
-kiz
-dVg
-tDs
-moo
+cyz
 vsP
-brN
-yhl
+cUp
+mtY
+kiz
+pUM
 smD
 wDJ
-dSO
+tpq
+vsP
+fiY
+wlQ
+oae
 dRA
 dRA
-uhf
+dRA
+fbB
 kot
 kot
 dRA
@@ -199861,7 +200691,7 @@ qix
 pFq
 gVi
 bXw
-tvQ
+flO
 flO
 flO
 kdU
@@ -199876,18 +200706,18 @@ cQO
 cbw
 pjd
 jRz
-dVg
-xFy
-nwH
-kea
-ylp
+wqe
+vsP
+vsP
+vsP
+vsP
 fxe
-vsP
-vsP
-vsP
+iqs
+ybK
 dRA
-hrb
-mzO
+toL
+htZ
+htZ
 mMK
 iaj
 vgJ
@@ -200112,40 +200942,40 @@ vOa
 ghD
 nke
 ckR
-awq
+igl
 ycf
 vhH
 vZT
+khh
 vSF
-tSk
 vSF
 vSF
 voU
 uPs
 skq
-ezv
+brN
 fIE
-fiY
+ezv
 ezv
 kvh
 lci
-nWA
+vsP
 haT
-uHq
+voi
 hPQ
-dVg
-koA
-vsB
-vey
-crH
-yhl
+pUM
 qyI
 wDJ
-fdc
+vey
+vsP
+yhl
+aIW
+bzO
 dRA
-bkn
+oiR
+hXT
 tiz
-mdI
+nCd
 nCd
 wyy
 dRA
@@ -200369,7 +201199,7 @@ vOa
 dXc
 nke
 ckR
-cuJ
+igl
 eAC
 cUf
 wnr
@@ -200379,27 +201209,27 @@ mMF
 xfD
 tnw
 snz
-awq
+qwB
 xEg
-vHh
-ezv
+fIE
 rQW
-fgl
 aRV
-hfU
-dVg
+aRV
+uEt
+vsP
+nkU
 xzZ
 lkX
-dVg
+scl
 psB
 voi
+cqM
 vsP
-fMo
-scl
-bfK
+hJh
+hXT
 pTn
-dun
 dRA
+wro
 nfX
 ctR
 toL
@@ -200626,28 +201456,27 @@ iEr
 ckR
 nke
 ckR
-cuJ
+awq
 vpM
 wtF
-wtF
+kQI
 yiU
 jPJ
 jPJ
 jPJ
 jPJ
 jPJ
-jPJ
-lcZ
+dBA
+toV
 fwl
-jyF
 cFr
+ljF
 aeX
-kZZ
-aeX
-dVg
-dVg
-dVg
-dVg
+lcZ
+lcZ
+gLx
+gLx
+gLx
 cJm
 cJm
 cJm
@@ -200656,10 +201485,11 @@ cJm
 cJm
 cJm
 cJm
-dRA
+cJm
+mTv
 iHs
 cnG
-aJW
+toL
 coR
 hUZ
 dRA
@@ -200892,19 +201722,18 @@ jPJ
 nCS
 mOh
 sHx
-wro
-gqk
+eng
+kkO
 tVB
 rLY
-oOp
 hkd
+ihX
 aJA
 pQC
-irP
-gLx
+lcZ
+myh
 rwq
-aMv
-mia
+rwq
 cJm
 eHg
 ktT
@@ -200913,10 +201742,11 @@ iKu
 hiB
 xvV
 gve
-dRA
+cJm
+htZ
 pTY
 wpy
-rJA
+jPM
 nCd
 hXT
 myz
@@ -201148,20 +201978,19 @@ igl
 jPJ
 pyz
 byc
-cqc
 cOn
-beN
+pCP
 kPF
+rqK
 vKW
-lqQ
-jUv
-oIA
+oOp
+oOp
 tkj
-nfs
-gLx
+fac
+lcZ
+rok
 lnZ
 pki
-sqv
 nHJ
 jlW
 dpI
@@ -201170,10 +201999,11 @@ efv
 kJD
 qjV
 jlW
-dRA
+cJm
+aIh
+hXT
 hVC
 bOo
-dfK
 wyy
 mge
 dsZ
@@ -201406,19 +202236,18 @@ eng
 aQK
 ren
 oCm
-mNe
 gqk
-sNS
-jxk
-qFH
-hkd
+eEz
+oOp
+vKW
+oOp
+oOp
 lqQ
 ahj
 nHf
-cRd
-yfI
-spc
-lVp
+lju
+oZN
+qvR
 nHJ
 gkB
 lZi
@@ -201427,11 +202256,12 @@ dKS
 yjy
 oSk
 prX
+cJm
 dRA
 dRA
 dRA
-dRA
-cqM
+sfe
+htZ
 htZ
 dsZ
 nVk
@@ -201660,22 +202490,21 @@ ptS
 sdA
 fid
 eng
-jvL
+mNe
 grZ
-grZ
-grZ
+xHd
 eng
+ojL
 nBq
 rTc
 iFy
 ePA
 sZA
 nNt
-lKp
-gLx
-hFE
-oZN
-lVp
+lcZ
+orz
+spc
+oNZ
 nHJ
 ejV
 wkN
@@ -201684,10 +202513,11 @@ eBv
 naF
 qRI
 hii
-dRA
-eBS
+cJm
+pjb
 xmP
 dRA
+hXT
 trD
 tGL
 dRA
@@ -201916,23 +202746,22 @@ jcf
 ptS
 sdA
 fWP
-sqQ
-pJi
+eng
+eng
 hZO
-flS
+eng
 xZI
 lgR
-iKn
-jxk
+oOp
+dyq
 eXQ
 rnL
-ocH
+oOp
 cYo
 vuy
 lju
-yfI
 oZN
-isI
+rTo
 kpu
 wsp
 gXC
@@ -201941,15 +202770,16 @@ wBk
 wBk
 oUL
 mYz
-hpN
-hpN
-hpN
-hpN
-hpN
-hpN
-hpN
-hpN
-hpN
+sNP
+sPX
+sPX
+sPX
+sPX
+sPX
+sPX
+sPX
+sPX
+dEB
 xRY
 tUP
 hpN
@@ -202174,22 +203004,21 @@ rAn
 jbx
 urf
 vga
-sdA
-nkU
+uHq
+pJi
 rPE
-bVk
-aQL
+qaT
 nXk
+oOp
 jxk
 brn
 pnT
-ewZ
-cYo
-iFU
-oew
+oOp
+oLl
+tSk
 tqI
 oZN
-oJD
+dIb
 cJm
 nAz
 tJc
@@ -202200,13 +203029,14 @@ uHg
 rrp
 sNP
 vTc
+atx
 sXY
-adh
+moo
 nDg
 adh
-sXY
 vri
-hpN
+sPX
+iCA
 nGm
 hXT
 hpN
@@ -202435,7 +203265,7 @@ omG
 omG
 jTC
 ykx
-rcZ
+qLa
 qLa
 mPB
 nAh
@@ -202443,15 +203273,14 @@ ujO
 ewZ
 lAc
 bON
-bzO
 lRR
+isI
 oJQ
-vHl
 cJm
 cJm
 cJm
 cJm
-kLF
+cJm
 kLF
 kLF
 kLF
@@ -202463,7 +203292,8 @@ ncI
 ncI
 ncI
 qpb
-hpN
+sPX
+iCA
 nGm
 iCA
 hpN
@@ -202685,25 +203515,24 @@ uiL
 rqF
 ixz
 pzr
-jbx
+jYl
 vrL
 oWu
-sdA
+hDR
 aNh
-rPE
-nfS
-aQL
+hrb
+pCC
 bAL
-hMX
-brn
+oOp
+jxk
 dbj
-ewZ
-kRj
+ntv
+oOp
 iFU
-cUp
+sLQ
 uRn
 oZN
-oJD
+eWD
 kLF
 ovf
 pQP
@@ -202715,12 +203544,13 @@ utD
 nKm
 wLq
 cDm
-wTr
+itj
 cDm
-fqT
+xnK
 cDm
-ikV
-hpN
+jDU
+sPX
+hXT
 lLm
 iCA
 alC
@@ -202942,25 +203772,24 @@ uiL
 dIk
 qNg
 sdA
-sdA
+bfK
 gMN
-kQI
-hDR
-ixz
+dJK
+vgu
+sEn
 nfS
 ahI
 lgR
-iKn
+oOp
 hMX
 cdC
 iAq
-vbM
+oOp
 kRj
-tmL
+vuy
 lju
-yfI
 oZN
-jnm
+miu
 vzM
 tgj
 oMe
@@ -202973,11 +203802,12 @@ nKm
 ttZ
 acp
 kdD
-eGp
+elG
 ksy
 qOo
-dmG
-hpN
+sqv
+sPX
+hXT
 mgS
 hXT
 alC
@@ -203201,23 +204031,22 @@ lyK
 sdA
 dNF
 pwS
-dJK
+ptj
 wxM
 pOm
 tpv
 dJK
 pbQ
 pvv
-jxk
+iKn
 fOE
 oSQ
-bXj
-kRj
-pyo
-gLx
-eSO
+uJF
+qol
+lcZ
+sNp
 dUK
-iPv
+xGF
 hne
 amF
 wtQ
@@ -203227,14 +204056,15 @@ atE
 vqB
 jCv
 nKm
-lWD
+iZR
 tCQ
 fWR
 hIT
 leN
 grl
 oGQ
-hpN
+sPX
+htZ
 eWX
 hXT
 alC
@@ -203456,25 +204286,24 @@ tfQ
 dJK
 sPC
 ixz
-nfS
+hoX
 loc
 nTe
 ykl
 qNY
 qTS
 xmg
-ptj
 uhN
-jxk
-mOE
-uQg
+oOp
+vKW
+oOp
+oOp
 uJF
 gTc
-iFU
-cRd
-yfI
+nHf
+lju
 oZN
-iPv
+kmU
 hne
 qvd
 hgo
@@ -203484,14 +204313,15 @@ xkb
 mqH
 cim
 nKm
-rok
+pOC
 tCQ
 tCQ
 tCQ
 kXX
 grl
 yfn
-hpN
+sPX
+aJW
 nGm
 dEB
 hpN
@@ -203717,21 +204547,20 @@ pCr
 tHE
 jFQ
 ulS
-iDh
+sdA
 ijK
 bui
 qqd
 xnq
 tRu
-uJF
-qBf
-oIA
+oOp
+oOp
 blI
 tAR
-gLx
-jHx
+lcZ
+qtw
 oZN
-iPv
+dfK
 hne
 iNk
 rJd
@@ -203747,8 +204576,9 @@ fXR
 udm
 dtf
 eOK
-aIW
-hpN
+bVS
+sPX
+iCA
 nGm
 hXT
 hpN
@@ -203976,19 +204806,18 @@ dip
 tue
 kzH
 jdd
-eIq
-ptj
-nTm
-qtE
-oOp
+dJK
+rTs
+bAL
+vKW
 uQg
+mOH
 aHf
 dnz
-ihX
-gLx
-xYF
-pKO
-itj
+lcZ
+qgk
+oZN
+ihG
 kLF
 rBm
 wGi
@@ -204002,10 +204831,11 @@ sPX
 xeu
 ybu
 jGv
-gUF
+xWq
 xeu
 sPX
-hpN
+sPX
+hXT
 eYv
 hXT
 hpN
@@ -204234,18 +205064,17 @@ dJK
 dJK
 dJK
 dJK
-dJK
 lcZ
+nwH
 mSJ
-jyF
 cFr
+ljF
 aeX
-kZZ
-aeX
-gLx
-mTv
-oZN
-oLl
+lcZ
+lcZ
+gqS
+pKO
+hag
 kLF
 kLF
 kLF
@@ -204255,14 +205084,15 @@ kLF
 nKm
 nKm
 nKm
-dXq
+tSq
+twT
+twT
 sqG
-sqG
-alU
+gbq
 rRN
 hzQ
 iUw
-sEn
+hXT
 mgS
 jVT
 hpN
@@ -204491,7 +205321,7 @@ tuq
 iNF
 cZU
 cCS
-lCk
+qfV
 ftE
 kEh
 qbQ
@@ -204500,26 +205330,26 @@ cMi
 lQJ
 sqG
 alU
-bBw
-qbQ
+tzr
+adz
 fCK
 tzr
+twT
+twT
+twT
+twT
+twT
 sqG
 twT
 alU
-sqG
-sqG
-alU
-sqG
-sqG
-bBw
-qbQ
+tzr
+wjM
 kzZ
 jMQ
 eOq
 eWU
 bdn
-sDc
+hXT
 xLh
 etY
 hpN
@@ -204746,14 +205576,14 @@ jFQ
 jFQ
 qpO
 pJY
-xJM
+bkF
 qvy
 gLa
 gXf
 wms
 oRS
 krJ
-krJ
+pMa
 krJ
 krJ
 krJ
@@ -204769,14 +205599,14 @@ upv
 upv
 upv
 upv
-pOi
+upv
 vIE
 ihS
-jYl
+upv
 jmB
 iyG
 xMB
-dRA
+hXT
 nGm
 tGQ
 hpN
@@ -204995,25 +205825,25 @@ nrH
 fHn
 nke
 ckR
-lCk
-oBv
+nOm
+lfM
 uYN
-lCk
+dCQ
 luY
 sVE
 jXc
 xJM
 pKC
-iJZ
+nOm
 adA
 jDR
 cMB
 tnR
 jDR
-nnU
+jDR
 nnU
 rOZ
-htm
+xoo
 xoo
 ues
 ndZ
@@ -205025,15 +205855,15 @@ mXM
 mXM
 mXM
 xoo
-aDt
-aDt
-aDt
-aDt
-aDt
+jfx
+tvQ
+xMB
+xMB
+yeD
 gCn
-alX
-gCn
-dRA
+yeD
+yeD
+yeD
 fFW
 knd
 hpN
@@ -205252,25 +206082,25 @@ nrH
 nYw
 nke
 ckR
-lCk
-uYN
+nOm
+cNQ
 oBv
-lCk
+mPJ
 nhZ
 bri
-tOz
+pJY
 pBE
-hiQ
-dKk
+pyo
 adA
+oCy
 hIG
 qWw
-pMa
-neD
+qOg
+qOg
+lOV
 nnU
-pPG
 elu
-htm
+xoo
 chc
 wdz
 jvO
@@ -205283,14 +206113,14 @@ xyZ
 xmN
 xoo
 xeg
-sTU
-sTU
-uxN
-aDt
+blx
+oFB
+jfx
+uTL
 owG
-pFE
-dDI
-dRA
+saM
+bvA
+yeD
 nGm
 aOV
 hpN
@@ -205509,25 +206339,25 @@ cbP
 btr
 iur
 lSF
-lCk
-lCk
-lCk
-lCk
-lCk
-lCk
+nOm
+eSO
+kPk
+dCQ
+nhZ
+oaU
 wCb
 ces
 pyi
-jDU
-adA
+dhQ
+wqi
 bRT
 fgr
+maI
 qOg
-fWo
+dvk
 nnU
-pPG
 qOt
-htm
+xoo
 mjM
 ykG
 rZS
@@ -205542,12 +206372,12 @@ xoo
 iCv
 blx
 ubr
-uIF
+jfx
 ueU
-xNK
-fys
+bOW
+fKm
 ruV
-dRA
+yeD
 nGm
 aOV
 iCA
@@ -205766,25 +206596,25 @@ sSA
 qFS
 iur
 fUh
-lCk
-mPJ
-mPJ
-mPJ
+nOm
+crq
+crq
+nOm
 kVP
 mZE
-kmU
-abw
+nOm
 crq
-bVS
-dhQ
+crq
+adA
+irP
 jZz
 blT
 kdz
 vjG
+kCr
 nnU
-nNa
 uBe
-htm
+xoo
 fsl
 qoT
 dgi
@@ -205799,12 +206629,12 @@ xoo
 xGa
 vGl
 xmJ
-sfM
-ueU
+jfx
+axu
 xNK
 fys
 gXP
-dRA
+yeD
 aoD
 pIh
 prz
@@ -206023,25 +206853,25 @@ cbP
 uap
 iur
 ckR
-lCk
+nOm
 hGP
 wrk
-oaU
+dCQ
 uSG
 qze
-qze
-qze
-mPJ
-kjg
+dCQ
+wYT
+cWF
 adA
-bRT
-orz
-qOg
+adA
+adA
+adA
+vzt
 gNQ
+sqQ
 nnU
-dIf
-lpq
-htm
+uBe
+xoo
 fiJ
 mcn
 sYg
@@ -206054,14 +206884,14 @@ wwS
 vTG
 xoo
 iPC
-rqK
-gTy
-oTG
-ueU
-xNK
-fys
+vGl
+sRi
+jfx
+eBS
+crH
+xUX
 nUh
-dRA
+yeD
 nGm
 hXT
 hXT
@@ -206280,25 +207110,25 @@ cbP
 jtW
 iur
 ckR
-lCk
+nOm
 cNQ
-xdh
+oBv
 rfx
 pKo
+dxK
 mPJ
-mPJ
-mPJ
+nhZ
 bhy
-kjg
 adA
+qQb
 peT
-kQM
+wqA
 mvr
 lmq
+vpo
 nnU
-uBe
 jgy
-htm
+xoo
 ged
 erS
 aYE
@@ -206313,12 +207143,12 @@ xoo
 ofC
 dNO
 ubt
-fYg
-aDt
+jfx
+lcn
 xRz
 xUX
-lOk
-dRA
+wvI
+yeD
 hHe
 nGm
 hXT
@@ -206537,45 +207367,45 @@ cbP
 uap
 iur
 xhv
-lCk
+nOm
 viK
 lJc
-dKd
+dCQ
 xyV
 fwy
 dCQ
-fwy
+qpJ
 ucd
-mGN
-yeD
+adA
+peT
 thB
 wqA
-thB
-yeD
+kgd
+cqc
+oIA
 nnU
-lpq
-htm
-htm
-htm
-htm
-htm
-htm
-htm
-htm
+elu
 xoo
 xoo
 xoo
 xoo
 xoo
-wUC
-wUC
+xoo
+xoo
+xoo
+xoo
+xoo
+xoo
+xoo
 jfx
-wUC
-aDt
-aDt
+jfx
+jfx
+jfx
+yeD
+yeD
 cbm
-aDt
-hpN
+yeD
+yeD
 dRA
 rlp
 dRA
@@ -206794,32 +207624,32 @@ cbP
 uap
 iur
 ckR
-lCk
-rDd
 nOm
-lhZ
+nOm
+nOm
+nOm
 buy
-qze
-qze
-qze
-mQp
-qaT
-yeD
-uYE
-dbP
-saM
-bvA
+nOm
+nOm
+nOm
+nOm
+adA
+adA
+adA
+adA
+adA
+puw
+adA
 nnU
+elu
 nPZ
-htm
-uHT
 xun
-ppe
-uHT
+htm
+fiK
 awe
-xun
-htm
-eEz
+ppe
+fiK
+uwa
 uGN
 sTP
 xpY
@@ -206828,11 +207658,11 @@ tVF
 lKe
 qWx
 quL
-aDt
+yeD
 wAw
-xIi
+mXp
 jpT
-hpN
+yeD
 oTM
 bsf
 aSI
@@ -207051,45 +207881,45 @@ qjt
 uap
 iur
 tHA
-lCk
-sjf
-kko
-tUK
-qtp
-mPJ
-mPJ
-mPJ
-qze
-qaT
-yeD
-clY
-kFF
-gbq
-wnx
 nnU
+sjf
+hkP
 nPZ
+qtp
+nPZ
+luc
+dIf
+kYb
+uGd
+nNa
+nnU
+kFF
+nPZ
+wnx
+lpq
+rKJ
+elu
+nPZ
+ejY
 htm
-uHT
+fiK
 ruR
 gAg
-uHT
-lzQ
-aYv
 fiK
-qtA
-oCy
-oUd
+lzQ
+ruR
+sTP
 kFp
 kEz
 umf
-umf
+puQ
 tDV
 pwF
 qxT
 dba
 mXp
 ddK
-hpN
+yeD
 qVI
 njy
 xHy
@@ -207308,45 +208138,45 @@ uCV
 pdA
 iur
 ckR
-lCk
-qze
-qze
-qze
+trI
+unT
+unT
+cVX
 nPb
 pdc
 kds
-oWz
-fVJ
+kds
+kds
 uvq
-yeD
+cRd
 dic
-qqM
+uvq
 oOE
 stV
-nnU
+qKG
 bIa
-htm
+uta
 uHT
+nPZ
+htm
+fiK
 ruR
 oyk
 qMf
 uwa
-uEt
-htm
-aDt
 ljJ
-aDt
-aDt
+sTP
+xYF
 dsq
 uqs
 uYQ
 fLX
 hIA
-aDt
+sTP
 bpx
 npt
 pTw
-hpN
+yeD
 dRA
 qAq
 vjI
@@ -207567,43 +208397,43 @@ rWB
 lGE
 nnU
 nnU
-nnU
-nnU
-kKc
-nnU
-nnU
-nnU
-nnU
-nnU
-nnU
-kqJ
-wvS
-wvI
-lMr
-nnU
-lpq
 htm
+htm
+htm
+htm
+htm
+htm
+htm
+htm
+htm
+htm
+nnU
+aUZ
+bgG
+luc
+pPG
+hjg
 fzv
+fJB
+htm
+pTa
 dgp
 ikW
-xZX
+hMV
 krL
 lzQ
-hMV
-kEA
-uQa
 sbf
-kFp
+wFa
 uaw
 gTy
-tKx
-dLq
+puQ
+aWA
 amN
-htm
-htm
-htm
-htm
-htm
+sTP
+yeD
+yeD
+yeD
+yeD
 hHC
 itB
 kHC
@@ -207823,40 +208653,40 @@ kkl
 kkl
 sKd
 nnU
-nNa
-nPZ
-hkP
-rKi
-fOH
 luc
+luc
+luc
+luc
+luc
+luc
+luc
+luc
+luc
+luc
+htm
+nqw
 nPZ
-nPZ
-nPZ
-nnU
-nnU
-ioA
-nnU
-nnU
-nnU
-nPZ
+bgG
+iwo
+pPG
+vHl
+uHT
+lpq
 htm
 jan
 veB
-lfM
+eQb
 wBZ
 qAi
 jGA
-htm
-sRz
-oiR
-fcj
-xpY
+sTP
+bdx
 rCF
 hDp
 rFm
 aWA
 vkj
-htm
+sTP
 rVq
 rjp
 css
@@ -208079,41 +208909,41 @@ sKd
 sKd
 kkl
 avQ
-rFp
-unT
-unT
-unT
-oZf
-pjb
-pjb
-pjb
-pjb
-tWi
-lrj
-lrj
-rWq
+nnU
+luc
+luc
+luc
+luc
+luc
+luc
+luc
+luc
+luc
+luc
+htm
+pTa
 fcd
-amp
-bxW
+bgG
+gXm
 oqa
+uYk
+uHT
+nPZ
 htm
 nqw
 nPZ
 ikW
 nPZ
 pyY
-nPZ
-htm
-htm
-htm
-htm
-htm
-htm
-htm
-htm
-htm
-htm
-htm
+eIq
+sTP
+sTP
+sTP
+sTP
+sTP
+vaB
+sTP
+sTP
 qRE
 tnr
 fZm
@@ -208338,37 +209168,37 @@ kkl
 bMM
 nnU
 nnU
-kYb
-uta
-hFm
-hFm
-gqS
-hFm
-vpo
-fGO
-hFm
-hFm
+luc
+luc
+luc
+luc
+luc
+luc
+luc
+luc
+luc
+htm
 oAw
-nFH
 lpq
-lpq
+bgG
+eit
 fJB
-lOV
-wqe
+bgG
+uHT
 bCK
 mpF
 tqC
 tsA
 fpz
 rnF
-qJE
+dpz
 qJE
 rzl
 lhE
 iuy
 nnU
 rIv
-hSq
+qJE
 rIv
 nnU
 mlU
@@ -208604,20 +209434,20 @@ htm
 htm
 htm
 htm
-nnU
-bgG
-nPZ
-luc
-nPZ
-ugS
 htm
-yaU
+mtm
+nPZ
+bgG
+lpq
+luc
+iDh
+uHT
 jLm
-iiS
+htm
 nyB
 rYl
 kcM
-htm
+oUI
 uuk
 qJE
 rzl
@@ -208625,7 +209455,7 @@ fNH
 aaz
 biB
 nPZ
-nPZ
+qJE
 nPZ
 nnU
 rzl
@@ -208861,34 +209691,34 @@ stA
 rkL
 kYH
 htm
-pTa
+htm
 pjT
-nPZ
+hQm
+bgG
+rua
 nnU
-mtm
-eFQ
+kEA
+uHT
+xXq
 htm
 htm
 htm
 htm
 htm
 htm
-htm
-htm
-luc
-qJE
-nnU
-nnU
+bXj
 nnU
 nnU
+nnU
+nnU
 nPZ
-nPZ
-nPZ
-nPZ
-nPZ
-nPZ
-nPZ
-luc
+qEP
+qEP
+qEP
+ker
+mzO
+qEP
+qEP
 nPZ
 nPZ
 eWp


### PR DESCRIPTION
## Что этот PR делает

Большой ремап меда и рнд с прилегающими техами. Добавлена комната отдыха для пациентов в меде, морг с вирусологией пересены на нижний этаж, расширена нижняя химия, добавлен заброшенный мед и комната запасных химикатов, кабинет психолога внесен в мед (частично).
Разделение от рнд, чтобы все было не так плохо с проверкой.
Гитхаб ишуе произошел, новый пр старого ремапа.

## Почему это хорошо для игры

Приближаем огромную коробку к более понятной и удобной.

## Изображения изменений

![StrongDMM-2025-04-23 17 43 48](https://github.com/user-attachments/assets/a2d83b01-df5e-4820-aaac-685d4975301b)
![StrongDMM-2025-04-23 17 43 56](https://github.com/user-attachments/assets/dd272bf5-2e1a-4659-9aae-5697de378bfb)

## Тестирование

Локалка

## Changelog

:cl:
map: Кибериада: ремап Меда
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
