### PR TITLE
More characters slots for supporters

### DIFF
--- a/modular_bandastation/preferences/code/modules/client/preferences.dm
+++ b/modular_bandastation/preferences/code/modules/client/preferences.dm
@@ -1,12 +1,22 @@
 #define BASE_LOADOUT_POINTS 5
 #define LOADOUT_POINTS_PER_DONATION_LEVEL 3
+#define BASE_SAVE_SLOTS 5
+#define MAX_SAVE_SLOTS 9
+#define SAVE_SLOTS_PER_DONATOR_LEVEL 1
 
 /datum/preferences
-	max_save_slots = 5
+	max_save_slots = BASE_SAVE_SLOTS
 	var/loadout_points_spent = 0
+
+/datum/preferences/New(client/parent)
+	. = ..()
+	max_save_slots = clamp(BASE_SAVE_SLOTS + parent.get_donator_level() * SAVE_SLOTS_PER_DONATOR_LEVEL, BASE_SAVE_SLOTS, MAX_SAVE_SLOTS)
 
 /datum/preferences/proc/get_loadout_max_points()
 	return BASE_LOADOUT_POINTS + parent.get_donator_level() * LOADOUT_POINTS_PER_DONATION_LEVEL
 
 #undef BASE_LOADOUT_POINTS
 #undef LOADOUT_POINTS_PER_DONATION_LEVEL
+#undef BASE_SAVE_SLOTS
+#undef MAX_SAVE_SLOTS
+#undef SAVE_SLOTS_PER_DONATOR_LEVEL


### PR DESCRIPTION
## Что этот PR делает
Closes https://github.com/ss220club/BandaStation/pull/1569
Добавляет дополнительные слоты персонажей людям с донат уровнем
Пока максимум 9, т.к надо сделать поддержку чисел больше 9 у привязки персонажа к профессии

## Почему это хорошо для игры
Дополнительные слоты за поддержку это логично

## Changelog

:cl:
add: Дополнительные слоты персонажей для людей с уровнем подписки
/:cl: