### PR TITLE
Balance: Flechette shotgun projectiles speed

### DIFF
--- a/modular_bandastation/balance/_balance.dme
+++ b/modular_bandastation/balance/_balance.dme
@@ -18,6 +18,7 @@
 #include "code/human_stripping.dm"
 #include "code/laser.dm"
 #include "code/materials_market.dm"
+#include "code/projectiles/flechette.dm"
 #include "code/religion.dm"
 #include "code/speed/base_speed.dm"
 #include "code/speed/movespeed_modifier.dm"

--- a/modular_bandastation/balance/code/projectiles/flechette.dm
+++ b/modular_bandastation/balance/code/projectiles/flechette.dm
@@ -1,0 +1,2 @@
+/obj/projectile/bullet/pellet/flechette
+	speed = 0.8


### PR DESCRIPTION

## Что этот PR делает
Ускоряет скорость прожектайлов флешетов до скорости прожектайлов резины, не допуская такого рода ситуаций (исключая спиди-гонщиков, которые догоняют всё):
https://cdn.discordapp.com/attachments/1097182855613907004/1402011775699783701/2025-08-05_00-33-05.mp4?ex=68925cb7&is=68910b37&hm=6ae6be5f9a6fbbf16811a302c26677b025d0bd91952923e1dedf0a5cfc66da8e&
## Почему это хорошо для игры
Ты не можешь догнать свои же флешеты под малым ускорением.
## Тестирование
Локалка
## Changelog

:cl: Ez-Briz
balance: Прожектайлы флешетов теперь летят быстрее (скорость как у резины), не позволяя их ловить стрелку.
/:cl:
