### PR TITLE
[WiP] Add: ERP Redux

### DIFF
--- a/modular_bandastation/ert/_ert.dme
+++ b/modular_bandastation/ert/_ert.dme
@@ -1,3 +1,5 @@
 #include "_ert.dm"
 
 #include "code/ert_manager.dm"
+#include "code/ert_outfits.dm"
+#include "code/ert_presets.dm"

--- a/modular_bandastation/ert/_ert.dme
+++ b/modular_bandastation/ert/_ert.dme
@@ -1,5 +1,5 @@
 #include "_ert.dm"
 
 #include "code/ert_manager.dm"
-#include "code/ert_outfits.dm"
 #include "code/ert_presets.dm"
+#include "code/ert_outfits.dm"

--- a/modular_bandastation/ert/code/ert_manager.dm
+++ b/modular_bandastation/ert/code/ert_manager.dm
@@ -88,6 +88,8 @@ ADMIN_VERB(ert_manager, R_ADMIN, "ERT Manager", "Manage ERT reqests.", ADMIN_CAT
 					new_ert = new /datum/ert/red
 				if("Gamma")
 					new_ert = new /datum/ert/gamma
+				if("Epsilon")
+					new_ert = new /datum/ert/epsilon
 				else
 					to_chat(usr, "<span class='userdanger'>Invalid ERT type.</span>")
 					return
@@ -294,7 +296,9 @@ ADMIN_VERB(ert_manager, R_ADMIN, "ERT Manager", "Manage ERT reqests.", ADMIN_CAT
 				if("Red")
 					priority_announce("Внимание, [station_name()]. Мы направляем усиленный отряд быстрого реагирования кода «РЭД». Ожидайте.", "ОБР в пути")
 				if("Gamma")
-					priority_announce("Внимание, [station_name()]. Мы направляем элитный отряд быстрого реагирования кода «ГАММА». Ожидайте.", "ОБР в пути")
+					priority_announce("Внимание, [station_name()]. Мы направляем ударный отряд быстрого реагирования кода «ГАММА». Ожидайте.", "ОБР в пути")
+				if("Epsilon")
+					priority_announce("Внимание, [station_name()]. Мы направляем элитный отряд быстрого реагирования кода «ЭПСИЛОН». Ожидайте.", "ОБР в пути")
 
 	//Open the Armory doors
 	if(ertemplate.opendoors)
@@ -307,6 +311,11 @@ ADMIN_VERB(ert_manager, R_ADMIN, "ERT Manager", "Manage ERT reqests.", ADMIN_CAT
 	leader_role = /datum/antagonist/ert/commander/red
 	roles = list(/datum/antagonist/ert/security/red, /datum/antagonist/ert/medic/red, /datum/antagonist/ert/engineer/red)
 	code = "Gamma"
+
+/datum/ert/epsilon
+	leader_role = /datum/antagonist/ert/commander/red
+	roles = list(/datum/antagonist/ert/security/red, /datum/antagonist/ert/medic/red, /datum/antagonist/ert/engineer/red)
+	code = "Epsilon"
 
 /obj/effect/landmark/ert_brief_spawn
 	name = "ertbriefspawn"

--- a/modular_bandastation/ert/code/ert_manager.dm
+++ b/modular_bandastation/ert/code/ert_manager.dm
@@ -307,6 +307,15 @@ ADMIN_VERB(ert_manager, R_ADMIN, "ERT Manager", "Manage ERT reqests.", ADMIN_CAT
 			CHECK_TICK
 	return TRUE
 
+/datum/ert/gamma
+	leader_role = /datum/antagonist/ert/commander/gamma
+	roles = list(/datum/antagonist/ert/security/gamma, /datum/antagonist/ert/medic/gamma, /datum/antagonist/ert/engineer/gamma)
+	code = "Gamma"
+
+/datum/ert/epsilon
+	leader_role = /datum/antagonist/ert/commander/epsilon
+	roles = list(/datum/antagonist/ert/security/epsilon, /datum/antagonist/ert/medic/epslion, /datum/antagonist/ert/engineer/epslion)
+	code = "Epsilon"
 
 #undef ERT_EXPERIENCED_LEADER_CHOOSE_TOP
 #undef DUMMY_HUMAN_SLOT_ADMIN

--- a/modular_bandastation/ert/code/ert_manager.dm
+++ b/modular_bandastation/ert/code/ert_manager.dm
@@ -307,19 +307,6 @@ ADMIN_VERB(ert_manager, R_ADMIN, "ERT Manager", "Manage ERT reqests.", ADMIN_CAT
 			CHECK_TICK
 	return TRUE
 
-/datum/ert/gamma
-	leader_role = /datum/antagonist/ert/commander/red
-	roles = list(/datum/antagonist/ert/security/red, /datum/antagonist/ert/medic/red, /datum/antagonist/ert/engineer/red)
-	code = "Gamma"
-
-/datum/ert/epsilon
-	leader_role = /datum/antagonist/ert/commander/red
-	roles = list(/datum/antagonist/ert/security/red, /datum/antagonist/ert/medic/red, /datum/antagonist/ert/engineer/red)
-	code = "Epsilon"
-
-/obj/effect/landmark/ert_brief_spawn
-	name = "ertbriefspawn"
-	icon_state = "ert_brief_spawn"
 
 #undef ERT_EXPERIENCED_LEADER_CHOOSE_TOP
 #undef DUMMY_HUMAN_SLOT_ADMIN

--- a/modular_bandastation/ert/code/ert_outfits.dm
+++ b/modular_bandastation/ert/code/ert_outfits.dm
@@ -27,9 +27,9 @@
 		/obj/item/pipe_dispenser = 1,
 		/obj/item/stack/sheet/iron = 50,
 		/obj/item/stack/sheet/glass = 50,
-		/obj/item/stack/sheet/plasteel = 50
-		/obj/item/melee/baton/security/boomerang = 1
-	)
+		/obj/item/stack/sheet/plasteel = 50,
+		/obj/item/melee/baton/security/boomerang = 1,
+		)
 
 /datum/outfit/centcom/ert/medic
 	backpack_contents = list(
@@ -58,7 +58,7 @@
 
 /datum/outfit/centcom/ert/commander/alert
 	l_hand = /obj/item/gun/energy/e_gun/nuclear
-	l_pocket = /obj/item/melee/energy/sword/blue
+	l_pocket = /obj/item/melee/energy/sword/saber/blue
 
 /datum/outfit/centcom/ert/janitor
 	backpack_contents = list(
@@ -80,17 +80,25 @@
 	)
 
 /datum/outfit/centcom/ert/commander/gamma
-
-/datum/antagonist/ert/security/gamma
-
-/datum/antagonist/ert/medic/gamma
-
-/datum/antagonist/ert/engineer/gamma
+	l_hand = /obj/item/gun/energy/disabler
 
 /datum/outfit/centcom/ert/commander/epsilon
+	l_hand = /obj/item/gun/energy/disabler
 
-/datum/antagonist/ert/security/epsilon
+/datum/outfit/centcom/ert/security/gamma
+	l_hand = /obj/item/gun/energy/disabler
 
-/datum/antagonist/ert/medic/epsilon
+/datum/outfit/centcom/ert/medic/gamma
+	l_hand = /obj/item/gun/energy/disabler
 
-/datum/antagonist/ert/engineer/epsilon
+/datum/outfit/centcom/ert/engineer/gamma
+	l_hand = /obj/item/gun/energy/disabler
+
+/datum/outfit/centcom/ert/security/epsilon
+	l_hand = /obj/item/gun/energy/disabler
+
+/datum/outfit/centcom/ert/medic/epsilon
+	l_hand = /obj/item/gun/energy/disabler
+
+/datum/outfit/centcom/ert/engineer/epsilon
+	l_hand = /obj/item/gun/energy/disabler

--- a/modular_bandastation/ert/code/ert_outfits.dm
+++ b/modular_bandastation/ert/code/ert_outfits.dm
@@ -1,0 +1,96 @@
+/datum/outfit/centcom/ert/security
+	l_hand = /obj/item/gun/energy/disabler/smg
+	backpack_contents = list(
+		/obj/item/melee/baton/telescopic/gold = 1,
+		/obj/item/storage/box/handcuffs = 2,
+	)
+	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
+	gloves = /obj/item/clothing/gloves/tackler
+
+/datum/outfit/centcom/ert/security/alert
+	l_hand = /obj/item/gun/energy/e_gun
+
+/datum/outfit/centcom/ert/engineer
+	l_hand = /obj/item/gun/energy/disabler
+	backpack_contents = list(
+		/obj/item/construction/rcd/loaded/upgraded = 1,
+		/obj/item/pipe_dispenser = 1,
+		/obj/item/stack/sheet/iron = 50,
+		/obj/item/stack/sheet/glass = 50,
+		/obj/item/stack/sheet/plasteel = 50
+	)
+
+/datum/outfit/centcom/ert/engineer/alert
+	l_hand = /obj/item/gun/energy/e_gun
+	backpack_contents = list(
+		/obj/item/construction/rcd/loaded/upgraded = 1,
+		/obj/item/pipe_dispenser = 1,
+		/obj/item/stack/sheet/iron = 50,
+		/obj/item/stack/sheet/glass = 50,
+		/obj/item/stack/sheet/plasteel = 50
+		/obj/item/melee/baton/security/boomerang = 1
+	)
+
+/datum/outfit/centcom/ert/medic
+	backpack_contents = list(
+		/obj/item/melee/baton/telescopic = 1,
+		/obj/item/reagent_containers/hypospray = 1,
+		/obj/item/storage/box/hug/plushes = 1,
+	)
+	r_hand = /obj/item/gun/energy/disabler
+
+/datum/outfit/centcom/ert/medic/alert
+	backpack_contents = list(
+		/obj/item/melee/baton/security/loaded = 1,
+		/obj/item/reagent_containers/hypospray = 1,
+		/obj/item/storage/box/hug/plushes = 1,
+		/obj/item/storage/box/medipens = 1,
+		/obj/item/storage/medkit/advanced = 1,
+	)
+	r_hand = /obj/item/gun/energy/e_gun
+
+/datum/outfit/centcom/ert/commander
+	backpack_contents = list(
+		/obj/item/megaphone/command = 1,
+		/obj/item/ammo_box/magazine/wt550m9 = 3,
+	)
+	l_hand = /obj/item/gun/ballistic/automatic/wt550
+
+/datum/outfit/centcom/ert/commander/alert
+	l_hand = /obj/item/gun/energy/e_gun/nuclear
+	l_pocket = /obj/item/melee/energy/sword/blue
+
+/datum/outfit/centcom/ert/janitor
+	backpack_contents = list(
+		/obj/item/grenade/clusterbuster/cleaner = 1,
+		/obj/item/mop/advanced = 1,
+		/obj/item/reagent_containers/cup/bucket = 1,
+		/obj/item/storage/box/lights/mixed = 1,
+		/obj/item/construction/rtd = 1,
+		/obj/item/lightreplacer = 1,
+	)
+	l_hand = /obj/item/storage/bag/trash
+
+/datum/outfit/centcom/ert/janitor/heavy
+	backpack_contents = list(
+		/obj/item/grenade/clusterbuster/cleaner = 3,
+		/obj/item/storage/box/lights/mixed = 1,
+		/obj/item/construction/rtd = 1,
+		/obj/item/lightreplacer/blue = 1,
+	)
+
+/datum/outfit/centcom/ert/commander/gamma
+
+/datum/antagonist/ert/security/gamma
+
+/datum/antagonist/ert/medic/gamma
+
+/datum/antagonist/ert/engineer/gamma
+
+/datum/outfit/centcom/ert/commander/epsilon
+
+/datum/antagonist/ert/security/epsilon
+
+/datum/antagonist/ert/medic/epsilon
+
+/datum/antagonist/ert/engineer/epsilon

--- a/modular_bandastation/ert/code/ert_outfits.dm
+++ b/modular_bandastation/ert/code/ert_outfits.dm
@@ -79,6 +79,7 @@
 		/obj/item/lightreplacer/blue = 1,
 	)
 
+///////////////////// ДАЛЕЕ ЗАТЫЧКИ /////////////////////
 /datum/outfit/centcom/ert/commander/gamma
 	l_hand = /obj/item/gun/energy/disabler
 

--- a/modular_bandastation/ert/code/ert_presets.dm
+++ b/modular_bandastation/ert/code/ert_presets.dm
@@ -34,21 +34,31 @@
 	role = "Heavy Duty Janitor"
 	outfit = /datum/outfit/centcom/ert/janitor/heavy
 
+// GAMMA
+/datum/antagonist/ert/security/gamma
+	outfit = /datum/outfit/centcom/ert/security/gamma
+
+/datum/antagonist/ert/medic/gamma
+	outfit = /datum/outfit/centcom/ert/medic/gamma
+
+/datum/antagonist/ert/engineer/gamma
+	outfit = /datum/outfit/centcom/ert/engineer/gamma
+
 /datum/antagonist/ert/commander/gamma
 	outfit = /datum/outfit/centcom/ert/commander/gamma
 
+// EPSILON
+/datum/antagonist/ert/security/epsilon
+	outfit = /datum/outfit/centcom/ert/security/epsilon
+
+/datum/antagonist/ert/medic/epslion
+	outfit = /datum/outfit/centcom/ert/medic/epsilon
+
+/datum/antagonist/ert/engineer/epslion
+	outfit = /datum/outfit/centcom/ert/engineer/epsilon
+
 /datum/antagonist/ert/commander/epsilon
 	outfit = /datum/outfit/centcom/ert/commander/epsilon
-
-/datum/ert/gamma
-	leader_role = /datum/antagonist/ert/commander/gamma
-	roles = list(/datum/antagonist/ert/security/gamma, /datum/antagonist/ert/medic/gamma, /datum/antagonist/ert/engineer/gamma)
-	code = "Gamma"
-
-/datum/ert/epsilon
-	leader_role = /datum/antagonist/ert/commander/epsilon
-	roles = list(/datum/antagonist/ert/security/epslion, /datum/antagonist/ert/medic/epslion, /datum/antagonist/ert/engineer/epslion)
-	code = "Epsilon"
 
 /obj/effect/landmark/ert_brief_spawn
 	name = "ertbriefspawn"

--- a/modular_bandastation/ert/code/ert_presets.dm
+++ b/modular_bandastation/ert/code/ert_presets.dm
@@ -1,0 +1,55 @@
+/datum/antagonist/ert/security
+	outfit = /datum/outfit/centcom/ert/security
+
+/datum/antagonist/ert/security/red
+	outfit = /datum/outfit/centcom/ert/security/alert
+
+/datum/antagonist/ert/engineer
+	role = "Engineer"
+	outfit = /datum/outfit/centcom/ert/engineer
+
+/datum/antagonist/ert/engineer/red
+	outfit = /datum/outfit/centcom/ert/engineer/alert
+
+/datum/antagonist/ert/medic
+	role = "Medical Officer"
+	outfit = /datum/outfit/centcom/ert/medic
+
+/datum/antagonist/ert/medic/red
+	outfit = /datum/outfit/centcom/ert/medic/alert
+
+/datum/antagonist/ert/commander
+	role = "Commander"
+	outfit = /datum/outfit/centcom/ert/commander
+	plasmaman_outfit = /datum/outfit/plasmaman/centcom_commander
+
+/datum/antagonist/ert/commander/red
+	outfit = /datum/outfit/centcom/ert/commander/alert
+
+/datum/antagonist/ert/janitor
+	role = "Janitor"
+	outfit = /datum/outfit/centcom/ert/janitor
+
+/datum/antagonist/ert/janitor/heavy
+	role = "Heavy Duty Janitor"
+	outfit = /datum/outfit/centcom/ert/janitor/heavy
+
+/datum/antagonist/ert/commander/gamma
+	outfit = /datum/outfit/centcom/ert/commander/gamma
+
+/datum/antagonist/ert/commander/epsilon
+	outfit = /datum/outfit/centcom/ert/commander/epsilon
+
+/datum/ert/gamma
+	leader_role = /datum/antagonist/ert/commander/gamma
+	roles = list(/datum/antagonist/ert/security/gamma, /datum/antagonist/ert/medic/gamma, /datum/antagonist/ert/engineer/gamma)
+	code = "Gamma"
+
+/datum/ert/epsilon
+	leader_role = /datum/antagonist/ert/commander/epsilon
+	roles = list(/datum/antagonist/ert/security/epslion, /datum/antagonist/ert/medic/epslion, /datum/antagonist/ert/engineer/epslion)
+	code = "Epsilon"
+
+/obj/effect/landmark/ert_brief_spawn
+	name = "ertbriefspawn"
+	icon_state = "ert_brief_spawn"

--- a/tgui/packages/tgui/interfaces/ErtManager.tsx
+++ b/tgui/packages/tgui/interfaces/ErtManager.tsx
@@ -159,6 +159,7 @@ const SendERT = (props) => {
     Amber = 'orange',
     Red = 'red',
     Gamma = 'yellow',
+    Epsilon = 'purple',
   }
 
   return (


### PR DESCRIPTION

## Что этот PR делает
Как заявляет предыдущий разработчик: ERP - Emergency Response Party.
Добавляет Epsilon отряд в ERT Manager, изменяет пресеты всех других отрядов.
## Почему это хорошо для игры
РЕД ЕРТ больше не бегает с пульсачом, ГАММА != РЕД (кто это вообще сделал???), больше вариантов для различных ситуаций на станции.
## Изображения изменений
Да.
## Тестирование
Да.
## Changelog

:cl: Ez-Briz
add: Изменены пресеты всех отрядов ЕРТ, добавлен новый отряд - Epsilon.
fix: Gamma ЕРТ больше не клон Red ЕРТ.
admin: Добавлен Epsilon отряд в ERT Manager.
/:cl:
## Обзор от Sourcery

Добавление команды экстренного реагирования "Эпсилон" (ERT) в игру, изменение конфигураций и пресетов команд ERT.

Новые возможности:
- Добавлена команда Epsilon ERT в качестве нового варианта команды экстренного реагирования.
- Представлены новые комплекты формы ERT и пресеты антагонистов для команды "Эпсилон".

Улучшения:
- Уточнена конфигурация команды Gamma ERT.
- Обновлен менеджер ERT для поддержки выбора команды "Эпсилон".

Рутинные задачи:
- Созданы новые файлы для комплектов формы и пресетов ERT.
- Обновлен пользовательский интерфейс для включения цвета команды "Эпсилон".

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Epsilon Emergency Response Team (ERT) to the game, modifying ERT team configurations and presets

New Features:
- Added Epsilon ERT as a new emergency response team option
- Introduced new ERT outfits and antagonist presets for Epsilon team

Enhancements:
- Refined Gamma ERT team configuration
- Updated ERT manager to support Epsilon team selection

Chores:
- Created new files for ERT outfits and presets
- Updated UI to include Epsilon team color

</details>