### PR TITLE
Fix: Flatpack can no longer be inserted into the Bag of Holding

### DIFF
--- a/code/datums/storage/subtypes/others/bag_of_holding.dm
+++ b/code/datums/storage/subtypes/others/bag_of_holding.dm
@@ -8,15 +8,18 @@
 	var/list/obj/item/storage/backpack/holding/matching = typecache_filter_list(to_insert.get_all_contents(), typecacheof(/obj/item/storage/backpack/holding))
 	matching -= parent
 	matching -= real_location
-	/// BANDASTATION ADDITION START - Flatpack fix
-	set_holdable(cant_hold_list = /obj/item/flatpack)
-	/// BANDASTATION ADDITION END - Flatpack fix
 
 	if((istype(to_insert, /obj/item/storage/backpack/holding) || length(matching)) && can_insert(to_insert, user))
 		INVOKE_ASYNC(src, PROC_REF(recursive_insertion), to_insert, user)
 		return FALSE
 
 	return ..()
+
+	/// BANDASTATION ADDITION START - Flatpack fix
+/datum/storage/bag_of_holding/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
+	. = ..()
+	set_holdable(cant_hold_list = /obj/item/flatpack)
+	/// BANDASTATION ADDITION END - Flatpack fix
 
 /datum/storage/bag_of_holding/proc/recursive_insertion(obj/item/to_insert, mob/living/user)
 	var/area/bag_area = get_area(user)

--- a/code/datums/storage/subtypes/others/bag_of_holding.dm
+++ b/code/datums/storage/subtypes/others/bag_of_holding.dm
@@ -8,6 +8,9 @@
 	var/list/obj/item/storage/backpack/holding/matching = typecache_filter_list(to_insert.get_all_contents(), typecacheof(/obj/item/storage/backpack/holding))
 	matching -= parent
 	matching -= real_location
+	/// BANDASTATION ADDITION START - Flatpack fix
+	set_holdable(cant_hold_list = /obj/item/flatpack)
+	/// BANDASTATION ADDITION END - Flatpack fix
 
 	if((istype(to_insert, /obj/item/storage/backpack/holding) || length(matching)) && can_insert(to_insert, user))
 		INVOKE_ASYNC(src, PROC_REF(recursive_insertion), to_insert, user)


### PR DESCRIPTION
## Что этот PR делает

Флатпаки больше невозможно класть в БоХ

## Почему это хорошо для игры

Флатпаки можно было класть в БОХ и таким образом в рюкзаке иметь машинерию, людей и т.д., что явно бредик

## Тестирование

Локалка

## Changelog

:cl:
fix: Флатпаки больше нельзя класть в БоХ
/:cl:

## Обзор от Sourcery

Исправления ошибок:
- Отключена возможность вставлять Flatpacks в Bag of Holding

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Disabled the ability to insert Flatpacks into the Bag of Holding

</details>