### PR TITLE
Ability to pick forced heavy pirates

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
+++ b/code/controllers/subsystem/dynamic/dynamic_ruleset_midround.dm
@@ -92,7 +92,7 @@
 	config_tag = "Heavy Pirates"
 	midround_type = HEAVY_MIDROUND
 	jobban_flag = ROLE_TRAITOR
-	ruleset_flags = RULESET_INVADER
+	ruleset_flags = RULESET_INVADER|RULESET_ADMIN_CONFIGURABLE // BANDASTATION EDIT
 	weight = 3
 	min_pop = 25
 	min_antag_cap = 0 // ship will spawn if there are no ghosts around


### PR DESCRIPTION
## Что этот PR делает
Дает админу выбирать банду пиратов при форсе тяжелых пиратов, а не только при форсе легких

## Почему это хорошо для игры
Adminbus

## Тестирование
Локальные тесты

## Changelog

:cl:
admin: Возможность выбрать банду пиратов при форсе тяжелых пиратов
/:cl:
