### PR TITLE
Fix paper text field

### DIFF
--- a/tgui/packages/tgui/interfaces/PaperSheet/TextAreaSection.tsx
+++ b/tgui/packages/tgui/interfaces/PaperSheet/TextAreaSection.tsx
@@ -177,13 +177,13 @@ export function TextAreaSection(props: TextAreaSectionProps) {
       }
     >
       <TextArea
-        ref={textAreaRef}
         autoFocus
+        className="Paper__TextArea"
+        ref={textAreaRef}
         value={textAreaText}
         textColor={useColor}
         fontFamily={useFont}
         bold={useBold}
-        height="100%"
         backgroundColor={paper_color}
         dontUseTabForIndent={paperReplacementHint.length > 0}
         onKeyDown={handleTextAreaKeyDown}

--- a/tgui/packages/tgui/styles/interfaces/Paper.scss
+++ b/tgui/packages/tgui/styles/interfaces/Paper.scss
@@ -17,6 +17,12 @@
     word-wrap: break-word;
   }
 
+  &__TextArea {
+    height: 100%;
+    width: 100%;
+    border: none;
+  }
+
   &__Hints {
     overflow: hidden auto;
     scroll-padding: var(--space-m);


### PR DESCRIPTION
## Что этот PR делает
Fixes #1403

![XHCwTsstve](https://github.com/user-attachments/assets/21c6f0ee-f315-4fd2-a56f-06129fd5fcf2)

## Почему это хорошо для игры
> Что этот PR делает

## Изображения изменений
> Почему это хорошо для игры

## Тестирование
> Изображения изменений

## Changelog

:cl:
fix: Поле вводу у бумаги теперь выглядит как раньше
/:cl:

## Краткое описание от Sourcery

Исправлена стилизация и макет поля ввода текста в интерфейсе пользователя.

Исправления ошибок:
- Устранены проблемы с отображением текстового поля путем удаления явных ограничений по высоте и добавления стилизации на всю ширину.

Улучшения:
- Скорректирована стилизация текстовой области, чтобы она заполняла всю область ввода.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the styling and layout of the paper text input field in the user interface

Bug Fixes:
- Resolved text field display issues by removing explicit height constraints and adding full-width styling

Enhancements:
- Adjusted the text area styling to fill the entire paper input area

</details>