### PR TITLE
Cyberiad: Various improvements and fixes [Revisit edition]

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -30206,7 +30206,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "hmM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom,
 /obj/effect/turf_decal/siding/white{
 	dir = 5

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -56454,13 +56454,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
-"nDd" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/station/service/kitchen/coldroom/ghetto)
 "nDf" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral{
@@ -77282,7 +77275,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/freezer,
 /obj/structure/plasticflaps/kitchen,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/turf/open/floor/iron/white,
 /area/station/service/kitchen/coldroom/ghetto)
 "sDN" = (
 /obj/machinery/camera/directional/north{
@@ -137510,7 +137503,7 @@ oIg
 qaE
 ldb
 sXK
-nDd
+jqs
 tuR
 sOd
 wWh

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -4777,8 +4777,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/plasma/spawner/directional/north,
+/obj/structure/window/reinforced/plasma/spawner/directional/east,
+/obj/structure/window/reinforced/plasma/spawner/directional/west,
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
 "bhy" = (
@@ -5038,7 +5039,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "bkf" = (
@@ -9381,6 +9381,10 @@
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
+"clJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/service/kitchen/coldroom/ghetto)
 "clK" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -19575,11 +19579,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "eJu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/white/end{
-	dir = 8
-	},
-/turf/open/floor/iron/kitchen_coldroom/dark,
+/obj/machinery/duct,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "eJx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23112,6 +23113,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"fCV" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/service/kitchen/coldroom/ghetto)
 "fDa" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -26866,9 +26873,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
 "gyK" = (
-/obj/machinery/light/small/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/obj/machinery/gibber,
+/obj/effect/turf_decal/siding/white,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen_coldroom/dark,
 /area/station/service/kitchen/coldroom/ghetto)
 "gyL" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -30029,7 +30039,7 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "hkN" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/door/poddoor/preopen{
 	id = "research_lockdown";
 	name = "Research Lockdown Blast Doors"
@@ -31779,7 +31789,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "hFm" = (
@@ -38578,6 +38587,12 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
+"jqs" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/service/kitchen/coldroom/ghetto)
 "jqv" = (
 /obj/structure/table/wood,
 /obj/structure/mirror/directional/north,
@@ -45970,10 +45985,10 @@
 	pixel_x = 15;
 	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 1
-	},
 /obj/structure/sign/poster/random/directional/west,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "ldi" = (
@@ -47086,11 +47101,11 @@
 /turf/open/floor/plating,
 /area/station/security/detectives_office)
 "lre" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+/obj/effect/turf_decal/siding/white/end{
 	dir = 8
 	},
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron/kitchen_coldroom/dark,
 /area/station/service/kitchen/coldroom/ghetto)
 "lrf" = (
 /obj/machinery/light/small/directional/east,
@@ -50605,15 +50620,6 @@
 "miI" = (
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
-"miQ" = (
-/obj/machinery/gibber,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/white,
-/turf/open/floor/iron/kitchen_coldroom/dark,
-/area/station/service/kitchen/coldroom/ghetto)
 "miT" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/reagent_containers/cup/glass/bottle/whiskey{
@@ -55308,11 +55314,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "noQ" = (
-/obj/machinery/door/window/left/directional/south{
+/obj/machinery/door/window/brigdoor/right/directional/north{
 	name = "Mass Driver Door";
 	req_access = list("ordnance")
 	},
-/obj/machinery/door/window/left/directional/north{
+/obj/machinery/door/window/brigdoor/right/directional/south{
 	name = "Mass Driver Door";
 	req_access = list("ordnance")
 	},
@@ -56448,6 +56454,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
+"nDd" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/service/kitchen/coldroom/ghetto)
 "nDf" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral{
@@ -57361,6 +57374,10 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/starboard/fore)
+"nPj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/service/kitchen/coldroom/ghetto)
 "nPk" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/closet/emcloset,
@@ -61041,9 +61058,6 @@
 /obj/item/food/grown/tomato{
 	pixel_x = 6;
 	pixel_y = -1
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
@@ -66840,10 +66854,6 @@
 "qaE" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/machinery/light_switch/directional/west,
-/mob/living/basic/goat/pete{
-	name = "Боря"
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "qaG" = (
@@ -73455,6 +73465,7 @@
 "rJy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/duct,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "rJA" = (
@@ -75043,6 +75054,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"sbY" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/service/kitchen/coldroom/ghetto)
 "sca" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -77267,7 +77282,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/freezer,
 /obj/structure/plasticflaps/kitchen,
-/obj/machinery/duct,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "sDN" = (
@@ -78725,7 +78739,7 @@
 /area/station/service/library)
 "sXk" = (
 /obj/effect/landmark/start/hangover,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "sXl" = (
@@ -78766,8 +78780,10 @@
 	},
 /area/station/engineering/hallway/west)
 "sXK" = (
-/obj/machinery/light/small/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/mob/living/basic/goat/pete{
+	name = "Боря"
+	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "sXO" = (
@@ -80614,6 +80630,11 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"tuR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/service/kitchen/coldroom/ghetto)
 "tuZ" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/cable,
@@ -85351,9 +85372,6 @@
 /area/station/maintenance/starboard/upper)
 "uGq" = (
 /obj/structure/closet/secure_closet/freezer/meat,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/tlv_cold_room,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
@@ -88058,8 +88076,8 @@
 "vox" = (
 /obj/structure/table/reinforced,
 /obj/item/sharpener,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 1
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
@@ -137492,10 +137510,10 @@ oIg
 qaE
 ldb
 sXK
+nDd
+tuR
 sOd
 wWh
-ceC
-ceC
 ceC
 ceC
 ceC
@@ -137749,10 +137767,10 @@ uGq
 hFc
 vox
 sXk
+jqs
+nPj
 hmM
 wWh
-doz
-doz
 doz
 ceC
 ceC
@@ -138005,11 +138023,11 @@ sDM
 cRk
 dcl
 rJy
+clJ
+clJ
 lyW
 sWx
 wWh
-doz
-doz
 doz
 ceC
 ceC
@@ -138263,10 +138281,10 @@ bSG
 bka
 eJu
 lre
+clJ
+fCV
 cXX
 wWh
-ceC
-ceC
 vbK
 ceC
 vbK
@@ -138517,13 +138535,13 @@ lpU
 klF
 wWh
 ugR
+sbY
 mzG
-miQ
 gyK
+clJ
+clJ
 iOB
 wWh
-doz
-doz
 vbK
 ceC
 vbK
@@ -138779,8 +138797,8 @@ iBi
 iBi
 iBi
 iBi
-ceC
-ceC
+wWh
+wWh
 vbK
 jEk
 vbK

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -447,7 +447,7 @@
 "agC" = (
 /obj/machinery/rnd/server,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/turf/open/floor/circuit,
+/turf/open/floor/circuit/telecomms/server,
 /area/station/science/server)
 "agH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1916,7 +1916,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "ayR" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -5038,7 +5038,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/freezer,
+/obj/machinery/duct,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "bkf" = (
 /obj/structure/disposalpipe/segment,
@@ -7082,7 +7083,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto/morgue)
 "bJW" = (
-/obj/machinery/computer/atmos_alert,
+/obj/machinery/computer/atmos_alert/station_only,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 8
 	},
@@ -7818,13 +7819,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "bSG" = (
-/obj/machinery/airalarm/directional/north,
 /obj/structure/closet/secure_closet/freezer,
 /obj/item/food/meat/slab/pig,
 /obj/item/food/meat/slab/pig,
 /obj/item/food/meat/slab/pig,
-/obj/effect/mapping_helpers/airalarm/tlv_cold_room,
-/turf/open/floor/iron/freezer,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "bSX" = (
 /obj/effect/turf_decal/tile/purple/half{
@@ -9014,7 +9015,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/item/surgery_tray/full,
+/obj/effect/spawner/surgery_tray/full,
 /obj/structure/table/glass,
 /obj/machinery/digital_clock/directional/south,
 /turf/open/floor/iron/white,
@@ -9797,7 +9798,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "cqR" = (
-/obj/machinery/computer/station_alert,
+/obj/machinery/computer/station_alert/station_only,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "cqV" = (
@@ -11945,7 +11946,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/freezer,
+/obj/machinery/duct,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "cRo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12545,7 +12547,10 @@
 /area/station/service/library/ghetto)
 "cXX" = (
 /obj/structure/kitchenspike,
-/turf/open/floor/iron/freezer,
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/turf/open/floor/iron/kitchen_coldroom/dark,
 /area/station/service/kitchen/coldroom/ghetto)
 "cXY" = (
 /obj/structure/railing{
@@ -12801,7 +12806,7 @@
 	desc = "A cold, hard place for your final rest.";
 	name = "Morgue Slab"
 	},
-/obj/item/surgery_tray/full/morgue,
+/obj/effect/spawner/surgery_tray/full/morgue,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "cZW" = (
@@ -13006,7 +13011,8 @@
 "dcl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/freezer,
+/obj/machinery/duct,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "dcn" = (
 /obj/structure/closet/secure_closet/brig,
@@ -14589,7 +14595,7 @@
 "dve" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/telecomms,
 /area/station/science/server)
 "dvg" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
@@ -16352,10 +16358,7 @@
 /area/station/maintenance/department/security/ghetto)
 "dSh" = (
 /obj/effect/turf_decal/bot_white,
-/obj/structure/guncase/ecase{
-	open = 0;
-	anchored = 1
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/armory/e_gun,
 /obj/effect/turf_decal/tile/dark_red/diagonal_edge,
 /turf/open/floor/iron/dark/textured_large,
@@ -17850,7 +17853,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/telecomms,
 /area/station/science/server)
 "emi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19571,6 +19574,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"eJu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/white/end{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen_coldroom/dark,
+/area/station/service/kitchen/coldroom/ghetto)
 "eJx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
@@ -23036,6 +23046,7 @@
 /obj/machinery/door/window/right/directional/west{
 	req_access = list("science")
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "fCk" = (
@@ -23089,7 +23100,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/telecomms,
 /area/station/science/server)
 "fCS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23753,7 +23764,7 @@
 /area/station/maintenance/starboard/upper)
 "fJD" = (
 /obj/structure/cable,
-/obj/machinery/computer/atmos_alert{
+/obj/machinery/computer/atmos_alert/station_only{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -24245,7 +24256,10 @@
 /area/station/command/heads_quarters/blueshield)
 "fPT" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/right/directional/west,
+/obj/machinery/door/window/right/directional/west{
+	req_access = list("kitchen");
+	name = "Kitchen Delivery"
+	},
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/service/kitchen/kitchen_backroom)
@@ -24485,7 +24499,7 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
-	codes_txt = "delivery";
+	codes_txt = "delivery;dir=8";
 	location = "Kitchen"
 	},
 /turf/open/floor/plating,
@@ -25267,7 +25281,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "gcJ" = (
-/obj/machinery/computer/atmos_alert{
+/obj/machinery/computer/atmos_alert/station_only{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/corner{
@@ -25908,7 +25922,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/table/glass,
-/obj/item/surgery_tray/full,
+/obj/effect/spawner/surgery_tray/full,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
 "gkK" = (
@@ -26359,7 +26373,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/telecomms,
 /area/station/science/server)
 "gqs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26853,7 +26867,8 @@
 /area/station/maintenance/ghetto/auxiliary)
 "gyK" = (
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/freezer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "gyL" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -27960,7 +27975,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gLS" = (
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -29220,7 +29235,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/telecomms,
 /area/station/science/server)
 "haT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29994,6 +30009,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -30180,20 +30196,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "hmM" = (
-/obj/structure/closet/crate/freezer/food,
-/obj/item/food/grown/tomato{
-	pixel_x = -2;
-	pixel_y = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom,
+/obj/effect/turf_decal/siding/white{
+	dir = 5
 	},
-/obj/item/food/grown/tomato{
-	pixel_x = -6;
-	pixel_y = -2
-	},
-/obj/item/food/grown/tomato{
-	pixel_x = 6;
-	pixel_y = -1
-	},
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/kitchen_coldroom/dark,
 /area/station/service/kitchen/coldroom/ghetto)
 "hmV" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -31768,13 +31776,11 @@
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
 "hFc" = (
-/mob/living/basic/goat/pete{
-	name = "Боря"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/freezer,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "hFm" = (
 /obj/structure/disposalpipe/segment,
@@ -32934,8 +32940,9 @@
 /obj/structure/rack,
 /obj/item/gun/energy/ionrifle,
 /obj/item/gun/energy/temperature/security,
-/obj/item/clothing/suit/hooded/ablative,
 /obj/effect/turf_decal/tile/dark_red/diagonal_edge,
+/obj/item/gun/ballistic/automatic/battle_rifle,
+/obj/item/clothing/suit/hooded/ablative,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
 "hTZ" = (
@@ -33218,13 +33225,14 @@
 /area/station/maintenance/aft)
 "hXX" = (
 /obj/machinery/navbeacon{
-	codes_txt = "delivery";
+	codes_txt = "delivery;dir=2";
 	location = "Janitor"
 	},
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
 /area/station/maintenance/aft)
 "hXY" = (
 /obj/machinery/door/poddoor/preopen{
@@ -33845,6 +33853,7 @@
 	id = "research_lockdown";
 	name = "Research Lockdown Blast Doors"
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "igl" = (
@@ -36479,6 +36488,13 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/upper)
+"iOB" = (
+/obj/structure/kitchenspike,
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/turf/open/floor/iron/kitchen_coldroom/dark,
+/area/station/service/kitchen/coldroom/ghetto)
 "iOJ" = (
 /obj/item/clothing/head/collectable/kitty,
 /obj/item/clothing/head/collectable/rabbitears,
@@ -36802,9 +36818,8 @@
 /area/station/hallway/secondary/service)
 "iSW" = (
 /obj/structure/table,
-/obj/item/taperecorder{
-	pixel_x = -4;
-	pixel_y = 2
+/obj/item/fish_tank/lawyer{
+	pixel_y = 6
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
@@ -36832,7 +36847,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "iTy" = (
-/obj/machinery/computer/atmos_alert{
+/obj/machinery/computer/atmos_alert/station_only{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -37300,6 +37315,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/kitchen/small,
 /area/station/service/kitchen/kitchen_backroom/ghetto)
 "iYX" = (
@@ -37741,7 +37757,7 @@
 /area/station/engineering/supermatter/room)
 "jel" = (
 /obj/structure/cable,
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 1
 	},
 /obj/machinery/keycard_auth/wall_mounted/directional/south,
@@ -38464,6 +38480,10 @@
 	pixel_y = 7
 	},
 /obj/item/pen,
+/obj/item/taperecorder{
+	pixel_x = 10;
+	pixel_y = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "job" = (
@@ -39990,6 +40010,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"jIb" = (
+/obj/effect/turf_decal/bot,
+/obj/item/bot_assembly/repairbot,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/ghetto)
 "jIc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -41030,7 +41055,7 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/plating,
-/area/station/maintenance/fore)
+/area/station/security/brig)
 "jVO" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/table,
@@ -42874,7 +42899,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/telecomms,
 /area/station/science/server)
 "ksQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43091,6 +43116,10 @@
 /obj/item/assembly/flash/handheld,
 /obj/item/assembly/flash/handheld,
 /obj/item/assembly/flash/handheld,
+/obj/item/toy/crayon/spraycan/roboticist{
+	pixel_x = -12;
+	pixel_y = 6
+	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "kvr" = (
@@ -43533,6 +43562,7 @@
 	pixel_x = -3;
 	pixel_y = -10
 	},
+/obj/structure/fish_mount/bar/directional/north,
 /turf/open/floor/iron/checker,
 /area/station/service/bar/atrium/ghetto)
 "kBw" = (
@@ -45940,7 +45970,11 @@
 	pixel_x = 15;
 	pixel_y = 4
 	},
-/turf/open/floor/iron/freezer,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 1
+	},
+/obj/structure/sign/poster/random/directional/west,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "ldi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47053,7 +47087,10 @@
 /area/station/security/detectives_office)
 "lre" = (
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/iron/freezer,
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "lrf" = (
 /obj/machinery/light/small/directional/east,
@@ -47675,7 +47712,10 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/ghetto/port)
 "lyW" = (
-/turf/open/floor/iron/freezer,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "lyZ" = (
 /obj/item/kirbyplants/random,
@@ -50567,7 +50607,12 @@
 /area/station/science/robotics/lab)
 "miQ" = (
 /obj/machinery/gibber,
-/turf/open/floor/iron/freezer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/iron/kitchen_coldroom/dark,
 /area/station/service/kitchen/coldroom/ghetto)
 "miT" = (
 /obj/structure/table/wood/fancy/green,
@@ -51827,6 +51872,10 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/magistrate)
+"mzG" = (
+/obj/structure/sink/kitchen/directional/west,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/service/kitchen/coldroom/ghetto)
 "mzJ" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable,
@@ -53791,7 +53840,7 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/security/detective,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/fore)
+/area/station/security/detectives_office)
 "mXA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/machinery/light/small/directional/north,
@@ -55310,7 +55359,7 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "npG" = (
-/obj/machinery/computer/station_alert,
+/obj/machinery/computer/station_alert/station_only,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
 /area/station/command/bridge)
@@ -57864,7 +57913,7 @@
 "nWt" = (
 /obj/machinery/rnd/server/master,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/turf/open/floor/circuit,
+/turf/open/floor/circuit/telecomms/server,
 /area/station/science/server)
 "nWu" = (
 /obj/machinery/vending/assist,
@@ -59272,7 +59321,7 @@
 /obj/machinery/light/small/directional/west,
 /obj/machinery/door/window/right/directional/north{
 	req_access = list("bar");
-	name = "Bar Deliverys"
+	name = "Bar Delivery"
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
@@ -60937,6 +60986,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/eva,
 /obj/machinery/door/airlock/command/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "oHt" = (
@@ -60979,8 +61029,23 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "oIg" = (
-/obj/structure/reagent_dispensers/cooking_oil,
-/turf/open/floor/iron/freezer,
+/obj/structure/closet/crate/freezer/food,
+/obj/item/food/grown/tomato{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/food/grown/tomato{
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/item/food/grown/tomato{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "oIi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -61011,7 +61076,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/fore)
+/area/station/security/holding_cell)
 "oIz" = (
 /obj/structure/sink/kitchen/directional/east,
 /turf/open/floor/plating,
@@ -61421,6 +61486,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/plasticflaps/kitchen,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/server)
 "oND" = (
@@ -62869,7 +62935,9 @@
 /area/station/maintenance/ghetto/fore/starboard)
 "pgc" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/door/window/brigdoor/right/directional/north,
+/obj/machinery/door/window/brigdoor/right/directional/north{
+	req_access = list("brig")
+	},
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
@@ -63855,7 +63923,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/light/directional/south,
 /obj/structure/table/glass,
-/obj/item/surgery_tray/full,
+/obj/effect/spawner/surgery_tray/full,
 /obj/machinery/digital_clock/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
@@ -66771,7 +66839,12 @@
 /area/station/maintenance/ghetto/fore/starboard)
 "qaE" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/iron/freezer,
+/obj/machinery/light_switch/directional/west,
+/mob/living/basic/goat/pete{
+	name = "Боря"
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "qaG" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
@@ -68173,7 +68246,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/item/surgery_tray/full,
+/obj/effect/spawner/surgery_tray/full,
 /obj/structure/table/glass,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
@@ -69289,7 +69362,7 @@
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "qJI" = (
 /obj/machinery/firealarm/directional/north,
-/obj/machinery/computer/atmos_alert{
+/obj/machinery/computer/atmos_alert/station_only{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -69311,15 +69384,16 @@
 	opacity = 1
 	},
 /obj/machinery/navbeacon{
-	codes_txt = "delivery";
+	codes_txt = "delivery;dir=1";
 	location = "Security"
 	},
 /obj/machinery/door/poddoor/preopen{
 	name = "Security Blast Door";
 	id = "Secure Gate"
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
-/area/station/maintenance/fore)
+/area/station/security/brig)
 "qKk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -73378,6 +73452,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/interrogation)
+"rJy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/service/kitchen/coldroom/ghetto)
 "rJA" = (
 /obj/structure/window/spawner/directional/south,
 /obj/structure/table/reinforced,
@@ -74324,6 +74403,7 @@
 	},
 /obj/structure/table,
 /obj/machinery/airalarm/directional/north,
+/obj/effect/mapping_helpers/airalarm/tlv_kitchen,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "rVa" = (
@@ -77186,7 +77266,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/freezer,
-/turf/open/floor/iron/freezer,
+/obj/structure/plasticflaps/kitchen,
+/obj/machinery/duct,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "sDN" = (
 /obj/machinery/camera/directional/north{
@@ -77295,6 +77377,7 @@
 	location = "Medbay"
 	},
 /obj/structure/plasticflaps/opaque,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "sEo" = (
@@ -77988,9 +78071,11 @@
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
 "sOd" = (
-/obj/structure/closet/crate/freezer,
-/obj/item/food/cheese/wheel,
-/turf/open/floor/iron/freezer,
+/obj/structure/reagent_dispensers/cooking_oil,
+/obj/effect/turf_decal/siding/white{
+	dir = 9
+	},
+/turf/open/floor/iron/kitchen_coldroom/dark,
 /area/station/service/kitchen/coldroom/ghetto)
 "sOi" = (
 /obj/structure/disposalpipe/segment,
@@ -78570,10 +78655,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "sWx" = (
-/obj/structure/chair/stool{
-	dir = 1
-	},
-/turf/open/floor/iron/freezer,
+/obj/structure/closet/crate/freezer,
+/obj/item/food/cheese/wheel,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "sWy" = (
 /obj/machinery/door/airlock/security,
@@ -78640,7 +78725,8 @@
 /area/station/service/library)
 "sXk" = (
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/freezer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "sXl" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -78681,7 +78767,8 @@
 /area/station/engineering/hallway/west)
 "sXK" = (
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/freezer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "sXO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -79552,7 +79639,7 @@
 /area/station/command/heads_quarters/hos)
 "tlk" = (
 /obj/machinery/airalarm/directional/west,
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -80291,7 +80378,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/telecomms,
 /area/station/science/server)
 "tsW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -80420,6 +80507,7 @@
 /obj/machinery/door/window/right/directional/south{
 	req_access = list("medical")
 	},
+/obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "tue" = (
@@ -81784,6 +81872,7 @@
 	pixel_x = 7
 	},
 /obj/effect/turf_decal/tile/purple/half,
+/obj/item/flesh_shears,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "tLc" = (
@@ -82150,7 +82239,7 @@
 /turf/open/floor/carpet/black,
 /area/station/command/meeting_room)
 "tPy" = (
-/obj/machinery/computer/station_alert{
+/obj/machinery/computer/station_alert/station_only{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -83565,7 +83654,7 @@
 /obj/item/food/grown/onion,
 /obj/item/food/grown/onion,
 /obj/structure/closet/crate/freezer/food,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "ugS" = (
 /obj/structure/disposalpipe/segment{
@@ -83618,10 +83707,7 @@
 /area/station/science/ordnance/office)
 "uhz" = (
 /obj/effect/turf_decal/bot_white,
-/obj/structure/guncase/shotgun{
-	open = 0;
-	anchored = 1
-	},
+/obj/structure/rack,
 /obj/effect/spawner/random/armory/shotgun,
 /obj/effect/turf_decal/tile/dark_red/diagonal_edge,
 /turf/open/floor/iron/dark/textured_large,
@@ -85264,10 +85350,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "uGq" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/iron/freezer,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/effect/mapping_helpers/airalarm/tlv_cold_room,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "uGu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -87969,7 +88058,10 @@
 "vox" = (
 /obj/structure/table/reinforced,
 /obj/item/sharpener,
-/turf/open/floor/iron/freezer,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "voG" = (
 /obj/structure/chair{
@@ -90172,7 +90264,7 @@
 	location = "Bar"
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/plating,
 /area/station/service/bar)
 "vPo" = (
 /obj/machinery/light/small/directional/north,
@@ -90766,6 +90858,7 @@
 /obj/machinery/door/airlock/command/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/science/rd,
+/obj/structure/plasticflaps/kitchen,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "vXo" = (
@@ -91332,7 +91425,7 @@
 "wfo" = (
 /obj/machinery/atmospherics/components/unary/passive_vent,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/telecomms,
 /area/station/science/server)
 "wfp" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
@@ -93899,6 +93992,7 @@
 /obj/machinery/door/window/left/directional/south{
 	req_access = list("medical")
 	},
+/obj/effect/mapping_helpers/airlock/red_alert_access,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "wLD" = (
@@ -96210,6 +96304,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/obj/structure/plasticflaps/kitchen,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "xod" = (
@@ -99788,7 +99883,7 @@
 	opacity = 1
 	},
 /obj/machinery/navbeacon{
-	codes_txt = "delivery";
+	codes_txt = "delivery;dir=8";
 	location = "engineering"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -99799,6 +99894,7 @@
 	name = "Drone Fabricator";
 	req_access = list("engine_equip")
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/dronefabricator)
 "ykh" = (
@@ -99952,7 +100048,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/telecomms,
 /area/station/science/server)
 "ylP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -126398,7 +126494,7 @@ npV
 npV
 ppi
 dKo
-pnB
+jIb
 pnB
 ssc
 pnB
@@ -137908,7 +138004,7 @@ hky
 sDM
 cRk
 dcl
-lyW
+rJy
 lyW
 sWx
 wWh
@@ -138165,7 +138261,7 @@ cwa
 wWh
 bSG
 bka
-lyW
+eJu
 lre
 cXX
 wWh
@@ -138421,10 +138517,10 @@ lpU
 klF
 wWh
 ugR
-lyW
+mzG
 miQ
 gyK
-cXX
+iOB
 wWh
 doz
 doz
@@ -201091,7 +201187,7 @@ drc
 wBV
 sxU
 xqz
-fgy
+dww
 kJd
 kJd
 kJd
@@ -201348,7 +201444,7 @@ qlK
 rEF
 icU
 pSj
-fgy
+dww
 fgy
 fgy
 fgy


### PR DESCRIPTION
## Что этот PR делает
Различные улучшения и фиксы, читать чейнджлог

## Changelog

:cl:
map: Кибериада получила различные улучшения и фиксы, а также актуализацию до некоторых вещей с других карт. Подробности описаны ниже.
qol: Холодные комнаты (кухня, серверная РнД и прочее) теперь действительно морозят. Морозилка кухни, в частности, обзавелась машинерией с контуром охлаждения. Также в проходные добавлены заслонки, дабы они не пропускали холод.
add: В оружейную добавлена 1 единица NT BR-38 в соответствии с остальными картами. Посмотрим как это будет играться.
add: В переходную между магистратом и юристами был добавлен переносной аквариум (who asked?).
add: Роботехам был добавлен специальный балончик с краской для перекраски робоконечностей.
add: Генетикам добавлен инструмент, позволяющий изменять внешние черты (например крылья).
add: Surgery Tray в операционных и морге теперь имеет мизерный шанс заспавниться в виде медицинского тулбокса.
fix: Мониторинги алёртов Station и Atmos теперь отображают только станционный уровень.
fix: Ящики оружейной с egun'ами и дробовиками были обратно заменены на rack, из-за кривого спавна.
fix: Небольшие исправления зон техи-бриг.
fix: Метки доставок теперь корректно определяют в какую сторону нужно расположить доставленный груз.
fix: Исправлены доступы у некоторых точек доставки.
/:cl:
