### PR TITLE
Increase max charges for holy watermelons

### DIFF
--- a/code/modules/hydroponics/unique_plant_genes.dm
+++ b/code/modules/hydroponics/unique_plant_genes.dm
@@ -15,9 +15,9 @@
 	if(!.)
 		return
 	var/obj/item/seeds/our_seed = our_plant.get_plant_seed()
-	shield_uses = round(our_seed.potency / 95) // BANDASTATION EDIT - Original:  / 20)
+	shield_uses = round(our_seed.potency / 50) // BANDASTATION EDIT - Original:  / 20)
 	//deliver us from evil o melon god
-	if(shield_uses >= 1) // BANDASTATION Addition - No more shield if potency less than 95
+	if(shield_uses >= 1) // BANDASTATION Addition - No more shield if potency less than 50
 		our_plant.AddComponent(/datum/component/anti_magic, \
 			antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY, \
 			inventory_flags = ITEM_SLOT_HANDS, \


### PR DESCRIPTION
## Что этот PR делает

Повышает максимальное количество зарядов антимагии до 2-х, при 100 единицах потенции. Теперь для 1 заряда антимагии требуется 50 единиц потенции

## Почему это хорошо для игры

Запрос Шусса - https://discord.com/channels/1097181193939730453/1097521716013568011/1393190907968360551

## Тестирование

Локалка

## Changelog

:cl:
balance: Максимальное количество зарядов антимагии для святого арбуза повышено с 1 до 2-х при 100 единицах потенции
/:cl:
