### PR TITLE
Fix: Bring back climbing hooks on Cyberiad

### DIFF
--- a/_maps/cyberiad.json
+++ b/_maps/cyberiad.json
@@ -6,6 +6,7 @@
 	"fluff_name": "ИСН Кибериада",
 	"welcome_sound_override": "modular_bandastation/aesthetics_sounds/sound/welcome_sounds/welcome_cyberiad.ogg",
 	"main_floor": 2,
+	"give_players_hooks": 1,
 	"shuttles": {
 		"cargo": "cargo_box",
 		"ferry": "ferry_fancy",


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Возвращает крюки на Кибериаду, которые исчезли ввиду изменения на апстриме.

## Changelog

:cl:
fix: Экипажу Кибериады возвращены крюки, которые исчезли в результате непредвиденных нами последствий.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
