### PR TITLE
Cyberiad: custom shuttle circuit board spawner

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -18891,7 +18891,12 @@
 	},
 /obj/machinery/status_display/ai/directional/north,
 /obj/machinery/light/small/directional/north,
-/obj/item/toy/figure/ninja,
+/obj/item/assembly/flash/handheld{
+	pixel_x = -5
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = 7
+	},
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
 "eBD" = (
@@ -57277,6 +57282,9 @@
 /obj/item/stock_parts/power_store/cell/high{
 	pixel_y = 6
 	},
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_y = 2
+	},
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
 "nOH" = (
@@ -62085,12 +62093,6 @@
 /obj/item/aicard{
 	pixel_y = 4
 	},
-/obj/item/assembly/flash/handheld{
-	pixel_x = 7
-	},
-/obj/item/assembly/flash/handheld{
-	pixel_x = -5
-	},
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
 "oWo" = (
@@ -62721,9 +62723,7 @@
 /obj/item/plant_analyzer{
 	pixel_y = 12
 	},
-/obj/item/stock_parts/power_store/cell/high{
-	pixel_y = 2
-	},
+/obj/item/toy/figure/ninja,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
 "peq" = (


### PR DESCRIPTION
## Что этот PR делает

Добавление в хранилище плат набора для создания кастомного шаттла, и платы АПЦ.

## Почему это хорошо для игры

Платы АПЦ по какой-то причине не было, наличие ее в хранилище полезно, лишним не будет. Набор для кастомного шаттла нужен одиноким исследователям космоса, чтобы они не тратили поинт РНД на изучение и не ждали это самое изучение.

## Изображения изменений

![Screenshot_306](https://github.com/user-attachments/assets/1c5178ad-b0fa-4aae-ab39-b716a8ac4819)

## Тестирование

Локалка

## Changelog

:cl:
map: Кибериада: в хранилище плат теперь есть набор для кастомного шаттла, а также плата АПЦ.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->

## Обзор от Sourcery

Добавлен набор для создания кастомных плат шаттла и плата APC в хранилище плат Киберяда для упрощения постройки шаттлов и предоставления платы APC.

Новые функции:
- Добавлен набор для создания кастомных плат шаттла в хранилище плат Киберяда
- Добавлена плата APC в хранилище плат Киберяда

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add custom shuttle circuit board kit and APC board to Cyberiad's circuit board storage to streamline shuttle construction and provide an APC board.

New Features:
- Add custom shuttle circuit board kit to Cyberiad’s circuit board storage
- Add APC circuit board to Cyberiad’s circuit board storage

</details>