### PR TITLE
admin only admin chat

### DIFF
--- a/code/datums/keybinding/admin.dm
+++ b/code/datums/keybinding/admin.dm
@@ -3,7 +3,7 @@
 	weight = WEIGHT_ADMIN
 
 /datum/keybinding/admin/can_use(client/user)
-	return user.holder ? TRUE : FALSE
+	return user.holder?.rank_flags() & R_ADMIN /// Bandastation edit: admins only admin chat
 
 /datum/keybinding/admin/admin_say
 	hotkey_keys = list("F3")


### PR DESCRIPTION
## Что этот PR делает

В админ чат теперь могут писать только... админы и выше


:cl:
admin: В админ чат теперь могут писать только... админы и выше
/:cl:

## Обзор от Sourcery

Улучшения:
- Ограничено использование админ-чата только игроками с флагом R_ADMIN

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Limit admin chat usage to players holding the R_ADMIN flag

</details>