### PR TITLE
Cyberiad: cursed med remap. Part 1

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -514,7 +514,6 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "ahp" = (
@@ -561,7 +560,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
@@ -1465,13 +1463,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "atx" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
 	},
-/obj/item/radio/intercom/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "atB" = (
@@ -1756,6 +1753,9 @@
 "axs" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
@@ -2640,12 +2640,13 @@
 /turf/open/water,
 /area/station/maintenance/ghetto/garden)
 "aHf" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/machinery/stasis,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/obj/structure/sign/poster/official/safety_eye_protection/directional/north,
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/head/utility/welding,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
+/area/station/medical/chemistry/ghetto)
 "aHh" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -2840,15 +2841,13 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
 "aJA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
-/obj/machinery/stasis{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/central)
 "aJL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -2911,13 +2910,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "aKH" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/stripes,
+/obj/machinery/status_display/ai/directional/north,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/smooth,
 /area/station/medical/chemistry/ghetto)
 "aKM" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -4652,8 +4648,6 @@
 	dir = 1;
 	id = "durka2"
 	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/door/window/brigdoor/security/cell/left/directional/south{
 	name = "Isolator"
 	},
@@ -5605,10 +5599,23 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "brn" = (
+/obj/structure/railing,
+/obj/structure/table/reinforced/rglass,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/railing,
+/obj/item/stack/medical/gauze{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/stack/medical/mesh{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/item/stack/medical/suture{
+	pixel_x = -9;
+	pixel_y = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "brr" = (
@@ -6191,12 +6198,10 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "byc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "byf" = (
@@ -7556,13 +7561,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/qm)
-"bPQ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/medical/chemistry/ghetto)
 "bPR" = (
 /obj/structure/table,
 /obj/item/radio/intercom/prison/directional/north,
@@ -8100,14 +8098,9 @@
 /turf/open/floor/iron/stairs/medium,
 /area/station/hallway/primary/central/fore)
 "bXj" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/area/station/medical/chemistry/ghetto)
 "bXn" = (
 /turf/closed/wall,
 /area/station/cargo/drone_bay/ghetto)
@@ -9645,12 +9638,20 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/kitchen)
 "coR" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor2-old"
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/table/reinforced/rglass,
+/obj/item/clothing/neck/stethoscope{
+	pixel_y = 8
+	},
+/obj/item/clothing/neck/stethoscope{
+	pixel_y = 4
+	},
+/obj/item/clothing/neck/stethoscope,
 /turf/open/floor/iron/white,
-/area/station/maintenance/aft)
+/area/station/medical/treatment_center)
 "coZ" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
@@ -10086,7 +10087,9 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/central)
 "cuC" = (
-/obj/machinery/vending/wardrobe/chem_wardrobe,
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/tank_holder/extinguisher,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "cuJ" = (
@@ -10362,9 +10365,10 @@
 /turf/open/space/openspace,
 /area/space/nearstation)
 "cye" = (
-/obj/machinery/chem_heater/withbuffer,
-/turf/open/floor/iron/dark/textured,
-/area/station/medical/chemistry/ghetto)
+/obj/item/storage/medkit/emergency,
+/obj/structure/table/glass,
+/turf/open/floor/iron/white,
+/area/station/medical/paramedic)
 "cyl" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -10390,10 +10394,10 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/checkpoint/medical)
 "cyz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
 	},
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "cyA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -11410,10 +11414,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/ghetto)
 "cKC" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes,
-/turf/open/floor/iron/smooth,
-/area/station/medical/chemistry/ghetto)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/station/medical/psychology)
 "cKE" = (
 /obj/machinery/vending/boozeomat,
 /obj/effect/decal/cleanable/dirt,
@@ -11974,11 +11979,13 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "cRy" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
 	},
-/turf/open/floor/wood/large,
-/area/station/service/bar/atrium/ghetto)
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/camera/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/ghetto)
 "cRA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -12093,10 +12100,10 @@
 /area/station/cargo/storage)
 "cTa" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/mess,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/machinery/light/small/dim/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
 "cTb" = (
@@ -12198,7 +12205,7 @@
 "cUf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
+/area/station/medical/medbay/aft)
 "cUg" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/red{
@@ -12425,14 +12432,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "cVX" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/structure/sign/warning/electric_shock/directional/west,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/iron/smooth,
 /area/station/medical/chemistry/ghetto)
 "cWl" = (
 /obj/effect/turf_decal/tile/dark_green{
@@ -12499,9 +12502,6 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "cXq" = (
@@ -13969,16 +13969,7 @@
 /area/station/maintenance/starboard/aft)
 "dnz" = (
 /obj/effect/turf_decal/tile/blue/full,
-/obj/structure/table/reinforced,
-/obj/machinery/defibrillator_mount,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_y = 4;
-	pixel_x = -6
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_y = 4;
-	pixel_x = 7
-	},
+/obj/machinery/stasis,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "dnB" = (
@@ -14621,16 +14612,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
 "dvk" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "ghetto_medical_storage"
-	},
-/obj/machinery/button/door/directional/south{
-	id = "ghetto_medical_storage";
-	name = "Shutters Control"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/obj/structure/sign/warning/no_smoking/circle,
+/turf/closed/wall,
+/area/station/medical/medbay/lobby)
 "dvm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14818,19 +14802,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "dxK" = (
-/obj/structure/sign/poster/official/safety_eye_protection/directional/north,
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
-	color = "#ff0000";
-	name = "Scrubbers multi deck pipe adapter"
-	},
-/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
-	color = "#0000ff";
-	name = "Supply multi deck pipe adapter"
-	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/floor/iron/smooth,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chemistry/ghetto)
 "dxQ" = (
 /obj/effect/turf_decal/tile/red{
@@ -16559,9 +16532,15 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "dVc" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/central)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/landmark/start/chemist,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/ghetto)
 "dVf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -16788,6 +16767,9 @@
 	color = "#52B4E9"
 	},
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "dXQ" = (
@@ -17580,7 +17562,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/chem_master,
+/obj/machinery/chem_dispenser,
 /turf/open/floor/engine,
 /area/station/medical/pharmacy)
 "eiH" = (
@@ -17590,12 +17572,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "eiK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/camera/directional/south{
+	c_tag = "Medbay Chemistry Lab - South";
+	network = list("ss13","medbay")
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "eiM" = (
@@ -17812,10 +17793,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "elG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
 	},
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "elH" = (
 /obj/structure/cable,
@@ -18561,10 +18544,27 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
 "ewZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/table/reinforced/rglass,
+/obj/item/storage/pill_bottle/penacid{
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/cup/bottle/morphine{
+	pixel_x = 2;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/cup/bottle/epinephrine{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/syringe/antiviral{
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/syringe/epinephrine,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "exb" = (
@@ -18818,10 +18818,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
-/obj/structure/closet/secure_closet/chemical,
-/obj/item/construction/plumbing,
-/obj/item/radio/headset/headset_med,
-/obj/item/radio/headset/headset_med,
+/obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "eAG" = (
@@ -19473,6 +19470,7 @@
 	dir = 8
 	},
 /obj/machinery/disposal/bin,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "eIw" = (
@@ -20266,7 +20264,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "eTo" = (
-/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/large,
 /area/station/service/bar/atrium/ghetto)
 "eTt" = (
@@ -20513,12 +20511,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
-"eWD" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
 "eWG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -20581,8 +20573,7 @@
 /turf/open/floor/wood,
 /area/station/maintenance/aft)
 "eXr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/dim/directional/east,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
 "eXt" = (
@@ -20884,14 +20875,12 @@
 /turf/open/floor/wood/parquet,
 /area/station/security/courtroom)
 "fbN" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/ghetto)
 "fbS" = (
 /obj/item/kirbyplants/random/dead,
 /obj/effect/spawner/random/maintenance,
@@ -21208,14 +21197,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
 "fgl" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/holopad,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
+/area/station/medical/pharmacy)
 "fgq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21553,9 +21538,9 @@
 /area/station/maintenance/department/engine/ghetto)
 "fjz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
 "fjA" = (
@@ -21940,12 +21925,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "fof" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/sign/warning/vacuum/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/obj/structure/chair/office/light{
+	dir = 1;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/chemistry/ghetto)
 "fog" = (
 /obj/effect/turf_decal/siding/wideplating_new/light{
 	dir = 6
@@ -24707,36 +24692,9 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "fVL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder{
-	pixel_x = -1;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_x = 3;
-	pixel_y = -8
-	},
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_x = -3;
-	pixel_y = -8
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	pixel_y = -6
-	},
-/obj/item/reagent_containers/dropper{
-	pixel_y = -7
-	},
-/obj/structure/sign/warning/no_smoking/directional/north,
-/obj/machinery/camera/directional/north{
-	c_tag = "Medbay - Chemistry Lab East";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "fVV" = (
 /obj/effect/turf_decal/stripes/line{
@@ -26290,10 +26248,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
-"goV" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
 "gpb" = (
 /turf/open/floor/iron,
 /area/station/maintenance/port)
@@ -26366,9 +26320,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "gqk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/medical/paramedic)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/iron/smooth,
+/area/station/medical/chemistry/ghetto)
 "gqq" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
@@ -26562,7 +26518,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
-/obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/button/door/directional/west{
 	id = "chemistry_access_shutters";
@@ -26571,6 +26526,7 @@
 	pixel_x = 0;
 	pixel_y = -24
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "gtv" = (
@@ -27265,18 +27221,13 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/east,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "gDI" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/machinery/light_switch/directional/east{
-	pixel_x = 23
-	},
-/turf/open/floor/iron/white,
+/obj/structure/cable,
+/obj/machinery/chem_heater/withbuffer,
+/turf/open/floor/iron/dark,
 /area/station/medical/chemistry/ghetto)
 "gDU" = (
 /obj/machinery/light/small/directional/south,
@@ -27958,6 +27909,10 @@
 	color = "#8C3E00"
 	},
 /obj/machinery/newscaster/directional/east,
+/obj/structure/disposalpipe/segment,
+/obj/item/toy/plush/moth{
+	name = "Dr. Moff"
+	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "gLG" = (
@@ -28013,9 +27968,9 @@
 /area/station/maintenance/starboard/upper)
 "gMr" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 5
+	dir = 8
 	},
-/obj/effect/landmark/event_spawn,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "gMH" = (
@@ -29218,14 +29173,6 @@
 "had" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/ghetto/port)
-"hag" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
 "hah" = (
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
@@ -29624,7 +29571,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
-/obj/machinery/airalarm/directional/south,
+/obj/structure/sign/departments/chemistry/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "hfV" = (
@@ -31798,8 +31745,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
 	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
@@ -32128,19 +32075,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"hJh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
 "hJi" = (
 /obj/machinery/igniter/incinerator_atmos{
 	id = "waste_incinerator_igniter"
@@ -32324,14 +32258,16 @@
 /turf/open/floor/iron,
 /area/station/maintenance/aft)
 "hLw" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/turf/open/floor/plating,
 /area/station/medical/chemistry/ghetto)
 "hLA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -32428,6 +32364,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "hNa" = (
@@ -32607,9 +32544,13 @@
 /turf/open/floor/plating,
 /area/station/tcommsat/server)
 "hPk" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/obj/machinery/light/directional/west,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/ghetto)
 "hPv" = (
 /obj/structure/railing{
 	dir = 8
@@ -32634,23 +32575,17 @@
 /turf/closed/wall,
 /area/station/cargo/sorting)
 "hPQ" = (
-/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
-	color = "#0000ff";
-	name = "Supply multi deck pipe adapter";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
-	color = "#ff0000";
-	dir = 1;
-	name = "Scrubbers multi deck pipe adapter"
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/yellow/fourcorners,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/table,
+/obj/item/book/manual/wiki/chemistry{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/book/manual/wiki/grenades,
+/obj/item/book/manual/wiki/plumbing{
+	pixel_x = 4;
+	pixel_y = -4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "hPR" = (
@@ -32811,11 +32746,16 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "hSo" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
 	},
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron/white,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/station/medical/chemistry/ghetto)
 "hSq" = (
 /obj/structure/closet/wardrobe/black,
@@ -33623,12 +33563,15 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "idc" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Medbay - Chemistry Lab North";
-	network = list("ss13","medbay")
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light_switch/directional/north,
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil{
+	pixel_y = 3
 	},
-/obj/machinery/chem_master,
-/turf/open/floor/iron/dark/textured_large,
+/obj/item/stack/cable_coil,
+/obj/item/multitool,
+/turf/open/floor/iron/smooth,
 /area/station/medical/chemistry/ghetto)
 "idm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33968,10 +33911,12 @@
 	dir = 6
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/landmark/start/hangover,
-/obj/structure/bed/medical/anchored{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_y = 4;
+	pixel_x = 7
 	},
+/obj/machinery/defibrillator_mount,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "iii" = (
@@ -34049,11 +33994,11 @@
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/light/warm/no_nightlight/directional/east,
+/obj/structure/disposalpipe/trunk/multiz/down{
+	dir = 1
+	},
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "ijf" = (
@@ -34717,11 +34662,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "irP" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/structure/bed/medical/anchored,
+/obj/structure/table/reinforced,
+/obj/machinery/defibrillator_mount,
+/obj/effect/turf_decal/tile/blue/full,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_y = 4;
+	pixel_x = -6
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "irW" = (
@@ -34837,16 +34785,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
 "itj" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/chem_dispenser,
+/obj/machinery/requests_console/auto_name/directional/north,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
 /turf/open/floor/iron/dark,
-/area/station/medical/surgery/theatre)
+/area/station/medical/chemistry/ghetto)
 "itk" = (
 /obj/machinery/chem_master/condimaster{
 	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
@@ -35325,8 +35270,9 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "iAJ" = (
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/iron/dark/textured_large,
+/obj/effect/landmark/event_spawn,
+/obj/machinery/holopad,
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "iAQ" = (
 /obj/structure/cable,
@@ -35384,15 +35330,9 @@
 /area/station/service/hydroponics/garden)
 "iBx" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/item/pen{
-	pixel_x = -5;
-	pixel_y = 8
-	},
 /obj/structure/table/reinforced/rglass,
+/obj/item/hand_labeler,
+/obj/item/stack/package_wrap,
 /obj/item/toy/figure/chemist,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
@@ -35583,10 +35523,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
-"iEl" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
 "iEn" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -36691,6 +36627,9 @@
 	name = "Tom's bed"
 	},
 /mob/living/basic/pet/dog/pug,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "iRE" = (
@@ -38600,7 +38539,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/structure/sign/poster/random/directional/east,
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -39420,13 +39358,6 @@
 /obj/structure/fluff/shower_drain,
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/prison/ghetto)
-"jAR" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/effect/landmark/start/chemist,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
 "jAW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/structure/girder,
@@ -40716,14 +40647,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
 "jRz" = (
-/obj/machinery/plumbing/receiver{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/yellow/end{
-	dir = 4
-	},
 /obj/machinery/light/directional/south,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "jRH" = (
 /obj/structure/bed,
@@ -41462,11 +41388,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "kae" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/landmark/start/chemist,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "kak" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -42856,12 +42782,14 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel/monastery)
 "ksr" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/ghetto)
 "kst" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43107,7 +43035,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "kvl" = (
@@ -43414,7 +43341,6 @@
 "kzH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/airalarm/directional/east,
 /obj/machinery/camera/directional/east{
 	c_tag = "Medbay - Lobby Reception";
 	network = list("ss13","medbay")
@@ -44461,8 +44387,13 @@
 	dir = 5
 	},
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/light/directional/north,
-/obj/machinery/chem_heater/withbuffer,
+/obj/structure/table/reinforced/rglass,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_y = 6
+	},
 /turf/open/floor/engine,
 /area/station/medical/pharmacy)
 "kKi" = (
@@ -44776,9 +44707,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "kOg" = (
@@ -45041,8 +44969,6 @@
 "kRj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "kRp" = (
@@ -45653,11 +45579,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "kZe" = (
-/obj/machinery/plumbing/sender,
 /obj/effect/turf_decal/siding/yellow/end{
-	dir = 8
+	dir = 4
 	},
-/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/plumbing/sender{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/medical/chemistry/ghetto)
 "kZm" = (
@@ -46183,17 +46110,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "lgR" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id = "quarantine";
-	name = "Quarantine Lockdown";
-	opacity = 0
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/no_smoking/circle,
-/turf/open/floor/plating,
-/area/station/medical/medbay/lobby)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/ghetto)
 "lha" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -46399,17 +46326,14 @@
 /turf/open/floor/grass,
 /area/station/maintenance/starboard/upper)
 "ljF" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/table/reinforced,
-/obj/item/radio/intercom/directional/east,
-/obj/item/stack/cable_coil{
-	pixel_y = 3
-	},
-/obj/item/stack/cable_coil,
-/obj/item/multitool,
-/turf/open/floor/iron/dark/textured_half{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "ljJ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -46476,15 +46400,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/storage)
 "lkX" = (
-/obj/structure/ladder,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/door/window/left/directional/north{
-	name = "Chemistry Lab Access Hatch";
-	req_access = list("plumbing")
-	},
-/obj/effect/turf_decal/stripes/box,
-/obj/structure/sign/departments/chemistry/directional/south,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "lla" = (
@@ -46949,6 +46866,9 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/psychologist,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "lpU" = (
@@ -47633,13 +47553,13 @@
 /turf/open/floor/carpet/black,
 /area/station/command/meeting_room)
 "lxE" = (
-/obj/effect/spawner/random/engineering/atmospherics_portable,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/machinery/status_display/evac/directional/west,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
-/turf/open/floor/iron/large,
-/area/station/maintenance/ghetto/central)
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/ghetto)
 "lxI" = (
 /obj/machinery/power/turbine/turbine_outlet,
 /turf/open/floor/engine,
@@ -48625,21 +48545,9 @@
 /area/station/maintenance/ghetto/fore/starboard)
 "lKp" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/table/reinforced/rglass,
 /obj/machinery/light/directional/south,
 /obj/machinery/airalarm/directional/south,
-/obj/item/storage/pill_bottle/penacid{
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/cup/bottle/morphine{
-	pixel_x = 2;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/cup/bottle/epinephrine{
-	pixel_x = 14;
-	pixel_y = 4
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "lKu" = (
@@ -52560,10 +52468,12 @@
 /turf/open/floor/iron/smooth,
 /area/station/commons/toilet/restrooms)
 "mHs" = (
-/obj/machinery/firealarm/directional/east,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "mHA" = (
 /obj/structure/frame,
@@ -52636,35 +52546,21 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "mIn" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 1
-	},
-/obj/structure/table/reinforced/rglass,
-/obj/item/screwdriver{
-	pixel_x = 2;
-	pixel_y = 11
-	},
-/obj/item/grenade/chem_grenade{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/grenade/chem_grenade{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/grenade/chem_grenade{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/grenade/chem_grenade{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/stack/cable_coil{
-	pixel_x = 6
-	},
 /obj/structure/sign/poster/official/science/directional/west,
 /obj/machinery/light/directional/west,
+/obj/structure/table/reinforced/rglass,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 8
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = -8
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 8
+	},
+/obj/item/storage/box/syringes{
+	pixel_y = 11
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "mIo" = (
@@ -53024,8 +52920,19 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/chem_mass_spec,
-/obj/machinery/light_switch/directional/east,
+/obj/structure/table/reinforced/rglass,
+/obj/item/storage/bag/chemistry,
+/obj/item/storage/bag/chemistry,
+/obj/item/clothing/mask/gas{
+	pixel_y = 6
+	},
+/obj/item/clothing/mask/gas{
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'";
+	name = "Chemistry Cleaner"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "mMK" = (
@@ -53110,24 +53017,17 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "mNQ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
 	},
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "mOh" = (
-/obj/machinery/light_switch/directional/west,
 /obj/effect/landmark/start/paramedic,
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "mOl" = (
@@ -54482,9 +54382,9 @@
 /area/station/maintenance/ghetto/fore/starboard)
 "nfs" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/iv_drip,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/machinery/iv_drip,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "nfA" = (
@@ -55232,14 +55132,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/table/glass,
-/obj/item/soap/nanotrasen{
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/machinery/light/small/directional/north,
+/obj/structure/chair/comfy/teal,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "nol" = (
@@ -55987,44 +55883,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "nxv" = (
-/obj/item/assembly/timer{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/obj/item/assembly/timer{
-	pixel_x = 8;
-	pixel_y = 3
-	},
-/obj/item/assembly/timer{
-	pixel_x = 8
-	},
-/obj/item/assembly/timer{
-	pixel_x = 8;
-	pixel_y = -3
-	},
-/obj/item/assembly/igniter{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/assembly/igniter{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/item/assembly/igniter{
-	pixel_x = -6
-	},
-/obj/item/assembly/igniter{
-	pixel_x = -6;
-	pixel_y = -3
-	},
-/obj/structure/table/reinforced/rglass,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
+/obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/camera/directional/west{
 	c_tag = "Medbay - Chemistry";
 	network = list("ss13","medbay")
 	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/chem_mass_spec,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "nxS" = (
@@ -56138,9 +56006,8 @@
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "nAb" = (
-/obj/structure/ladder,
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/iron/smooth,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "nAh" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -56269,7 +56136,6 @@
 "nBq" = (
 /obj/machinery/vending/medical,
 /obj/machinery/light/directional/north,
-/obj/structure/sign/poster/official/help_others/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
@@ -56334,10 +56200,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "nBO" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/surgery/theatre)
 "nBR" = (
 /obj/effect/spawner/random/structure/chair_maintenance{
 	dir = 1
@@ -56405,7 +56273,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "nCS" = (
-/obj/item/radio/intercom/directional/west,
 /obj/machinery/computer/crew,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
@@ -57386,9 +57253,14 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "nPs" = (
-/obj/effect/spawner/random/structure/girder,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/ghetto)
 "nPv" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -58382,11 +58254,8 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
 "obP" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/box/white{
-	color = "#52B4E9"
-	},
-/turf/open/floor/iron/white/smooth_large,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "obV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60569,10 +60438,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "oCm" = (
-/obj/structure/table/glass,
-/obj/item/storage/medkit/emergency,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/landmark/navigate_destination/chemfactory,
 /turf/open/floor/iron/white,
-/area/station/medical/paramedic)
+/area/station/medical/chemistry/ghetto)
 "oCs" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -61081,9 +60951,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/garden)
 "oIA" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/construction/plumbing{
+	pixel_y = -5
+	},
+/obj/item/construction/plumbing,
+/obj/machinery/newscaster/directional/north,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
+/area/station/medical/chemistry/ghetto)
 "oID" = (
 /obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
 /obj/effect/turf_decal/siding/thinplating_new/light/end{
@@ -61338,6 +61216,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/duct,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "oLo" = (
@@ -61613,14 +61492,9 @@
 /area/station/engineering/hallway)
 "oPj" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/structure/cable,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "oPo" = (
@@ -61902,8 +61776,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "oSR" = (
@@ -64006,9 +63878,14 @@
 /turf/open/floor/plating,
 /area/station/science/research)
 "ptj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/medical/medbay/lobby)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/ghetto)
 "ptk" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -64477,18 +64354,7 @@
 /area/station/maintenance/fore)
 "pyo" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/table/reinforced/rglass,
 /obj/machinery/light/directional/south,
-/obj/item/reagent_containers/syringe/epinephrine,
-/obj/item/reagent_containers/syringe/antiviral{
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/syringe/calomel{
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/syringe{
-	pixel_y = 12
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "pyp" = (
@@ -64513,10 +64379,17 @@
 "pyz" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/airalarm/directional/north,
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/flashlight/pen/paramedic,
+/obj/item/toy/figure/paramedic,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "pyM" = (
 /obj/machinery/vending/coffee,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "pyV" = (
@@ -64702,27 +64575,10 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
 "pBD" = (
-/obj/item/book/manual/wiki/plumbing{
-	pixel_x = 4;
-	pixel_y = -4
-	},
-/obj/item/book/manual/wiki/grenades,
-/obj/item/book/manual/wiki/chemistry{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/obj/machinery/status_display/evac/directional/east,
-/obj/structure/table/reinforced,
-/obj/item/storage/box/syringes,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "pBE" = (
 /obj/structure/disposalpipe/segment{
@@ -64888,9 +64744,14 @@
 /turf/open/floor/wood/large,
 /area/station/service/bar/atrium/ghetto)
 "pCC" = (
-/obj/effect/spawner/random/structure/barricade,
+/obj/effect/turf_decal/siding/yellow/end{
+	dir = 8
+	},
+/obj/machinery/plumbing/sender{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/area/station/medical/chemistry/ghetto)
 "pCG" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
@@ -64915,10 +64776,14 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "pCP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/departments/chemistry,
-/turf/open/floor/plating,
-/area/station/medical/pharmacy)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/central)
 "pCT" = (
 /obj/structure/flora/bush/jungle/b/style_random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -65142,8 +65007,8 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "pFr" = (
@@ -65895,9 +65760,12 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage)
 "pOC" = (
-/obj/effect/spawner/random/structure/tank_holder,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/ghetto)
 "pOI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -66009,9 +65877,13 @@
 /turf/open/floor/carpet,
 /area/station/maintenance/starboard/aft)
 "pQC" = (
-/obj/effect/turf_decal/tile/blue/full,
-/obj/structure/table/reinforced,
-/obj/machinery/defibrillator_mount,
+/obj/machinery/stasis{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "pQP" = (
@@ -67306,14 +67178,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/structure/table/reinforced/rglass,
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_y = 6
-	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_y = 6
-	},
 /turf/open/floor/engine,
 /area/station/medical/pharmacy)
 "qiz" = (
@@ -67800,9 +67664,6 @@
 /obj/structure/table/wood,
 /obj/machinery/computer/records/medical/laptop{
 	pixel_y = 2
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
 	},
 /obj/machinery/button/door/directional/south{
 	id = "psych_office";
@@ -69737,7 +69598,6 @@
 /obj/structure/chair/office/light{
 	dir = 8
 	},
-/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "qOf" = (
@@ -70578,10 +70438,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "qZe" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "qZi" = (
@@ -70989,6 +70849,9 @@
 /area/station/service/hydroponics/garden)
 "rdT" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "reb" = (
@@ -71821,6 +71684,17 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 6
+	},
+/obj/item/pen{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/structure/desk_bell{
+	pixel_x = 7
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "rnj" = (
@@ -72767,9 +72641,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "rAh" = (
-/obj/machinery/light/directional/north,
-/obj/effect/landmark/navigate_destination/chemfactory,
-/turf/open/floor/iron/smooth,
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "rAk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -73061,13 +72937,25 @@
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "rEd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/item/plunger{
+	pixel_x = 3
 	},
-/obj/machinery/vending/wardrobe/chem_wardrobe,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
+/obj/item/plunger{
+	pixel_x = -3
 	},
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/item/stack/ducts/fifty,
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/evac/directional/north,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
 /area/station/medical/chemistry/ghetto)
 "rEh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -73691,12 +73579,10 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "rMh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/iv_drip,
-/obj/item/wheelchair,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/central)
+/obj/effect/turf_decal/stripes,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/medical/chemistry/ghetto)
 "rMk" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Central Hallway - South-West";
@@ -74238,9 +74124,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "rTt" = (
@@ -74847,8 +74731,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/chem_dispenser,
 /obj/machinery/status_display/evac/directional/north,
+/obj/machinery/chem_master,
 /turf/open/floor/engine,
 /area/station/medical/pharmacy)
 "rZR" = (
@@ -74982,9 +74866,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "sbF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
+	dir = 6
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
@@ -75236,10 +75120,9 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
 "sdK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/obj/structure/sign/warning/no_smoking/circle,
+/turf/closed/wall,
+/area/station/medical/paramedic)
 "sdN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
@@ -76021,9 +75904,16 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "snz" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/door/window/left/directional/west{
+	name = "Chemistry Lab Access Hatch";
+	req_access = list("plumbing")
+	},
+/obj/structure/ladder{
+	name = "chemistry lab access"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "snB" = (
@@ -76302,6 +76192,7 @@
 	c_tag = "Medbay - Lobby";
 	network = list("ss13","medbay")
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "sqT" = (
@@ -77488,21 +77379,9 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "sFs" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/structure/table/wood/fancy/red,
-/obj/item/plate/small{
-	color = "#454545";
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/cigarette/cigar{
-	pixel_y = 10;
-	pixel_x = -3
-	},
-/turf/open/floor/wood/large,
-/area/station/service/bar/atrium/ghetto)
+/obj/structure/sign/departments/chemistry,
+/turf/closed/wall/r_wall,
+/area/station/medical/pharmacy)
 "sFx" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -77635,23 +77514,21 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "sHx" = (
-/obj/machinery/firealarm/directional/west,
-/obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/item/flashlight/pen/paramedic,
-/obj/item/toy/figure/paramedic,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "sHy" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+/obj/machinery/plumbing/receiver{
+	dir = 1
 	},
-/obj/machinery/status_display/evac/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/obj/effect/turf_decal/siding/yellow/end{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/medical/medbay/aft)
 "sHE" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/table/optable,
@@ -78053,10 +77930,11 @@
 /turf/closed/wall/r_wall,
 /area/station/medical/surgery/fore)
 "sNS" = (
-/obj/structure/closet/crate/medical,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/structure/sign/poster/official/help_others/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "sOa" = (
@@ -78195,6 +78073,7 @@
 	dir = 5
 	},
 /obj/machinery/vending/coffee,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "sPI" = (
@@ -79084,18 +78963,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "tdr" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/construction/plumbing,
-/obj/item/construction/plumbing{
-	pixel_y = -5
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/iron/smooth,
 /area/station/medical/chemistry/ghetto)
 "tdD" = (
 /obj/structure/table/reinforced,
@@ -79137,8 +79008,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "teg" = (
-/obj/structure/sign/warning/electric_shock/directional/north,
-/turf/open/floor/iron/smooth,
+/obj/effect/landmark/start/chemist,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/medical/chemistry/ghetto)
 "tem" = (
 /obj/effect/mapping_helpers/broken_floor,
@@ -79397,11 +79271,35 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/fore)
 "tiu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/structure/railing{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/table/reinforced/rglass,
+/obj/item/reagent_containers/applicator/patch/libital{
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/applicator/patch/aiuri{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/applicator/patch/libital{
+	pixel_x = -6;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/applicator/patch/aiuri{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/applicator/patch/libital{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/applicator/patch/aiuri{
+	pixel_x = 6;
+	pixel_y = 4
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/treatment_center)
 "tiz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/mapping_helpers/broken_floor,
@@ -79753,9 +79651,11 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
-/obj/structure/chair/comfy/teal,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
+/obj/structure/table/glass,
+/obj/item/soap/nanotrasen{
+	pixel_y = 2
+	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "tmK" = (
@@ -79763,34 +79663,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "tmL" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/table/reinforced/rglass,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/mesh{
-	pixel_x = -8;
-	pixel_y = -5
-	},
-/obj/item/stack/medical/mesh{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/obj/item/stack/medical/gauze{
-	pixel_x = 7
-	},
-/obj/item/stack/medical/gauze{
-	pixel_x = 7;
-	pixel_y = 6
-	},
-/obj/item/stack/medical/suture{
-	pixel_x = -9;
-	pixel_y = -7
-	},
-/obj/item/stack/medical/suture{
-	pixel_x = -9;
-	pixel_y = 4
-	},
+/obj/machinery/light/floor,
 /turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/area/station/medical/chemistry/ghetto)
 "tmN" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -79880,22 +79755,21 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
-/obj/item/storage/box/syringes{
-	pixel_y = 16
-	},
+/obj/machinery/light_switch/directional/east,
+/obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/table/reinforced/rglass,
-/obj/item/storage/box/beakers{
-	pixel_y = 6;
-	pixel_x = -8
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/gloves/latex{
+	pixel_y = 5
 	},
-/obj/item/storage/box/beakers{
-	pixel_y = 6;
-	pixel_x = 8
+/obj/item/clothing/glasses/science{
+	pixel_y = -2
 	},
-/obj/machinery/firealarm/directional/east,
-/obj/item/hand_labeler{
-	pixel_x = -8;
-	pixel_y = 2
+/obj/item/clothing/glasses/science{
+	pixel_y = 4
+	},
+/obj/item/clothing/glasses/science{
+	pixel_y = 10
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
@@ -80030,15 +79904,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/ghetto)
 "toY" = (
 /obj/machinery/button/door/directional/west{
 	id = "Toilet4";
@@ -80077,12 +79944,12 @@
 /turf/open/floor/iron/stairs/left,
 /area/station/security/holding_cell)
 "tpq" = (
-/obj/machinery/status_display/ai/directional/north,
-/obj/machinery/plumbing/sender,
-/obj/effect/turf_decal/siding/yellow/end{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "tpu" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
@@ -80101,6 +79968,9 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced/spawner/directional/west,
+/obj/item/clipboard{
+	pixel_y = 3
+	},
 /obj/item/paper_bin{
 	pixel_y = 4
 	},
@@ -80298,8 +80168,10 @@
 /area/station/maintenance/aft)
 "trI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
-/area/station/medical/psychology)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/ghetto)
 "trL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -80421,12 +80293,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "ttv" = (
-/obj/structure/cable/multilayer/multiz,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/station/medical/chemistry/ghetto)
+/area/station/maintenance/ghetto/central)
 "ttw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/port_gen/pacman,
@@ -81124,18 +80993,22 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "tCm" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
 	},
-/obj/structure/table/wood/fancy/red,
-/obj/item/flashlight/lamp/green{
-	pixel_y = 14
+/obj/machinery/fax{
+	fax_name = "Medical";
+	name = "Medical Fax Machine"
 	},
-/obj/item/stack/spacecash/c100{
-	pixel_y = 2
-	},
-/turf/open/floor/wood/large,
-/area/station/service/bar/atrium/ghetto)
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/lobby)
 "tCo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/office{
@@ -81365,13 +81238,27 @@
 /turf/open/floor/iron/textured_large,
 /area/station/command/teleporter)
 "tEW" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder{
+	pixel_x = -1;
+	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = 3;
+	pixel_y = -8
+	},
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = -3;
+	pixel_y = -8
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_y = -6
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_y = -7
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
 /area/station/medical/chemistry/ghetto)
 "tEX" = (
 /obj/machinery/door/airlock/maintenance,
@@ -82484,13 +82371,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "tUe" = (
-/obj/effect/spawner/random/engineering/atmospherics_portable,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
-/turf/open/floor/iron/large,
-/area/station/maintenance/ghetto/central)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/ghetto)
 "tUn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/siding/thinplating_new{
@@ -83040,15 +82927,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/electrical/ghetto)
-"tZP" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/camera/directional/south{
-	c_tag = "Medbay - Chemistry Lab South";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
 "tZV" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -83173,25 +83051,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "uaZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/structure/table/reinforced,
-/obj/item/plunger{
-	pixel_x = 3
-	},
-/obj/item/plunger{
-	pixel_x = -3
-	},
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/obj/item/stack/ducts/fifty,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "ubf" = (
 /obj/structure/plasticflaps/opaque,
@@ -83286,13 +83148,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/ordnance)
-"uco" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/mess,
-/obj/machinery/light/small/dim/directional/east,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/central)
 "ucp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -83893,12 +83748,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
 "ujG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/sign/warning/vacuum/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white/smooth_large,
+/area/station/medical/chemistry/ghetto)
 "ujN" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "warehouse_shutters";
@@ -84045,8 +83902,8 @@
 /turf/open/floor/iron,
 /area/station/science/lobby)
 "ulS" = (
-/obj/machinery/computer/crew,
 /obj/structure/sign/poster/official/random/directional/north,
+/obj/machinery/computer/records/medical,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "ulV" = (
@@ -85211,9 +85068,28 @@
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "uDD" = (
-/obj/structure/chair/sofa/right/maroon,
-/turf/open/floor/wood/large,
-/area/station/service/bar/atrium/ghetto)
+/obj/machinery/door/airlock/maintenance{
+	name = "Chemistry Maintenance"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/ghetto)
 "uDH" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -85948,6 +85824,8 @@
 /obj/item/reagent_containers/cup/beaker/large{
 	pixel_y = 6
 	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/engine,
 /area/station/medical/pharmacy)
 "uMR" = (
@@ -86158,11 +86036,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
-"uPs" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
 "uPu" = (
 /obj/structure/spacevine{
 	can_spread = 0;
@@ -86463,8 +86336,6 @@
 	dir = 1;
 	id = "durka1"
 	},
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/door/window/brigdoor/security/cell/left/directional/south{
 	name = "Isolator"
 	},
@@ -87424,6 +87295,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/engine,
 /area/station/medical/pharmacy)
 "vhH" = (
@@ -88734,32 +88608,17 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "vuy" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/table/reinforced/rglass,
-/obj/item/reagent_containers/applicator/patch/aiuri{
-	pixel_x = 6
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
 	},
-/obj/item/reagent_containers/applicator/patch/aiuri{
-	pixel_x = 6;
-	pixel_y = 2
+/obj/machinery/camera/directional/west{
+	c_tag = "Medbay Chemistry Lab - West";
+	network = list("ss13","medbay")
 	},
-/obj/item/reagent_containers/applicator/patch/aiuri{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/applicator/patch/libital{
-	pixel_x = -6
-	},
-/obj/item/reagent_containers/applicator/patch/libital{
-	pixel_x = -6;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/applicator/patch/libital{
-	pixel_x = -6;
-	pixel_y = 4
-	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
-/area/station/medical/treatment_center)
+/area/station/medical/chemistry/ghetto)
 "vuF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -89626,9 +89485,6 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "vGI" = (
@@ -90410,13 +90266,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "vRI" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/storage/box/syringes,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
 /area/station/medical/chemistry/ghetto)
 "vRP" = (
 /obj/effect/turf_decal/stripes/line{
@@ -90636,17 +90494,13 @@
 /turf/open/floor/iron/white/corner,
 /area/station/service/kitchen/kitchen_backroom/ghetto)
 "vUI" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
-/obj/item/book/manual/wiki/grenades,
-/obj/item/book/manual/wiki/plumbing{
-	pixel_x = 5
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/item/book/manual/wiki/chemistry{
-	pixel_x = 8
-	},
-/obj/structure/table,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/medical/chemistry/ghetto)
 "vVf" = (
 /obj/effect/turf_decal/box/red,
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -91027,8 +90881,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "vZV" = (
@@ -91585,12 +91440,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "whx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
+	dir = 10
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "whz" = (
@@ -92068,10 +91921,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay/ghetto)
 "wnr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
-/area/station/medical/pharmacy)
+/area/station/medical/chemistry/ghetto)
 "wnx" = (
 /obj/structure/chair/comfy/teal{
 	dir = 4
@@ -92095,14 +91949,13 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "wob" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/head/utility/welding,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
+/obj/effect/turf_decal/stripes,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Medbay Chemistry Lab - North";
+	network = list("ss13","medbay")
 	},
+/turf/open/floor/iron/smooth,
 /area/station/medical/chemistry/ghetto)
 "woc" = (
 /obj/effect/spawner/random/maintenance,
@@ -92289,7 +92142,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "wro" = (
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
 /obj/structure/table/glass,
 /obj/item/clothing/glasses/hud/health{
@@ -92301,6 +92153,8 @@
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_y = 10
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "wrs" = (
@@ -92524,19 +92378,33 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "wuA" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/screwdriver{
+	pixel_x = 2;
+	pixel_y = 11
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/grenade/chem_grenade{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 6
+	},
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
-/obj/item/clothing/glasses/science{
-	pixel_y = -2
-	},
-/obj/item/clothing/glasses/science{
-	pixel_y = 4
-	},
-/obj/item/clothing/glasses/science{
-	pixel_y = 10
-	},
-/obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "wuK" = (
@@ -93281,12 +93149,9 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "wCT" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/medbay/lobby)
 "wCV" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
@@ -95254,12 +95119,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/aft)
 "xck" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 5
-	},
-/obj/machinery/requests_console/auto_name/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/area/station/medical/medbay/aft)
 "xcl" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 8
@@ -95440,8 +95302,16 @@
 /obj/item/reagent_containers/dropper{
 	pixel_y = 11
 	},
-/obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/table/reinforced/rglass,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/item/reagent_containers/cup/bottle/epinephrine{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/cup/bottle/multiver{
+	pixel_x = 7;
+	pixel_y = 3
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "xem" = (
@@ -95587,14 +95457,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'";
-	name = "Chemistry Cleaner";
-	pixel_y = 14
-	},
-/obj/structure/table/reinforced/rglass,
-/obj/machinery/airalarm/directional/east,
+/obj/structure/sink/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "xfI" = (
@@ -96009,11 +95872,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "xkj" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "xkk" = (
 /obj/structure/table/reinforced,
@@ -96133,20 +95994,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "xmg" = (
-/obj/structure/table/glass,
-/obj/item/clipboard{
-	pixel_y = 3
-	},
-/obj/item/clothing/neck/stethoscope,
-/obj/item/clothing/neck/stethoscope{
-	pixel_y = 4
-	},
-/obj/item/clothing/neck/stethoscope{
-	pixel_y = 8
-	},
-/obj/machinery/light_switch/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/lobby)
+/area/station/medical/chemistry/ghetto)
 "xmh" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -96227,9 +96079,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "xmP" = (
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "floor2-old"
-	},
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
@@ -96287,11 +96136,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "xnK" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/white,
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/chem_master,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/sign/warning/no_smoking/directional/north,
+/turf/open/floor/iron/dark,
 /area/station/medical/chemistry/ghetto)
 "xnP" = (
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -96855,9 +96704,8 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/ghetto)
 "xvz" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chemistry/ghetto)
 "xvV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -97469,9 +97317,6 @@
 	c_tag = "Medbay - Waiting Room";
 	network = list("ss13","medbay")
 	},
-/obj/machinery/light_switch/directional/east{
-	pixel_x = 24
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "xEo" = (
@@ -97844,10 +97689,9 @@
 /turf/open/openspace,
 /area/station/science/xenobiology)
 "xJl" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/stripes/box,
+/obj/structure/ladder,
+/turf/open/floor/iron/smooth,
 /area/station/medical/chemistry/ghetto)
 "xJn" = (
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -98658,10 +98502,10 @@
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/department/security/ghetto)
 "xTi" = (
-/obj/machinery/status_display/evac/directional/north,
-/obj/machinery/chem_dispenser,
-/turf/open/floor/iron/dark,
-/area/station/medical/chemistry/ghetto)
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
+/area/station/service/bar/atrium/ghetto)
 "xTn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -98880,6 +98724,8 @@
 	pixel_y = 12
 	},
 /obj/structure/table/reinforced/rglass,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "xWm" = (
@@ -98974,7 +98820,7 @@
 	dir = 1
 	},
 /obj/item/reagent_containers/cup/glass/mug,
-/obj/machinery/light_switch/directional/north,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "xXN" = (
@@ -99055,12 +98901,11 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
 "xYF" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/structure/disposalpipe/trunk/multiz{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/surgery/theatre)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central)
 "xYK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -99329,11 +99174,11 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
 	},
-/obj/machinery/reagentgrinder{
-	pixel_x = -2;
-	pixel_y = 12
-	},
-/obj/structure/table/reinforced/rglass,
+/obj/structure/closet/secure_closet/chemical,
+/obj/item/construction/plumbing,
+/obj/item/radio/headset/headset_med,
+/obj/item/radio/headset/headset_med,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "ycr" = (
@@ -99823,16 +99668,39 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "yiU" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/item/storage/bag/chemistry,
-/obj/item/storage/bag/chemistry,
-/obj/item/clothing/mask/gas{
+/obj/item/assembly/timer{
+	pixel_x = 8;
 	pixel_y = 6
 	},
-/obj/item/clothing/mask/gas{
+/obj/item/assembly/timer{
+	pixel_x = 8;
+	pixel_y = 3
+	},
+/obj/item/assembly/timer{
+	pixel_x = 8
+	},
+/obj/item/assembly/timer{
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/item/assembly/igniter{
+	pixel_x = -6;
 	pixel_y = 6
+	},
+/obj/item/assembly/igniter{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/assembly/igniter{
+	pixel_x = -6
+	},
+/obj/item/assembly/igniter{
+	pixel_x = -6;
+	pixel_y = -3
 	},
 /obj/structure/table/reinforced/rglass,
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "yjk" = (
@@ -99913,11 +99781,7 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "ykl" = (
-/obj/structure/table/glass,
-/obj/machinery/fax{
-	fax_name = "Medical";
-	name = "Medical Fax Machine"
-	},
+/obj/machinery/computer/crew,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "ykp" = (
@@ -132111,13 +131975,13 @@ guN
 guN
 mOI
 mOI
-doz
-doz
-ceC
-doz
-doz
-doz
-doz
+mOI
+mOI
+mOI
+mOI
+mOI
+mOI
+mOI
 ceC
 doz
 doz
@@ -132367,13 +132231,13 @@ liU
 eVb
 rqb
 bCC
-mOI
-mOI
-mOI
-mOI
-mOI
-mOI
-mOI
+bBe
+dEJ
+bBe
+bBe
+rqb
+mdv
+dlM
 mOI
 ceC
 vbK
@@ -132624,12 +132488,12 @@ guN
 guN
 guN
 gJQ
-bBe
-dEJ
-bBe
-bBe
-rqb
-mdv
+pkq
+tXJ
+cbv
+naU
+mOI
+qXM
 dlM
 mOI
 doz
@@ -132881,13 +132745,13 @@ doz
 doz
 guN
 mOI
-pkq
-tXJ
-cbv
-naU
 mOI
 mOI
-dlM
+mOI
+mOI
+mOI
+hzl
+tZn
 mOI
 doz
 mOI
@@ -133137,14 +133001,14 @@ ceC
 ceC
 ceC
 ceC
+ceC
+ceC
+ceC
+ceC
+ceC
 mOI
-mOI
-mOI
-mOI
-mOI
-mOI
-hzl
-tZn
+qXM
+aJA
 mOI
 mOI
 mOI
@@ -133400,7 +133264,7 @@ doz
 doz
 doz
 mOI
-qXM
+fAb
 cTa
 fjz
 dlM
@@ -133411,14 +133275,14 @@ dlM
 dlM
 dlM
 nWv
-gjQ
-isK
-nPs
-fRL
-qAb
-fRL
-cKf
+pCP
+eXr
+ttv
+xYF
 dGY
+dGY
+dGY
+qAb
 duo
 mOI
 mOI
@@ -133647,33 +133511,33 @@ guN
 raA
 raA
 raA
-raA
-raA
-raA
 iZA
 iZA
+iZA
+iZA
+iZA
 doz
 doz
 doz
 doz
 mOI
-fAb
-uco
-mOI
-dvk
 mOI
 mOI
-mOI
-jKW
-kMs
-kMs
-kMs
-dGY
-kMs
-dGY
-dVc
-isK
-dGY
+vzJ
+vzJ
+vzJ
+vzJ
+vzJ
+vzJ
+vzJ
+vzJ
+vzJ
+uDD
+vzJ
+vzJ
+vzJ
+vzJ
+cKf
 dGY
 dGY
 dGY
@@ -133913,36 +133777,36 @@ iZA
 iZA
 doz
 doz
-mOI
-mOI
-mOI
-mOI
-dGY
+doz
+doz
+doz
+vzJ
+cVX
 nPs
 pOC
-mOI
-jKW
+pOC
+vuy
 hPk
 lxE
 tUe
+lgR
+gMr
+gNY
+pCC
+vzJ
+cKf
+fRL
 mOI
 mOI
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
+mOI
+mOI
+mOI
+mOI
+fif
+fif
+fif
+fif
+fif
 rQp
 nBf
 fif
@@ -134170,36 +134034,36 @@ mca
 iZA
 doz
 doz
-ceC
-ceC
-ceC
-mOI
-eXr
-pCC
-rMh
-mOI
-hJh
-mOI
-mOI
-mOI
+doz
+doz
+doz
+hLw
+lBE
+ksr
+sux
+sux
+sux
+sux
+sux
+sux
+xmg
+sux
+cLk
+kZe
+vzJ
+vzJ
+vzJ
 mOI
 doz
-vzJ
-kZe
-lBE
-oPj
-tEW
-tEW
-tEW
-tEW
-cVX
-atx
-hLw
-mNQ
-sHy
-hag
-gNY
-vzJ
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+fif
 xXv
 wfp
 fif
@@ -134425,38 +134289,38 @@ lJm
 uFT
 kDA
 iZA
-iZA
-ceC
-ceC
 doz
-ceC
-mOI
-mOI
-mOI
-mOI
-mOI
-jKW
-mOI
-ceC
 doz
-hUE
 doz
-vzJ
+doz
+doz
+hSo
+rMh
+ljF
+fVL
+toV
+trI
+pBD
+pBD
+pBD
+pBD
+xkj
+elG
 tpq
-lBE
+tpq
 whx
-wRS
-sux
-sux
-sux
-sux
-sux
-sux
-sux
-cyz
-sdK
-ttv
 vzJ
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+fif
 cmE
 bBN
 fif
@@ -134680,40 +134544,40 @@ dAy
 qST
 nTj
 lPa
-cRy
-sFs
+eTo
 iZA
 doz
-ceC
-doz
-ceC
 doz
 doz
 doz
-doz
-mOI
-jKW
-mOI
-ceC
-doz
-hUE
 doz
 vzJ
+aKH
+ksr
+uaZ
+kos
+wRS
+sux
+sux
+sux
+sux
+sux
+sux
 dxK
 xkj
 eiK
-lcn
-sux
-sux
-sux
-sux
-sux
-sux
-sux
-sux
-kos
-cLk
 vzJ
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+fif
 xXv
 rQp
 fif
@@ -134937,40 +134801,40 @@ wjd
 pIw
 kTA
 kTA
-kTA
-uDD
+eTo
 iZA
-ceC
-ceC
 doz
-ceC
-ceC
-ceC
-ceC
-ceC
-mOI
-jKW
-mOI
-ceC
 doz
-hUE
+doz
+doz
 doz
 vzJ
-nAb
-cKC
-sbF
-goV
-vRI
-eDZ
-eDZ
-eDZ
-eDZ
-eDZ
-eDZ
-eWD
+xJl
+dVc
+oCm
+sux
+sux
+sux
+sux
+sux
+sux
+sux
+sux
+sux
 kos
-tZP
+fKm
 vzJ
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+fif
 xXv
 rQp
 fzk
@@ -135194,40 +135058,40 @@ wjd
 ckY
 kTA
 kTA
-eZs
-nTj
+xTi
 iZA
-ceC
-vbK
-vbK
-vbK
-vbK
-vbK
-mOI
-mOI
-mOI
-jKW
-mOI
-ceC
 doz
-hUE
+doz
+doz
+doz
 doz
 vzJ
-rAh
-cKC
-sbF
-goV
-aKH
-aKH
-aKH
-bUL
-aKH
-aKH
-aKH
-xJl
+gqk
+ljF
+uaZ
+sux
+sux
+sux
+tmL
+sux
+sux
+sux
+sux
+sux
 kos
 cLk
 vzJ
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+fif
 xXv
 xXv
 fzk
@@ -135452,39 +135316,39 @@ oqM
 cSk
 oRu
 eTo
-tCm
 iZA
 doz
-job
 doz
 doz
 doz
-jEk
-ksr
-dGY
-fbN
-jKW
-qUM
-ceC
-vbK
-hUE
-ceC
+doz
 vzJ
-teg
-cKC
-sbF
-aKM
+wob
+ksr
+uaZ
 sux
 sux
 sux
 sux
 sux
-sux
-sux
+rAh
+eDZ
+qZe
 sux
 kos
 cLk
 vzJ
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+fif
 kPe
 vIH
 fzk
@@ -135710,38 +135574,38 @@ kOU
 iOg
 kDA
 iZA
-iZA
-ceC
-vbK
-vbK
-vbK
-vbK
-vbK
-mOI
-mOI
-mOI
-fof
-mOI
-ceC
-vbK
-ceC
-ceC
-vzJ
-cye
-nBO
-wCT
-tiu
+doz
+doz
+doz
+doz
+doz
+hLw
+rMh
+ljF
+uaZ
 sux
+lcn
+nAb
+mNQ
+cyz
+bXj
+bXj
+fbN
 sux
-sux
-sux
-sux
-sux
-sux
-elG
 kos
 cLk
 vzJ
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+fif
 xXv
 xXv
 fzk
@@ -135969,36 +135833,36 @@ eIx
 iZA
 doz
 doz
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-ceC
-mOI
-jKW
-mOI
-ceC
-vbK
 doz
 doz
-vzJ
-idc
-xvz
-gMr
-hFR
-sVt
+doz
+hSo
+tdr
+ptj
+uaZ
+iAJ
+obP
 sux
 sux
 sux
+bXj
+bXj
+fbN
 sux
-sux
-sux
-kos
 kos
 cLk
 vzJ
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+fif
 xXv
 xXv
 fif
@@ -136226,36 +136090,36 @@ iZA
 iZA
 doz
 doz
-ceC
 doz
-doz
-doz
-doz
-doz
-doz
-mOI
-jKW
-mOI
-ceC
-vbK
 doz
 doz
 vzJ
-xTi
-bPQ
-kae
-uaZ
+idc
 pKc
+uaZ
 sux
+aKM
+cyz
+wnr
+nAb
+bXj
+bXj
+fbN
 sux
-sux
-sux
-sux
-sux
-sux
-sux
-fKm
+kos
+cLk
 vzJ
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+fif
 fuD
 ooa
 fif
@@ -136474,45 +136338,45 @@ aPM
 cfm
 ejC
 raA
-raA
-raA
-raA
 iZA
 iZA
-doz
-doz
-doz
-doz
-ceC
-doz
+iZA
+iZA
+iZA
 doz
 doz
 doz
 doz
 doz
-mOI
-jKW
-mOI
-ceC
-vbK
-vbK
+doz
 doz
 vzJ
-mHs
-wob
-tdr
-ljF
-tSq
-sVt
+aHf
+pKc
+uaZ
 sux
 sux
 sux
 sux
 sux
+kae
+bUL
+atx
 sux
-sux
+kos
 cLk
 vzJ
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+fif
 rQp
 wfp
 fif
@@ -136740,36 +136604,36 @@ doz
 doz
 doz
 doz
-ceC
 doz
 doz
 doz
-ceC
-ceC
-ceC
-qUM
-jKW
-mOI
-mOI
-mOI
-vbK
+vzJ
+rEd
+pKc
+fVL
+sux
+sux
+sux
+tmL
+sux
+sux
+sux
+sux
+sux
+kos
+fKm
+vzJ
 doz
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-hSo
-obP
-sux
-sux
-sux
-sux
-sux
-sux
-cLk
-vzJ
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+fif
 xXv
 pHj
 fif
@@ -136997,36 +136861,36 @@ ceC
 ceC
 ceC
 ceC
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-qUM
-jKW
-ksr
-dGY
-fbN
-jEk
-ceC
-ceC
-ceC
 ceC
 ceC
 ceC
 vzJ
-xck
-jAR
+oIA
+tSq
+mHs
 hFR
-hFR
-gDI
-qZe
-hFR
-mWk
-xnK
+sVt
+sux
+sux
+sux
+sux
+sux
+sux
+sux
+kos
+cLk
 vzJ
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+fif
 xXv
 tmK
 fif
@@ -137252,38 +137116,38 @@ doz
 doz
 doz
 doz
+doz
+doz
+doz
+doz
 ceC
-doz
-doz
-doz
-ceC
-doz
-doz
-doz
-doz
-qUM
+vzJ
+itj
+teg
+vUI
+vRI
 ujG
-mOI
-mOI
-mOI
-vbK
+sux
+sux
+sux
+sux
+sux
+sux
+xvz
+kos
+eiK
+vzJ
 doz
 doz
 doz
 doz
 doz
 doz
-vzJ
-fVL
-pBD
-iAJ
-rEd
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vzJ
+doz
+doz
+doz
+doz
+fif
 rQp
 wfp
 fif
@@ -137514,32 +137378,32 @@ doz
 doz
 doz
 ceC
-doz
-doz
-doz
-doz
-mOI
-jKW
-mOI
-ceC
-vbK
-vbK
-doz
-doz
-doz
-doz
-doz
-ceC
 vzJ
+xnK
+fof
+gDI
+tEW
+cRy
+oPj
+hFR
+hFR
+hFR
+mWk
+oPj
+hFR
+hFR
+sbF
 vzJ
-vzJ
-vzJ
-vzJ
-vzJ
-vbK
-vbK
-ceC
-ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 fif
 xXv
 xXv
@@ -137771,22 +137635,22 @@ doz
 doz
 doz
 ceC
-doz
-doz
-doz
-ceC
-mOI
-jKW
-mOI
-ceC
-vbK
-vbK
-vbK
-ceC
-vbK
-vbK
-vbK
-vbK
+vzJ
+vzJ
+hLw
+hLw
+hLw
+vzJ
+vzJ
+vzJ
+vzJ
+vzJ
+vzJ
+vzJ
+vzJ
+vzJ
+vzJ
+vzJ
 vbK
 vbK
 vbK
@@ -138031,10 +137895,10 @@ ceC
 doz
 doz
 doz
-ceC
-mOI
-jKW
-mOI
+doz
+doz
+doz
+vbK
 ceC
 vbK
 doz
@@ -138289,9 +138153,9 @@ doz
 doz
 doz
 doz
-mOI
-jKW
-mOI
+doz
+doz
+vbK
 ceC
 ceC
 vbK
@@ -138544,11 +138408,11 @@ vbK
 vbK
 vbK
 vbK
-mOI
-mOI
-mOI
-jKW
-qUM
+vbK
+vbK
+vbK
+vbK
+vbK
 ceC
 ceC
 doz
@@ -138800,12 +138664,12 @@ doz
 doz
 doz
 doz
-jEk
-ksr
-dGY
-fbN
-jKW
-mOI
+doz
+doz
+doz
+doz
+doz
+vbK
 ceC
 ceC
 ceC
@@ -139058,11 +138922,11 @@ vbK
 vbK
 vbK
 vbK
-mOI
-mOI
-mOI
-fof
-mOI
+vbK
+vbK
+vbK
+vbK
+vbK
 ceC
 vbK
 ceC
@@ -139317,9 +139181,9 @@ doz
 doz
 doz
 doz
-mOI
-jKW
-mOI
+doz
+doz
+vbK
 ceC
 vbK
 ceC
@@ -139574,9 +139438,9 @@ vbK
 vbK
 vbK
 vbK
-mOI
-jKW
-qUM
+vbK
+vbK
+vbK
 ceC
 vbK
 doz
@@ -139832,8 +139696,8 @@ siJ
 siJ
 siJ
 siJ
-jKW
-mOI
+doz
+vbK
 ceC
 vbK
 doz
@@ -140089,8 +139953,8 @@ cBQ
 huF
 mDR
 siJ
-jKW
-mOI
+doz
+vbK
 ceC
 vbK
 doz
@@ -140346,8 +140210,8 @@ meC
 meC
 gEj
 tlu
-jKW
-mOI
+doz
+vbK
 ceC
 cfT
 ceC
@@ -140603,8 +140467,8 @@ gbZ
 meC
 cKE
 siJ
-jKW
-qUM
+doz
+vbK
 ceC
 vbK
 ceC
@@ -140860,8 +140724,8 @@ rwC
 xXW
 hnY
 siJ
-jKW
-mOI
+doz
+vbK
 ceC
 vbK
 doz
@@ -141117,8 +140981,8 @@ meC
 meC
 syU
 siJ
-jKW
-mOI
+doz
+vbK
 ceC
 vbK
 doz
@@ -141374,8 +141238,8 @@ meC
 meC
 sEm
 siJ
-jKW
-mOI
+doz
+vbK
 ceC
 ipz
 ipz
@@ -141631,7 +141495,7 @@ ntv
 siJ
 siJ
 siJ
-toV
+ipz
 ipz
 ipz
 ipz
@@ -198693,8 +198557,8 @@ uAy
 jSn
 iRy
 kOJ
-trI
 fNX
+cKC
 gIs
 pvJ
 jct
@@ -199464,7 +199328,7 @@ dbo
 gto
 dVg
 oFy
-vUI
+kiz
 dVg
 xDo
 swA
@@ -199705,23 +199569,23 @@ awq
 rZO
 dBA
 axs
-iEl
 vSF
+fgl
 sgT
 fbX
 nFc
 uMQ
-pCP
+awq
 noj
 kNW
 oMC
-ezv
+xck
 tKt
 aXV
 vzt
 cbw
 jar
-kiz
+sHy
 dVg
 tDs
 moo
@@ -200219,17 +200083,17 @@ awq
 ycf
 vhH
 vZT
-vSF
+wtF
 tSk
 vSF
 vSF
 voU
-uPs
+sgT
 skq
 ezv
 fIE
 fiY
-ezv
+cUf
 kvh
 lci
 nWA
@@ -200474,20 +200338,20 @@ nke
 ckR
 cuJ
 eAC
-cUf
-wnr
+vSF
+vSF
 cuC
 gDC
 mMF
 xfD
 tnw
 snz
-awq
+sFs
 xEg
 vHh
 ezv
 rQW
-fgl
+aRV
 aRV
 hfU
 dVg
@@ -200763,7 +200627,7 @@ dRA
 iHs
 cnG
 aJW
-coR
+wyy
 hUZ
 dRA
 vyE
@@ -200996,12 +200860,12 @@ nCS
 mOh
 sHx
 wro
-gqk
+eng
 tVB
 rLY
 oOp
 hkd
-aJA
+lqQ
 pQC
 irP
 gLx
@@ -201258,7 +201122,7 @@ kPF
 vKW
 lqQ
 jUv
-oIA
+oOp
 tkj
 nfs
 gLx
@@ -201506,11 +201370,11 @@ bDE
 bVk
 hDB
 eng
+mNe
 aQK
 ren
-oCm
-mNe
-gqk
+cye
+eng
 sNS
 jxk
 qFH
@@ -201767,7 +201631,7 @@ jvL
 grZ
 grZ
 grZ
-eng
+sdK
 nBq
 rTc
 iFy
@@ -202024,14 +201888,14 @@ pJi
 hZO
 flS
 xZI
-lgR
+nTe
 iKn
 jxk
 eXQ
 rnL
 ocH
 cYo
-vuy
+iFU
 lju
 yfI
 oZN
@@ -202543,7 +202407,7 @@ qLa
 mPB
 nAh
 ujO
-ewZ
+coR
 lAc
 bON
 bzO
@@ -202800,8 +202664,8 @@ bAL
 hMX
 brn
 dbj
-ewZ
-kRj
+tiu
+iFU
 iFU
 cUp
 uRn
@@ -203052,14 +202916,14 @@ hDR
 ixz
 nfS
 ahI
-lgR
+nTe
 iKn
 hMX
 cdC
 iAq
 vbM
-kRj
-tmL
+iFU
+iFU
 lju
 yfI
 oZN
@@ -203308,13 +203172,13 @@ dJK
 wxM
 pOm
 tpv
-dJK
-pbQ
+tCm
+dvk
 pvv
 jxk
 fOE
 oSQ
-bXj
+gTc
 kRj
 pyo
 gLx
@@ -203564,9 +203428,9 @@ loc
 nTe
 ykl
 qNY
+wCT
 qTS
-xmg
-ptj
+pbQ
 uhN
 jxk
 mOE
@@ -203828,7 +203692,7 @@ xnq
 tRu
 uJF
 qBf
-oIA
+oOp
 blI
 tAR
 gLx
@@ -204080,18 +203944,18 @@ tue
 kzH
 jdd
 eIq
-ptj
+dJK
 nTm
 qtE
 oOp
 uQg
-aHf
+uJF
 dnz
 ihX
 gLx
-xYF
-pKO
-itj
+mTv
+oZN
+iPv
 kLF
 rBm
 wGi
@@ -204346,8 +204210,8 @@ aeX
 kZZ
 aeX
 gLx
-mTv
-oZN
+nBO
+pKO
 oLl
 kLF
 kLF

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -12432,9 +12432,9 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "cVX" = (
-/obj/structure/sign/warning/electric_shock/directional/west,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/stripes,
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/medical/chemistry/ghetto)
 "cWl" = (
@@ -20572,10 +20572,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/aft)
-"eXr" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/central)
 "eXt" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -21728,6 +21724,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "flP" = (
@@ -22579,6 +22576,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "fwx" = (
@@ -23666,6 +23664,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "fII" = (
@@ -27697,7 +27696,6 @@
 "gJQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/meter,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/central)
@@ -27909,7 +27907,6 @@
 	color = "#8C3E00"
 	},
 /obj/machinery/newscaster/directional/east,
-/obj/structure/disposalpipe/segment,
 /obj/item/toy/plush/moth{
 	name = "Dr. Moff"
 	},
@@ -31745,8 +31742,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
@@ -32365,6 +32362,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "hNa" = (
@@ -33996,9 +33994,6 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/light/warm/no_nightlight/directional/east,
-/obj/structure/disposalpipe/trunk/multiz/down{
-	dir = 1
-	},
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "ijf" = (
@@ -34151,6 +34146,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "ikV" = (
@@ -36483,9 +36479,6 @@
 /area/station/cargo/storage)
 "iPv" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
@@ -36627,9 +36620,6 @@
 	name = "Tom's bed"
 	},
 /mob/living/basic/pet/dog/pug,
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "iRE" = (
@@ -36894,6 +36884,15 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
+"iUF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central)
 "iUI" = (
 /mob/living/carbon/human/species/monkey,
 /obj/structure/sink/directional/east,
@@ -38366,8 +38365,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39050,6 +39049,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "jxl" = (
@@ -41648,6 +41648,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "kdW" = (
@@ -43773,6 +43774,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "kEl" = (
@@ -50237,6 +50239,15 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
+"mfs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central)
 "mft" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -51179,6 +51190,10 @@
 /obj/machinery/door/poddoor/massdriver_trash,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"mrP" = (
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/pharmacy)
 "mrQ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/vomit,
@@ -53163,6 +53178,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "mPE" = (
@@ -53386,6 +53402,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "mSM" = (
@@ -61209,9 +61226,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "oLl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -64387,9 +64401,6 @@
 /area/station/medical/paramedic)
 "pyM" = (
 /obj/machinery/vending/coffee,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
 "pyV" = (
@@ -64780,7 +64791,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
@@ -67999,6 +68010,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "qtM" = (
@@ -68648,6 +68660,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "qBP" = (
@@ -72432,6 +72445,10 @@
 /obj/item/toy/basketball,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"rvK" = (
+/obj/structure/disposalpipe/trunk/multiz,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central)
 "rvO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -73564,6 +73581,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "rMa" = (
@@ -74094,6 +74112,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "rTd" = (
@@ -75208,6 +75227,9 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
 "sfs" = (
@@ -75922,8 +75944,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/service/general,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /turf/open/floor/plating,
 /area/station/service/bar/atrium/ghetto)
 "snG" = (
@@ -76499,6 +76521,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "svh" = (
@@ -80292,10 +80315,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
-"ttv" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
 "ttw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/port_gen/pacman,
@@ -82227,6 +82246,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "tRx" = (
@@ -89528,6 +89548,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "vHk" = (
@@ -89885,6 +89906,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "vLb" = (
@@ -95488,6 +95510,13 @@
 /obj/structure/falsewall,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"xfV" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/disposalpipe/trunk/multiz/down{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "xfY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/red{
@@ -98900,12 +98929,6 @@
 "xYA" = (
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
-"xYF" = (
-/obj/structure/disposalpipe/trunk/multiz{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central)
 "xYK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -132503,8 +132526,8 @@ mOI
 doz
 vbK
 mOI
-dGY
-dlM
+rvK
+mfs
 mOI
 gPR
 dGY
@@ -132761,7 +132784,7 @@ doz
 vbK
 mOI
 cKf
-dlM
+iUF
 mOI
 ydo
 maq
@@ -133276,9 +133299,9 @@ dlM
 dlM
 nWv
 pCP
-eXr
-ttv
-xYF
+isK
+dGY
+dGY
 dGY
 dGY
 dGY
@@ -198038,8 +198061,8 @@ oBG
 oBG
 oBG
 smv
-rTb
-uAy
+cNA
+xfV
 jSn
 tKe
 tgC
@@ -200086,7 +200109,7 @@ vZT
 wtF
 tSk
 vSF
-vSF
+mrP
 voU
 sgT
 skq


### PR DESCRIPTION
## Что этот PR делает

Первая часть ремапа меда (снова), химия, комната парамеда, трубы и столы в холле, приемная.

## Почему это хорошо для игры

Ремап пора закончить

## Изображения изменений
![StrongDMM-2025-07-04 17 36 15](https://github.com/user-attachments/assets/4273c75e-7036-4404-8c95-f0651af91fff)
![StrongDMM-2025-07-04 17 12 55](https://github.com/user-attachments/assets/1cdcd82a-59a1-4b23-b6b9-9b09153cc17c)
![StrongDMM-2025-07-04 17 13 23](https://github.com/user-attachments/assets/cb4a9534-b2cc-47a1-8bd4-afb19580a2e1)
![StrongDMM-2025-07-04 17 13 28](https://github.com/user-attachments/assets/2a5e8080-b591-4e2d-a42e-c7b9d990e52b)
![StrongDMM-2025-07-04 17 39 46](https://github.com/user-attachments/assets/581f52d4-9505-40fd-bf54-9b4d33aafbd3)

## Тестирование

Локалка

## Changelog

:cl:
map: Кибериада: первая часть ремапа меда, а именно - увеличена нижняя химия, добавлен выход из нижней химии в техи, вход в нижнюю химию через лестницу теперь в верхней химии, добавлена раковина в верхнюю химию, переставлены столы в обоих химиях; добавлена в приемную комнату консоль с медицинскими записями; в коморке парамеда немного переставлены местами ящик и столы; в холл меда добавлены столы с базовыми медикаментами, убраны 2 кровати, на которых лежали по большей части только медики, пустой ящик в холле заменен на ящик с протезами.
/:cl:
