### PR TITLE
Fix: clickable link discord after linking

### DIFF
--- a/modular_bandastation/metaserver/code/discord_link.dm
+++ b/modular_bandastation/metaserver/code/discord_link.dm
@@ -16,7 +16,7 @@
 		to_chat(src, span_warning("Привязка Discord сейчас недоступна."))
 		return
 
-	if(SScentral.is_player_discord_linked(src))
+	if(SScentral.is_player_discord_linked(ckey))
 		to_chat(src, span_warning("Вы уже привязали свою учетную запись Discord."))
 		return
 


### PR DESCRIPTION
Читай тайтл

## Обзор от Sourcery

Исправления ошибок:
- Передавать ckey игрока вместо src в `is_player_discord_linked`, чтобы правильно определять существующие связи с Discord.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Pass the player’s ckey instead of src to is_player_discord_linked to properly detect existing Discord links

</details>