### PR TITLE
Move crow feather cloak to autodrobe

### DIFF
--- a/modular_bandastation/loadout/code/categories/neck.dm
+++ b/modular_bandastation/loadout/code/categories/neck.dm
@@ -9,9 +9,3 @@
 	name = "Fancy Cloak"
 	item_path = /obj/item/clothing/neck/cloak/fancy_cloak
 	donator_level = DONATOR_TIER_2
-
-//MARK: Tier 3
-/datum/loadout_item/neck/crow
-	name = "Воронья мантия"
-	item_path = /obj/item/clothing/neck/crow
-	donator_level = DONATOR_TIER_3

--- a/modular_bandastation/objects/_objects.dm
+++ b/modular_bandastation/objects/_objects.dm
@@ -11,6 +11,10 @@
 			qdel(recipe)
 			break
 
+	GLOB.autodrobe_supernatural_items += list(
+		/obj/item/clothing/neck/crow = 1,
+	)
+
 	GLOB.autodrobe_fancy_items += list(
 		/obj/item/clothing/under/carnival/formal = 2,
 		/obj/item/clothing/under/carnival/jacket = 2,


### PR DESCRIPTION
## Что этот PR делает
Перемещает воронью мантию из лодаута в AutoDrobe
Количество в AutoDrobe - 1 штука

## Почему это хорошо для игры
Мантия слишком заметная и должна быть не такой доступной

## Тестирование
Локальные тесты

## Changelog

:cl:
add: Воронья мантия добавлена в AutoDrobe
del: Воронья мантия удалена из лодаута
/:cl: