### PR TITLE
Fix buttonable default bomber

### DIFF
--- a/modular_bandastation/objects/code/items/clothing/suits/bomber.dm
+++ b/modular_bandastation/objects/code/items/clothing/suits/bomber.dm
@@ -8,7 +8,10 @@
 	icon = 'modular_bandastation/objects/icons/obj/clothing/suits/bomber.dmi'
 	icon_state = "bombersci"
 	worn_icon = 'modular_bandastation/objects/icons/mob/clothing/suits/bomber.dmi'
-	buttonable = TRUE
+
+/obj/item/clothing/suit/jacket/bomber/science/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/toggle_icon)
 
 // Roboticist
 /obj/item/clothing/suit/jacket/bomber/roboticist
@@ -17,4 +20,7 @@
 	icon = 'modular_bandastation/objects/icons/obj/clothing/suits/bomber.dmi'
 	icon_state = "bomberrobo"
 	worn_icon = 'modular_bandastation/objects/icons/mob/clothing/suits/bomber.dmi'
-	buttonable = TRUE
+
+/obj/item/clothing/suit/jacket/bomber/roboticist/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/toggle_icon)

--- a/modular_bandastation/objects/code/items/clothing/suits/suits.dm
+++ b/modular_bandastation/objects/code/items/clothing/suits/suits.dm
@@ -1,11 +1,3 @@
-/obj/item/clothing/suit
-	var/buttonable = FALSE
-
-/obj/item/clothing/suit/Initialize(mapload)
-	. = ..()
-	if(buttonable)
-		AddComponent(/datum/component/toggle_icon)
-
 /obj/item/clothing/suit/hooded/shark_costume
 	name = "shark costume"
 	desc = "Костюм из 'синтетической' кожи акулы, пахнет."


### PR DESCRIPTION
## Что этот PR делает
Фиксит сломанный спрайт у застёгнутого дефолтного бомбера, путём убирания возможности его застегнуть
Думаю чел который это делал, не учёл что у стандартного спрайтов нет на такой случай
Fixes #1506

## Тестирование
Заспавнил все бомберы, застёгиваются только те что должны

## Changelog

:cl:
fix: Дефолтный бомбер больше нельзя застегнуть - это ломало спрайт так как его банально не было
/:cl:
