### PR TITLE
add proper gender specific randomization for tts seed

### DIFF
--- a/modular_bandastation/tts/code/preferences/tts_preferences.dm
+++ b/modular_bandastation/tts/code/preferences/tts_preferences.dm
@@ -11,6 +11,9 @@
 	target.dna.tts_seed_dna = seed
 	GLOB.human_to_tts["[target.real_name]"] = seed
 
+/datum/preference/text/tts_seed/create_informed_default_value(datum/preferences/preferences)
+	return SStts220.pick_tts_seed_by_gender(preferences.read_preference(/datum/preference/choiced/gender))
+
 /datum/preference/numeric/volume/sound_tts_volume_radio
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 	savefile_key = "sound_tts_volume_radio"
@@ -38,8 +41,3 @@
 
 /datum/preference/numeric/volume/sound_tts_volume_announcement/create_default_value()
 	return maximum / 2
-
-/mob/living/carbon/human/randomize_human_appearance(randomize_flags)
-	. = ..()
-	var/datum/component/tts_component/tts_component = GetComponent(/datum/component/tts_component)
-	tts_component.tts_seed = tts_component.get_random_tts_seed_by_gender()

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/MainPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/MainPage.tsx
@@ -416,6 +416,10 @@ export function MainPage(props: MainPageProps) {
   if (randomBodyEnabled) {
     nonContextualPreferences['random_species'] =
       data.character_preferences.randomization['species'];
+    // BANDASTATION ADDITION START - TTS
+    nonContextualPreferences['random_tts_seed'] =
+      data.character_preferences.randomization['tts_seed'];
+    // BANDASTATION ADDITION END - TTS
   } else {
     // We can't use random_name/is_accessible because the
     // server doesn't know whether the random toggle is on.

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/randomization.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/randomization.tsx
@@ -52,3 +52,25 @@ export const random_species: Feature<RandomSetting> = {
     );
   },
 };
+
+// BANDASTATION ADDITION START - TTS
+export const random_tts_seed: Feature<RandomSetting> = {
+  name: 'Случайный голос',
+  component: (props) => {
+    const { act, data } = useBackend<PreferencesMenuData>();
+    const tts_seed = data.character_preferences.randomization['tts_seed'];
+
+    return (
+      <RandomizationButton
+        setValue={(newValue) =>
+          act('set_random_preference', {
+            preference: 'tts_seed',
+            value: newValue,
+          })
+        }
+        value={tts_seed || RandomSetting.Disabled}
+      />
+    );
+  },
+};
+// BANDASTATION ADDITION END - TTS


### PR DESCRIPTION
## Что этот PR делает

ТТС теперь корректно рандомизируется под гендер.
Добавлена возможность рандомизировать ТТС так же как и другие рандомизируемые настройки (для антага, для всех, не рандомизировать)

## Тестирование

Проверил рандомизацию - всё работает

## Changelog

:cl:
fix: ТТС теперь корректно рандомизируется под гендер
add: добавлена возможность рандомизировать ТТС так же как и другие рандомизируемые настройки (для антага, для всех, не рандомизировать)
/:cl:
