### PR TITLE
 Cyberiad: Fix elevator decals

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -60380,11 +60380,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto/aft)
-"oyC" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/transport/linear/public,
-/turf/open/floor/plating/elevatorshaft,
-/area/station/maintenance/ghetto/starboard)
 "oyJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -143421,7 +143416,7 @@ nRp
 gUL
 mFY
 rPQ
-oyC
+mFY
 ipz
 qTP
 mkF
@@ -143678,7 +143673,7 @@ hyp
 gUL
 mFY
 unJ
-oyC
+mFY
 ipz
 nIE
 vKq


### PR DESCRIPTION

## Что этот PR делает

Убираем пару лишних декалей, которые остались под шахтой лифта

## Почему это хорошо для игры

Меньше мусора

## Изображения изменений
## Тестирование

Локалка

## Changelog

:cl:
map: Кибериада: убраны лишние декали в шахте лифта
/:cl:
