### PR TITLE
Add HoS display case with donut

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -11583,6 +11583,10 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
+"cMD" = (
+/obj/structure/displaycase/hos,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/hos)
 "cMI" = (
 /obj/structure/fermenting_barrel,
 /turf/open/floor/wood,
@@ -201848,7 +201852,7 @@ kJd
 tVE
 tuM
 wKB
-pwb
+cMD
 tVE
 tVE
 tVE

--- a/modular_bandastation/objects/code/structures/displaycase.dm
+++ b/modular_bandastation/objects/code/structures/displaycase.dm
@@ -1,2 +1,10 @@
 /obj/structure/displaycase/captain
 	req_access = list(ACCESS_CAPTAIN)
+
+/obj/structure/displaycase/hos
+	desc = "Гарантия того, что работа будет непременно выполнена."
+	req_access = list(ACCESS_HOS)
+
+/obj/structure/displaycase/hos/Initialize(mapload)
+	start_showpiece_type = pick(subtypesof(/obj/item/food/donut))
+	return ..()


### PR DESCRIPTION

## Что этот PR делает
Closes https://github.com/ss220club/BandaStation/issues/1316
Добавляет пончик в кейсе для ГСБ на Кибериаде.

## Почему это хорошо для игры
Ам-ням.

## Изображения изменений
![image](https://github.com/user-attachments/assets/bfa58cd3-0b25-4b17-8989-5cb0fb318b64)

## Тестирование
Локалка

## Changelog

:cl:
add: Кибериада: ГСБ добавлен пончик в защищенном дисплей-кейсе.
/:cl:
## Обзор от Sourcery

Добавлен специальный стенд для Главы Службы Безопасности (HoS) со случайно выбранным пончиком на карте Cyberiad.

Новые функции:
- Создан уникальный стенд для HoS с ограниченным доступом.
- Добавлен случайный пончик в качестве экспоната в стенд HoS.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a special display case for the Head of Security (HoS) with a randomly selected donut on the Cyberiad map

New Features:
- Created a unique display case for the HoS with restricted access
- Added a random donut as the display item in the HoS case

</details>