### PR TITLE
Staff jobs by priority

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -458,36 +458,24 @@ SUBSYSTEM_DEF(job)
 	// From assign_all_overflow_positions()
 	// 4. Anyone with the overflow role enabled has been given the overflow role.
 
-	// Copy the joinable occupation list and filter out ineligible occupations due to above job assignments.
-	var/list/available_occupations = joinable_occupations.Copy()
-	var/datum/job_department/command_department = get_department_type(/datum/job_department/command)
-
-	for(var/datum/job/job in available_occupations)
-		// Make sure the job isn't filled. If it is, remove it from the list so it doesn't get checked.
+	/// BANDASTATION EDIT START - Job Priority Staffing
+	var/list/available_occupations = list()
+	for(var/datum/job/job as anything in joinable_occupations)
+		// Make sure the job isn't filled
 		if((job.current_positions >= job.spawn_positions) && job.spawn_positions != -1)
 			job_debug("DO: Job is now filled, Job: [job], Current: [job.current_positions], Limit: [job.spawn_positions]")
-			available_occupations -= job
 			continue
 
-		// Command jobs are handled via fill_all_head_positions_at_priority(...)
-		// Remove these jobs from the list of available occupations to prevent multiple players being assigned to the same
-		// limited role without constantly having to iterate over the available_occupations list and re-check them.
-		if(job in command_department?.department_jobs)
-			available_occupations -= job
+		available_occupations += job
 
 	job_debug("DO: Running standard job assignment")
 
 	for(var/level in level_order)
-		job_debug("JOBS: Filling in head roles, Level: [job_priority_level_to_string(level)]")
-		// Fill the head jobs first each level
-		fill_all_head_positions_at_priority(level)
-
 		// Loop through all unassigned players
-		for(var/mob/dead/new_player/player in unassigned)
-			if(!allow_all)
-				if(popcap_reached())
-					job_debug("JOBS: Popcap reached, trying to reject player: [player]")
-					try_reject_player(player)
+		for(var/mob/dead/new_player/player as anything in unassigned)
+			if(!allow_all && popcap_reached())
+				job_debug("JOBS: Popcap reached, trying to reject player: [player]")
+				try_reject_player(player)
 
 			job_debug("JOBS: Finding a job for player: [player], at job priority pref: [job_priority_level_to_string(level)]")
 
@@ -513,14 +501,16 @@ SUBSYSTEM_DEF(job)
 				job_debug("JOBS: Player not eligible for any available jobs at this priority level: [player]")
 				continue
 
-			// Otherwise, pick one of those jobs at random.
-			var/datum/job/picked_job = pick(possible_jobs)
+			// Otherwise, pick highest priority job.
+			var/datum/job/picked_job = pick_highest_priority_job(possible_jobs)
 
 			job_debug("JOBS: Now assigning role to player: [player], Job:[picked_job.title]")
 			assign_role(player, picked_job, do_eligibility_checks = FALSE)
 			if((picked_job.current_positions >= picked_job.spawn_positions) && picked_job.spawn_positions != -1)
 				job_debug("JOBS: Job is now full, Job: [picked_job], Positions: [picked_job.current_positions], Limit: [picked_job.spawn_positions]")
 				available_occupations -= picked_job
+
+	/// BANDASTATION EDIT END - Job Priority Staffing
 
 	job_debug("DO: Ending standard job assignment")
 
@@ -533,7 +523,7 @@ SUBSYSTEM_DEF(job)
 	job_debug("DO: Handle unrejectable unassigned")
 	//Mop up people who can't leave.
 	for(var/mob/dead/new_player/player in unassigned) //Players that wanted to back out but couldn't because they're antags (can you feel the edge case?)
-		if(!give_random_job(player))
+		if(!give_priority_job(player)) /// BANDASTATION EDIT - Job Priority Staffing
 			if(!assign_role(player, get_job_type(overflow_role))) //If everything is already filled, make them an assistant
 				job_debug("DO: Forced antagonist could not be assigned any random job or the overflow role. divide_occupations failed.")
 				job_debug("---------------------------------------------------")
@@ -575,7 +565,7 @@ SUBSYSTEM_DEF(job)
 				try_reject_player(player)
 				return
 		if (BERANDOMJOB)
-			if(!give_random_job(player))
+			if(!give_priority_job(player)) /// BANDASTATION EDIT - Job Priority Staffing
 				job_debug("HU: Player cannot be given a random job, trying to reject: [player]")
 				try_reject_player(player)
 				return
@@ -881,18 +871,20 @@ SUBSYSTEM_DEF(job)
 		// However no guarantee of game state between then and now, so don't skip eligibility checks on assign_role.
 		assign_role(new_player, get_job(dynamic_forced_occupations[new_player]))
 
-	// Get JP_HIGH department Heads of Staff in place. Indirectly useful for the Revolution ruleset to have as many Heads as possible.
-	job_debug("APP: Assigning all JP_HIGH head of staff roles.")
-	var/head_count = fill_all_head_positions_at_priority(JP_HIGH)
+	/// BANDASTATION REMOVAL START - Job Priority Staffing
+	// // Get JP_HIGH department Heads of Staff in place. Indirectly useful for the Revolution ruleset to have as many Heads as possible.
+	// job_debug("APP: Assigning all JP_HIGH head of staff roles.")
+	// var/head_count = fill_all_head_positions_at_priority(JP_HIGH)
 
-	// If nobody has JP_HIGH on a Head role, try to force at least one Head of Staff so every shift has the best chance
-	// of having at least one leadership role.
-	if(head_count == 0)
-		force_one_head_assignment()
+	// // If nobody has JP_HIGH on a Head role, try to force at least one Head of Staff so every shift has the best chance
+	// // of having at least one leadership role.
+	// if(head_count == 0)
+	// 	force_one_head_assignment()
 
-	// Fill out all AI positions.
-	job_debug("APP: Filling all AI positions")
-	fill_ai_positions()
+	// // Fill out all AI positions.
+	// job_debug("APP: Filling all AI positions")
+	// fill_ai_positions()
+	/// BANDASTATION REMOVAL END - Job Priority Staffing
 
 /datum/controller/subsystem/job/proc/assign_all_overflow_positions()
 	job_debug("OVRFLW: Assigning all overflow roles.")

--- a/modular_bandastation/jobs/_jobs.dme
+++ b/modular_bandastation/jobs/_jobs.dme
@@ -1,5 +1,7 @@
 #include "_jobs.dm"
 
+#include "code/controller/subsystem/job.dm"
+
 // NT Representation department
 #include "code/departments/nt_representation.dm"
 
@@ -55,3 +57,5 @@
 #include "code/job_types/explorer/landmarks.dm"
 #include "code/job_types/explorer/pda.dm"
 #include "code/job_types/explorer/trim.dm"
+
+#include "code/job_types/job_staffing_priority.dm"

--- a/modular_bandastation/jobs/code/controller/subsystem/job.dm
+++ b/modular_bandastation/jobs/code/controller/subsystem/job.dm
@@ -1,0 +1,43 @@
+/datum/controller/subsystem/job/proc/pick_highest_priority_job(list/jobs)
+	PRIVATE_PROC(TRUE)
+
+	if(!length(jobs))
+		return null
+
+	return shuffle_and_sort_jobs_by_staffing_priority(jobs)[1]
+
+/datum/controller/subsystem/job/proc/give_priority_job(mob/dead/new_player/player)
+	job_debug("GRJ: Giving random priority job, Player: [player]")
+	. = FALSE
+	if(QDELETED(player))
+		job_debug("GRJ: Player is deleted, aborting")
+		return .
+
+	for(var/datum/job/job as anything in shuffle_and_sort_jobs_by_staffing_priority(joinable_occupations))
+		if((job.current_positions >= job.spawn_positions) && job.spawn_positions != -1)
+			job_debug("GRJ: Job lacks spawn positions to be eligible, Player: [player], Job: [job]")
+			continue
+
+		if(istype(job, get_job_type(overflow_role))) // We don't want to give him assistant, that's boring!
+			job_debug("GRJ: Skipping overflow role, Player: [player], Job: [job]")
+			continue
+
+		if(job.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND) //If you want a command position, select it!
+			job_debug("GRJ: Skipping command role, Player: [player], Job: [job]")
+			continue
+
+		// This check handles its own output to job_debug.
+		if(check_job_eligibility(player, job, "GRJ", add_job_to_log = TRUE) != JOB_AVAILABLE)
+			continue
+
+		if(assign_role(player, job, do_eligibility_checks = FALSE))
+			job_debug("GRJ: Random job given, Player: [player], Job: [job]")
+			return TRUE
+
+		job_debug("GRJ: Player eligible but assign_role failed, Player: [player], Job: [job]")
+
+/datum/controller/subsystem/job/proc/shuffle_and_sort_jobs_by_staffing_priority(list/jobs) as /list
+	if(!length(jobs))
+		return list()
+
+	return sortTim(shuffle(jobs), GLOBAL_PROC_REF(cmp_job_staffing_priority))

--- a/modular_bandastation/jobs/code/job_types/job_staffing_priority.dm
+++ b/modular_bandastation/jobs/code/job_types/job_staffing_priority.dm
@@ -1,0 +1,149 @@
+#define STAFFING_PRIORITY_CRITICAL 1
+#define STAFFING_PRIORITY_VERY_IMPORTANT 2
+#define STAFFING_PRIORITY_IMPORTANT 3
+#define STAFFING_PRIORITY_MODERATE 4
+#define STAFFING_PRIORITY_MINOR 5
+#define STAFFING_PRIORITY_NEGLIGIBLE 6
+
+/proc/cmp_job_staffing_priority(datum/job/A, datum/job/B)
+	if(A.staffing_priority == B.staffing_priority)
+		return cmp_numeric_asc(A.current_positions / A.spawn_positions, B.current_positions / B.spawn_positions)
+
+	return cmp_numeric_asc(A.staffing_priority, B.staffing_priority)
+
+/datum/job
+	/// Determines in which priority this job is assigned to players during roundstart
+	var/staffing_priority = STAFFING_PRIORITY_NEGLIGIBLE
+
+// MARK: Captain
+/datum/job/captain
+	staffing_priority = STAFFING_PRIORITY_CRITICAL
+
+// MARK: Silicons
+/datum/job/ai
+	staffing_priority = STAFFING_PRIORITY_VERY_IMPORTANT
+
+/datum/job/cyborg
+	staffing_priority = STAFFING_PRIORITY_MINOR
+
+// MARK: Security
+/datum/job/head_of_security
+	staffing_priority = STAFFING_PRIORITY_IMPORTANT
+
+/datum/job/warden
+	staffing_priority = STAFFING_PRIORITY_MINOR
+
+/datum/job/detective
+	staffing_priority = STAFFING_PRIORITY_MINOR
+
+/datum/job/security_officer
+	staffing_priority = STAFFING_PRIORITY_MODERATE
+
+/datum/job/prisoner
+	staffing_priority = STAFFING_PRIORITY_NEGLIGIBLE
+
+// MARK: Engineering
+/datum/job/chief_engineer
+	staffing_priority = STAFFING_PRIORITY_IMPORTANT
+
+/datum/job/station_engineer
+	staffing_priority = STAFFING_PRIORITY_MODERATE
+
+/datum/job/atmospheric_technician
+	staffing_priority = STAFFING_PRIORITY_MINOR
+
+// MARK: Medical
+/datum/job/chief_medical_officer
+	staffing_priority = STAFFING_PRIORITY_IMPORTANT
+
+/datum/job/doctor
+	staffing_priority = STAFFING_PRIORITY_MODERATE
+
+/datum/job/chemist
+	staffing_priority = STAFFING_PRIORITY_MINOR
+
+/datum/job/paramedic
+	staffing_priority = STAFFING_PRIORITY_MINOR
+
+/datum/job/coroner
+	staffing_priority = STAFFING_PRIORITY_NEGLIGIBLE
+
+// MARK: Service
+/datum/job/head_of_personnel
+	staffing_priority = STAFFING_PRIORITY_IMPORTANT
+
+/datum/job/bartender
+	staffing_priority = STAFFING_PRIORITY_NEGLIGIBLE
+
+/datum/job/botanist
+	staffing_priority = STAFFING_PRIORITY_MODERATE
+
+/datum/job/clown
+	staffing_priority = STAFFING_PRIORITY_MINOR
+
+/datum/job/cook
+	staffing_priority = STAFFING_PRIORITY_MODERATE
+
+/datum/job/curator
+	staffing_priority = STAFFING_PRIORITY_NEGLIGIBLE
+
+/datum/job/janitor
+	staffing_priority = STAFFING_PRIORITY_NEGLIGIBLE
+
+/datum/job/mime
+	staffing_priority = STAFFING_PRIORITY_MINOR
+
+/datum/job/psychologist
+	staffing_priority = STAFFING_PRIORITY_NEGLIGIBLE
+
+/datum/job/chaplain
+	staffing_priority = STAFFING_PRIORITY_NEGLIGIBLE
+
+// MARK: Science
+/datum/job/research_director
+	staffing_priority = STAFFING_PRIORITY_IMPORTANT
+
+/datum/job/scientist
+	staffing_priority = STAFFING_PRIORITY_MODERATE
+
+/datum/job/roboticist
+	staffing_priority = STAFFING_PRIORITY_MINOR
+
+/datum/job/geneticist
+	staffing_priority = STAFFING_PRIORITY_MINOR
+
+// MARK: Cargo
+/datum/job/quartermaster
+	staffing_priority = STAFFING_PRIORITY_IMPORTANT
+
+/datum/job/cargo_technician
+	staffing_priority = STAFFING_PRIORITY_NEGLIGIBLE
+
+/datum/job/bitrunner
+	staffing_priority = STAFFING_PRIORITY_MINOR
+
+/datum/job/shaft_miner
+	staffing_priority = STAFFING_PRIORITY_MODERATE
+
+/datum/job/explorer
+	staffing_priority = STAFFING_PRIORITY_NEGLIGIBLE
+
+// MARK: Justice
+/datum/job/magistrate
+	staffing_priority = STAFFING_PRIORITY_MINOR
+
+/datum/job/lawyer
+	staffing_priority = STAFFING_PRIORITY_NEGLIGIBLE
+
+// MARK: Nanotrasen Representation
+/datum/job/nanotrasen_representative
+	staffing_priority = STAFFING_PRIORITY_MINOR
+
+/datum/job/blueshield
+	staffing_priority = STAFFING_PRIORITY_NEGLIGIBLE
+
+#undef STAFFING_PRIORITY_VERY_HIGH
+#undef STAFFING_PRIORITY_HIGH
+#undef STAFFING_PRIORITY_MEDIUM
+#undef STAFFING_PRIORITY_LOW
+#undef STAFFING_PRIORITY_VERY_LOW


### PR DESCRIPTION
## Что этот PR делает

Изменяет алгоритм выдачи профессии игрокам таким образом:
### Было:
1) Выдаются главы на высокий приоритет
2) Выдается ИИ
3) Выдаются профессии начиная с высокого приоритета у игрока - в первую очередь главы
4) Остальные профессии выдаются случайным образом, по приоритету у игрока

### Стало:
 Профессии выдаются по приоритету важности и уровню заполненности профессии.
 Капитану выдан наивысший приоритет, за ним ИИ, после них главы.
 Далее критические должности типа СБ, Инженеров, Медикова, Повара, Ботаника и тд.

Если у профессий одинаковый уровень важности и заполненности - профессия выдается случайным образом.

## Почему это хорошо для игры

Профессии высокой важности заполняются в первую очередь, когда всякие священники, мимы, клоуны - в последнюю.

## Тестирование

Локально вроде бы сортирует всё правильно. Надо проверить с игроками

## Changelog

:cl:
add: Изменяет алгоритм выдачи профессии игрокам таким образом:
  Было:
  1) Выдаются главы на высокий приоритет
  2) Выдается ИИ
  3) Выдаются профессии начиная с высокого приоритета у игрока - в первую очередь главы
  4) Остальные профессии выдаются случайным образом, по приоритету у игрока
  
  Стало:
  Профессии выдаются по приоритету важности и уровню заполненности профессии.
  Капитану выдан наивысший приоритет, за ним ИИ, после них главы.
  Далее критические должности типа СБ, Инженеров, Медикова, Повара, Ботаника и тд.

  Если у профессий одинаковый уровень важности и заполненности - профессия выдается случайным образом.
/:cl:
