### PR TITLE
load player donator level before prefs init, properly read admin flags on prefs creation, fix cult ascended threshold usage

### DIFF
--- a/code/__HELPERS/admin.dm
+++ b/code/__HELPERS/admin.dm
@@ -2,9 +2,18 @@
 /proc/is_admin(client/client)
 	return !isnull(GLOB.admin_datums[client.ckey]) || !isnull(GLOB.deadmins[client.ckey])
 
+/// BANDASTATION ADIITION START - Loadout
+/// Returns admin rights player has, REGARDLESS of if they're deadminned or not.
+/proc/get_player_admin_flags(client/client)
+	if(CONFIG_GET(flag/enable_localhost_rank) && client.is_localhost())
+		return R_EVERYTHING
+
+	var/datum/admins/holder = GLOB.admin_datums[client.ckey] || GLOB.deadmins[client.ckey]
+	return holder?.rank_flags()
+/// BANDASTATION ADIITION END - Loadout
+
 /// Sends a message in the event that someone attempts to elevate their permissions through invoking a certain proc.
 /proc/alert_to_permissions_elevation_attempt(mob/user)
 	var/message = " has tried to elevate permissions!"
 	message_admins(key_name_admin(user) + message)
 	log_admin(key_name(user) + message)
-

--- a/code/modules/antagonists/cult/datums/cult_team.dm
+++ b/code/modules/antagonists/cult/datums/cult_team.dm
@@ -55,7 +55,7 @@
 	/// BANDASTATION EDIT START - Cult thresholds rebalance
 	var/highpop_thresold_reached = alive >= CULT_HIGHPOP_THRESHOLD
 	var/cult_risen_threshold = highpop_thresold_reached ? CULT_RISEN_HIGHPOP : CULT_RISEN_LOWPOP
-	var/cult_ascended_threshold = highpop_thresold_reached ? CULT_RISEN_HIGHPOP : CULT_RISEN_LOWPOP
+	var/cult_ascended_threshold = highpop_thresold_reached ? CULT_ASCENDENT_HIGHPOP : CULT_ASCENDENT_LOWPOP
 	var/ratio = alive ? cultplayers / alive : 1
 	/// BANDASTATION EDIT END - Cult thresholds rebalance
 
