### PR TITLE
Fix `Who` BSOD

### DIFF
--- a/tgui/packages/tgui/interfaces/Who/Ping.tsx
+++ b/tgui/packages/tgui/interfaces/Who/Ping.tsx
@@ -1,18 +1,22 @@
 import { Icon, Stack, Tooltip } from 'tgui-core/components';
 
 export function ShowPing(props) {
-  const { user } = props;
+  const { ping } = props.user;
+  const { lastPing, avgPing } = ping;
+
   return (
     <Stack wrap>
-      <Tooltip content="Текущий пинг" position={'bottom-end'}>
+      <Tooltip content="Текущий пинг" position="bottom-end">
         <Stack.Item color="green">
-          <Icon name="clock-rotate-left" /> {Math.round(user.ping.lastPing)}ms
+          <Icon mr={1} name="clock-rotate-left" />
+          {ping ? `${Math.round(lastPing)}ms` : <Icon name="infinity" />}
         </Stack.Item>
       </Tooltip>
       <Stack.Divider />
-      <Tooltip content="Средний пинг" position={'bottom-end'}>
+      <Tooltip content="Средний пинг" position="bottom-end">
         <Stack.Item color="orange">
-          <Icon name="chart-simple" /> {Math.round(user.ping.avgPing)}ms
+          <Icon mr={1} name="chart-simple" />
+          {ping ? `${Math.round(avgPing)}ms` : <Icon name="infinity" />}
         </Stack.Item>
       </Tooltip>
     </Stack>

--- a/tgui/packages/tgui/interfaces/Who/Subject.tsx
+++ b/tgui/packages/tgui/interfaces/Who/Subject.tsx
@@ -1,3 +1,4 @@
+import { useCopyToClipboard } from '@uidotdev/usehooks';
 import { useState } from 'react';
 import {
   Button,
@@ -7,6 +8,7 @@ import {
   Stack,
   Tooltip,
 } from 'tgui-core/components';
+import { classes } from 'tgui-core/react';
 import { toTitleCase } from 'tgui-core/string';
 
 import { useBackend } from '../../backend';
@@ -62,6 +64,8 @@ export function Subject(props) {
 function SubjectInfoList(props) {
   const { subject } = props;
   const [showSpoiler, setShowSpoiler] = useState(false);
+  const [copiedText, copyToClipboard] = useCopyToClipboard();
+  const localHost = '127.0.0.1';
 
   return (
     <Stack vertical>
@@ -149,15 +153,22 @@ function SubjectInfoList(props) {
             label="IP пользователя"
             buttons={
               <Button
-                icon={showSpoiler ? 'eye' : 'eye-slash'}
-                selected={showSpoiler}
-                tooltip={showSpoiler ? 'Скрыть IP' : 'Показать IP'}
-                tooltipPosition={'bottom-end'}
-                onClick={() => setShowSpoiler(!showSpoiler)}
+                icon="copy"
+                tooltip="Скопировать IP"
+                tooltipPosition="top-end"
+                onClick={() => copyToClipboard(subject.accountIp || localHost)}
               />
             }
           >
-            {showSpoiler ? subject.accountIp : 'СКРЫТО'}
+            <span
+              className={classes([
+                'Who_Spoiler',
+                showSpoiler && 'Who_Spoiler--visible',
+              ])}
+              onClick={() => setShowSpoiler(!showSpoiler)}
+            >
+              {subject.accountIp || localHost}
+            </span>
           </LabeledList.Item>
           <LabeledList.Item label="Возраст аккаунта">
             {numberToDays(subject.accountAge)}
@@ -204,7 +215,7 @@ function SubjectInfoActions(props) {
       <Stack.Item>
         <Button
           color="red"
-          icon="skull-crossbones"
+          icon="hand-fist"
           tooltip="Наказать"
           onClick={() => act('smite', { ref: subjectRef })}
         />

--- a/tgui/packages/tgui/styles/interfaces/Who.scss
+++ b/tgui/packages/tgui/styles/interfaces/Who.scss
@@ -60,3 +60,31 @@
     }
   }
 }
+
+@property --spoiler-mask {
+  syntax: '<percentage>';
+  initial-value: 0%;
+  inherits: true;
+}
+
+.Who_Spoiler {
+  cursor: var(--cursor-pointer);
+  user-select: none;
+  position: relative;
+
+  &:before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-color: var(--color-secondary);
+    mask-image: radial-gradient(
+      transparent calc(var(--spoiler-mask) - 25%),
+      black var(--spoiler-mask)
+    );
+    transition: --spoiler-mask var(--transition-time-slow);
+  }
+
+  &--visible {
+    --spoiler-mask: 125%;
+  }
+}


### PR DESCRIPTION
## Что этот PR делает
Должно пофиксить БСОД когда чел не в своём теле и его чекают через WHO
Fixes #1537

Ну и пара дИзАйНерСкИх правок

## Почему это хорошо для игры
Меньше багов

## Изображения изменений

![IrR2zvkVZf](https://github.com/user-attachments/assets/210acdfb-a217-485d-bca6-66f8741f6611)

## Тестирование
Ну типа?

## Changelog

:cl:
fix: WHO больше не должен выдавать БЛЯТЬ когда вы чекаете битраннера в битране.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
