### PR TITLE
Fix: Rubber bullets are not useable with pacifism again

### DIFF
--- a/modular_bandastation/objects/code/items/weapons/ranged/ballistic/ammo_casings.dm
+++ b/modular_bandastation/objects/code/items/weapons/ranged/ballistic/ammo_casings.dm
@@ -11,7 +11,6 @@
 	icon = 'modular_bandastation/objects/icons/obj/weapons/guns/ammo.dmi'
 	icon_state = "sr-casing"
 	projectile_type = /obj/projectile/bullet/c35sol/rubber
-	harmful = FALSE
 
 // .35 Sol ripper, similar to the detective revolver's dumdum rounds, causes slash wounds and is weak to armor
 /obj/item/ammo_casing/c35sol/ripper
@@ -72,7 +71,6 @@
 	name = "7.62x39mm rubber bullet casing"
 	desc = "Патрон с резиновой пулей калибра 7.62x39мм гражданского назначения."
 	projectile_type = /obj/projectile/bullet/a762x39/rubber
-	harmful = FALSE
 
 /obj/item/ammo_casing/a762x39/hunting
 	name = "7.62x39mm hunting bullet casing"
@@ -105,7 +103,6 @@
 	desc = "Стандартный осколочно-резиновый винтовочный патрон ТСФ калибра .40 Sol Long. Разрывается при ударе, выбрасывая резиновую шрапнель, которая может вывести цель из строя."
 	icon_state = "40sol_disabler"
 	projectile_type = /obj/projectile/bullet/c40sol/fragmentation
-	harmful = FALSE
 
 // .40 Sol match grade, bounces a lot, and if there's less than 20 bullet armor on wherever these hit, it'll go completely through the target and out the other side
 /obj/item/ammo_casing/c40sol/pierce
@@ -136,7 +133,6 @@
 	icon = 'modular_bandastation/objects/icons/obj/weapons/guns/ammo.dmi'
 	icon_state = "sr-casing"
 	projectile_type = /obj/projectile/bullet/c9x25mm/rubber
-	harmful = FALSE
 
 /obj/item/ammo_casing/c9x25mm/hp
 	name = "9x25mm NT hollow-point bullet casing"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Убирает возможность стрелять резиной из пушек ТСФ и ГП9
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
balance: Больше нельзя стрелять с ГП9 и других пушек заряженными резиной
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
