### PR TITLE
Toy Swine Fix

### DIFF
--- a/modular_bandastation/objects/code/items/pig.dm
+++ b/modular_bandastation/objects/code/items/pig.dm
@@ -6,8 +6,8 @@
 	inhand_icon_state = "pig"
 	lefthand_file = 'modular_bandastation/objects/icons/mob/inhands/pig_lefthand.dmi'
 	righthand_file = 'modular_bandastation/objects/icons/mob/inhands/pig_righthand.dmi'
-	attack_verb_continuous = list("хрюкает", "верещит")
-	attack_verb_simple = list("хрюкает", "верещит")
+	attack_verb_continuous = list("хрюкает")
+	attack_verb_simple = list("хрюкаете")
 	squeak_override = list('modular_bandastation/objects/sounds/oink.ogg' = 1)
 	w_class = WEIGHT_CLASS_SMALL
 	resistance_flags = FLAMMABLE


### PR DESCRIPTION
## Что этот PR делает

Фиксит мой косяк с написание текстом удара(Вы хрюкает себя с помощью той пиг на Вы хрюкаете себя с помощью пиг той).
Также удаляет вариант удара *верещит* 

## Почему это хорошо для игры

Фиксы это хорошо

## Изображения изменений

## Тестирование

Локалка

## Changelog

:cl:
typo: Исправлен текст удара игрушечной свиньи
del: Удалена текстовая версия удара (верещит) игрушечной свиньи 
/:cl:

## Обзор от Sourcery

Изменение глаголов атаки для предмета "игрушечный поросёнок" для исправления текстового описания и удаления альтернативного глагола атаки.

Исправления ошибок:
- Исправлено текстовое описание для действия атаки игрушечного поросёнка.

Мелкие задачи:
- Удалено 'верещит' (squeals) из списка глаголов атаки.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modify the attack verbs for the toy pig item to correct a text description and remove an alternative attack verb

Bug Fixes:
- Corrected the text description for the toy pig's attack action

Chores:
- Removed 'верещит' (squeals) from the attack verb list

</details>