### PR TITLE
Balance: Make Paddy great again

### DIFF
--- a/modular_bandastation/balance/_balance.dme
+++ b/modular_bandastation/balance/_balance.dme
@@ -23,6 +23,7 @@
 #include "code/speed/movespeed_modifier.dm"
 #include "code/station_traits.dm"
 #include "code/supply_packs.dm"
+#include "code/vehicle/paddy.dm"
 #include "code/weapons/baton.dm"
 #include "code/wounds/cranial_fissure.dm"
 

--- a/modular_bandastation/balance/code/vehicle/paddy.dm
+++ b/modular_bandastation/balance/code/vehicle/paddy.dm
@@ -1,0 +1,4 @@
+/obj/vehicle/sealed/mecha/ripley/paddy
+	movedelay = 1.5
+	slow_pressure_step_in = 2
+	fast_pressure_step_in = 1.5


### PR DESCRIPTION
## Что этот PR делает
Модульно возвращает скорость падди в состояние до его нерфа (https://github.com/tgstation/tgstation/pull/91463).
## Почему это хорошо для игры
Падди теперь не пылится в гараже и от него есть смысл. Теперь он быстрее мародёра (до этого был одной скорости).
## Тестирование
Лклка
## Changelog

:cl: Ez-Briz
balance: Скорость падди возвращена до нормальных значений (как у рипли).
/:cl:
