### PR TITLE
Update Cyberiad.dmm

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -45,8 +45,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "aaz" = (
-/obj/item/clothing/head/soft/blue,
-/obj/effect/decal/cleanable/blood/old,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "aaC" = (
@@ -100,11 +99,14 @@
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/backroom/ghetto)
 "abw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
@@ -272,6 +274,8 @@
 "adQ" = (
 /obj/structure/sign/poster/contraband/random/directional/east,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/starboard)
 "aec" = (
@@ -953,13 +957,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "amp" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/graffiti{
+	spawn_loot_chance = 50
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/area/station/maintenance/department/medical/morgue)
 "amF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -1190,10 +1192,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "apz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/sign/warning/bodysposal/directional/east,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/area/station/maintenance/ghetto/starboard)
 "apA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1614,18 +1619,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "avs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "avu" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -1652,11 +1648,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "avQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard/west)
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "awa" = (
 /obj/structure/railing/corner/end{
 	dir = 8
@@ -1669,10 +1665,12 @@
 /turf/open/floor/carpet/black,
 /area/station/maintenance/starboard/fore)
 "awe" = (
-/obj/machinery/atmospherics/components/binary/valve/on,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "awk" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -2748,17 +2746,12 @@
 /turf/open/floor/plating/reinforced,
 /area/station/cargo/storage)
 "aIh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/toy/cards/deck/cas/black{
-	pixel_x = -7
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
-/obj/item/toy/cards/deck/cas{
-	pixel_x = 5;
-	pixel_y = 10
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/turf/open/floor/iron/white,
+/area/station/medical/morgue)
 "aIl" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
@@ -3142,6 +3135,17 @@
 "aNy" = (
 /turf/closed/wall,
 /area/station/security/prison/ghetto)
+"aND" = (
+/obj/structure/table/optable{
+	desc = "A cold, hard place for your final rest.";
+	name = "Morgue Slab"
+	},
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "aNI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3933,26 +3937,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "aWA" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/syringes{
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/item/storage/box/gloves{
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/obj/item/storage/box/masks{
-	pixel_x = 4;
-	pixel_y = 6
-	},
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
+/obj/structure/table/glass,
+/obj/machinery/microwave,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "aWB" = (
@@ -4154,11 +4144,14 @@
 "aYE" = (
 /obj/structure/table/glass,
 /obj/machinery/firealarm/directional/east,
-/obj/item/computer_disk/medical,
-/obj/item/computer_disk/medical,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
+/obj/item/storage/medkit/regular{
+	pixel_y = 6
+	},
+/obj/item/computer_disk/medical,
+/obj/item/computer_disk/medical,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "aYN" = (
@@ -4785,10 +4778,13 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
 "bhy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/machinery/light/small/directional/south{
+	name = "maintenance light";
+	nightshift_allowed = 0;
+	nightshift_enabled = 1
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/obj/machinery/duct,
+/turf/open/floor/iron/freezer,
 /area/station/medical/morgue)
 "bhz" = (
 /turf/open/floor/iron,
@@ -4970,18 +4966,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "bjo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/tile/dark_blue/anticorner{
+	dir = 8
 	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
+/obj/machinery/smartfridge/organ,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "bjq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5206,17 +5197,15 @@
 /turf/open/floor/iron/herringbone,
 /area/station/maintenance/aft)
 "blT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
-	dir = 8
-	},
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "bmd" = (
@@ -5274,11 +5263,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "bnm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/mess,
-/obj/structure/frame/machine/secured,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/obj/structure/table/bronze,
+/obj/item/clothing/under/costume/jabroni,
+/obj/item/clothing/head/costume/bronze,
+/turf/open/floor/bronze,
+/area/station/maintenance/starboard/upper)
 "bnr" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "testlab";
@@ -5350,9 +5339,8 @@
 /turf/open/misc/beach/sand,
 /area/station/hallway/secondary/exit/departure_lounge)
 "boK" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
+/obj/effect/mapping_helpers/broken_floor,
+/obj/item/stack/sheet/bronze/thirty,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "boM" = (
@@ -5588,12 +5576,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/ghetto)
 "bri" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/window/right/directional/north{
-	name = "Body Disposal"
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "brl" = (
 /obj/structure/rack,
@@ -5776,6 +5759,10 @@
 /obj/machinery/light/broken/directional/north,
 /turf/open/floor/iron/small,
 /area/station/maintenance/ghetto/central)
+"bsS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/bronze,
+/area/station/maintenance/starboard/upper)
 "bsT" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -5884,12 +5871,22 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "buy" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
 /area/station/medical/morgue)
 "buC" = (
 /obj/structure/table/reinforced,
@@ -5951,9 +5948,26 @@
 /turf/open/floor/plating,
 /area/station/security/interrogation/ghetto)
 "bvA" = (
-/obj/effect/spawner/random/vending/snackvend,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/medical/cryo)
 "bvF" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/trimline/dark_blue/line{
@@ -6228,10 +6242,14 @@
 	},
 /area/station/hallway/secondary/entry)
 "byg" = (
-/obj/structure/closet/crate/freezer,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/table/glass,
+/obj/item/stack/medical/mesh,
+/obj/item/stack/medical/suture,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/maintenance/starboard/upper)
 "byv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6299,13 +6317,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "bzn" = (
-/obj/effect/decal/cleanable/vomit,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/area/station/maintenance/department/medical/morgue)
 "bzp" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron,
@@ -6554,14 +6567,11 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "bCK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/valve/on,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
 "bCN" = (
@@ -6605,13 +6615,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "bDp" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/sign/warning/no_smoking/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "bDu" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -6860,9 +6867,11 @@
 /turf/closed/wall,
 /area/station/commons/storage/primary)
 "bGl" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/spawner/random/structure/chair_flipped{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard)
 "bGo" = (
 /obj/item/radio/intercom/directional/north,
 /obj/structure/closet/secure_closet/atmospherics,
@@ -6938,8 +6947,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "bIa" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
@@ -7509,11 +7519,9 @@
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "bOW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sink/kitchen/directional/south,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "bPa" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -7785,9 +7793,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/storage)
 "bRT" = (
-/obj/machinery/cryo_cell,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
@@ -7995,11 +8003,13 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/ghetto/starboard/aft)
 "bVS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "bVV" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8733,14 +8743,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "ces" = (
-/obj/machinery/door/window/right/directional/east{
-	name = "Coroner"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/small,
+/obj/structure/chair/comfy/teal{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "cex" = (
 /obj/structure/table/reinforced,
@@ -8990,12 +9000,10 @@
 	},
 /area/station/service/hydroponics)
 "chY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/bar/fourcorners,
-/obj/effect/spawner/random/trash/mess,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "cic" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9432,10 +9440,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "clY" = (
-/obj/structure/sink/directional/south,
-/obj/structure/mirror/directional/north,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/structure/disposalpipe/segment,
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "cmg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9640,11 +9648,8 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port/aft)
 "coB" = (
-/obj/structure/table/reinforced,
-/obj/item/trash/tray,
-/obj/effect/spawner/random/food_or_drink/pizzaparty,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/medical/morgue)
 "coR" = (
 /obj/structure/railing{
 	dir = 1
@@ -9825,11 +9830,11 @@
 /turf/open/floor/carpet,
 /area/station/service/library/ghetto)
 "crq" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken/directional/east,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/bronze,
+/area/station/maintenance/starboard/upper)
 "crv" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -9947,10 +9952,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "csD" = (
+/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "csF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10390,9 +10395,13 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "cys" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/preopen{
+	elevator_mode = 1;
+	transport_linked_id = "morgue_elevator"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/kitchen)
+/area/station/medical/morgue)
 "cyw" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -10677,11 +10686,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "cBQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/west,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/shower/directional/east,
+/obj/structure/curtain,
+/obj/item/bikehorn/rubberducky,
+/turf/open/floor/iron/freezer,
+/area/station/medical/morgue)
 "cBU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -10763,8 +10772,15 @@
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/office)
 "cCS" = (
-/obj/machinery/smartfridge/organ,
-/turf/open/floor/iron/dark/small,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "cDj" = (
 /obj/effect/turf_decal/tile/neutral/half{
@@ -11162,23 +11178,9 @@
 /turf/open/floor/cult,
 /area/station/maintenance/starboard/fore)
 "cHV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 4
-	},
-/obj/structure/table/optable,
-/obj/effect/spawner/random/medical/surgery_tool,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "cHW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11428,10 +11430,9 @@
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "cKE" = (
-/obj/machinery/vending/boozeomat,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/station/medical/virology)
 "cKJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/sink/directional/east,
@@ -11549,14 +11550,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "cMi" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/structure/bodycontainer/morgue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay)
+/obj/machinery/camera/directional/east{
+	c_tag = "Medbay - Morgue East";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "cMm" = (
 /obj/structure/cable,
 /mob/living/basic/crab{
@@ -11592,9 +11597,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "cMD" = (
@@ -11696,11 +11698,11 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "cNQ" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 2
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "cNR" = (
 /obj/effect/spawner/random/maintenance,
@@ -11992,6 +11994,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/camera/directional/east,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "cRA" = (
@@ -12811,12 +12814,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "cZU" = (
-/obj/structure/table/optable{
-	desc = "A cold, hard place for your final rest.";
-	name = "Morgue Slab"
+/obj/effect/spawner/random/vending/colavend,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/obj/effect/spawner/surgery_tray/full/morgue,
-/turf/open/floor/iron/dark/small,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "cZW" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -12974,13 +12976,17 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/storage)
 "dbP" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/machinery/camera/directional/north{
+	c_tag = "Medbay - Morgue North";
+	network = list("ss13","medbay")
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/computer/records/medical/laptop,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "dbS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -13051,10 +13057,9 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "dcV" = (
-/obj/structure/barricade/wooden/crude,
-/obj/structure/barricade/wooden,
+/obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
+/area/station/maintenance/department/medical/morgue)
 "dcX" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/structure/closet/emcloset,
@@ -13177,6 +13182,15 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/security/courtroom)
+"dfg" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/ghetto)
 "dfo" = (
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
@@ -13389,8 +13403,12 @@
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "dhQ" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/closed/wall,
+/obj/machinery/cryo_cell,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/structure/sign/warning/bodysposal/directional/east,
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "dhR" = (
 /obj/structure/table,
@@ -13411,12 +13429,16 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/security/ghetto)
 "dic" = (
-/obj/machinery/washing_machine,
-/obj/machinery/light/small/directional/north,
-/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "dii" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13560,6 +13582,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"djv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "djA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13895,11 +13926,10 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/port)
 "dmA" = (
-/obj/structure/chair/sofa/bench/solo{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
+/area/station/maintenance/department/medical/morgue)
 "dmB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14164,12 +14194,16 @@
 /turf/open/floor/wood,
 /area/station/security/prison/mess)
 "dpz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Medbay - Cryogenics";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "dpE" = (
 /obj/machinery/light/small/directional/south{
 	name = "maintenance light";
@@ -14218,6 +14252,18 @@
 /obj/structure/chair/office,
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/ghetto/fore/starboard)
+"dqA" = (
+/obj/machinery/lift_indicator/directional/north{
+	linked_elevator_id = "morgue_elevator"
+	},
+/obj/machinery/button/elevator/directional/north{
+	id = "morgue_elevator"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "dqU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14866,27 +14912,29 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "dyq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/effect/spawner/random/maintenance/two,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/button/elevator/directional/east{
+	id = "morgue_elevator"
+	},
+/obj/machinery/lift_indicator/directional/east{
+	linked_elevator_id = "morgue_elevator"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "dyr" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "dys" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "dyy" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -15230,11 +15278,10 @@
 /turf/closed/wall,
 /area/station/security/checkpoint/engineering)
 "dCQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/floor,
-/obj/effect/mapping_helpers/dead_body_placer,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "dCU" = (
 /obj/structure/cable,
@@ -15643,16 +15690,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "dIb" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/barricade/wooden/crude,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/unres{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "dId" = (
 /obj/structure/closet/emcloset{
 	contents_initialized = 1;
@@ -15663,8 +15705,9 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
 "dIf" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/bronze,
 /area/station/maintenance/starboard/upper)
 "dIk" = (
 /obj/structure/sign/departments/medbay/alt,
@@ -15685,6 +15728,16 @@
 /obj/effect/spawner/random/trash/caution_sign,
 /turf/open/floor/iron/white/herringbone,
 /area/station/maintenance/ghetto/starboard/aft)
+"dIC" = (
+/obj/structure/table/bronze,
+/obj/item/food/grown/rose{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/cup/glass/trophy/bronze_cup{
+	pixel_x = 5
+	},
+/turf/open/floor/bronze,
+/area/station/maintenance/starboard/upper)
 "dIJ" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/effect/decal/cleanable/dirt,
@@ -15785,11 +15838,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay/ghetto)
 "dKd" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/bodycontainer/morgue{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/medical/morgue)
 "dKj" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -15801,17 +15851,12 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "dKk" = (
-/obj/structure/table,
-/obj/machinery/computer/records/medical/laptop{
-	dir = 1;
-	pixel_y = 5
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
 	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 8;
-	pixel_y = 12
-	},
-/turf/open/floor/iron/dark/small,
-/area/station/medical/morgue)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "dKo" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/engine/ghetto)
@@ -15956,6 +16001,9 @@
 /area/station/security/execution)
 "dLq" = (
 /obj/effect/turf_decal/tile/green/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "dLz" = (
@@ -16425,11 +16473,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "dTr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/machinery/oven/range,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/turf/closed/wall,
+/area/station/maintenance/department/medical/morgue)
 "dTt" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -19744,6 +19789,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hop)
+"eLJ" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "eLO" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -19952,6 +20005,29 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
+"eOJ" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/obj/structure/table/glass,
+/obj/item/storage/box/syringes{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/storage/box/gloves{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/storage/box/masks{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "eOK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -20046,11 +20122,15 @@
 /turf/open/floor/carpet/green,
 /area/station/commons/dorms/apartment1)
 "eQb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "eQc" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/red{
@@ -20908,12 +20988,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "fcd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/machinery/light/small/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/junction{
-	dir = 1
+/obj/effect/spawner/random/trash/mess,
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
@@ -21215,13 +21292,11 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "fgr" = (
+/obj/structure/cable,
+/obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "fgw" = (
@@ -21448,12 +21523,15 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/vending/wallmed/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "fiK" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/starboard/upper)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/open/floor/iron/white,
+/area/station/medical/morgue)
 "fiO" = (
 /obj/machinery/door/window/brigdoor/left/directional/north{
 	name = "Creature Pen";
@@ -21934,6 +22012,9 @@
 	dir = 1;
 	pixel_y = 3
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry/ghetto)
 "fog" = (
@@ -22007,12 +22088,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "fpz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "fpA" = (
 /obj/structure/cable,
@@ -22336,17 +22413,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "ftE" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
+/obj/machinery/light/small/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Medbay - Hallway - North";
+	network = list("ss13","medbay")
+	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
-/obj/machinery/light/small/directional/north,
-/obj/machinery/camera/directional/north{
-	c_tag = "Medbay - Hallway North";
-	network = list("ss13","medbay")
-	},
-/obj/structure/sign/departments/morgue/directional/north,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "ftL" = (
@@ -22598,9 +22673,22 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "fwy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/machinery/light/small/directional/east{
+	name = "maintenance light";
+	nightshift_allowed = 0;
+	nightshift_enabled = 1;
+	nightshift_light_power = 0.4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/item/reagent_containers/spray/cleaner,
+/obj/structure/table/glass,
+/obj/machinery/camera/directional/east{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Patients Rooms East"
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "fwF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22843,9 +22931,11 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "fzv" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
+/obj/structure/table/bronze,
+/obj/effect/spawner/random/medical/memeorgans{
+	spawn_loot_count = 1
+	},
+/turf/open/floor/bronze,
 /area/station/maintenance/starboard/upper)
 "fzC" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -23279,6 +23369,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/showroomfloor,
 /area/station/maintenance/ghetto/port)
+"fEP" = (
+/obj/structure/rack,
+/obj/item/crowbar/red,
+/obj/item/wrench,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "fEV" = (
 /obj/machinery/computer/security/wooden_tv,
 /obj/machinery/button/door/directional/east{
@@ -23480,11 +23576,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "fGO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/table/bronze,
+/obj/effect/spawner/random/medical/memeorgans{
+	spawn_loot_count = 1
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/turf/open/floor/bronze,
 /area/station/maintenance/starboard/upper)
 "fGS" = (
 /obj/structure/chair/office,
@@ -23748,12 +23845,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "fJB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "fJD" = (
@@ -23938,7 +24030,7 @@
 "fLX" = (
 /obj/effect/turf_decal/tile/green/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
@@ -23971,16 +24063,14 @@
 /turf/open/floor/stone,
 /area/station/service/hydroponics/ghetto)
 "fMF" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/spawner/random/structure/barricade,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "fMH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -24067,10 +24157,16 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/theater)
 "fNH" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/structure/bodycontainer/morgue{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/camera/directional/south{
+	c_tag = "Medbay - Morgue South";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "fNJ" = (
 /obj/structure/secure_safe/directional/north,
 /obj/effect/mapping_helpers/broken_floor,
@@ -24196,8 +24292,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "fOH" = (
-/obj/item/storage/box/bodybags,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/bronze,
 /area/station/maintenance/starboard/upper)
 "fOS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24693,10 +24790,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "fVJ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral/anticorner{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/vending/wardrobe/coroner_wardrobe,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "fVL" = (
 /obj/structure/cable,
@@ -24742,20 +24840,11 @@
 /turf/open/floor/carpet,
 /area/station/service/library)
 "fWo" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple{
+	dir = 9
 	},
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/door/window/right/directional/north{
-	req_access = list("medical")
-	},
-/obj/effect/turf_decal/box/white{
-	color = "#52B4E9"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "fWu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25150,11 +25239,10 @@
 	},
 /area/station/commons/lounge)
 "gbq" = (
-/obj/structure/chair/comfy/teal{
-	dir = 4
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/effect/mapping_helpers/broken_floor,
+/obj/item/kirbyplants/organic/plant20,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "gbs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25227,9 +25315,26 @@
 /turf/open/floor/wood/large,
 /area/station/service/theater)
 "gbZ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/table,
+/obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/area/station/maintenance/ghetto/starboard)
+"gcj" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/cup/bottle/formaldehyde{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "gcr" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -25577,6 +25682,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
+"ggp" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/machinery/door/airlock/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "ggq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -25753,6 +25865,14 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
+"gif" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/ghetto)
 "gik" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -25977,11 +26097,14 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "glK" = (
-/obj/item/instrument/recorder,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "glP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -26058,14 +26181,16 @@
 /turf/open/floor/eighties/red,
 /area/station/maintenance/port/aft)
 "gmX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "gnb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table/wood,
@@ -26281,10 +26406,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "gpy" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
+/area/station/maintenance/department/medical/morgue)
 "gpE" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/spawner/random/maintenance/two,
@@ -26367,9 +26491,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
 "gqS" = (
-/obj/machinery/light/small/directional/east,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/obj/item/flashlight/flare/candle,
+/obj/effect/decal/cleanable/crayon/rune4{
+	color = "red"
+	},
+/turf/open/floor/bronze,
 /area/station/maintenance/starboard/upper)
 "gqT" = (
 /obj/structure/cable,
@@ -26821,6 +26947,10 @@
 /obj/item/reagent_containers/cup/glass/waterbottle,
 /turf/open/floor/wood,
 /area/station/maintenance/aft)
+"gyD" = (
+/obj/effect/spawner/random/structure/tank_holder,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "gyF" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -27234,6 +27364,7 @@
 "gDI" = (
 /obj/structure/cable,
 /obj/machinery/chem_heater/withbuffer,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry/ghetto)
 "gDU" = (
@@ -27248,15 +27379,25 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay/ghetto)
 "gEj" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "gEm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/frame/computer,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/area/station/maintenance/department/medical/morgue)
 "gEo" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/camera/directional/north{
@@ -27666,10 +27807,20 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
 "gIU" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/wooden,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/door/window/right/directional/north{
+	req_access = list("medical")
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/starboard/upper)
 "gIV" = (
 /obj/effect/spawner/random/structure/chair_maintenance{
 	dir = 8
@@ -27836,7 +27987,10 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/small,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "gLj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -28110,17 +28264,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gNQ" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/door/window/right/directional/north{
-	req_access = list("medical")
-	},
-/obj/effect/turf_decal/box/white{
-	color = "#52B4E9"
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
@@ -28139,13 +28285,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "gNZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "gOb" = (
 /obj/structure/table/wood,
 /obj/item/modular_computer/laptop,
@@ -28361,13 +28508,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "gPC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/effect/spawner/random/trash/crushed_can{
-	pixel_y = 10
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "gPI" = (
 /obj/machinery/holopad/secure,
 /obj/machinery/ai_slipper,
@@ -28752,10 +28899,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/abandoned_gambling_den)
 "gVD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "gVF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28923,6 +29073,10 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/structure/sign/warning/cold_temp/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "gXi" = (
@@ -29041,15 +29195,16 @@
 /turf/open/floor/wood,
 /area/station/maintenance/aft)
 "gYx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
+/obj/structure/transport/linear/public,
+/obj/effect/landmark/transport/transport_id{
+	specific_transport_id = "morgue_elevator"
+	},
+/obj/effect/abstract/elevator_music_zone{
+	linked_elevator_id = "aft_vator";
+	range = 2
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/station/medical/morgue)
 "gYA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -29843,7 +29998,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/ghetto)
 "hiQ" = (
-/turf/open/floor/iron/dark/small,
+/obj/structure/table/wood,
+/obj/machinery/microwave/engineering/cell_included,
+/obj/machinery/light/small/directional/south{
+	name = "maintenance light";
+	nightshift_allowed = 0;
+	nightshift_enabled = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "hiW" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
@@ -29855,14 +30018,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "hjg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "hjn" = (
 /obj/machinery/atmospherics/components/unary/passive_vent/layer2{
 	dir = 8
@@ -30087,16 +30247,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard/west)
 "hmg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
 	},
-/obj/structure/table/wood,
-/obj/item/food/canned/peaches/maint,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "hmi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/grille,
@@ -30276,13 +30434,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "hnY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks{
-	dir = 1
+/obj/structure/chair/sofa/bench/left{
+	dir = 4
 	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard)
 "hnZ" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -30513,24 +30669,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hqD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table_frame,
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/obj/machinery/processor,
-/obj/item/clothing/suit/apron/chef,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/structure/table_or_rack,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "hqJ" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/flora/bush/lavendergrass,
@@ -30722,6 +30864,10 @@
 "hub" = (
 /turf/closed/wall,
 /area/station/science/lab)
+"hum" = (
+/obj/effect/spawner/random/engineering/flashlight,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "hun" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/camera/directional/south{
@@ -30801,11 +30947,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "huF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/north,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "huO" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/effect/turf_decal/bot,
@@ -31497,14 +31648,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "hDp" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/donkpockets,
-/obj/machinery/camera/directional/east{
-	c_tag = "Virology - Break Room";
-	network = list("ss13","medbay")
-	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
+	dir = 5
+	},
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
@@ -31883,17 +32032,44 @@
 /turf/open/floor/grass,
 /area/station/maintenance/ghetto/garden)
 "hGP" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "hGS" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"hGT" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/tile/dark_blue/anticorner{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/camera{
+	pixel_y = 4;
+	pixel_x = -3
+	},
+/obj/item/paper_bin{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/obj/item/toy/figure/coroner{
+	pixel_y = -3
+	},
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "hGY" = (
 /obj/machinery/photocopier/prebuilt,
 /obj/effect/turf_decal/siding/wood{
@@ -32046,10 +32222,9 @@
 /area/station/medical/virology)
 "hIG" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
+	dir = 8
 	},
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/machinery/light_switch/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "hIL" = (
@@ -32357,9 +32532,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
 "hMV" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/starboard/upper)
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/obj/structure/mannequin/skeleton,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "hMX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32608,6 +32787,9 @@
 /area/station/maintenance/ghetto/starboard)
 "hQm" = (
 /obj/effect/spawner/random/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "hQF" = (
@@ -33214,11 +33396,13 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "hYw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/west,
-/obj/structure/table/wood,
-/turf/open/floor/stone,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/light/small/directional/west{
+	name = "maintenance light";
+	nightshift_allowed = 0;
+	nightshift_enabled = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard)
 "hYK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -33984,12 +34168,15 @@
 /turf/open/floor/plating,
 /area/station/security/checkpoint/arrivals)
 "iiS" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
 "iiT" = (
@@ -34408,6 +34595,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "iov" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
@@ -34435,24 +34625,14 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
 "ioA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id = "quarantine";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 1
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/medical/break_room)
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "ioD" = (
 /obj/machinery/door/airlock,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -34577,10 +34757,20 @@
 /turf/open/floor/iron/stairs/right,
 /area/station/security/holding_cell)
 "iqs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/door/window/right/directional/north{
+	req_access = list("medical")
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "iqu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -35037,13 +35227,10 @@
 /turf/open/floor/iron,
 /area/station/science/research)
 "iwo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/structure/desk_bell{
-	pixel_x = -3
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "iwq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36022,12 +36209,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "iJZ" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/dark/small,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "iKc" = (
 /obj/machinery/button/door/directional/north{
@@ -36354,10 +36538,15 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/dronefabricator)
 "iNF" = (
-/obj/machinery/computer/operating{
-	dir = 4
+/obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
-/turf/open/floor/iron/dark/small,
+/obj/machinery/camera/directional/west{
+	network = list("ss13","medbay");
+	c_tag = "Medbay - Patients Rooms"
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "iNG" = (
 /obj/item/seeds/apple,
@@ -37897,6 +38086,7 @@
 /obj/item/trash/pistachios,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "jgF" = (
@@ -39513,26 +39703,12 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage)
 "jDR" = (
-/obj/effect/spawner/structure/window,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/cryo)
 "jDU" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/item/pen{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/item/camera{
-	pixel_y = 4;
-	pixel_x = -14
-	},
-/obj/item/toy/figure/coroner,
-/turf/open/floor/iron/dark/small,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/closed/wall,
 /area/station/medical/morgue)
 "jDW" = (
 /obj/effect/turf_decal/stripes/line{
@@ -39638,15 +39814,9 @@
 /area/station/maintenance/starboard/aft)
 "jEU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/item/kitchen/rollingpin,
-/obj/item/reagent_containers/condiment/sugar,
-/obj/item/reagent_containers/condiment/enzyme,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "jFb" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
@@ -40030,10 +40200,12 @@
 /turf/closed/wall/rust,
 /area/station/service/hydroponics/ghetto)
 "jJh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/chair/wood,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/dead_body_placer,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "jJp" = (
 /obj/structure/table/wood,
 /obj/item/megaphone{
@@ -40209,14 +40381,17 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "jLm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/directional/west,
+/obj/structure/table,
+/obj/item/storage/fancy/cigarettes/cigpack_robust{
+	pixel_x = 6
+	},
+/obj/item/lighter{
+	pixel_x = -6
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
 "jLr" = (
@@ -41122,8 +41297,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "jXc" = (
-/obj/machinery/photocopier/prebuilt,
-/turf/open/floor/iron/dark/small,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "jXg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41169,6 +41350,32 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
+"jXU" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/pill_bottle/mannitol,
+/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "jXX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -41312,13 +41519,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
 "jZz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/stack/medical/mesh,
-/obj/machinery/defibrillator_mount/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "jZG" = (
@@ -41549,13 +41754,9 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "kcM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "kcN" = (
 /obj/structure/grille/broken,
@@ -41586,14 +41787,9 @@
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/command/nuke_storage)
 "kdc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
-	},
-/obj/structure/table_frame,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "kdj" = (
 /obj/structure/table,
 /obj/item/flatpack{
@@ -41621,15 +41817,18 @@
 /turf/open/floor/iron/white/diagonal,
 /area/station/maintenance/ghetto/starboard/aft)
 "kds" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "kdz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/machinery/holopad,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "kdD" = (
@@ -41662,6 +41861,10 @@
 "kdW" = (
 /obj/item/storage/box/bodybags,
 /obj/structure/rack,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "kea" = (
@@ -41692,10 +41895,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "ker" = (
-/obj/structure/closet/emcloset,
-/obj/structure/sign/warning/vacuum/directional/east,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/curtain,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
+/area/station/medical/morgue)
 "key" = (
 /obj/structure/closet/wardrobe/botanist,
 /obj/effect/decal/cleanable/dirt,
@@ -42036,10 +42239,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "kjg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/effect/spawner/random/structure/table,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "kjo" = (
 /obj/structure/rack,
 /obj/item/restraints/legcuffs/beartrap{
@@ -42103,11 +42306,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard/west)
 "kko" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/obj/effect/landmark/start/coroner,
+/turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "kkq" = (
 /obj/effect/turf_decal/stripes/line{
@@ -42343,12 +42544,12 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "kmU" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/spawner/random/maintenance,
+/obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "kna" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
@@ -42669,13 +42870,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "kqJ" = (
-/obj/structure/table/wood,
-/obj/structure/bedsheetbin{
-	pixel_y = -2
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "kqR" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron/dark/smooth_large,
@@ -43775,14 +43974,13 @@
 "kEh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/junction{
-	dir = 8
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "kEl" = (
@@ -43967,13 +44165,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "kFF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/grille,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "kFH" = (
 /obj/structure/table,
 /obj/item/folder{
@@ -44375,23 +44571,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/storage)
 "kKc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "open";
-	id = "quarantine";
-	name = "Quarantine Lockdown";
-	opacity = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/grunge,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/structure/falsewall,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "kKh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -44791,11 +44974,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "kPk" = (
-/obj/effect/turf_decal/tile/bar/half{
-	dir = 1
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 10
 	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "kPl" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -44893,6 +45077,13 @@
 /obj/effect/turf_decal/tile/purple/half,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"kQo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "kQv" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -44924,17 +45115,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "kQM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/area/station/medical/morgue)
 "kQP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -45131,6 +45317,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
+"kSY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "kTi" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -45285,13 +45480,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "kVP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/mirror/directional/north,
+/obj/structure/sink/directional/south,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "kVS" = (
 /obj/effect/mapping_helpers/airlock/locked,
@@ -45473,8 +45667,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "kYb" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
+/obj/item/food/grown/poppy/geranium{
+	pixel_x = -5
+	},
+/obj/structure/table/bronze,
+/obj/item/food/grown/poppy/geranium{
+	pixel_x = 5
+	},
+/turf/open/floor/wood/ebonite,
 /area/station/maintenance/starboard/upper)
 "kYf" = (
 /turf/open/floor/iron/stairs/right,
@@ -46018,24 +46218,23 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/ghetto/central/aft)
 "lfw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/spawner/random/trash/mess,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "lfL" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood/parquet,
 /area/station/security/courtroom)
 "lfM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/area/station/maintenance/department/medical/morgue)
 "lfP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46204,13 +46403,10 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "lhZ" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/bodycontainer/morgue{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/morgue)
+/obj/structure/closet/firecloset,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "lic" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
@@ -46505,18 +46701,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "lmq" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/storage/toolbox/emergency{
-	pixel_y = 4
-	},
-/obj/item/wrench/medical,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/item/radio/intercom/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "lmt" = (
@@ -46724,6 +46913,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/starboard)
 "lor" = (
@@ -47014,6 +47206,9 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/qm)
+"lqV" = (
+/turf/open/floor/iron/freezer,
+/area/station/medical/morgue)
 "lrd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -47042,12 +47237,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "lrj" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/broken/directional/south,
+/obj/structure/statue/drake,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "lrk" = (
@@ -47308,6 +47499,12 @@
 	color = "#9a9a9a"
 	},
 /area/station/commons/lounge)
+"ltW" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/closet/crate/medical,
+/obj/effect/spawner/random/maintenance/three,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "ltX" = (
 /obj/structure/frame/computer,
 /obj/effect/decal/cleanable/dirt,
@@ -47405,14 +47602,11 @@
 /turf/open/floor/stone,
 /area/station/service/hydroponics/ghetto)
 "luY" = (
-/obj/structure/disposaloutlet{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "lvg" = (
 /obj/machinery/light/directional/east,
@@ -48400,6 +48594,10 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"lIS" = (
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "lIT" = (
 /obj/structure/closet,
 /obj/item/flashlight,
@@ -48416,8 +48614,20 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/department/security/ghetto)
 "lJc" = (
-/obj/effect/landmark/start/coroner,
-/turf/open/floor/iron/dark,
+/obj/structure/bed,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/item/toy/plush/hampter,
+/turf/open/floor/iron/white,
+/area/station/medical/morgue)
+"lJh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "lJi" = (
 /obj/structure/cable,
@@ -48506,12 +48716,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage)
 "lKe" = (
-/obj/structure/table/glass,
-/obj/machinery/microwave,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/west,
+/obj/structure/sink/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "lKf" = (
@@ -48734,12 +48942,9 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "lMr" = (
-/obj/structure/chair/comfy/teal{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "lMu" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -48937,17 +49142,22 @@
 /obj/item/multitool,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
+"lOH" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
+/area/station/medical/morgue)
 "lOR" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/maintenance/port)
 "lOV" = (
-/obj/machinery/door/airlock/atmos,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "lOX" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/item/phone{
@@ -49228,10 +49438,12 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "lSt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard)
 "lSv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -49266,6 +49478,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/security/ghetto/aft)
+"lTm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/morgue)
 "lTt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49462,6 +49681,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
+"lVr" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard)
 "lVu" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/break_room)
@@ -49920,11 +50143,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "maI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "maN" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/spacecash/c10,
@@ -50233,9 +50457,27 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
 "meC" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Morgue Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "meG" = (
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/iron,
@@ -50967,12 +51209,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "mpF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan{
+	dir = 8
+	},
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
 "mpV" = (
@@ -51351,11 +51595,16 @@
 /turf/open/floor/carpet/orange,
 /area/station/maintenance/starboard/fore)
 "mtX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/effect/spawner/random/maintenance/four,
-/turf/open/floor/stone,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/table/bronze,
+/obj/item/food/grown/poppy/lily{
+	pixel_x = 5
+	},
+/obj/item/food/grown/poppy/lily{
+	pixel_x = -5
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "mtY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -51375,13 +51624,12 @@
 /turf/open/floor/circuit/green,
 /area/station/science/xenobiology)
 "muc" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/effect/turf_decal/delivery,
-/obj/item/knife/kitchen,
-/obj/item/storage/box/donkpockets,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "mul" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/kitchen/small,
@@ -51489,10 +51737,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/abandoned)
 "mvr" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "mvt" = (
@@ -52153,11 +52401,11 @@
 /turf/open/floor/pod,
 /area/station/maintenance/ghetto/storage)
 "mDR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/clothing/under/suit/waiter,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/turf_decal/trimline/neutral/end{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "mDW" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -52435,18 +52683,9 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "mGN" = (
-/obj/machinery/light/small/directional/south{
-	name = "maintenance light";
-	nightshift_allowed = 0;
-	nightshift_enabled = 1
-	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Medbay - Morgue South"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/bronze,
+/area/station/maintenance/starboard/upper)
 "mGR" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -53199,8 +53438,8 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "mPJ" = (
-/obj/structure/bodycontainer/morgue,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/machinery/duct,
+/turf/open/floor/iron/freezer,
 /area/station/medical/morgue)
 "mPO" = (
 /obj/machinery/light/small/directional/west,
@@ -53260,11 +53499,12 @@
 /turf/open/floor/wood,
 /area/station/maintenance/aft)
 "mQp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/morgue)
+/obj/machinery/cryo_cell,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "mQq" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/circuit,
@@ -53467,13 +53707,13 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/ghetto/starboard/aft)
 "mTq" = (
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/mask/muzzle,
+/obj/structure/sign/warning/bodysposal/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/effect/turf_decal/tile/bar,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "mTu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table/wood,
@@ -53495,6 +53735,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/station/maintenance/aft)
+"mTC" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/light_switch/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "mTH" = (
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
@@ -53648,6 +53896,18 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"mVT" = (
+/obj/machinery/door/window/right/directional/east{
+	name = "Coroner"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "mVU" = (
 /obj/effect/decal/cleanable/molten_object/large,
 /obj/effect/decal/cleanable/dirt,
@@ -53937,12 +54197,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/prison)
 "mZd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "mZo" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -53974,12 +54232,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/abandoned_gambling_den)
 "mZE" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/machinery/holopad,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "mZH" = (
 /obj/machinery/suit_storage_unit/rd,
@@ -54343,38 +54603,9 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "neD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/obj/structure/table/glass,
-/obj/machinery/camera/directional/south{
-	c_tag = "Medbay - Cryogenics";
-	network = list("ss13","medbay")
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/storage/pill_bottle/mannitol,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/machinery/requests_console/directional/south{
-	department = "Medbay";
-	name = "Medbay Requests Console"
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
@@ -54596,14 +54827,10 @@
 /turf/open/floor/carpet,
 /area/station/service/library/ghetto)
 "nhZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "nib" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -55577,9 +55804,18 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "ntv" = (
-/obj/effect/spawner/random/structure/barricade,
+/obj/structure/rack,
+/obj/effect/spawner/random/medical/injector,
+/obj/effect/spawner/random/medical/surgery_tool,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/area/station/maintenance/department/medical/morgue)
+"ntH" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/structure/sign/warning/gas_mask/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "ntK" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -55959,11 +56195,10 @@
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "nyB" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
 "nyL" = (
@@ -56521,7 +56756,7 @@
 "nFH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
-	dir = 9
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
@@ -56558,14 +56793,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "nGp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/obj/effect/turf_decal/tile/neutral/full,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "nGs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/trimline/dark_blue/corner{
@@ -56745,10 +56977,11 @@
 /turf/open/floor/plating,
 /area/station/commons/storage/emergency)
 "nIk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/station/maintenance/department/medical/morgue)
 "nIl" = (
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -56765,6 +56998,13 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/starboard)
+"nIL" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 6
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "nIQ" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -57180,13 +57420,17 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nOm" = (
-/obj/machinery/door/window/right/directional/east{
-	name = "Coroner"
+/obj/machinery/door/window/right/directional/north{
+	name = "Body Disposal";
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "nOp" = (
 /obj/machinery/light/directional/north,
@@ -57237,14 +57481,13 @@
 "nPb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "nPg" = (
 /obj/structure/chair/wood,
 /obj/effect/mapping_helpers/broken_floor,
@@ -58161,12 +58404,12 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto/fore)
 "oaU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "oaV" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -58391,6 +58634,14 @@
 	dir = 8
 	},
 /area/station/engineering/atmos)
+"ocM" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/tile/neutral/anticorner{
+	dir = 4
+	},
+/obj/structure/bed/medical/emergency,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "ocS" = (
 /obj/structure/broken_flooring/pile/directional/west,
 /turf/open/floor/plating,
@@ -58482,10 +58733,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "odT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard)
 "odU" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/maintenance,
@@ -58505,17 +58760,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/abandoned_gambling_den)
 "oef" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/spawner/random/structure/barricade,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/trunk/multiz{
+	dir = 8
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/area/station/maintenance/ghetto/starboard)
 "oek" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/steam_vent,
@@ -58980,11 +59232,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "okh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/dinnerware,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
+/area/station/maintenance/department/medical/morgue)
 "okj" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -59109,6 +59360,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"omb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "ome" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/button/door/directional/east{
@@ -59503,12 +59762,8 @@
 /turf/open/floor/carpet/red,
 /area/station/service/bar/atrium/ghetto)
 "oqa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "oqb" = (
@@ -59659,15 +59914,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "orz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/bodycontainer/morgue,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "orS" = (
 /obj/structure/table,
 /obj/item/melee/baton/security/cattleprod,
@@ -60312,11 +60564,8 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "oAw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small/directional/north,
+/obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "oAz" = (
@@ -60389,7 +60638,11 @@
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/port/greater)
 "oBv" = (
-/turf/open/floor/plating,
+/obj/structure/table/reinforced/rglass,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "oBx" = (
 /obj/structure/closet/emcloset,
@@ -60597,10 +60850,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "oDP" = (
-/obj/effect/spawner/random/structure/tank_holder,
-/obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
+/area/station/maintenance/department/medical/morgue)
 "oDR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -61475,13 +61728,17 @@
 	},
 /area/station/commons/dorms)
 "oOE" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "oOF" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/holopad/secure,
@@ -61875,12 +62132,12 @@
 /turf/open/misc/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "oTG" = (
-/obj/structure/table/glass,
 /obj/item/hand_labeler{
 	pixel_x = 2;
 	pixel_y = 2
 	},
 /obj/effect/turf_decal/trimline/green/filled/line,
+/obj/structure/table/glass,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "oTM" = (
@@ -62094,12 +62351,12 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "oWz" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "oWA" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
@@ -62274,12 +62531,7 @@
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "oZf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "oZm" = (
@@ -62596,17 +62848,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "pdc" = (
-/obj/machinery/light/small/directional/east{
-	name = "maintenance light";
-	nightshift_allowed = 0;
-	nightshift_enabled = 1;
-	nightshift_light_power = 0.4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "pdl" = (
 /obj/item/stack/rods,
 /turf/open/space/openspace,
@@ -62740,12 +62988,7 @@
 /turf/open/floor/iron/white/diagonal,
 /area/station/maintenance/ghetto/starboard/aft)
 "peT" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
+/turf/open/openspace,
 /area/station/medical/cryo)
 "peV" = (
 /obj/structure/railing,
@@ -63084,11 +63327,11 @@
 /turf/open/floor/carpet/black,
 /area/station/command/meeting_room)
 "pjb" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/obj/item/flashlight/flare/candle,
+/obj/effect/decal/cleanable/crayon/rune2{
+	color = "red"
+	},
+/turf/open/floor/bronze,
 /area/station/maintenance/starboard/upper)
 "pjd" = (
 /obj/effect/turf_decal/stripes/line{
@@ -63139,10 +63382,9 @@
 /turf/open/floor/carpet,
 /area/station/service/library)
 "pjT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/spawner/random/medical/memeorgans,
+/obj/structure/closet/crate/freezer,
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "pjU" = (
@@ -63712,12 +63954,12 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/fore)
 "pqx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
+/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/bar/half{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "pqy" = (
 /obj/structure/spacevine{
 	can_spread = 0;
@@ -63903,8 +64145,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
@@ -64245,10 +64487,10 @@
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/department/security/ghetto)
 "pwQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/medical,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/area/station/maintenance/department/medical/morgue)
 "pwS" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -64367,8 +64609,14 @@
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "pyi" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/iron/dark/small,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/structure/chair/comfy/teal{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "pyk" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -64600,11 +64848,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "pBE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/small,
+/obj/structure/table/wood,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "pBF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65010,9 +65256,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
 "pEZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/photocopier,
+/obj/effect/turf_decal/tile/dark_blue/anticorner,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "pFd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/decal/cleanable/dirt,
@@ -65395,22 +65644,23 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "pJY" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/coroner,
-/turf/open/floor/iron/dark/small,
-/area/station/medical/morgue)
-"pKc" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
+/obj/structure/bodycontainer/morgue{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry/ghetto)
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
+"pKc" = (
+/obj/machinery/space_heater,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/starboard)
 "pKo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "pKp" = (
 /turf/closed/wall,
@@ -65432,8 +65682,12 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/ghetto)
 "pKC" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/dark/small,
+/obj/machinery/airalarm/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/chair/comfy/teal{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "pKF" = (
 /obj/effect/spawner/random/structure/girder,
@@ -65484,16 +65738,15 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "pLp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/tile/neutral/anticorner{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
+/obj/structure/closet{
+	name = "janitorial supplies"
 	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/item/pushbroom,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "pLr" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/end{
@@ -65581,7 +65834,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "pMa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "pMn" = (
@@ -66258,9 +66514,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "pUM" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/stone,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/spawner/random/medical/injector,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "pUU" = (
 /obj/item/reagent_containers/spray/plantbgone,
 /obj/item/reagent_containers/spray/pestspray{
@@ -66572,6 +66830,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
+"pYv" = (
+/obj/machinery/portable_atmospherics/canister{
+	anchored = 1
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "pYB" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -66747,9 +67012,12 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
 "qaT" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "qaY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -67662,10 +67930,12 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "qof" = (
-/obj/machinery/vending/snack,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/morgue)
 "qow" = (
 /obj/structure/easel,
 /obj/effect/decal/cleanable/dirt,
@@ -67787,16 +68057,25 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/starboard/fore)
 "qpJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "qpO" = (
 /obj/machinery/light/directional/north,
-/obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/dark/small,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/duct,
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "qpQ" = (
 /obj/machinery/door/firedoor,
@@ -67875,14 +68154,13 @@
 /turf/open/floor/iron/white/herringbone,
 /area/station/maintenance/ghetto/starboard/aft)
 "qqM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/cable,
-/obj/effect/landmark/start/medical_doctor,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "qqN" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/ghetto/starboard/aft)
@@ -67987,20 +68265,24 @@
 "qtp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
+"qtw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
-"qtw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard)
 "qtA" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
@@ -68146,11 +68428,20 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "qvy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark/small,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "qvB" = (
 /obj/structure/stairs/east{
@@ -68424,11 +68715,14 @@
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/starboard)
 "qze" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/trunk/multiz/down{
+	dir = 2
 	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/morgue)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "qzl" = (
 /obj/structure/railing{
 	dir = 8
@@ -68458,6 +68752,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"qzu" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Morgue"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "qzv" = (
 /obj/machinery/shower/directional/west,
 /obj/structure/fluff/shower_drain,
@@ -68864,8 +69170,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "qEP" = (
-/turf/closed/wall/rust,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "qEY" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/dark,
@@ -68904,10 +69211,13 @@
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
 "qFE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/item/flashlight/flare/candle,
+/obj/effect/decal/cleanable/crayon/rune2{
+	color = "red"
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/area/station/maintenance/starboard/upper)
 "qFH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -69211,6 +69521,14 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/magistrate)
+"qJp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/chair/bronze{
+	dir = 8
+	},
+/turf/open/floor/bronze,
+/area/station/maintenance/starboard/upper)
 "qJs" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -69315,15 +69633,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto)
 "qKG" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/chair_comfy{
 	dir = 8
 	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
+/area/station/maintenance/department/medical/morgue)
 "qKH" = (
 /obj/machinery/computer/upload/borg{
 	dir = 1
@@ -69572,21 +69887,9 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "qNJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "qNK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard,
@@ -69604,11 +69907,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
 "qNP" = (
-/obj/machinery/light/small/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "qNX" = (
 /obj/structure/sign/poster/contraband/random/directional/north,
 /obj/machinery/light/small/broken/directional/north,
@@ -69734,11 +70036,9 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "qPF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/stone,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard)
 "qPH" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -69746,17 +70046,14 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "qQb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/window/right/directional/south{
+	name = "Coroner"
 	},
-/obj/item/chair/plastic,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "qQf" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
@@ -70130,8 +70427,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "qVj" = (
-/turf/closed/wall,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "qVo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70166,11 +70464,9 @@
 /area/station/maintenance/ghetto/starboard)
 "qVM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/cable_coil,
-/obj/structure/frame/computer,
-/obj/machinery/light/small/directional/north,
+/obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/area/station/maintenance/department/medical/morgue)
 "qVO" = (
 /obj/structure/chair/office,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
@@ -70251,9 +70547,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "qWx" = (
@@ -70430,6 +70724,14 @@
 "qYD" = (
 /turf/closed/wall,
 /area/station/security/interrogation/ghetto)
+"qYI" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/structure/bodycontainer/morgue{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "qYJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -70439,10 +70741,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "qYS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/medical/virology)
 "qYT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -70496,6 +70797,17 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/dronefabricator)
+"qZw" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/rack,
+/obj/item/reagent_containers/cup/glass/bottle/vodka,
+/obj/item/storage/fancy/cigarettes/cigpack_uplift,
+/obj/item/storage/box/matches{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "qZA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -71010,12 +71322,10 @@
 /turf/open/floor/iron,
 /area/station/science/lobby)
 "rfx" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 1
-	},
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/public/glass,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "rfD" = (
 /obj/structure/table,
@@ -71266,11 +71576,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "rik" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/starboard)
+/area/station/maintenance/department/medical/morgue)
 "rip" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/red{
@@ -71767,15 +72075,11 @@
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/starboard/aft)
 "rnF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
-/obj/machinery/door/airlock/atmos,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/maintenance/starboard/upper)
+/area/station/hallway/primary/starboard)
 "rnG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -72003,10 +72307,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "rqA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/bar/fourcorners,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "rqF" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -72316,6 +72621,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/maintenance/aft)
+"rum" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/ghetto)
 "ruq" = (
 /obj/machinery/button/door/directional/west{
 	id = "Toilet2";
@@ -72497,10 +72809,12 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/ghetto/starboard/aft)
 "rwC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/basic/goose/vomit,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "rwD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -72885,11 +73199,15 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/break_room)
 "rCF" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/hallway/primary/starboard)
 "rCL" = (
 /obj/machinery/light/directional/west,
 /obj/structure/closet/emcloset,
@@ -72919,12 +73237,9 @@
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/security/lockers)
 "rDd" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/bodycontainer/morgue{
-	dir = 2
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/medical/morgue)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "rDh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -73062,26 +73377,23 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "rFm" = (
-/obj/structure/table/glass,
-/obj/machinery/computer/records/medical/laptop{
-	dir = 8;
-	pixel_x = -2
-	},
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
+/obj/item/storage/box/donkpockets,
+/obj/machinery/camera/directional/east{
+	c_tag = "Virology - Break Room";
+	network = list("ss13","medbay")
+	},
+/obj/structure/table/glass,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "rFp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/spawner/random/medical/patient_stretcher,
+/obj/item/clothing/head/soft/blue,
 /turf/open/floor/plating,
-/area/station/hallway/primary/starboard/west)
+/area/station/maintenance/starboard/upper)
 "rFs" = (
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood/tile,
@@ -73422,12 +73734,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "rKi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
+/obj/effect/decal/cleanable/blood/footprints{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/bronze,
 /area/station/maintenance/starboard/upper)
 "rKx" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
@@ -73850,10 +74160,13 @@
 	name = "Quarantine Lockdown";
 	opacity = 0
 	},
-/obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/duct,
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/medical/medbay)
 "rPa" = (
@@ -74409,17 +74722,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "rWq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "rWy" = (
@@ -74649,11 +74953,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "rYl" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
 "rYm" = (
@@ -74805,9 +75105,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "saM" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "saO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -75282,11 +75584,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "sfM" = (
-/obj/structure/table/glass,
-/obj/item/paper{
-	pixel_y = 4
-	},
 /obj/effect/turf_decal/trimline/green/filled/line,
+/obj/structure/table/glass,
+/obj/machinery/computer/records/medical/laptop{
+	dir = 1;
+	pixel_y = 5
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "sfS" = (
@@ -75508,8 +75811,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "siJ" = (
-/turf/closed/wall,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 9
+	},
+/obj/structure/bodycontainer/morgue,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "siL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -75551,12 +75858,10 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/ghetto)
 "sjf" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/effect/spawner/random/maintenance,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "sjj" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4,
@@ -76452,16 +76757,15 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/bar/backroom/ghetto)
 "stV" = (
-/obj/structure/table/wood,
-/obj/machinery/light/directional/south,
-/obj/machinery/microwave/engineering/cell_included,
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/camera/directional/south{
-	c_tag = "Medbay - Break Room";
-	network = list("ss13","medbay")
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
 	},
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "stY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -76833,13 +77137,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "syU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 1
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/structure/transport/linear/public,
+/turf/open/floor/plating/elevatorshaft,
+/area/station/medical/morgue)
 "syV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -77292,10 +77592,12 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
 "sEm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/simple{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "sEn" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -77437,6 +77739,12 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"sFS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/effect/spawner/random/maintenance/three,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "sFU" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_burn_chamber_input,
 /turf/open/floor/engine/vacuum,
@@ -77457,9 +77765,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "sGh" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Chemistry Lab Exit"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/medical/pharmacy,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
+/area/station/medical/chemistry/ghetto)
 "sGr" = (
 /obj/machinery/door/airlock/public,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -77702,10 +78018,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "sJc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/stone,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/landmark/start/hangover,
+/obj/effect/spawner/random/structure/table_fancy,
+/obj/effect/spawner/random/medical/minor_healing,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "sJo" = (
 /obj/machinery/firealarm/directional/south,
 /obj/structure/table,
@@ -77882,10 +78199,20 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "sLQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "open";
+	id = "quarantine";
+	name = "Quarantine Lockdown";
+	opacity = 0
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "sLZ" = (
 /obj/machinery/door/airlock/corporate,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -78561,8 +78888,11 @@
 /turf/open/floor/iron/small,
 /area/station/maintenance/ghetto/central)
 "sVE" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
+/obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "sVT" = (
 /obj/structure/disposalpipe/segment,
@@ -78813,11 +79143,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "sZN" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
+/area/station/maintenance/department/medical/morgue)
 "sZT" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/line,
@@ -78987,6 +79315,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"tdk" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/morgue)
 "tdm" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -79053,6 +79388,9 @@
 /obj/effect/landmark/start/chemist,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry/ghetto)
@@ -79253,13 +79591,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
 "thB" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id = "medical_break"
-	},
-/turf/open/floor/plating,
-/area/station/medical/break_room)
+/obj/machinery/light/small/directional/east,
+/turf/open/openspace,
+/area/station/medical/cryo)
 "thD" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/maintenance,
@@ -79608,8 +79942,16 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "tlu" = (
-/turf/closed/wall/rust,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/coroner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "tlA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -80114,13 +80456,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "tqC" = (
-/obj/machinery/atmospherics/components/binary/valve/on{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
 "tqG" = (
@@ -80277,11 +80619,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/gravity_generator)
 "tsA" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/valve/on{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
 "tsD" = (
@@ -80463,20 +80803,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "tuq" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags{
-	pixel_x = -6;
-	pixel_y = -6
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
-/obj/item/storage/box/bodybags{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/cup/bottle/formaldehyde{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/turf/open/floor/iron/dark/small,
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "tuv" = (
 /obj/structure/cable,
@@ -81102,6 +81433,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"tCN" = (
+/obj/effect/spawner/random/structure/musician/piano/random_piano,
+/turf/open/floor/bronze,
+/area/station/maintenance/starboard/upper)
 "tCP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -81296,6 +81631,7 @@
 	pixel_y = -7
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry/ghetto)
 "tEX" = (
@@ -82084,8 +82420,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "tOz" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/small,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "tOL" = (
 /obj/machinery/camera/directional/north{
@@ -82335,6 +82674,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "tSu" = (
@@ -82450,12 +82792,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "tUK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "tUP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,
@@ -82580,12 +82919,11 @@
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/hos)
 "tVF" = (
-/obj/structure/sink/directional/east,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "tVG" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical,
@@ -82624,12 +82962,10 @@
 /turf/open/floor/iron/herringbone,
 /area/station/maintenance/aft)
 "tWi" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/maintenance/four,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/bronze,
 /area/station/maintenance/starboard/upper)
 "tWj" = (
 /obj/structure/table/wood,
@@ -83171,10 +83507,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "ucd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/coroner,
-/turf/open/floor/iron/dark,
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/open/floor/iron/freezer,
 /area/station/medical/morgue)
 "ucj" = (
 /obj/effect/turf_decal/stripes/line{
@@ -83407,10 +83743,10 @@
 /turf/open/space/openspace,
 /area/space/nearstation)
 "ufh" = (
+/obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/area/station/maintenance/starboard/upper)
 "ufk" = (
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
@@ -83561,12 +83897,13 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "ugS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/atmos,
+/obj/effect/mapping_helpers/airlock/access/all/engineering,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/cable,
-/obj/structure/sign/warning/gas_mask/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "ugU" = (
@@ -83580,11 +83917,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "ugX" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/food_or_drink/cake_ingredients,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/components/binary/valve/on{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "uhc" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -84226,12 +84563,15 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "uqs" = (
-/obj/effect/turf_decal/tile/green/fourcorners,
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "uqu" = (
 /obj/machinery/grill{
 	pixel_y = 8
@@ -84416,13 +84756,15 @@
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
 "uub" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/mess,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard)
 "uuc" = (
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/carpet/green,
@@ -84437,10 +84779,13 @@
 /turf/open/floor/iron,
 /area/station/security/range)
 "uuk" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/sign/warning/gas_mask/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/morgue)
 "uum" = (
 /obj/machinery/mineral/stacking_machine{
 	input_dir = 2;
@@ -84514,9 +84859,6 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/mechbay)
 "uvq" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 6
-	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "uvI" = (
@@ -84547,7 +84889,6 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
@@ -84711,13 +85052,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "uxN" = (
-/obj/structure/table,
 /obj/item/soap{
 	pixel_y = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
 	},
+/obj/structure/table/glass,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "uxX" = (
@@ -84945,6 +85286,7 @@
 "uBe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "uBk" = (
@@ -85150,11 +85492,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "uEt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "uEL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -85405,12 +85744,10 @@
 /turf/closed/wall/r_wall,
 /area/station/security/interrogation/ghetto)
 "uHT" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/air{
-	anchored = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/xeno,
+/obj/item/toy/plush/ratplush,
+/turf/open/floor/bronze,
 /area/station/maintenance/starboard/upper)
 "uHW" = (
 /obj/machinery/camera/autoname/directional/north{
@@ -85476,7 +85813,6 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "uIF" = (
-/obj/structure/table/glass,
 /obj/item/paper_bin{
 	pixel_x = -6;
 	pixel_y = 4
@@ -85486,6 +85822,10 @@
 	pixel_y = 6
 	},
 /obj/effect/turf_decal/trimline/green/filled/line,
+/obj/structure/table/glass,
+/obj/item/paper{
+	pixel_y = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "uIH" = (
@@ -85519,6 +85859,13 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/security/office)
+"uJe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "uJj" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -85603,9 +85950,9 @@
 /area/station/maintenance/starboard/fore)
 "uJP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/bar)
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "uJS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -86266,10 +86613,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "uSk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry/ghetto)
 "uSA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -86280,14 +86630,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "uSG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "uST" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
@@ -86634,10 +86981,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "uYk" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/spawner/random/frog,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "uYv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -86650,17 +86996,9 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/fore)
 "uYE" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/obj/machinery/button/door/directional/south{
-	id = "Psychological office";
-	name = "Medical Break Room Shutters Control";
-	normaldoorcontrol = 1;
-	specialfunctions = 4;
-	pixel_y = 24
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/bronze,
+/area/station/maintenance/starboard/upper)
 "uYI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -86686,14 +87024,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/prison)
 "uYN" = (
-/obj/item/storage/backpack/duffelbag/clown/cream_pie,
-/turf/open/floor/plating,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/item/toy/plush/shark,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "uYQ" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder{
-	pixel_y = 8
-	},
 /obj/effect/turf_decal/tile/green/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -86819,12 +87159,14 @@
 /turf/open/openspace,
 /area/station/science/xenobiology)
 "vaB" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/food_or_drink/cake_ingredients,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/sign/warning/gas_mask/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "vaF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -87400,10 +87742,11 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "viK" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 2
+/obj/structure/table/reinforced/rglass,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "viO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -87476,12 +87819,11 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "vjG" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/light/directional/south,
-/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "vjI" = (
@@ -87606,13 +87948,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "vky" = (
-/obj/effect/turf_decal/tile/neutral/half,
-/obj/effect/turf_decal/tile/neutral/half,
-/obj/effect/turf_decal/tile/neutral/half,
-/obj/effect/turf_decal/tile/neutral/half,
-/obj/structure/sink/kitchen/directional/south,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/east,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "vkz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -88140,9 +88484,8 @@
 /area/station/security/mechbay)
 "vqm" = (
 /obj/structure/table,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/effect/spawner/random/maintenance,
 /obj/machinery/light/small/directional/east,
+/obj/effect/spawner/random/trash/janitor_supplies,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "vqu" = (
@@ -88620,6 +88963,13 @@
 	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
 	},
 /area/station/security/prison/ghetto)
+"vui" = (
+/obj/machinery/light/small/directional/west,
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/starboard)
 "vun" = (
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 1
@@ -89794,6 +90144,15 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
+"vJx" = (
+/obj/machinery/door/window/right/directional/east{
+	name = "Coroner"
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "vJz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible/layer2{
 	dir = 6
@@ -90203,6 +90562,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/checker,
 /area/station/service/bar/atrium/ghetto)
+"vPL" = (
+/obj/structure/sign/departments/restroom,
+/turf/closed/wall,
+/area/station/medical/morgue)
 "vPN" = (
 /obj/machinery/telecomms/bus/preset_three,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
@@ -91444,6 +91807,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
+"whf" = (
+/obj/structure/closet/emcloset,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "whg" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/structure/table/reinforced,
@@ -91866,10 +92234,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "wlQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/surgery_tray/full/morgue,
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "wlR" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
@@ -91962,6 +92334,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay/ghetto)
+"wnh" = (
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "wnr" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -91969,12 +92351,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "wnx" = (
-/obj/structure/chair/comfy/teal{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "wnH" = (
 /obj/machinery/mecha_part_fabricator,
 /turf/open/floor/iron/dark,
@@ -92109,19 +92494,33 @@
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "wqe" = (
-/obj/machinery/atmospherics/components/binary/valve/on,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/atmos,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/effect/mapping_helpers/airlock/access/all/engineering,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/upper)
 "wqi" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/requests_console/directional/south{
+	department = "Medbay";
+	name = "Medbay Requests Console"
+	},
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/structure/table/glass,
+/obj/item/storage/toolbox/emergency{
+	pixel_y = 4
+	},
+/obj/item/wrench/medical,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "wqj" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
@@ -92134,17 +92533,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/locker)
 "wqA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/poddoor{
+	elevator_mode = 1;
+	transport_linked_id = "morgue_elevator"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/iron/white,
-/area/station/medical/break_room)
+/area/station/medical/cryo)
 "wqI" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -92169,11 +92563,11 @@
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "wrk" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "wrm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -92348,17 +92742,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wtl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "wtn" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/closet{
@@ -92541,11 +92930,12 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "wvI" = (
-/obj/structure/chair/comfy/teal{
+/obj/structure/girder,
+/obj/structure/disposalpipe/segment{
 	dir = 8
 	},
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "wvJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -92570,14 +92960,14 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/aft)
 "wvS" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/station/medical/break_room)
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "wvT" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -93098,11 +93488,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "wCb" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/vending/wardrobe/coroner_wardrobe,
-/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/small,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "wCj" = (
 /obj/machinery/duct,
@@ -93405,11 +93799,15 @@
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
 "wFa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/bar/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "wFf" = (
 /obj/structure/chair/sofa/right/maroon{
 	dir = 4
@@ -94901,13 +95299,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "wYT" = (
-/obj/structure/cable,
-/obj/structure/table,
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 1
+	},
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "wYX" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -95006,6 +95403,11 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/station/commons/storage/emergency)
+"xaS" = (
+/obj/machinery/light/small/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "xaT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -95223,13 +95625,8 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "xdh" = (
-/obj/machinery/door/window/right/directional/west{
-	name = "Coroner"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "xdk" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -95257,10 +95654,12 @@
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "xdu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/station/medical/morgue)
 "xdz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -95740,18 +96139,22 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "xii" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
+/obj/machinery/computer/operating,
+/obj/effect/turf_decal/tile/dark_blue/anticorner{
 	dir = 1
 	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/turf/open/floor/iron/dark/small,
+/area/station/medical/morgue)
 "xim" = (
-/obj/machinery/vending/cola,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/kitchen)
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/anticorner,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "xiu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -96679,9 +97082,11 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "xun" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 5
+/obj/machinery/portable_atmospherics/canister/air{
+	anchored = 1
 	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "xur" = (
@@ -97051,15 +97456,12 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "xyV" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/event_spawn,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/obj/machinery/holopad,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "xyZ" = (
 /obj/structure/bed/dogbed/runtime,
@@ -97536,6 +97938,11 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/command/storage/eva)
+"xGj" = (
+/obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "xGq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -97575,11 +97982,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "xGF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/stone,
-/area/station/maintenance/ghetto/bar)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "xGR" = (
 /obj/structure/sign/departments/medbay/alt/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -97769,8 +98178,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
 "xJM" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/small,
+/obj/structure/chair/comfy/teal{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "xJQ" = (
 /obj/machinery/light/small/directional/west,
@@ -97909,12 +98320,11 @@
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "xLq" = (
+/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/vomit,
-/obj/effect/turf_decal/tile/bar/fourcorners,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/morgue)
 "xLv" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 8
@@ -98328,16 +98738,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/abandoned)
 "xQn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/tile/neutral/half{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/medical/morgue)
 "xQu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/cable,
@@ -98792,6 +99199,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"xWv" = (
+/obj/machinery/shower/directional/east,
+/obj/structure/curtain,
+/obj/item/soap/deluxe,
+/turf/open/floor/iron/freezer,
+/area/station/medical/morgue)
 "xWy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -98903,10 +99316,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "xXW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/bar)
+/obj/structure/transport/linear/public,
+/obj/machinery/elevator_control_panel/directional/west{
+	linked_elevator_id = "morgue_elevator";
+	preset_destination_names = list("2"="Morgue                                Deck", "3"="Cryo                                Deck")
+	},
+/turf/open/floor/plating/elevatorshaft,
+/area/station/medical/morgue)
 "xYb" = (
 /obj/structure/table/wood,
 /obj/item/phone{
@@ -99053,12 +99469,13 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "xZX" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister{
-	anchored = 1
+/obj/effect/spawner/random/trash/mess,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/area/station/maintenance/department/medical/morgue)
 "xZZ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Port to Fuel Pipe";
@@ -99138,18 +99555,9 @@
 /turf/open/floor/eighties/red,
 /area/station/maintenance/port/aft)
 "yaU" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/item/lighter{
-	pixel_x = -6
-	},
-/obj/item/storage/fancy/cigarettes/cigpack_robust{
-	pixel_x = 6
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/starboard/upper)
+/obj/structure/sign/warning/biohazard/directional/north,
+/turf/open/openspace,
+/area/station/medical/cryo)
 "ybc" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/iron/dark,
@@ -99379,8 +99787,11 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "yeD" = (
-/turf/closed/wall,
-/area/station/medical/break_room)
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "yeF" = (
 /obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/tile/blue{
@@ -99667,17 +100078,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "yiF" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/bar/opposingcorners{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/turf/open/floor/iron/kitchen,
-/area/station/maintenance/ghetto/kitchen)
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "yiG" = (
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
@@ -99964,22 +100369,11 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/science/server)
 "ylP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/radio{
-	desc = "An old handheld radio. You could use it, if you really wanted to.";
-	icon_state = "radio";
-	name = "old radio";
-	pixel_y = 15
+/obj/machinery/atmospherics/pipe/smart/simple{
+	dir = 5
 	},
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = 3
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/kitchen)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "ylQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -136138,7 +136532,7 @@ doz
 doz
 vzJ
 idc
-pKc
+ksr
 uaZ
 sux
 aKM
@@ -136395,7 +136789,7 @@ doz
 doz
 vzJ
 aHf
-pKc
+ksr
 uaZ
 sux
 sux
@@ -136652,7 +137046,7 @@ doz
 doz
 vzJ
 rEd
-pKc
+ksr
 fVL
 sux
 sux
@@ -137416,7 +137810,7 @@ ceC
 ceC
 ceC
 ceC
-ceC
+chY
 doz
 doz
 doz
@@ -137427,10 +137821,10 @@ fof
 gDI
 tEW
 cRy
-oPj
-hFR
-hFR
-hFR
+uSk
+rum
+gif
+dfg
 mWk
 oPj
 hFR
@@ -137671,13 +138065,13 @@ ceC
 ceC
 doz
 doz
-doz
+ceC
 doz
 ceC
 doz
 doz
-doz
-ceC
+dTr
+dTr
 vzJ
 vzJ
 hLw
@@ -137687,7 +138081,7 @@ vzJ
 vzJ
 vzJ
 vzJ
-vzJ
+sGh
 vzJ
 vzJ
 vzJ
@@ -137928,38 +138322,38 @@ ceC
 ceC
 doz
 doz
-doz
+ceC
 doz
 ceC
 doz
 doz
+dTr
+sJc
+rDd
+avs
+rDd
+rDd
+rDd
+dmA
+rDd
+qVM
+sLQ
+kQo
+bDp
+tVF
+pwQ
+gyD
+coB
 doz
-ceC
+job
 doz
 doz
-doz
-doz
+job
 doz
 doz
 vbK
-ceC
-vbK
-doz
-doz
-ceC
-doz
 job
 doz
-doz
-job
-doz
-doz
-job
-doz
-doz
-vbK
-job
-job
 doz
 fif
 wfp
@@ -138185,28 +138579,28 @@ ceC
 vbK
 doz
 doz
-doz
+ceC
 doz
 ceC
 doz
 doz
-doz
-ceC
-doz
-doz
-doz
-doz
-doz
-doz
-vbK
-ceC
-ceC
-vbK
-vbK
-ceC
-ceC
-ceC
-vbK
+sZN
+qKG
+rik
+uYk
+rik
+amp
+okh
+rDd
+oDP
+dcV
+dTr
+pUM
+bzn
+xZX
+bzn
+hum
+coB
 vbK
 vbK
 vbK
@@ -138441,29 +138835,29 @@ vbK
 ceC
 vbK
 vbK
-vbK
-vbK
-vbK
-ceC
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
 ceC
 ceC
-doz
-qVj
-qVj
-qVj
-qVj
-qVj
+ceC
+chY
+ceC
+ceC
+sZN
+rDd
+rDd
+lCk
+lCk
+lCk
+lCk
+lCk
+lCk
+lCk
+lCk
+lCk
+lCk
+wtl
+jEU
+tUK
+coB
 ceC
 doz
 doz
@@ -138699,28 +139093,28 @@ jEk
 vbK
 doz
 doz
-doz
+ceC
 doz
 ceC
 doz
 doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-vbK
-ceC
-ceC
-ceC
-qVj
+sZN
+rDd
+rDd
+lCk
+xii
+aND
+gcj
+bjo
+fVJ
+gVD
+xQn
+pLp
+lCk
 mTq
 cHV
 jEU
-qVj
+coB
 ceC
 doz
 doz
@@ -138955,29 +139349,29 @@ doz
 ceC
 vbK
 vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
 ceC
-vbK
 ceC
-qVj
+ceC
+ceC
+ceC
+ceC
+dTr
+lfM
+dmA
+lCk
+wlQ
+kko
+qNP
+qQb
+lJh
+iJZ
+lOV
+bVS
+qzu
 vky
 rqA
 hqD
-qVj
+coB
 ceC
 doz
 doz
@@ -139213,28 +139607,28 @@ ceC
 vbK
 doz
 doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-vbK
 ceC
-vbK
-ceC
-qVj
-byg
-csD
+doz
+doz
+dTr
+dTr
+dTr
+bzn
+sFS
+lCk
+dbP
+dCQ
+dIb
+iwo
+wYT
+uEt
+lOV
+omb
+lCk
+dTr
+ggp
 nIk
-qVj
+coB
 ceC
 ceC
 ceC
@@ -139469,35 +139863,35 @@ vbK
 ceC
 vbK
 vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
-vbK
 ceC
-vbK
-doz
-qVj
+ceC
+ceC
+ceC
+dTr
+lIS
+kdc
+rik
+ntv
+lCk
+hGT
+hMV
+gPC
+pEZ
+ocM
+vJx
+mVT
+xim
+lCk
 qVj
 gpy
-qVj
-qVj
-qVj
-sGh
-sGh
-qVj
-qVj
-vbK
+ugX
+coB
+ceC
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -139725,36 +140119,36 @@ doz
 doz
 ceC
 txs
-siJ
-siJ
-siJ
-siJ
-siJ
-siJ
-siJ
-siJ
-siJ
-siJ
-siJ
-siJ
-siJ
-siJ
 doz
-vbK
-ceC
-vbK
 doz
-qVj
+ipz
+ipz
+ipz
+dTr
+dTr
+dTr
+gEm
+dTr
+lCk
+siJ
+orz
+orz
+orz
+orz
+uvq
+hmg
+kPk
+lCk
 mZd
 csD
 pqx
-qVj
-kdc
-xii
-xii
-gVD
-qVj
-vbK
+coB
+ceC
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -139982,36 +140376,36 @@ doz
 doz
 ceC
 vbK
-siJ
-uJP
+doz
+doz
+ipz
 gbZ
-gbZ
-mtX
+qTP
 hYw
 qPF
-uSk
-bGl
-sEm
-cBQ
+qTP
+lVr
+qTP
+lCk
 huF
 mDR
-siJ
-doz
-vbK
-ceC
-vbK
-doz
-qVj
+jJh
+mDR
+mDR
+uvq
+ioA
+fNH
+lCk
 muc
 xLq
 qNJ
-gIU
-avs
-xii
-xii
-cys
-qVj
-vbK
+coB
+ceC
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
@@ -140239,36 +140633,36 @@ doz
 vbK
 ceC
 vbK
-siJ
-qVM
-qFE
+doz
+doz
+hRA
 bGl
 odT
-eQb
-sJc
 lSt
-sLQ
+lSt
+lSt
+lSt
 apz
 meC
-meC
+gEj
 gEj
 tlu
-doz
-vbK
-ceC
-cfT
-ceC
-qVj
-bOW
+maI
+uJe
+awe
+abw
+qYI
+lCk
 nGp
-pqx
+nGp
+fEP
 coB
-wtl
-xii
-gNZ
-ylP
-qVj
-vbK
+ceC
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 vbK
@@ -140496,36 +140890,36 @@ doz
 vbK
 ceC
 vbK
-siJ
-gEm
-gbZ
-gbZ
-gbZ
-xGF
-uSk
-uSk
-xdu
-xdu
-gbZ
-meC
-cKE
-siJ
 doz
-vbK
-ceC
-vbK
-ceC
-qVj
+doz
+hRA
+qTP
+gfa
+ipz
+ipz
+ipz
+ipz
+ipz
+lCk
+lCk
+lCk
+lCk
+uqs
+xGj
+hjg
+fMF
+pJY
+lCk
 dTr
-wFa
-bDp
-qVj
-yiF
-xQn
-xii
-qNP
-qVj
-vbK
+dTr
+dTr
+coB
+ceC
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 jEk
@@ -140753,36 +141147,36 @@ ceC
 ceC
 ceC
 vbK
-siJ
-bnm
-bGl
-gbZ
-pUM
-qpJ
-sJc
-maI
-lSt
-iwo
-rwC
-xXW
-hnY
-siJ
 doz
-vbK
+doz
+ipz
+brP
+gfa
+ipz
 ceC
-vbK
+ceC
+ceC
+ceC
+lCk
+xXW
+syU
+cys
+yiF
+kqJ
+kqJ
+fMF
+pJY
+lCk
+ceC
+ceC
+ceC
+ceC
+ceC
 doz
-qVj
-vaB
-dys
-kPk
-uYk
-pLp
-lfw
-xii
-gVD
-qVj
-vbK
+doz
+doz
+doz
+doz
 doz
 doz
 vbK
@@ -141010,40 +141404,40 @@ oFI
 ipz
 ceC
 vbK
-siJ
-dyq
-gbZ
-gbZ
+doz
+doz
+ipz
+xmv
 uub
-gbZ
-bzn
-bGl
-odT
-gPC
-meC
-meC
+ipz
+ceC
+ceC
+doz
+doz
+lCk
+gYx
 syU
-siJ
-doz
-vbK
+cys
+dyq
+wFa
+cMi
+wvS
+nIL
+lCk
 ceC
-vbK
-doz
-qVj
-ugX
-chY
-pEZ
-uYk
-qQb
-hjg
-xii
-xim
-qVj
-vbK
-doz
 doz
 doz
 ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+vbK
 ceC
 fif
 fif
@@ -141267,42 +141661,42 @@ qTP
 ipz
 ceC
 doz
-siJ
-aIh
-jJh
-wqi
+ipz
+hRA
+hRA
+ipz
 qtw
-qYS
-ufh
-gbZ
-iqs
-glK
-meC
-meC
-sEm
-siJ
+ipz
+ceC
+doz
+doz
+doz
+lCk
+lCk
+lCk
+lCk
+lCk
+lCk
+lCk
+nOm
+lCk
+lCk
+ceC
+doz
+doz
+ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 vbK
 ceC
-ipz
-ipz
-qVj
-wYT
-sZN
-okh
-qVj
-hmg
-hjg
-gmX
-qof
-qVj
-vbK
-vbK
-vbK
 ceC
-ceC
-ceC
-doz
 fif
 rQp
 wfp
@@ -141524,42 +141918,42 @@ fHl
 ipz
 ipz
 doz
-siJ
-tlu
-tlu
-siJ
+ipz
+vIX
+hnY
+vui
 oef
-siJ
-fMF
-tlu
-tlu
-siJ
-ntv
-siJ
-siJ
-siJ
 ipz
-ipz
-ipz
-ipz
-dcV
-qVj
-qVj
-dIb
-qEP
-qVj
-qVj
-qKG
-wlQ
-qVj
-qVj
-iYR
-iYR
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 vbK
-job
+vbK
+vbK
+lCk
+wnh
+lCk
+ceC
+ceC
+doz
 doz
 ceC
 doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
 fif
 cmE
 vIH
@@ -141782,41 +142176,41 @@ fYU
 ipz
 ipz
 ipz
-vIX
-dmA
-wBP
-cwi
-cwi
-cwi
-cwi
-cwi
-ayj
-cwi
+jrb
+jrb
 qTP
+vqJ
 ipz
-qTP
-rik
-cwi
-bjo
-cwi
-cwi
-cwi
-cwi
-cwi
-cwi
-cwi
-cSQ
-cSQ
-cSQ
-cSQ
-cSQ
-cSQ
-iYR
-vbK
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 ceC
 doz
+lCk
+lCk
+lCk
+doz
+doz
+doz
+doz
+ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
 fif
 vOU
 emy
@@ -142041,39 +142435,39 @@ wBP
 qTP
 jrb
 qTP
-qTP
-cwi
-kEb
+woL
+gfa
 ipz
-ipz
-ipz
-ipz
-cwi
-cwi
-gYx
-dpz
-cwi
-qTP
-ipz
-ipz
-ipz
-ipz
-oDP
-qTP
-ker
-ipz
-iYR
-iYR
-iYR
-iYR
-iYR
-cSQ
-iYR
-vbK
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 ceC
 doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
+doz
+iYR
+iYR
+iYR
+iYR
+iYR
+iYR
+ceC
+doz
+doz
+doz
+ceC
 fif
 rQp
 kPe
@@ -142294,43 +142688,43 @@ rWC
 qTP
 pqc
 ygR
-jrb
+pKc
 woL
-tZs
+kEb
 adQ
 woL
-cwi
+gfa
 ipz
-hUE
 doz
 doz
-ipz
-ipz
-ipz
-ipz
-ipz
-ipz
-ipz
-ipz
+doz
+doz
+doz
+doz
+doz
 doz
 ceC
-ipz
-ipz
-oFI
-ipz
-ipz
+ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+ceC
 doz
 iYR
 lMT
 tNT
 qqN
-cSQ
+fKk
 iYR
 ceC
 ceC
 ceC
 ceC
-doz
+ceC
 fif
 ngd
 xXv
@@ -142564,24 +142958,24 @@ doz
 doz
 doz
 doz
-vbK
-vbK
-vbK
-vbK
 doz
 doz
 ceC
+ceC
 doz
-ipz
-qTP
-ipz
+doz
+doz
+doz
+doz
+doz
+doz
 ceC
 doz
 iYR
 key
 gdj
 ktZ
-cSQ
+fKk
 iYR
 fif
 fif
@@ -142813,7 +143207,7 @@ rlo
 aXE
 llI
 hRA
-vqJ
+gfa
 ipz
 doz
 doz
@@ -142825,13 +143219,13 @@ doz
 doz
 ceC
 ceC
-doz
-doz
-vbK
-doz
-ipz
-fHl
-ipz
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
 ceC
 ceC
 iYR
@@ -143072,6 +143466,12 @@ jwl
 gEZ
 qVL
 ipz
+ceC
+ceC
+ceC
+ceC
+ceC
+doz
 doz
 doz
 ceC
@@ -143080,15 +143480,9 @@ ceC
 doz
 doz
 doz
-ceC
-ceC
-ceC
 doz
 doz
 doz
-vbK
-jEk
-vbK
 doz
 doz
 iYR
@@ -204501,15 +204895,15 @@ tuq
 iNF
 cZU
 cCS
-lCk
+vPL
 ftE
 kEh
 qbQ
 iov
-cMi
 lQJ
-sqG
+twT
 alU
+sqG
 bBw
 qbQ
 fCK
@@ -204755,8 +205149,8 @@ jFQ
 jFQ
 jFQ
 qpO
-pJY
-xJM
+tOz
+uuk
 qvy
 gLa
 gXf
@@ -205008,22 +205402,22 @@ ckR
 lCk
 oBv
 uYN
-lCk
+dKd
 luY
 sVE
 jXc
 xJM
 pKC
-iJZ
+lCk
 adA
 jDR
 cMB
 tnR
 jDR
-nnU
-nnU
+jDR
+adA
 rOZ
-htm
+xoo
 xoo
 ues
 ndZ
@@ -205263,24 +205657,24 @@ nYw
 nke
 ckR
 lCk
-uYN
-oBv
-lCk
+cNQ
+xdh
+fiK
 nhZ
 bri
 tOz
 pBE
 hiQ
-dKk
-adA
+lCk
+mQp
 hIG
 qWw
 pMa
 neD
-nnU
-pPG
+iqs
+adA
 elu
-htm
+xoo
 chc
 wdz
 jvO
@@ -205294,7 +205688,7 @@ xmN
 xoo
 xeg
 sTU
-sTU
+eOJ
 uxN
 aDt
 owG
@@ -205520,24 +205914,24 @@ btr
 iur
 lSF
 lCk
-lCk
-lCk
-lCk
-lCk
-lCk
+aIh
+lOH
+dKd
+tdk
+lTm
 wCb
 ces
 pyi
 jDU
-adA
+jXU
 bRT
 fgr
+eLJ
 qOg
-fWo
-nnU
-pPG
+dpz
+adA
 qOt
-htm
+xoo
 mjM
 ykG
 rZS
@@ -205777,24 +206171,24 @@ qFS
 iur
 fUh
 lCk
-mPJ
-mPJ
-mPJ
+ker
+ker
+lCk
 kVP
 mZE
-kmU
-abw
-crq
-bVS
+lCk
+lCk
+lCk
+lCk
 dhQ
 jZz
 blT
 kdz
 vjG
-nnU
-nNa
+gIU
+adA
 uBe
-htm
+xoo
 fsl
 qoT
 dgi
@@ -206036,22 +206430,22 @@ ckR
 lCk
 hGP
 wrk
-oaU
+dKd
 uSG
-qze
-qze
-qze
-mPJ
-kjg
+kQM
+lCk
+xWv
+cBQ
+lCk
 adA
-bRT
-orz
-qOg
+adA
+adA
+dqA
 gNQ
-nnU
-dIf
-lpq
-htm
+wqi
+adA
+uBe
+xoo
 fiJ
 mcn
 sYg
@@ -206295,20 +206689,20 @@ cNQ
 xdh
 rfx
 pKo
-mPJ
-mPJ
+xdu
+qof
 mPJ
 bhy
-kjg
-adA
+lCk
+yaU
 peT
-kQM
+wqA
 mvr
 lmq
-nnU
-uBe
+byg
+adA
 jgy
-htm
+xoo
 ged
 erS
 aYE
@@ -206553,25 +206947,25 @@ lJc
 dKd
 xyV
 fwy
-dCQ
-fwy
+lCk
+lqV
 ucd
-mGN
-yeD
+lCk
+peT
 thB
 wqA
-thB
-yeD
-nnU
-lpq
-htm
-htm
-htm
-htm
-htm
-htm
-htm
-htm
+mTC
+gmX
+gNZ
+adA
+elu
+xoo
+xoo
+xoo
+xoo
+xoo
+xoo
+xoo
 xoo
 xoo
 xoo
@@ -206805,36 +207199,36 @@ uap
 iur
 ckR
 lCk
-rDd
-nOm
-lhZ
+lCk
+lCk
+lCk
 buy
-qze
-qze
-qze
-mQp
-qaT
-yeD
-uYE
-dbP
-saM
+lCk
+lCk
+lCk
+lCk
+lCk
+adA
+adA
+adA
+adA
 bvA
-nnU
-nPZ
+adA
+adA
+elu
 htm
-uHT
 xun
+sEm
 ppe
-uHT
-awe
 xun
-htm
+uwa
+ylP
+aDt
 eEz
 uGN
 sTP
 xpY
 puQ
-tVF
 lKe
 qWx
 quL
@@ -207061,37 +207455,37 @@ qjt
 uap
 iur
 tHA
-lCk
+nnU
 sjf
-kko
-tUK
+hkP
+uta
 qtp
-mPJ
-mPJ
-mPJ
-qze
+hFm
+vpo
+lhZ
+whf
 qaT
 yeD
 clY
 kFF
-gbq
+cTB
 wnx
-nnU
 nPZ
+xaS
+elu
 htm
-uHT
+xun
 ruR
 gAg
-uHT
+xun
 lzQ
 aYv
-fiK
+qYS
 qtA
 oCy
 oUd
 kFp
 kEz
-umf
 umf
 tDV
 pwF
@@ -207317,38 +207711,38 @@ aKX
 uCV
 pdA
 iur
-ckR
-lCk
-qze
-qze
+rnF
+rCF
+unT
+unT
 qze
 nPb
 pdc
-kds
 oWz
-fVJ
-uvq
-yeD
+oWz
+oWz
+qqM
+kSY
 dic
 qqM
 oOE
 stV
-nnU
+rwC
 bIa
+djv
 htm
-uHT
+xun
 ruR
 oyk
 qMf
 uwa
-uEt
-htm
+fWo
+aDt
 aDt
 ljJ
 aDt
 aDt
 dsq
-uqs
 uYQ
 fLX
 hIA
@@ -207586,26 +207980,26 @@ nnU
 nnU
 nnU
 nnU
-kqJ
-wvS
+nnU
+nnU
 wvI
 lMr
-nnU
-lpq
+luc
+pPG
+eQb
 htm
-fzv
+pTa
 dgp
 ikW
-xZX
+pYv
 krL
 lzQ
-hMV
+cKE
 kEA
 uQa
 sbf
 kFp
 uaw
-gTy
 tKx
 dLq
 amN
@@ -207833,35 +208227,35 @@ kkl
 kkl
 sKd
 nnU
-nNa
-nPZ
-hkP
+tCN
+bOW
+boK
 rKi
 fOH
-luc
+gqS
+uYE
+bOW
+fzv
+bnm
+htm
+nqw
+kds
 nPZ
-nPZ
-nPZ
-nnU
-nnU
-ioA
-nnU
-nnU
-nnU
-nPZ
+uJP
+pPG
+lfw
 htm
 jan
 veB
-lfM
+aaz
 wBZ
 qAi
 jGA
-htm
+aDt
 sRz
 oiR
 fcj
 xpY
-rCF
 hDp
 rFm
 aWA
@@ -208088,33 +208482,33 @@ sKd
 sKd
 sKd
 kkl
-avQ
-rFp
-unT
-unT
-unT
+sKd
+nnU
+qJp
+dIf
+mGN
 oZf
 pjb
-pjb
-pjb
-pjb
+uHT
+qFE
+oZf
 tWi
 lrj
-lrj
-rWq
+htm
+pTa
 fcd
-amp
-bxW
+nPZ
+gXm
 oqa
+glK
 htm
 nqw
 nPZ
 ikW
 nPZ
 pyY
-nPZ
-htm
-htm
+saM
+nnU
 htm
 htm
 htm
@@ -208349,34 +208743,34 @@ bMM
 nnU
 nnU
 kYb
-uta
-hFm
-hFm
+mtX
+gbq
+crq
 gqS
-hFm
-vpo
+uYE
+bsS
 fGO
-hFm
-hFm
+dIC
+htm
 oAw
 nFH
-lpq
-lpq
+nPZ
+ufh
 fJB
-lOV
+eFQ
 wqe
 bCK
 mpF
 tqC
 tsA
 fpz
-rnF
-qJE
 qJE
 rzl
 lhE
-iuy
-nnU
+qZw
+ltW
+pjT
+rzl
 rIv
 hSq
 rIv
@@ -208614,25 +209008,25 @@ htm
 htm
 htm
 htm
-nnU
-bgG
-nPZ
-luc
-nPZ
-ugS
 htm
-yaU
+mtm
+kmU
+luc
+qEP
+nPZ
+vaB
+htm
 jLm
 iiS
 nyB
 rYl
 kcM
-htm
-uuk
 qJE
 rzl
-fNH
-aaz
+rFp
+iuy
+iuy
+iuy
 biB
 nPZ
 nPZ
@@ -208871,24 +209265,24 @@ stA
 rkL
 kYH
 htm
-pTa
-pjT
+kjg
 nPZ
+kds
 nnU
 mtm
-eFQ
+nPZ
+qpJ
 htm
 htm
 htm
 htm
 htm
 htm
-htm
-htm
-luc
-qJE
+ugS
 nnU
 nnU
+rzl
+rzl
 nnU
 nnU
 nPZ
@@ -209129,23 +209523,23 @@ psK
 pww
 htm
 htm
-bgG
-hQm
+nPZ
+oaU
 aUZ
 luc
+nPZ
 kSA
-bxW
 bxW
 bxW
 lqL
 bfW
 xih
-xih
-xih
-xih
+ntH
+dys
+dys
 ozb
 uBk
-uBk
+xGF
 uvR
 cwk
 cwk
@@ -209386,9 +209780,9 @@ uZi
 xTs
 xjV
 htm
-boK
-gZR
-pwQ
+fJB
+dKk
+hFm
 aaC
 pWj
 pWj
@@ -209643,10 +210037,10 @@ rEX
 xTs
 xjV
 htm
-bgG
+nPZ
 hQm
 gXm
-lpq
+rWq
 nnU
 nnU
 nnU
@@ -209900,7 +210294,7 @@ wOD
 xTs
 xjV
 htm
-bgG
+avQ
 kdW
 vqm
 lpq


### PR DESCRIPTION
## Что этот PR делает

Вторая часть ремапа меда. Перенос морга на нижний этаж, добавлена комната пациентов, изменено крио, добавлено/изменено несколько комнат в техах.

## Почему это хорошо для игры

Ремап пора закончить

## Изображения изменений

![StrongDMM-2025-07-09 16 56 31](https://github.com/user-attachments/assets/912e926b-bdb2-4e46-aa1c-c769dc392e01)
![StrongDMM-2025-07-09 16 56 45](https://github.com/user-attachments/assets/0562277e-1f61-4501-afd3-9a5f58b7f9f4)
![StrongDMM-2025-07-09 16 56 59](https://github.com/user-attachments/assets/1ec79585-6c84-4f59-9951-fca74cbcb7e9)

## Тестирование

Локалка

## Changelog

:cl:
map: Кибериада: морг переехал на нижний этаж, добавлены техи морга, соединяющие нижнюю химию и морг. Комната с крио капсулами изменено, добавлен лифт. Добавлена комната пациентов вместо морга, совмещена с комнатой отдыха персонала. В кабинет СМО добавлена личная аптечка и настенный раздатчик медицины. В техах поменена комната регуляции атмоса для виро и техов меда, добавлена комната культистов Ратвара, и изменена заброшенная комната с вещами парамеда.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
