### PR TITLE
Fix sec department choice

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -52,11 +52,11 @@
 #define PARALLAX_DELAY_MED 1
 #define PARALLAX_DELAY_LOW 2
 
-#define SEC_DEPT_NONE "None"
-#define SEC_DEPT_ENGINEERING "Engineering"
-#define SEC_DEPT_MEDICAL "Medical"
-#define SEC_DEPT_SCIENCE "Science"
-#define SEC_DEPT_SUPPLY "Supply"
+#define SEC_DEPT_NONE "Нет"
+#define SEC_DEPT_ENGINEERING "Инженерный"
+#define SEC_DEPT_MEDICAL "Медицинский"
+#define SEC_DEPT_SCIENCE "Исследовательский"
+#define SEC_DEPT_SUPPLY "Снабжения"
 
 // Playtime tracking system, see jobs_exp.dm
 #define EXP_TYPE_LIVING "Living"

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -213,7 +213,7 @@ SECURITY_HAS_MAINT_ACCESS
 #EVERYONE_HAS_MAINT_ACCESS
 
 ## Comment this out this to make security officers spawn in departmental security posts
-SEC_START_BRIG
+#SEC_START_BRIG
 
 ## This variable is how you may configure "Scaling Access" for Departmental Security Officers.
 ## Set to 0/commented out for "off", Departmental Security Officers will never get additional room-specific access (beyond general departmental doors).


### PR DESCRIPTION
## Что этот PR делает
Комментит флаг `SEC_START_BRIG` на будущее 
Переводит опции выбора
Closes #1430

## Почему это хорошо для игры
trust me

## Изображения изменений
![image](https://github.com/user-attachments/assets/f2af8b00-fa71-44fb-a395-b450ae8b9b82)


## Тестирование
Локальные тесты

## Changelog

:cl:
fix: В настройках персонажа снова можно выбрать отдел для офицера СБ
/:cl: