### PR TITLE
cargo department color for explorer

### DIFF
--- a/modular_bandastation/jobs/code/job_types/explorer/trim.dm
+++ b/modular_bandastation/jobs/code/job_types/explorer/trim.dm
@@ -3,9 +3,9 @@
 	trim_icon = 'modular_bandastation/jobs/icons/obj/card.dmi'
 	trim_state = "trim_explorer"
 
-	department_color = COLOR_SERVICE_LIME
-	subdepartment_color = COLOR_SERVICE_LIME
-	sechud_icon_state = SECHUD_EXPLORER // change
+	department_color = COLOR_CARGO_BROWN
+	subdepartment_color = COLOR_CARGO_BROWN
+	sechud_icon_state = SECHUD_EXPLORER
 	minimal_access = list(
 		ACCESS_EVA,
 		ACCESS_CARGO,


### PR DESCRIPTION
## Что этот PR делает

closes https://github.com/ss220club/BandaStation/issues/1413

Карточка исследователя теперь имеет цвета своего отдела (снабжения)

## Changelog

:cl:
fix: Карточка исследователя теперь имеет цвета своего отдела (снабжения)
/:cl:

## Обзор от Sourcery

Улучшения:
- Изменены цвета идентификационной карты исследователя, чтобы соответствовать коричневой цветовой схеме грузового отдела.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Change explorer ID card colors to match cargo department's brown color scheme

</details>