@@ -78,7 +78,7 @@
 		/// BANDASTATION ADDITION START - Cult rebalance
 		priority_announce(
 			text = "Мы фиксируем активность из другого измерения, связаную с культом \"Nar'Sie\" на вашей станции. \
-				Согласно нашей информации, [ratio * 100]% экипажа станции были порабощены культом. \
+				Согласно нашей информации, [floor(ratio * 100)]% экипажа станции были порабощены культом. \
 				Сотрудники службы безопасности наделены правом беспрепятственно применять летальную силу против культистов. \
 				Остальному экипажу надлежит приготовиться защищать себя и свои отделы, не ведя охоту на культистов. \
 				Погибшие члены экипажа должны быть реанимированы и деконвертированы, как только ситуация будет взята под контроль.",

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -260,6 +260,10 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		persistent_client.byond_build = byond_build
 		persistent_client.byond_version = byond_version
 
+	if(SScentral.can_run())
+		SScentral.get_player_discord_async(ckey)
+		SScentral.update_player_donate_tier_blocking(src)
+
 	if(byond_version >= 516)
 		winset(src, null, list("browser-options" = "find,refresh,byondstorage"))
 

--- a/code/modules/client/persistent_client.dm
+++ b/code/modules/client/persistent_client.dm
@@ -39,11 +39,19 @@ GLOBAL_LIST_EMPTY_TYPED(persistent_clients, /datum/persistent_client)
 	/// World.time this player last died
 	var/time_of_death = 0
 
+	/// BANDASTATION ADDITION START - SScentral
+	/// Discord of the player
+	var/discord_id
+	/// Ckey of the player
+	var/ckey
+	/// BANDASTATION ADDITION END - SScentral
+
 /datum/persistent_client/New(ckey, client)
 	src.client = client
 	achievements = new(ckey)
 	GLOB.persistent_clients_by_ckey[ckey] = src
 	GLOB.persistent_clients += src
+	src.ckey = ckey /// BANDASTATION ADDITION - SScentral
 
 /datum/persistent_client/Destroy(force)
 	SHOULD_CALL_PARENT(FALSE)

--- a/code/modules/loadout/loadout_preference.dm
+++ b/code/modules/loadout/loadout_preference.dm
@@ -34,10 +34,6 @@
 /datum/preference/loadout/proc/sanitize_loadout_list(list/passed_list, datum/preferences/preferences) as /list
 	var/list/sanitized_list
 	/// BANDASTATION ADDITION START - Loadout
-	var/loadout_owner = preferences.parent?.mob
-	if(!loadout_owner)
-		return null
-
 	var/total_points_spent = 0
 	var/points_cap = preferences.get_loadout_max_points()
 	var/donator_level = preferences.parent.get_donator_level()
@@ -46,7 +42,7 @@
 		// Loading from json has each path in the list as a string that we need to convert back to typepath
 		var/obj/item/real_path = istext(path) ? text2path(path) : path
 		if(!ispath(real_path, /obj/item))
-			to_chat(loadout_owner, span_boldnotice("The following invalid item path was found \
+			to_chat(preferences.parent, span_boldnotice("The following invalid item path was found \
 				in your character loadout: [real_path || "null"]. \
 				It has been removed, renamed, or is otherwise missing - \
 				You may want to check your loadout settings."))
@@ -55,7 +51,7 @@
 
 		var/datum/loadout_item/loadout_item = GLOB.all_loadout_datums[real_path] /// BANDASTATION ADDITION - Loadout
 		if(!istype(loadout_item, /datum/loadout_item))
-			to_chat(loadout_owner, span_boldnotice("The following invalid loadout item was found \
+			to_chat(preferences.parent, span_boldnotice("The following invalid loadout item was found \
 				in your character loadout: [real_path || "null"]. \
 				It has been removed, renamed, or is otherwise missing - \
 				You may want to check your loadout settings."))
@@ -64,7 +60,7 @@
 		/// BANDASTATION ADDITION START - Loadout
 		if(loadout_item.donator_level > donator_level)
 			to_chat(
-				loadout_owner,
+				preferences.parent,
 				span_boldnotice(\
 					"Ваш донат уровень ([donator_level]) недостаточен для [loadout_item.name] \
 						с уровнем [loadout_item.donator_level]. Предмет убран из снаряжения." \
@@ -74,7 +70,7 @@
 
 		if(loadout_item.cost + total_points_spent > points_cap)
 			to_chat(
-				loadout_owner,
+				preferences.parent,
 				span_boldnotice(\
 					"У вас недостаточно очков ([points_cap - total_points_spent]) \
 						для [loadout_item.name] за [loadout_item.cost] очков. Предмет убран из снаряжения." \

--- a/modular_bandastation/loadout/code/client.dm
+++ b/modular_bandastation/loadout/code/client.dm
@@ -28,9 +28,9 @@
 	return max(donator_level, get_donator_level_from_admin())
 
 /client/proc/get_donator_level_from_admin()
-	if(!holder)
+	var/rank_flags = get_player_admin_flags(src)
+	if(!rank_flags)
 		return BASIC_DONATOR_LEVEL
-	var/rank_flags = holder.rank_flags()
 	if(rank_flags & R_EVERYTHING)
 		return MAX_DONATOR_LEVEL
 	if(rank_flags & R_ADMIN)

--- a/modular_bandastation/metaserver/_metaserver.dme
+++ b/modular_bandastation/metaserver/_metaserver.dme
@@ -2,6 +2,5 @@
 
 #include "code/admin.dm"
 #include "code/discord_link.dm"
-#include "code/donate.dm"
 #include "code/interview.dm"
 #include "code/ss_central.dm"

--- a/modular_bandastation/metaserver/code/discord_link.dm
+++ b/modular_bandastation/metaserver/code/discord_link.dm
@@ -1,21 +1,7 @@
-/datum/persistent_client
-	var/discord_id
-	var/ckey
-
-/datum/persistent_client/New(ckey, client)
-	. = ..()
-	src.ckey = ckey
-
 /datum/preferences/vv_edit_var(var_name, var_value)
 	if(var_name == "discord_id")
 		return FALSE
 	return ..()
-
-/client/New()
-	. = ..()
-	if(!SScentral.can_run())
-		return
-	SScentral.get_player_discord_async(ckey)
 
 /mob/dead/new_player/register_for_interview()
 	. = ..()

--- a/modular_bandastation/metaserver/code/donate.dm
+++ b/modular_bandastation/metaserver/code/donate.dm
@@ -1,5 +1,0 @@
-/client/New()
-	. = ..()
-	if(!SScentral.can_run())
-		return
-	SScentral.update_player_donate_tier_async(src)


### PR DESCRIPTION
## Что этот PR делает

closes https://github.com/ss220club/BandaStation/issues/1379
closes https://github.com/ss220club/BandaStation/issues/1377

## Changelog

:cl:
fix: Лодаут теперь снова сохраняется между раундами
fix: Админам корректно выдает очки лодаута при деадмине и при заходе на сервер
fix: Порог появления нимбов у культа использовал неправильное значение
/:cl: