### PR TITLE
Cyberiad: cold room fix

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -67389,14 +67389,14 @@
 /area/station/engineering/transit_tube)
 "qjt" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/right/directional/south{
-	name = "Hydroponics";
-	req_access = list("hydroponics")
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hydro";
 	name = "Hydroponics Shutter"
+	},
+/obj/machinery/door/window/right/directional/north{
+	name = "Hydroponics";
+	req_access = list("hydroponics")
 	},
 /turf/open/floor/plating,
 /area/station/service/hydroponics)


### PR DESCRIPTION
## Что этот PR делает

Фикс холодоса повара, а именно раньше, если открыть холодильник, срабатывали фаер алярмы, теперь все в порядке. Также дверца стойки ботаников теперь внутри, чтобы на стойку с коридора можно было что-то положить.

## Почему это хорошо для игры

Фаер алярмы плохо, ходить мешают. А к ботаникам теперь не надо долбиться, если принес семена/растения и тебе нужно идти по своим делам.

## Изображения изменений

![image](https://github.com/user-attachments/assets/60e4a9dc-9fc1-4423-b497-bd617a1eb6f4)
![StrongDMM-2025-07-03 20 24 24](https://github.com/user-attachments/assets/fae5178a-f201-4f6e-b291-0f58147bc77e)

## Тестирование

Локалка

## Changelog

:cl:
map: Кибериада: теперь при открытии холодильника у повара не срабатывают атмосферные тревоги. 
map: Кибериада: дверь на стойке ботаников теперь позволяет положить что-то со стороны коридора.
/:cl:
