### PR TITLE
Fix ID card description when applying sticker

### DIFF
--- a/modular_bandastation/objects/code/items/id_stickers.dm
+++ b/modular_bandastation/objects/code/items/id_stickers.dm
@@ -55,7 +55,7 @@
 /obj/item/card/id/advanced/update_desc(updates)
 	. = ..()
 	if(applied_sticker?.id_card_desc)
-		desc += "<br>[applied_sticker.id_card_desc]"
+		desc = "[src::desc]<br>[applied_sticker.id_card_desc]"
 	else
 		desc = src::desc
 


### PR DESCRIPTION
## Что этот PR делает
Что-то фиксит

## Почему это хорошо для игры
Не знаю

## Изображения изменений
(.)(.)

## Тестирование
Может ещё отсосать?

## Changelog

:cl:
fix: Наклейка больше не должна делать гигантское описание у карты
/:cl:

## Обзор от Sourcery

Исправления ошибок:
- Исправлен способ обновления описания ID-карты при применении стикера с описанием.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Corrected the way ID card description is updated when a sticker with a description is applied

</details>