### PR TITLE
standartize pigs as toy

### DIFF
--- a/code/_globalvars/arcade.dm
+++ b/code/_globalvars/arcade.dm
@@ -72,4 +72,5 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	/obj/item/clothing/glasses/trickblindfold = 2,
 	/obj/item/clothing/mask/party_horn = 2,
 	/obj/item/storage/box/party_poppers = 2,
+	/obj/item/toy/plush/pig = 1, /// BANDASTATION ADDITION - Pig toy
 ))

--- a/code/game/objects/effects/spawners/random/entertainment.dm
+++ b/code/game/objects/effects/spawners/random/entertainment.dm
@@ -277,6 +277,7 @@
 		/obj/item/toy/plush/abductor = 3,
 		/obj/item/toy/plush/abductor/agent = 3,
 		/obj/item/toy/plush/shark = 3,
+		/obj/item/toy/plush/pig = 2, /// BANDASTATION ADDITION - Pig toy
 		// super rare plushies
 		/obj/item/toy/plush/bubbleplush = 2,
 		/obj/item/toy/plush/ratplush = 2,

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -8,6 +8,7 @@
 	attack_verb_simple = list("thump", "whomp", "bump")
 	w_class = WEIGHT_CLASS_SMALL
 	resistance_flags = FLAMMABLE
+	var/use_delay_override /// BANDASTATION EDIT: add `use_delay_override`
 	var/list/squeak_override //Weighted list; If you want your plush to have different squeak sounds use this
 	var/stuffed = TRUE //If the plushie has stuffing in it
 	var/obj/item/grenade/grenade //You can remove the stuffing from a plushie and add a grenade to it for *nefarious uses*
@@ -43,7 +44,7 @@
 
 /obj/item/toy/plush/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/squeak, squeak_override)
+	AddComponent(/datum/component/squeak, squeak_override, use_delay_override = use_delay_override) /// BANDASTATION EDIT: add `use_delay_override`
 	AddElement(/datum/element/bed_tuckable, mapload, 6, -5, 90)
 	AddElement(/datum/element/toy_talk)
 

--- a/modular_bandastation/objects/_objects.dme
+++ b/modular_bandastation/objects/_objects.dme
@@ -72,7 +72,6 @@
 #include "code/items/storage/grenade_box.dm"
 #include "code/items/storage/id_stickers_box.dm"
 #include "code/items/storage/paper_spray_box.dm"
-#include "code/items/supply_packs.dm"
 #include "code/items/storage/tape_box.dm"
 #include "code/items/weapons/melee/centcom/baseball_bat.dm"
 #include "code/items/weapons/melee/centcom/rapier.dm"

--- a/modular_bandastation/objects/code/items/pig.dm
+++ b/modular_bandastation/objects/code/items/pig.dm
@@ -1,6 +1,6 @@
 /obj/item/toy/plush/pig
 	name = "pig toy"
-	desc = "Капитан Дементий! Тащи свиней! Экипажу нужны свиньи!"
+	desc = "Экипажу нужны свиньи!"
 	icon = 'modular_bandastation/objects/icons/obj/items/pig.dmi'
 	icon_state = "pig"
 	inhand_icon_state = "pig"
@@ -9,5 +9,6 @@
 	attack_verb_continuous = list("хрюкает")
 	attack_verb_simple = list("хрюкаете")
 	squeak_override = list('modular_bandastation/objects/sounds/oink.ogg' = 1)
+	use_delay_override = 4 SECONDS
 	w_class = WEIGHT_CLASS_SMALL
 	resistance_flags = FLAMMABLE

--- a/modular_bandastation/objects/code/items/supply_packs.dm
+++ b/modular_bandastation/objects/code/items/supply_packs.dm
@@ -1,9 +1,0 @@
-/datum/supply_pack/costumes_toys/pig
-	name = "toy pigs crate"
-	desc = "Вам нужны игрушечные свиньи? В этом ящике лежит 5 игрушечных свинок."
-	cost = CARGO_CRATE_VALUE * 4
-	access_view = FALSE
-	contains = list(
-		/obj/item/toy/plush/pig = 5
-    )
-	crate_name = "toy pigs crate"


### PR DESCRIPTION
## Что этот PR делает

Убирает отсылку к реальным людям из описания свиньи.
Убирает ящик с 5 свиньями.
Добавляет свинью в стандартный пул игрушек для спавнеров и аркадных автоматов.


## Changelog

:cl:
add: Игрушечная свинья  добавлена в стандартный пул игрушек для спавнеров и аркадных автоматов
add: Повышает КД на хрюканье свиньей в руках до 4-х секунд
del: Убрана отсылка к реальным людям из описания игрушечной свиньи
del: Удален ящик с 5 свиньями
/:cl:

## Обзор от Sourcery

Стандартизация и интеграция свинки-игрушки в игровую экосистему игрушек.

Новые возможности:
- Добавлена свинка-игрушка в призовой фонд аркады и случайные спавнеры.

Улучшения:
- Изменено описание свинки-игрушки для удаления конкретных ссылок.
- Добавлен 4-секундный кулдаун для взаимодействий со свинкой-игрушкой.

Задачи:
- Удален набор припасов, связанный со свинкой-игрушкой.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize and integrate pig toy into the game's toy ecosystem

New Features:
- Added pig toy to arcade prize pool and random spawners

Enhancements:
- Modified pig toy description to remove specific references
- Added a 4-second cooldown for pig toy interactions

Chores:
- Removed supply pack related to pig toy

</details>