### PR TITLE
Balance: Shade flags

### DIFF
--- a/code/modules/mob/living/basic/cult/shade.dm
+++ b/code/modules/mob/living/basic/cult/shade.dm
@@ -9,10 +9,7 @@
 	mob_biotypes = MOB_SPIRIT | MOB_UNDEAD
 	maxHealth = 40
 	health = 40
-	// BANDASTATION CHANGES START
-	pass_flags = PASSMOB | PASSTABLE
-	mobility_flags = MOBILITY_FLAGS_DEFAULT - MOBILITY_PULL
-	// BANDASTATION CHANGES END
+	status_flags = CANPUSH
 	speak_emote = list("hisses")
 	response_help_continuous = "puts their hand through"
 	response_help_simple = "put your hand through"

--- a/code/modules/mob/living/basic/cult/shade.dm
+++ b/code/modules/mob/living/basic/cult/shade.dm
@@ -9,7 +9,10 @@
 	mob_biotypes = MOB_SPIRIT | MOB_UNDEAD
 	maxHealth = 40
 	health = 40
-	status_flags = CANPUSH
+	// BANDASTATION CHANGES START
+	pass_flags = PASSMOB | PASSTABLE
+	mobility_flags = MOBILITY_FLAGS_DEFAULT - MOBILITY_PULL
+	// BANDASTATION CHANGES END
 	speak_emote = list("hisses")
 	response_help_continuous = "puts their hand through"
 	response_help_simple = "put your hand through"

--- a/modular_bandastation/balance/_balance.dme
+++ b/modular_bandastation/balance/_balance.dme
@@ -18,6 +18,7 @@
 #include "code/human_stripping.dm"
 #include "code/laser.dm"
 #include "code/materials_market.dm"
+#include "code/mobs/shade.dm"
 #include "code/religion.dm"
 #include "code/speed/base_speed.dm"
 #include "code/speed/movespeed_modifier.dm"

--- a/modular_bandastation/balance/code/mobs/shade.dm
+++ b/modular_bandastation/balance/code/mobs/shade.dm
@@ -1,4 +1,4 @@
 /mob/living/basic/shade
-	status_flags = null
+	status_flags = CANSTUN
 	pass_flags = PASSMOB | PASSTABLE | PASSSTRUCTURE | PASSMACHINE
 	mobility_flags = MOBILITY_FLAGS_DEFAULT - MOBILITY_PULL

--- a/modular_bandastation/balance/code/mobs/shade.dm
+++ b/modular_bandastation/balance/code/mobs/shade.dm
@@ -1,0 +1,4 @@
+/mob/living/basic/shade
+	status_flags = null
+	pass_flags = PASSMOB | PASSTABLE | PASSSTRUCTURE | PASSMACHINE
+	mobility_flags = MOBILITY_FLAGS_DEFAULT - MOBILITY_PULL


### PR DESCRIPTION
## Что этот PR делает
Добавляет нематериальному призраку флаг PASSMOB, PASSTABLE, PASSSTRUCTURE и PASSMACHINE, а также удаляет флаг CANPUSH. Также shade теперь не может PULL-ить кого-либо.
## Почему это хорошо для игры
Призрак больше не толкает своей метафизической тушкой куклы, не делает скоростной паровозик из 5-ти культяпок, а взаимен проходит через мобов, столы, машинерию и структуры (шкафы и т.п.).
## Тестирование
Лклка
## Changelog

:cl: Ez-Briz
balance: Shade больше не может толкать или тащить за собой кого-либо, летает через столы, мобов, машинерию и структуры.
/:cl:
