### PR TITLE
Remove re-added stat panel info

### DIFF
--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -38,8 +38,6 @@ SUBSYSTEM_DEF(statpanels)
 		global_data += list(
 			"Storyteller: [!SSgamemode.secret_storyteller && SSgamemode.current_storyteller ? SSgamemode.current_storyteller.name : "Secret"]", // BANDASTATION ADDITION - STORYTELLER
 			"Round ID: [GLOB.round_id ? GLOB.round_id : "NULL"]",
-			"Players Connected: [LAZYLEN(GLOB.clients)]", // BANDASTATION ADD
-			"Players in Lobby: [LAZYLEN(GLOB.new_player_list)]", // BANDASTATION ADD
 			"Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss", world.timezone)]",
 			"[SSticker.round_start_time ? "Round Time" : "Lobby Time"]: [ROUND_TIME()]", // BANDASTATION ADD
 			"Station Time: [station_time_timestamp()]",


### PR DESCRIPTION
## Что этот PR делает
Это было добавлено после того как оффы удалили после переноса в лобби
Мы давно перенесли это в лобби, а удалить либо я забыл, либо кто-то забыл при решении конфликта

## Changelog

:cl:
del: Удалена информация о количестве игроков в лобби с стат панели. Она есть в самом лобби
/:cl:
