### PR TITLE
Fix: Kitchen freezer on Cyberiad

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -30206,7 +30206,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "hmM" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom{
+	dir = 1
+	},
 /obj/effect/turf_decal/siding/white{
 	dir = 5
 	},
@@ -45984,7 +45986,6 @@
 	pixel_x = 15;
 	pixel_y = 4
 	},
-/obj/structure/sign/poster/random/directional/west,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
 	},
@@ -61051,6 +61052,7 @@
 	pixel_x = 6;
 	pixel_y = -1
 	},
+/obj/machinery/light/small/dim/directional/north,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "oIi" = (
@@ -75047,7 +75049,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "sbY" = (
-/obj/machinery/light/small/directional/east,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "sca" = (
@@ -80624,7 +80626,7 @@
 /area/station/commons/locker)
 "tuR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/obj/machinery/light/small/directional/west,
+/obj/machinery/light/small/dim/directional/west,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "tuZ" = (
@@ -83667,6 +83669,7 @@
 /obj/item/food/grown/onion,
 /obj/item/food/grown/onion,
 /obj/structure/closet/crate/freezer/food,
+/obj/machinery/light/small/dim/directional/north,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "ugS" = (
@@ -90183,6 +90186,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"vNq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/dim/directional/east,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/station/service/kitchen/coldroom/ghetto)
 "vNs" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -138531,7 +138539,7 @@ sbY
 mzG
 gyK
 clJ
-clJ
+vNq
 iOB
 wWh
 vbK


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Фикс алярмы в морозилке повара на Кибериаде.

## Тестирование
На локалке проверил.

## Changelog

:cl:
fix: Кибериада: Пофикшена алярма в морозилке повара.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
