### PR TITLE
Config: Delay for automatic crew transfer

### DIFF
--- a/modular_bandastation/automatic_crew_transfer/code/automatic_transfer_configuration.dm
+++ b/modular_bandastation/automatic_crew_transfer/code/automatic_transfer_configuration.dm
@@ -1,5 +1,5 @@
 /datum/config_entry/number/automatic_crew_transfer_vote_delay
-	default = 54000
+	default = 72000
 	min_val = 18000
 
 /datum/config_entry/number/automatic_crew_transfer_vote_interval


### PR DESCRIPTION
## Что этот PR делает
Увеличивает задержку до начала автоматического голосования на вызов эвакуации.

## Почему это хорошо для игры
Бесполезное, зачастую отключаемое админами голосование на таком раннем этапе (всегда есть факсы/ручной вызов, если нужно раньше).

## Тестирование
Циферки делают бим бам

## Changelog

:cl:
config: Теперь автоматическое голосование за вызов шаттла происходит на пол часа позже (2 часа с начала раунда).
/:cl:
