### PR TITLE
Character Preferences hotfix

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/MainPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/MainPage.tsx
@@ -110,8 +110,8 @@ function GenderButton(props: GenderButtonProps) {
                 <Button
                   key={gender}
                   selected={gender === props.gender}
-                  icon={GENDERS[gender].icon}
-                  tooltip={GENDERS[gender].text}
+                  icon={GENDERS[gender].icon || 'question'}
+                  tooltip={GENDERS[gender].text || 'Кто ты, воин?'}
                   tooltipPosition="top"
                   onClick={() => {
                     props.handleSetGender(gender);
@@ -125,7 +125,7 @@ function GenderButton(props: GenderButtonProps) {
     >
       <div>
         <Button
-          icon={GENDERS[props.gender].icon}
+          icon={GENDERS[props.gender].icon || 'question'}
           tooltip="Пол"
           tooltipPosition="top"
         />


### PR DESCRIPTION
## Что этот PR делает
Ёбаные боевые вертолёты, не могут открыть префы
Пора возвращаться к природе, сосунки

## Changelog

:cl:
fix: Боевые вертолёты в прошлом, не могут открыть окно настройки персонажа, возвращаемся к природе :madge:
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
