### PR TITLE
Remove cyborg gender

### DIFF
--- a/code/modules/client/preferences/silicon_gender.dm
+++ b/code/modules/client/preferences/silicon_gender.dm
@@ -1,3 +1,4 @@
+/* BANDASTATION REMOVAL
 #define SILICON_MALE "He/Him"
 #define SILICON_FEMALE "She/Her"
 #define SILICON_PLURAL "They/Them"
@@ -35,3 +36,4 @@
 #undef SILICON_FEMALE
 #undef SILICON_PLURAL
 #undef SILICON_NEUTER
+*/

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -96,6 +96,7 @@
 
 ///Sets cyborg gender from preferences. Expects a client.
 /mob/living/silicon/proc/set_gender(client/player_client)
+	/* BANDASTATION REMOVAL - ЭТО БЛЯТЬ КОНСЕРВНАЯ БАНКА!
 	var/silicon_pronouns = player_client.prefs.read_preference(/datum/preference/choiced/silicon_gender)
 	if(silicon_pronouns == /datum/preference/choiced/silicon_gender::use_character_gender)
 		gender = player_client.prefs.read_preference(/datum/preference/choiced/gender)
@@ -103,6 +104,8 @@
 	var/silicon_gender = /datum/preference/choiced/silicon_gender::pronouns_to_genders[silicon_pronouns]
 	if(!isnull(silicon_gender))
 		gender = silicon_gender
+	*/
+	gender = NEUTER
 
 /mob/living/silicon/proc/on_silicon_shocked(datum/source, shock_damage, shock_source, siemens_coeff, flags)
 	SIGNAL_HANDLER


### PR DESCRIPTION
## Что этот PR делает
Удаляет выбор гендера у боргов

## Почему это хорошо для игры
ВЫ - ёбаное ведро с болтами, какой нахуй гендер блять? Ладно бы тут ещё был выбор: Боевой вертолёт Апач | Оно

## Тестирование
Запустил локалку, зашёл за ведро с болтами, увидел `It's` при осмотре
Там ещё какой-то рантайм в логах, но думаю это никак не связано

## Changelog

:cl:
del: Борги больше не могут идентифицировать себя, а значит они снова умнее людей
/:cl:
