### PR TITLE
Add tooltips to chat badges

### DIFF
--- a/modular_bandastation/_defines220/code/defines/spans.dm
+++ b/modular_bandastation/_defines220/code/defines/spans.dm
@@ -1,1 +1,2 @@
 #define span_maptext(str) ("<span class='maptext'>" + str + "</span>")
+#define span_tooltip_img(tip, main_text) ("<span data-component=\"Tooltip\" data-content=\"" + tip + "\" class=\"tooltip-img\">" + main_text + "</span>")

--- a/modular_bandastation/chat/code/badges.dm
+++ b/modular_bandastation/chat/code/badges.dm
@@ -9,10 +9,10 @@ GLOBAL_LIST(badge_icons_cache)
 
 	var/list/badge_parts = list()
 	if(donator_badge_icon)
-		badge_parts += icon2base64html(donator_badge_icon)
+		badge_parts += span_tooltip_img("Уровень подписки: [donor_tier]", icon2base64html(donator_badge_icon))
 
 	if(worker_badge_icon)
-		badge_parts += icon2base64html(worker_badge_icon)
+		badge_parts += span_tooltip_img("[holder?.ranks[1]]", icon2base64html(worker_badge_icon))
 
 	var/list/parts = list()
 	if(length(badge_parts))

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1283,6 +1283,14 @@ $border-width-px: $border-width * 1px;
   color: #6699cc;
 }
 
+.tooltip-img > span {
+  vertical-align: middle;
+}
+
+.tooltip-img .icon {
+  vertical-align: unset;
+}
+
 @keyframes donor_shine {
   0%,
   33% {


### PR DESCRIPTION
## Что этот PR делает
Добавил тултипы бейджикам в чате

## Почему это хорошо для игры
Понятно что за бейджики, ну и гахер попросил

## Изображения изменений

![image](https://github.com/user-attachments/assets/447b91f6-96b2-422d-b111-86765f43d015)

## Changelog

:cl:
add: Бейджикам в чате добавлены тултипы при наведении
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
