### PR TITLE
Cyberiad: robo airlock

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -1756,9 +1756,9 @@
 /area/station/service/library)
 "awY" = (
 /obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior,
-/obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/engine,
 /area/station/science/ordnance)
 "axd" = (
@@ -18403,6 +18403,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
+/obj/machinery/button/door/directional/west{
+	id = "Skynet_launch";
+	name = "Mech Bay Door Control";
+	req_access = list("robotics")
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "erN" = (
@@ -33292,12 +33297,14 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
 "hWd" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/machinery/door/airlock/research{
+	name = "Mech Bay"
 	},
-/obj/structure/closet/firecloset,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/science/robotics,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard/west)
+/area/station/science/robotics/mechbay)
 "hWn" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -36257,11 +36264,6 @@
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "iKc" = (
-/obj/machinery/button/door/directional/north{
-	id = "Skynet_launch";
-	name = "Mech Bay Door Control";
-	req_access = list("robotics")
-	},
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
 	},
@@ -57550,10 +57552,9 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom/ghetto)
 "nPk" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/closet/emcloset,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard/west)
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron/dark,
+/area/station/hallway/primary/starboard)
 "nPl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60693,8 +60694,10 @@
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/port/greater)
 "oBv" = (
-/turf/open/floor/plating,
-/area/station/medical/morgue)
+/obj/structure/closet/emcloset,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/hallway/primary/starboard)
 "oBx" = (
 /obj/structure/closet/emcloset,
 /obj/effect/landmark/start/hangover/closet,
@@ -90152,9 +90155,9 @@
 /area/station/cargo/lobby)
 "vIA" = (
 /obj/machinery/door/airlock/research/glass/incinerator/ordmix_exterior,
-/obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance)
 "vIE" = (
@@ -95551,10 +95554,6 @@
 /obj/structure/curtain/cloth/fancy,
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/department/security/ghetto)
-"xba" = (
-/obj/item/radio/intercom/directional/west,
-/turf/closed/wall/r_wall,
-/area/station/science/ordnance)
 "xbb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -152622,7 +152621,7 @@ doz
 doz
 doz
 doz
-xba
+nFU
 naG
 xOK
 gKE
@@ -205550,8 +205549,8 @@ nrH
 fHn
 nke
 ckR
+nPk
 lCk
-oBv
 uYN
 lCk
 luY
@@ -205807,9 +205806,9 @@ nrH
 nYw
 nke
 ckR
+oBv
 lCk
 uYN
-oBv
 lCk
 nhZ
 bri
@@ -208892,7 +208891,7 @@ sKd
 kkl
 bMM
 nnU
-nnU
+nPZ
 kYb
 uta
 hFm
@@ -209147,8 +209146,8 @@ sKd
 sKd
 sKd
 kkl
-sKd
-hWd
+bMM
+htm
 htm
 htm
 htm
@@ -209919,8 +209918,8 @@ wfV
 sKd
 kkl
 sKd
-nPk
-vlt
+niF
+hWd
 iKc
 ruJ
 tZp


### PR DESCRIPTION
## Что этот PR делает

Добавляет в мехбей дверь рядом с шаттерами, переставляет шкафы, что стояли рядом левее в неиспользуемое пространство. Убирает интерком в стене в токсинах на нижнем этаже.

## Почему это хорошо для игры

Чтобы выйти из робо через мехбей тебе нужно или прокликивать кнопку шаттеров и выбегать, или оставлять открытым весь мехбей, или обходить через вход в рнд. Зачем все это, когда можно просто выйти через дверь?

## Изображения изменений

<img width="640" height="128" alt="StrongDMM-2025-08-03 02 12 32" src="https://github.com/user-attachments/assets/d17939b3-ada2-44d1-b809-8ee032ca3da5" />

## Тестирование

Локалка

## Changelog

:cl:
map: Кибериада: в мехбей в робо добавлена дверь возле шаттеров на выход в коридор, шкафы у входа в мехбей передвинуты. Убран лишний интерком в стене в токсинах на нижнем этаже.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
