### PR TITLE
remove glitters from scrubber overflow event

### DIFF
--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -32,8 +32,8 @@
 		/datum/reagent/consumable/condensedcapsaicin,
 		/datum/reagent/drug/mushroomhallucinogen,
 		/datum/reagent/lube,
-		/datum/reagent/glitter/blue,
-		/datum/reagent/glitter/pink,
+		// /datum/reagent/glitter/blue, // BANDASTATION REMOVAL - No Glitters
+		// /datum/reagent/glitter/pink, // BANDASTATION REMOVAL - No Glitters
 		/datum/reagent/cryptobiolin,
 		/datum/reagent/blood,
 		/datum/reagent/medicine/c2/multiver,
@@ -53,7 +53,7 @@
 		/datum/reagent/consumable/ethanol/beer,
 		/datum/reagent/hair_dye,
 		/datum/reagent/consumable/sugar,
-		/datum/reagent/glitter/white,
+		// /datum/reagent/glitter/white, // BANDASTATION REMOVAL - No Glitters
 		/datum/reagent/gravitum,
 		/datum/reagent/growthserum,
 		/datum/reagent/yuck,


### PR DESCRIPTION
## Что этот PR делает

Блестки уходите

## Changelog

:cl:
del: Блестки каким-то образом проникли обратно в событие переполнения скруббера. Теперь их снова не будет :madge:
/:cl:
