### PR TITLE
Cyberiad: fix banners

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -22,7 +22,6 @@
 /area/station/maintenance/ghetto/fore/starboard)
 "aav" = (
 /obj/machinery/status_display/ai/directional/north,
-/obj/item/banner/command,
 /obj/effect/turf_decal/siding/royal{
 	dir = 4
 	},
@@ -30,6 +29,7 @@
 /obj/effect/turf_decal/siding/royal{
 	dir = 8
 	},
+/obj/item/banner/command/mundane,
 /turf/open/floor/grass,
 /area/station/command/bridge)
 "aaw" = (
@@ -4370,7 +4370,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical/ghetto)
 "bbB" = (
-/obj/item/banner/command,
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "Central Hallway - North"
@@ -4378,6 +4377,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/item/banner/command/mundane,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "bbO" = (
@@ -6892,7 +6892,7 @@
 "bFM" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
-/obj/item/banner/cargo,
+/obj/item/banner/cargo/mundane,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "bFN" = (
@@ -14376,7 +14376,7 @@
 	id = "warehouse_shutters";
 	name = "Warehouse Shutters Control"
 	},
-/obj/item/banner/cargo,
+/obj/item/banner/cargo/mundane,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "drv" = (
@@ -25746,7 +25746,6 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/fore)
 "ghM" = (
-/obj/item/banner/command,
 /obj/structure/sign/directions/security/directional/north{
 	pixel_y = 39
 	},
@@ -25761,6 +25760,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/item/banner/command/mundane,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "ghN" = (
@@ -26034,9 +26034,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
 "glJ" = (
-/obj/item/banner/security,
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/machinery/firealarm/directional/south,
+/obj/item/banner/security/mundane,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "glK" = (
@@ -28430,7 +28430,7 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/status_display/evac/directional/west,
-/obj/item/banner/command,
+/obj/item/banner/command/mundane,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "gPo" = (
@@ -42523,9 +42523,9 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/ghetto/central/aft)
 "klW" = (
-/obj/item/banner/security,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/dim/directional/south,
+/obj/item/banner/security/mundane,
 /turf/open/floor/iron/dark/small,
 /area/station/security/interrogation/ghetto)
 "klX" = (
@@ -46204,8 +46204,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "ldj" = (
-/obj/item/banner/security,
 /obj/effect/turf_decal/tile/red/fourcorners,
+/obj/item/banner/security/mundane,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "ldx" = (
@@ -46464,8 +46464,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "lho" = (
-/obj/item/banner/security,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/banner/security/mundane,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/fore)
 "lhv" = (
@@ -60242,7 +60242,7 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/status_display/evac/directional/west,
-/obj/item/banner/command,
+/obj/item/banner/command/mundane,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "oxN" = (
@@ -75217,7 +75217,7 @@
 "sgS" = (
 /obj/machinery/power/apc/worn_out/directional/west,
 /obj/structure/cable,
-/obj/item/banner/command,
+/obj/item/banner/command/mundane,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/nanotrasen_representative)
 "sgT" = (
@@ -77292,8 +77292,8 @@
 /turf/open/openspace,
 /area/station/maintenance/port/fore)
 "sFg" = (
-/obj/item/banner/command,
 /obj/machinery/status_display/ai/directional/east,
+/obj/item/banner/command/mundane,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "sFk" = (
@@ -79312,9 +79312,9 @@
 /area/station/maintenance/starboard/fore)
 "tiW" = (
 /obj/structure/cable,
-/obj/item/banner/command,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/turf_decal/siding/wood,
+/obj/item/banner/command/mundane,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "tiX" = (
@@ -80840,8 +80840,8 @@
 /turf/open/openspace,
 /area/station/security/prison)
 "tAr" = (
-/obj/item/banner/command,
 /obj/structure/cable,
+/obj/item/banner/command/mundane,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "tAt" = (
@@ -90868,7 +90868,6 @@
 /area/station/commons/dorms)
 "vZx" = (
 /obj/machinery/status_display/ai/directional/north,
-/obj/item/banner/command,
 /obj/effect/turf_decal/siding/royal{
 	dir = 8
 	},
@@ -90877,6 +90876,7 @@
 /obj/effect/turf_decal/siding/royal{
 	dir = 4
 	},
+/obj/item/banner/command/mundane,
 /turf/open/floor/grass,
 /area/station/command/bridge)
 "vZy" = (


### PR DESCRIPTION
## Что этот PR делает

Исправляет маппер момент, а меняет подтип баннеров на станции на тот, что не лечит 15% ХП при использовании.

## Почему это хорошо для игры

Убираем возможность халявного хилла на 15%, пока это не начали абузить.

## Изображения изменений

<img width="632" height="335" alt="Screenshot_360" src="https://github.com/user-attachments/assets/9d378863-5513-4fc4-b30d-45bf3d5b259f" />

## Тестирование

Локалка

## Changelog

:cl:
map: Кибериада: изменен подтип у баннеров НТ, СБ, карго на тот, что не лечит при активации.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
