### PR TITLE
Translation: Traitor objectives

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -138,7 +138,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	item_owner = list(JOB_BARTENDER)
 	exists_on_map = TRUE
 	difficulty = 2
-	steal_hint = "Двухствольный дробовик, обычно находящийся у бармена. Если не нашлись у бармена, то можете найти в подсобке бара."
+	steal_hint = "Двухствольный дробовик, обычно находящийся у бармена. Если его нет у бармена, то можете найти в подсобке бара."
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/gun/ballistic/shotgun/doublebarrel)
@@ -177,7 +177,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	exists_on_map = TRUE
 	difficulty = 2
 	steal_hint = "Специализированный инструмент, что можно найти в лаборатории робототехников. \
-	    Вы можете использовать мультитул для открытия камеры хранения, или сломать грубой силой."
+		Вы можете использовать мультитул для открытия камеры хранения, или сломать грубой силой."
 
 /obj/item/crowbar/mechremoval/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/crowbar/mechremoval)
@@ -251,7 +251,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	exists_on_map = TRUE
 	difficulty = 3
 	steal_hint = "Револьвер калибра .38 special, что может быть у детектива. \
-		Если не нашлись у детектива, то можете найти в кабинете детектива."
+		Если его нет у детектива, то можете найти в его кабинете."
 
 /obj/item/gun/ballistic/revolver/c38/detective/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/gun/ballistic/revolver/c38/detective)
@@ -309,7 +309,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	item_owner = list(JOB_QUARTERMASTER)
 	exists_on_map = TRUE
 	difficulty = 2
-	steal_hint = "Карточка, дающая доступ к денежным средствам, хранящимся на станции. \
+	steal_hint = "Карточка, дающая доступ к фондам отдела снабжения. \
 		Обычно она хранится в шкафчике квартирмейстера, но особо внимательные могут носить её при себе или в бумажнике."
 
 /obj/item/card/id/departmental_budget/car/add_stealing_item_objective()
@@ -342,8 +342,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	exists_on_map = TRUE
 	difficulty = 4
 	steal_hint = "Запасная ID-карта самого главного на этой станции. \
-		Если поблизости нет официального капитана, вы можете найти на груди исполняющего обязанности капитана - одного из глав отдела. \
-		В противном случае вам придется вскрыть золотой сейф на мостике кислотой или взрывчаткой, чтобы добраться до него."
+			Если поблизости нет официального капитана, вы можете найти её на груди исполняющего обязанности капитана - одного из глав отдела."
 
 /obj/item/card/id/advanced/gold/captains_spare/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/card/id/advanced/gold/captains_spare)

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -189,7 +189,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	item_owner = list(JOB_CHAPLAIN)
 	exists_on_map = TRUE
 	difficulty = 2
-	steal_hint = "Священный артефакт, ообычно находящийся у священника. Если нет у священника, то можно найти в комнате священника. \
+	steal_hint = "Священный артефакт, обычно находящийся у священника. Если нет у священника, то можно найти в комнате священника. \
 		Если на станции есть священник, то он, скорее всего, превратится в какое-нибудь священное оружие, некоторые из которых... трудно снять с человека."
 
 /obj/item/nullrod/add_stealing_item_objective()
@@ -214,7 +214,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	item_owner = list(JOB_MIME)
 	exists_on_map = TRUE
 	difficulty = 1
-	steal_hint = "Маска мима. Он всегда должен быть на лице мима."
+	steal_hint = "Маска мима. Она всегда должен быть на лице мима."
 
 /obj/item/clothing/mask/gas/mime/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/clothing/mask/gas/mime)
@@ -293,7 +293,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 	exists_on_map = TRUE
 	difficulty = 3
-	steal_hint = "Оружие самообороны, стандартное для всех глав отделов, за исключением начальника службы безопасности."
+	steal_hint = "Оружие самообороны, стандартное для всех глав отделов, за исключением начальника службы безопасности. Редко находится не при владельце."
 
 /datum/objective_item/steal/traitor/telebaton/check_special_completion(obj/item/thing)
 	return thing.type == /obj/item/melee/baton/telescopic
@@ -342,7 +342,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	exists_on_map = TRUE
 	difficulty = 4
 	steal_hint = "Запасная ID-карта самого главного на этой станции. \
-		Если поблизости нет официального капитана, вы можете найти его приколотым к груди исполняющего обязанности капитана - одного из глав отдела. \
+		Если поблизости нет официального капитана, вы можете найти на груди исполняющего обязанности капитана - одного из глав отдела. \
 		В противном случае вам придется вскрыть золотой сейф на мостике кислотой или взрывчаткой, чтобы добраться до него."
 
 /obj/item/card/id/advanced/gold/captains_spare/add_stealing_item_objective()
@@ -377,7 +377,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	return add_item_to_steal(src, /obj/item/gun/energy/e_gun/hos)
 
 /datum/objective_item/steal/compactshotty
-	name = "перональный компактный дробовик смотрителя"
+	name = "персональный компактный дробовик смотрителя"
 	targetitem = /obj/item/gun/ballistic/shotgun/automatic/combat/compact
 	excludefromjob = list(JOB_WARDEN)
 	item_owner = list(JOB_WARDEN)
@@ -414,7 +414,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	return add_item_to_steal(src, /obj/item/tank/jetpack/oxygen/captain)
 
 /datum/objective_item/steal/magboots
-	name = "продвинутые магнитые ботинки главного инженера"
+	name = "продвинутые магнитные ботинки главного инженера"
 	targetitem = /obj/item/clothing/shoes/magboots/advance
 	excludefromjob = list(JOB_CHIEF_ENGINEER)
 	item_owner = list(JOB_CHIEF_ENGINEER)
@@ -447,7 +447,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	exists_on_map = TRUE
 	difficulty = 3
 	steal_hint = "Персональный медицинский инжектор главного врача. \
-		Обычно находящийся у него в медицинских принадлежностях или на поясе. Так же может быть найден в шкафу в его кабинете."
+		Обычно находящийся у него в медицинских принадлежностях или на поясе. Также может быть найден в шкафу в его кабинете."
 
 /obj/item/reagent_containers/hypospray/cmo/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/reagent_containers/hypospray/cmo)
@@ -486,7 +486,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	exists_on_map = TRUE
 	difficulty = 3
 	steal_hint = "Специальная броня, что может быть у директора исследований. \
-		Так же может быть найден в шкафчике."
+		Также может быть найдена в шкафчике."."
 
 /obj/item/clothing/suit/armor/reactive/teleport/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/clothing/suit/armor/reactive/teleport)
@@ -636,7 +636,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	excludefromjob = list(JOB_PSYCHOLOGIST, JOB_PARAMEDIC, JOB_CHEMIST, JOB_MEDICAL_DOCTOR, JOB_CHIEF_MEDICAL_OFFICER, JOB_CORONER)
 	exists_on_map = TRUE
 	difficulty = 1
-	steal_hint = "Плюшевая моль. Так же может быть найден у психолога, что лечит душевные травмы этой молью."
+	steal_hint = "Плюшевая моль. Также может быть найдена у психолога, что лечит душевные травмы этой молью."
 
 /obj/item/toy/plush/moth/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/toy/plush/moth)
@@ -646,7 +646,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	targetitem = /obj/item/toy/plush/lizard_plushie
 	exists_on_map = TRUE
 	difficulty = 1
-	steal_hint = "Плюшевая ящерица. Так же может быть найден в технических тоннелях."
+	steal_hint = "Плюшевая ящерица. Также может быть найдена в технических тоннелях."
 
 /obj/item/toy/plush/lizard_plushie/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/toy/plush/lizard_plushie)
@@ -773,7 +773,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 	exists_on_map = TRUE
 	difficulty = 2
-	steal_hint = "Двухрежимный энергетический карабин, что может быть найден в оружейной. Так же может быть у некоторых глав для их персональной защиты."
+	steal_hint = "Двухрежимный энергетический карабин, что может быть найден в оружейной. Также может быть у некоторых глав для их персональной защиты."
 
 /datum/objective_item/steal/spy/energy_gun/check_special_completion(obj/item/thing)
 	return thing.type == /obj/item/gun/energy/e_gun
@@ -856,7 +856,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 	exists_on_map = TRUE
 	difficulty = 1
-	steal_hint = "Штамп, принадлежащий главе отдела, что может быть найдена в их офисе."
+	steal_hint = "Штамп, принадлежащий главе отдела, что может быть найден в их офисе."
 
 /obj/item/stamp/head/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/stamp/head)
@@ -877,7 +877,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 		JOB_WARDEN,
 	)
 	difficulty = 1
-	steal_hint = "Пара солнцезащитных очков. У юристов обычно есть несколько штук, как и у некоторых глав. Также их можно получить, разобрав HUD-очки"
+	steal_hint = "Пара солнцезащитных очков. У юристов обычно есть несколько штук, как и у некоторых глав. Также их можно получить, разобрав HUD-очки."
 
 /datum/objective_item/steal/spy/ce_modsuit
 	name = "продвинутый МОД-костюм главного инженера"

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -132,19 +132,19 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 
 // Unique-ish low risk objectives
 /datum/objective_item/steal/traitor/bartender_shotgun
-	name = "bartender's shotgun"
+	name = "дробовик бармена"
 	targetitem = /obj/item/gun/ballistic/shotgun/doublebarrel
 	excludefromjob = list(JOB_BARTENDER)
 	item_owner = list(JOB_BARTENDER)
 	exists_on_map = TRUE
 	difficulty = 2
-	steal_hint = "A double-barrel shotgun usually found on the bartender's person, or if none are around, in the bar's backroom."
+	steal_hint = "Двухствольный дробовик, обычно находящийся у бармена. Если не нашлись у бармена, то можете найти в подсобке бара."
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/gun/ballistic/shotgun/doublebarrel)
 
 /datum/objective_item/steal/traitor/fireaxe
-	name = "fire axe"
+	name = "пожарный топор"
 	targetitem = /obj/item/fireaxe
 	excludefromjob = list(
 		JOB_ATMOSPHERIC_TECHNICIAN,
@@ -159,14 +159,14 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 	exists_on_map = TRUE
 	difficulty = 3
-	steal_hint = "Only two of these exist on the station - one in the bridge, and one in atmospherics. \
-		You can use a multitool to hack open the case, or break it open the hard way."
+	steal_hint = "Существует только два пожарных топора - один на мостике, а второй в атмосферном отделе. \
+		Вы можете использовать мультитул для открытия камеры хранения, или сломать грубой силой."
 
 /obj/item/fireaxe/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/fireaxe)
 
 /datum/objective_item/steal/traitor/big_crowbar
-	name = "mech removal tool"
+	name = "инструмент для удаления пилота из меха"
 	targetitem = /obj/item/crowbar/mechremoval
 	excludefromjob = list(
 		JOB_RESEARCH_DIRECTOR,
@@ -176,110 +176,111 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	item_owner = list(JOB_ROBOTICIST)
 	exists_on_map = TRUE
 	difficulty = 2
-	steal_hint = "A specialized tool found in the roboticist's lab. You can use a multitool to hack open the case, or break it open the hard way."
+	steal_hint = "Специализированный инструмент, что можно найти в лаборатории робототехников. \
+	    Вы можете использовать мультитул для открытия камеры хранения, или сломать грубой силой."
 
 /obj/item/crowbar/mechremoval/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/crowbar/mechremoval)
 
 /datum/objective_item/steal/traitor/nullrod
-	name = "chaplain's null rod"
+	name = "нулевой жезл священника"
 	targetitem = /obj/item/nullrod
 	excludefromjob = list(JOB_CHAPLAIN)
 	item_owner = list(JOB_CHAPLAIN)
 	exists_on_map = TRUE
 	difficulty = 2
-	steal_hint = "A holy artifact usually found on the chaplain's person, or if none are around, in the chapel's relic closet. \
-		If there is a chaplain aboard, it is likely be to be transformed into some holy weapon - some of which are... difficult to remove from their person."
+	steal_hint = "Священный артефакт, ообычно находящийся у священника. Если нет у священника, то можно найти в комнате священника. \
+		Если на станции есть священник, то он, скорее всего, превратится в какое-нибудь священное оружие, некоторые из которых... трудно снять с человека."
 
 /obj/item/nullrod/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/nullrod)
 
 /datum/objective_item/steal/traitor/clown_shoes
-	name = "clown's shoes"
+	name = "ботинки клоуна"
 	targetitem = /obj/item/clothing/shoes/clown_shoes
 	excludefromjob = list(JOB_CLOWN, JOB_CARGO_TECHNICIAN, JOB_QUARTERMASTER)
 	item_owner = list(JOB_CLOWN)
 	exists_on_map = TRUE
 	difficulty = 1
-	steal_hint = "The clown's huge, bright shoes. They should always be on the clown's feet."
+	steal_hint = "Огромные яркие ботинки клоуна. Они всегда должны быть на ногах клоуна."
 
 /obj/item/clothing/shoes/clown_shoes/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/clothing/shoes/clown_shoes)
 
 /datum/objective_item/steal/traitor/mime_mask
-	name = "mime's mask"
+	name = "маска мима"
 	targetitem = /obj/item/clothing/mask/gas/mime
 	excludefromjob = list(JOB_MIME, JOB_CARGO_TECHNICIAN, JOB_QUARTERMASTER)
 	item_owner = list(JOB_MIME)
 	exists_on_map = TRUE
 	difficulty = 1
-	steal_hint = "The mime's mask. It should always be on the mime's face."
+	steal_hint = "Маска мима. Он всегда должен быть на лице мима."
 
 /obj/item/clothing/mask/gas/mime/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/clothing/mask/gas/mime)
 
 /datum/objective_item/steal/traitor/pka
-	name = "protokinetic accelerator"
+	name = "протокинетический ускоритель"
 	targetitem = /obj/item/gun/energy/recharge/kinetic_accelerator
 	excludefromjob = list(JOB_SHAFT_MINER, JOB_CARGO_TECHNICIAN, JOB_QUARTERMASTER)
 	item_owner = list(JOB_SHAFT_MINER)
 	exists_on_map = TRUE
 	difficulty = 1
-	steal_hint = "A tool primarily used by shaft miners to mine. Most carry one (or multiple) on their person, \
-		but they can also be found in the Mining Station, Mining office, or Auxiliary Mining Base on the station."
+	steal_hint = "Инструмент, который в основном используется шахтерами при добыче полезных ископаемых. Большинство из них носят его с собой (или несколько), \
+		но его также можно найти в коморке шахтёров, либо где-то в шахтах."
 
 /obj/item/gun/energy/recharge/kinetic_accelerator/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/gun/energy/recharge/kinetic_accelerator)
 
 /datum/objective_item/steal/traitor/chef_moustache
-	name = "fancy fake moustache"
+	name = "модные накладные усы"
 	targetitem = /obj/item/clothing/mask/fakemoustache/italian
 	excludefromjob = list(JOB_COOK, JOB_HEAD_OF_PERSONNEL, JOB_CARGO_TECHNICIAN, JOB_QUARTERMASTER)
 	item_owner = list(JOB_COOK)
 	exists_on_map = TRUE
 	difficulty = 1
-	steal_hint = "The chef's fake Italian moustache, either found on their face or in the garbage, depending on who's on duty."
+	steal_hint = "Искусственные итальянские усы шеф-повара, найденные либо на лице, либо в мусорном ведре, в зависимости от того, кто дежурит."
 
 /obj/item/clothing/mask/fakemoustache/italian/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/clothing/mask/fakemoustache/italian)
 
 /datum/objective_item/steal/traitor/det_revolver
-	name = "detective's revolver"
+	name = "револьвер детектива"
 	targetitem = /obj/item/gun/ballistic/revolver/c38/detective
 	excludefromjob = list(JOB_DETECTIVE)
 	exists_on_map = TRUE
 	difficulty = 3
-	steal_hint = "A .38 special revolver found in the Detective's holder. \
-		Usually found on the Detective's person, or if none are around, in the detective's locker, in their office."
+	steal_hint = "Револьвер калибра .38 special, что может быть у детектива. \
+		Если не нашлись у детектива, то можете найти в кабинете детектива."
 
 /obj/item/gun/ballistic/revolver/c38/detective/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/gun/ballistic/revolver/c38/detective)
 
 /datum/objective_item/steal/traitor/lawyers_badge
-	name = "lawyer's badge"
+	name = "значок юриста"
 	targetitem = /obj/item/clothing/accessory/lawyers_badge
 	excludefromjob = list(JOB_LAWYER)
 	item_owner = list(JOB_LAWYER)
 	exists_on_map = TRUE
 	difficulty = 1
-	steal_hint = "The lawyer's badge. Usually pinned to their chest, but a spare can be obtained from their clothes vendor."
+	steal_hint = "Значок юриста. Обычно прикрепляется к груди, но запасной можно приобрести в вендормате."
 
 /obj/item/clothing/accessory/lawyers_badge/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/clothing/accessory/lawyers_badge)
 
 /datum/objective_item/steal/traitor/chief_engineer_belt
-	name = "chief engineer's belt"
+	name = "пояс главного инженера"
 	targetitem = /obj/item/storage/belt/utility/chief
 	excludefromjob = list(JOB_CHIEF_ENGINEER)
 	exists_on_map = TRUE
 	difficulty = 2
-	steal_hint = "The chief engineer's toolbelt, strapped to their waist at all times."
+	steal_hint = "Пояс с инструментами главного инженера, постоянно носимый им."
 
 /obj/item/storage/belt/utility/chief/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/storage/belt/utility/chief)
 
 /datum/objective_item/steal/traitor/telebaton
-	name = "head of staff's telescopic baton"
+	name = "телескопическую дубинку главы отдела"
 	targetitem = /obj/item/melee/baton/telescopic
 	excludefromjob = list(
 		JOB_RESEARCH_DIRECTOR,
@@ -292,7 +293,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 	exists_on_map = TRUE
 	difficulty = 3
-	steal_hint = "A self-defense weapon standard-issue for all heads of staffs barring the Head of Security. Rarely found off of their person."
+	steal_hint = "Оружие самообороны, стандартное для всех глав отделов, за исключением начальника службы безопасности."
 
 /datum/objective_item/steal/traitor/telebaton/check_special_completion(obj/item/thing)
 	return thing.type == /obj/item/melee/baton/telescopic
@@ -302,32 +303,32 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 		return add_item_to_steal(src, /obj/item/melee/baton/telescopic)
 
 /datum/objective_item/steal/traitor/cargo_budget
-	name = "cargo's departmental budget"
+	name = "бюджетную карта снабжения"
 	targetitem = /obj/item/card/id/departmental_budget/car
 	excludefromjob = list(JOB_QUARTERMASTER, JOB_CARGO_TECHNICIAN)
 	item_owner = list(JOB_QUARTERMASTER)
 	exists_on_map = TRUE
 	difficulty = 2
-	steal_hint = "A card that grants access to Cargo's funds. \
-		Normally found in the locker of the Quartermaster, but a particularly keen one may have it on their person or in their wallet."
+	steal_hint = "Карточка, дающая доступ к денежным средствам, хранящимся на станции. \
+		Обычно она хранится в шкафчике квартирмейстера, но особо внимательные могут носить её при себе или в бумажнике."
 
 /obj/item/card/id/departmental_budget/car/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/card/id/departmental_budget/car)
 
 /datum/objective_item/steal/traitor/captain_modsuit
-	name = "captain's magnate MOD control unit"
+	name = "капитанский МОД-костюм магнат"
 	targetitem = /obj/item/mod/control/pre_equipped/magnate
 	excludefromjob = list(JOB_CAPTAIN)
 	exists_on_map = TRUE
 	difficulty = 3
-	steal_hint = "An expensive, hand-crafted MOD unit made for the station's Captain. \
-		If not being worn by the Captain, you would find it in the Suit Storage Unit in their quarters."
+	steal_hint = "Дорогая модификация ручной работы, изготовленная для капитана станции. \
+		Если капитан не носит её, вы можете найти её в блоке хранилища костюмов в его каюте."
 
 /obj/item/mod/control/pre_equipped/magnate/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/mod/control/pre_equipped/magnate)
 
 /datum/objective_item/steal/traitor/captain_spare
-	name = "captain's spare ID"
+	name = "запасную ID-карту капитана"
 	targetitem = /obj/item/card/id/advanced/gold/captains_spare
 	excludefromjob = list(
 		JOB_RESEARCH_DIRECTOR,
@@ -340,9 +341,9 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 	exists_on_map = TRUE
 	difficulty = 4
-	steal_hint = "The spare ID of the High Lord himself. \
-		If there's no official Captain around, you may find it pinned to the chest of the Acting Captain - one of the Heads of Staff. \
-		Otherwise, you'll have to bust open the golden safe on the bridge with acid or explosives to get to it."
+	steal_hint = "Запасная ID-карта самого главного на этой станции. \
+		Если поблизости нет официального капитана, вы можете найти его приколотым к груди исполняющего обязанности капитана - одного из глав отдела. \
+		В противном случае вам придется вскрыть золотой сейф на мостике кислотой или взрывчаткой, чтобы добраться до него."
 
 /obj/item/card/id/advanced/gold/captains_spare/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/card/id/advanced/gold/captains_spare)
@@ -351,113 +352,113 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 
 // Will always generate even with no Captain due to its security and temptation to use it
 /datum/objective_item/steal/caplaser
-	name = "captain's antique laser gun"
+	name = "капитанский антикварный лазерный пистолет"
 	targetitem = /obj/item/gun/energy/laser/captain
 	excludefromjob = list(JOB_CAPTAIN)
 	exists_on_map = TRUE
 	difficulty = 4
-	steal_hint = "A self-charging laser gun found in a display case in the Captain's Quarters. \
-		Breaking it open may trigger a security alert, so be careful."
+	steal_hint = "Самозарядный лазерный пистолет, что может быть найден в витрине в каюте капитана. \
+		Его вскрытие может вызвать тревогу системы безопасности, поэтому будьте осторожны."
 
 /obj/item/gun/energy/laser/captain/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/gun/energy/laser/captain)
 
 /datum/objective_item/steal/hoslaser
-	name = "head of security's personal laser gun"
+	name = "персональный лазерный пистолет главы службы безопасности"
 	targetitem = /obj/item/gun/energy/e_gun/hos
 	excludefromjob = list(JOB_HEAD_OF_SECURITY)
 	item_owner = list(JOB_HEAD_OF_SECURITY)
 	exists_on_map = TRUE
 	difficulty = 4
-	steal_hint = "The Head of Security's unique three mode laser gun. \
-		Always found on their person, if they are alive, but may otherwise be found in their locker."
+	steal_hint = "Уникальный трехрежимный лазерный пистолет главы службы безопасности. \
+		Всегда находится при нём, если он жив, но в противном случае может быть найден в его шкафчике."
 
 /obj/item/gun/energy/e_gun/hos/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/gun/energy/e_gun/hos)
 
 /datum/objective_item/steal/compactshotty
-	name = "warden's personal compact shotgun"
+	name = "перональный компактный дробовик смотрителя"
 	targetitem = /obj/item/gun/ballistic/shotgun/automatic/combat/compact
 	excludefromjob = list(JOB_WARDEN)
 	item_owner = list(JOB_WARDEN)
 	exists_on_map = TRUE
 	difficulty = 4
-	steal_hint = "A miniaturized combat shotgun. May be found in Head of Security's locker or strapped to their back."
+	steal_hint = "Миниатюрный боевой дробовик. Его можно найти в шкафчике смотрителя или на его спине."
 
 /obj/item/gun/ballistic/shotgun/automatic/combat/compact/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/gun/ballistic/shotgun/automatic/combat/compact)
 
 /datum/objective_item/steal/handtele
-	name = "hand teleporter"
+	name = "ручной телепортер"
 	targetitem = /obj/item/hand_tele
 	excludefromjob = list(JOB_CAPTAIN, JOB_RESEARCH_DIRECTOR, JOB_HEAD_OF_PERSONNEL)
 	item_owner = list(JOB_CAPTAIN, JOB_RESEARCH_DIRECTOR)
 	exists_on_map = TRUE
 	difficulty = 3
-	steal_hint = "Only two of these devices exist on the station, with one sitting in the Teleporter Room \
-		for emergencies, and the other in the Captain's Quarters for personal use."
+	steal_hint = "На станции есть только два таких устройства, одно из которых находится в телепортерной \
+		для экстренных случаев, а другое - в каюте капитана для личного пользования."
 
 /obj/item/hand_tele/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/hand_tele)
 
 /datum/objective_item/steal/jetpack
-	name = "Captain's jetpack"
+	name = "реактивный ранец капитана"
 	targetitem = /obj/item/tank/jetpack/oxygen/captain
 	excludefromjob = list(JOB_CAPTAIN)
 	item_owner = list(JOB_CAPTAIN)
 	exists_on_map = TRUE
 	difficulty = 3
-	steal_hint = "A special yellow jetpack found in the Suit Storage Unit in the Captain's Quarters."
+	steal_hint = "Специальный жёлтый реактивный ранец может быть найден в блоке хранения костюмов в каюте капитана."
 
 /obj/item/tank/jetpack/oxygen/captain/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/tank/jetpack/oxygen/captain)
 
 /datum/objective_item/steal/magboots
-	name = "chief engineer's advanced magnetic boots"
+	name = "продвинутые магнитые ботинки главного инженера"
 	targetitem = /obj/item/clothing/shoes/magboots/advance
 	excludefromjob = list(JOB_CHIEF_ENGINEER)
 	item_owner = list(JOB_CHIEF_ENGINEER)
 	exists_on_map = TRUE
 	difficulty = 3
-	steal_hint = "A pair of magnetic boots found in the Chief Engineer's Suit Storage Unit. \
-		May also be found on their person, concealed beneath their MODsuit."
+	steal_hint = "Пара магнитных ботинок, что могут быть найдены в блоке хранения костюмов главного инженера. \
+		Их также можно найти на нём, спрятанные под МОД-костюмом."
 
 /obj/item/clothing/shoes/magboots/advance/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/clothing/shoes/magboots/advance)
 
 /datum/objective_item/steal/capmedal
-	name = "medal of captaincy"
+	name = "медаль капитанства"
 	targetitem = /obj/item/clothing/accessory/medal/gold/captain
 	excludefromjob = list(JOB_CAPTAIN)
 	item_owner = list(JOB_CAPTAIN)
 	exists_on_map = TRUE
 	difficulty = 3
-	steal_hint = "A gold medal found in the medal box in the Captain's Quarters. \
-		The Captain usually also has one pinned to their jumpsuit."
+	steal_hint = "Золотая медаль, что может быть найдена в коробке с медалями в каюте капитана. \
+		У капитана обычно тоже есть такая медаль, приколотая к комбинезону."
 
 /obj/item/clothing/accessory/medal/gold/captain/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/clothing/accessory/medal/gold/captain)
 
 /datum/objective_item/steal/hypo
-	name = "hypospray"
+	name = "гипоспрей"
 	targetitem = /obj/item/reagent_containers/hypospray/cmo
 	excludefromjob = list(JOB_CHIEF_MEDICAL_OFFICER)
 	item_owner = list(JOB_CHIEF_MEDICAL_OFFICER)
 	exists_on_map = TRUE
 	difficulty = 3
-	steal_hint = "The Chief Medical Officer's personal medical injector. \
-		Usually found amongst their medical supplies on their person, in their belt, or otherwise in their locker."
+	steal_hint = "Персональный медицинский инжектор главного врача. \
+		Обычно находящийся у него в медицинских принадлежностях или на поясе. Так же может быть найден в шкафу в его кабинете."
 
 /obj/item/reagent_containers/hypospray/cmo/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/reagent_containers/hypospray/cmo)
 
 /datum/objective_item/steal/nukedisc
-	name = "nuclear authentication disk"
+	name = "диск ядерной аутентификации"
 	targetitem = /obj/item/disk/nuclear
 	excludefromjob = list(JOB_CAPTAIN)
 	difficulty = 5
-	steal_hint = "THAT disk - you know the one. Carried by the Captain at all times (hopefully). \
-		Difficult to miss, but if you can't find it, the Head of Security and Captain both have devices to track its precise location."
+	steal_hint = "Вы знаете что за диск. Постоянно находится при капитане (возможно). \
+		Его трудно не заметить, но если вы не можете его найти, у главы службы безопасности и капитана есть устройства, позволяющие отследить его точное местоположение."
 
 /obj/item/disk/nuclear/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/disk/nuclear)
@@ -466,51 +467,51 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	return !N.fake
 
 /datum/objective_item/steal/ablative
-	name = "ablative trenchcoat"
+	name = "абляционный плащ"
 	targetitem = /obj/item/clothing/suit/hooded/ablative
 	excludefromjob = list(JOB_HEAD_OF_SECURITY, JOB_WARDEN)
 	item_owner = list(JOB_HEAD_OF_SECURITY)
 	exists_on_map = TRUE
 	difficulty = 4
-	steal_hint = "An ablative trechcoat found on the shelves of the Armory."
+	steal_hint = "Абляционный плащ, что может быть найден в оружейной."
 
 /obj/item/clothing/suit/hooded/ablative/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/clothing/suit/hooded/ablative)
 
 /datum/objective_item/steal/reactive
-	name = "reactive teleport armor"
+	name = "реактивную телепортирующую броню"
 	targetitem = /obj/item/clothing/suit/armor/reactive/teleport
 	excludefromjob = list(JOB_RESEARCH_DIRECTOR)
 	item_owner = list(JOB_RESEARCH_DIRECTOR)
 	exists_on_map = TRUE
 	difficulty = 3
-	steal_hint = "A special suit of armor found in the possession of the Research Director. \
-		You may otherwise find it in their locker."
+	steal_hint = "Специальная броня, что может быть у директора исследований. \
+		Так же может быть найден в шкафчике."
 
 /obj/item/clothing/suit/armor/reactive/teleport/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/clothing/suit/armor/reactive/teleport)
 
 /datum/objective_item/steal/documents
-	name = "any set of secret documents of any organization"
+	name = "любой набор секретных документов любой организации"
 	valid_containers = list(/obj/item/folder)
 	targetitem = /obj/item/documents
 	exists_on_map = TRUE
 	difficulty = 3
-	steal_hint = "A set of papers belonging to a megaconglomerate. \
-		Nanotrasen documents can easily be found in the station's vault. \
-		For other corporations, you may find them in strange and distant places. \
-		A photocopy may also suffice."
+	steal_hint = "Набор документов, принадлежащих мегаконгломерату. \
+		Документы Нанотрейзен можно легко найти в хранилище станции. \
+		Что касается других корпораций, то вы можете найти их в странных и отдаленных местах. \
+		Также может быть достаточно фотокопии."
 
 /obj/item/documents/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/documents) //Any set of secret documents. Doesn't have to be NT's
 
 /datum/objective_item/steal/nuke_core
-	name = "heavily radioactive plutonium core from the onboard self-destruct"
+	name = "высокорадиоактивный плутониевый сердечник из бортового устройства самоуничтожения"
 	valid_containers = list(/obj/item/nuke_core_container)
 	targetitem = /obj/item/nuke_core
 	exists_on_map = TRUE
 	difficulty = 4
-	steal_hint = "The core of the station's self-destruct device, found in the vault."
+	steal_hint = "Ядро устройства самоуничтожения станции. Находится в хранилище."
 
 /obj/item/nuke_core/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/nuke_core)
@@ -520,13 +521,13 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	..()
 
 /datum/objective_item/steal/hdd_extraction
-	name = "source code for Project Goon from the master R&D server mainframe"
+	name = "исходный код Project Goon с мэйнфрейма главного сервера исследований и разработок"
 	targetitem = /obj/item/computer_disk/hdd_theft
 	excludefromjob = list(JOB_RESEARCH_DIRECTOR, JOB_SCIENTIST, JOB_ROBOTICIST, JOB_GENETICIST)
 	item_owner = list(JOB_RESEARCH_DIRECTOR, JOB_SCIENTIST)
 	exists_on_map = TRUE
 	difficulty = 4
-	steal_hint = "The hard drive of the master research server, found in R&D's server room."
+	steal_hint = "Жесткий диск главного исследовательского сервера. Находится в серверной исследований и разработок."
 
 /obj/item/computer_disk/hdd_theft/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/computer_disk/hdd_theft)
@@ -537,11 +538,11 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 
 
 /datum/objective_item/steal/supermatter
-	name = "sliver of a supermatter crystal"
+	name = "осколок кристалла суперматерии"
 	targetitem = /obj/item/nuke_core/supermatter_sliver
 	valid_containers = list(/obj/item/nuke_core_container/supermatter)
 	difficulty = 5
-	steal_hint = "A small shard of the station's supermatter crystal engine."
+	steal_hint = "Маленький осколок станционного двигателя суперматерии."
 
 /datum/objective_item/steal/supermatter/New()
 	special_equipment += /obj/item/storage/box/syndie_kit/supermatter
@@ -552,10 +553,10 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 
 // Doesn't need item_owner = (JOB_AI) because this handily functions as a murder objective if there isn't one
 /datum/objective_item/steal/functionalai
-	name = "functional AI"
+	name = "функционирующий ИИ"
 	targetitem = /obj/item/aicard
 	difficulty = 5
-	steal_hint = "An intellicard (or MODsuit) containing an active, functional AI."
+	steal_hint = "Интелкарта (или МОД-костюм), содержащий активный, функциональный искусственный интеллект."
 
 /datum/objective_item/steal/functionalai/New()
 	. = ..()
@@ -581,14 +582,14 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	return FALSE
 
 /datum/objective_item/steal/blueprints
-	name = "station blueprints"
+	name = "чертежи станции"
 	targetitem = /obj/item/blueprints
 	excludefromjob = list(JOB_CHIEF_ENGINEER)
 	item_owner = list(JOB_CHIEF_ENGINEER)
 	altitems = list(/obj/item/photo)
 	exists_on_map = TRUE
 	difficulty = 3
-	steal_hint = "The blueprints of the station, found in the Chief Engineer's locker, or on their person. A picture may suffice."
+	steal_hint = "Чертежи станции можно найти в шкафчике главного инженера или при нём самом. Может подойти фотография чертежей."
 
 /obj/item/blueprints/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/blueprints)
@@ -603,13 +604,13 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	return FALSE
 
 /datum/objective_item/steal/blackbox
-	name = "Blackbox"
+	name = "чёрный ящик"
 	targetitem = /obj/item/blackbox
 	excludefromjob = list(JOB_CHIEF_ENGINEER, JOB_STATION_ENGINEER, JOB_ATMOSPHERIC_TECHNICIAN)
 	exists_on_map = TRUE
 	difficulty = 4
-	steal_hint = "The station's data Blackbox, found solely within Telecommunications."
-	destruction_method = "Too strong to be destroyed via normal means - needs to be dusted via the supermatter, or burnt in the chapel's crematorium."
+	steal_hint = "Черный ящик данных станции, доступный исключительно в телекоммуникационных сетях."
+	destruction_method = "Слишком крепкий, чтобы его можно было уничтожить обычными средствами - его нужно стереть в порошок с помощью суперматерии или сжечь в крематории часовни."
 
 /obj/item/blackbox/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/blackbox)
@@ -618,74 +619,74 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 // A number of special early-game steal objectives intended to be used with the steal-and-destroy objective.
 // They're basically items of utility or emotional value that may be found on many players or lying around the station.
 /datum/objective_item/steal/traitor/insuls
-	name = "some insulated gloves"
+	name = "пара изоляционных перчаток"
 	targetitem = /obj/item/clothing/gloves/color/yellow
 	excludefromjob = list(JOB_CARGO_TECHNICIAN, JOB_QUARTERMASTER, JOB_ATMOSPHERIC_TECHNICIAN, JOB_STATION_ENGINEER, JOB_CHIEF_ENGINEER)
 	item_owner = list(JOB_STATION_ENGINEER, JOB_CHIEF_ENGINEER)
 	exists_on_map = TRUE
 	difficulty = 1
-	steal_hint = "A basic pair of insulated gloves, usually worn by Assistants, Engineers, or Cargo Technicians."
+	steal_hint = "Обычная пара изоляционных перчаток, которые обычно носят ассистенты, инженеры или грузчики."
 
 /obj/item/clothing/gloves/color/yellow/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/clothing/gloves/color/yellow)
 
 /datum/objective_item/steal/traitor/moth_plush
-	name = "a cute moth plush toy"
+	name = "плюшевая милая моль"
 	targetitem = /obj/item/toy/plush/moth
 	excludefromjob = list(JOB_PSYCHOLOGIST, JOB_PARAMEDIC, JOB_CHEMIST, JOB_MEDICAL_DOCTOR, JOB_CHIEF_MEDICAL_OFFICER, JOB_CORONER)
 	exists_on_map = TRUE
 	difficulty = 1
-	steal_hint = "A moth plush toy. The Psychologist has one to help console patients."
+	steal_hint = "Плюшевая моль. Так же может быть найден у психолога, что лечит душевные травмы этой молью."
 
 /obj/item/toy/plush/moth/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/toy/plush/moth)
 
 /datum/objective_item/steal/traitor/lizard_plush
-	name = "a cute lizard plush toy"
+	name = "плюшевая милая ящерица"
 	targetitem = /obj/item/toy/plush/lizard_plushie
 	exists_on_map = TRUE
 	difficulty = 1
-	steal_hint = "A lizard plush toy. Often found hidden in maintenance."
+	steal_hint = "Плюшевая ящерица. Так же может быть найден в технических тоннелях."
 
 /obj/item/toy/plush/lizard_plushie/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/toy/plush/lizard_plushie)
 
 /datum/objective_item/steal/traitor/denied_stamp
-	name = "cargo's denied stamp"
+	name = "штамп отклонения снабжения"
 	targetitem = /obj/item/stamp/denied
 	excludefromjob = list(JOB_CARGO_TECHNICIAN, JOB_QUARTERMASTER, JOB_SHAFT_MINER)
 	exists_on_map = TRUE
 	difficulty = 1
-	steal_hint = "Cargo often has multiple of these red stamps lying around to process paperwork."
+	steal_hint = "В отделе снабжения часто валяется несколько таких красных штампов для обработки документов."
 
 /obj/item/stamp/denied/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/stamp/denied)
 
 /datum/objective_item/steal/traitor/granted_stamp
-	name = "cargo's granted stamp"
+	name = "штамп подтверждения снабжения"
 	targetitem = /obj/item/stamp/granted
 	excludefromjob = list(JOB_CARGO_TECHNICIAN, JOB_QUARTERMASTER, JOB_SHAFT_MINER)
 	exists_on_map = TRUE
 	difficulty = 1
-	steal_hint = "Cargo often has multiple of these green stamps lying around to process paperwork."
+	steal_hint = "В отделе снабжения часто валяется несколько таких зелёных штампов для обработки документов."
 
 /obj/item/stamp/granted/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/stamp/granted)
 
 /datum/objective_item/steal/traitor/space_law
-	name = "book on space law"
+	name = "книга космического закона"
 	targetitem = /obj/item/book/manual/wiki/security_space_law
 	excludefromjob = list(JOB_SECURITY_OFFICER, JOB_WARDEN, JOB_HEAD_OF_SECURITY, JOB_LAWYER, JOB_DETECTIVE)
 	exists_on_map = TRUE
 	difficulty = 1
-	steal_hint = "Sometimes found in the possession of members of Security and Lawyers. \
-		The courtroom and the library are also good places to look."
+	steal_hint = "Может быть найдена у офицеров службы безопасности и юристов. \
+		Зал суда, бриг и библиотека хорошие места, чтобы найти это."
 
 /obj/item/book/manual/wiki/security_space_law/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/book/manual/wiki/security_space_law)
 
 /datum/objective_item/steal/traitor/rpd
-	name = "a rapid pipe dispenser"
+	name = "быстрый раздатчик труб"
 	targetitem = /obj/item/pipe_dispenser
 	excludefromjob = list(
 		JOB_ATMOSPHERIC_TECHNICIAN,
@@ -699,13 +700,13 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	item_owner = list(JOB_CHIEF_ENGINEER)
 	exists_on_map = TRUE
 	difficulty = 1
-	steal_hint = "A tool often used by Engineers, Atmospherics Technicians, and Ordnance Technicians."
+	steal_hint = "Инструмент, используемый инженерами, атмосферными техниками и учёными."
 
 /obj/item/pipe_dispenser/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/pipe_dispenser)
 
 /datum/objective_item/steal/traitor/donut_box
-	name = "box of prized donuts"
+	name = "коробка отборных пончиков"
 	targetitem = /obj/item/storage/fancy/donut_box
 	excludefromjob = list(
 		JOB_CAPTAIN,
@@ -722,7 +723,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 	exists_on_map = TRUE
 	difficulty = 1
-	steal_hint = "Everyone has a box of donuts - you may most commonly find them on the Bridge, within Security, or in any department's break room."
+	steal_hint = "У всех есть коробки с пончиками. Можно найти на мостике, бриге или в комнате отдыха отделов."
 
 /obj/item/storage/fancy/donut_box/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/storage/fancy/donut_box)
@@ -731,18 +732,18 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	objective_type = OBJECTIVE_ITEM_TYPE_SPY
 
 /datum/objective_item/steal/spy/lamarr
-	name = "Research Director's pet headcrab"
+	name = "хедкраб директора исследований"
 	targetitem = /obj/item/clothing/mask/facehugger/lamarr
 	excludefromjob = list(JOB_RESEARCH_DIRECTOR)
 	exists_on_map = TRUE
 	difficulty = 3
-	steal_hint = "The Research Director's pet headcrab, Lamarr, found in a secure cage in their office."
+	steal_hint = "Хедкраб директора исследований Ламарр. Может быть найден в кабинете директора исследований."
 
 /obj/item/clothing/mask/facehugger/lamarr/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/clothing/mask/facehugger/lamarr)
 
 /datum/objective_item/steal/spy/disabler
-	name = "disabler"
+	name = "дизейблер"
 	targetitem = /obj/item/gun/energy/disabler
 	excludefromjob = list(
 		JOB_CAPTAIN,
@@ -753,10 +754,10 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 		JOB_WARDEN,
 	)
 	difficulty = 2
-	steal_hint = "A hand-held disabler, often found in the possession of Security Officers."
+	steal_hint = "Ручной дизейблер, часто находящийся в распоряжении офицеров службы безопасности."
 
 /datum/objective_item/steal/spy/energy_gun
-	name = "an energy gun"
+	name = "энергетический карабин"
 	targetitem = /obj/item/gun/energy/e_gun
 	excludefromjob = list(
 		JOB_CAPTAIN,
@@ -772,7 +773,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 	exists_on_map = TRUE
 	difficulty = 2
-	steal_hint = "A two-mode energy gun, found in the station's Armory, as well as in the hands of some heads of staff for personal defense."
+	steal_hint = "Двухрежимный энергетический карабин, что может быть найден в оружейной. Так же может быть у некоторых глав для их персональной защиты."
 
 /datum/objective_item/steal/spy/energy_gun/check_special_completion(obj/item/thing)
 	return thing.type == /obj/item/gun/energy/e_gun
@@ -782,7 +783,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 		return add_item_to_steal(src, /obj/item/gun/energy/e_gun)
 
 /datum/objective_item/steal/spy/laser_gun
-	name = "laser gun"
+	name = "лазерный карабин"
 	targetitem = /obj/item/gun/energy/laser
 	excludefromjob = list(
 		JOB_CAPTAIN,
@@ -798,7 +799,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 	exists_on_map = TRUE
 	difficulty = 3
-	steal_hint = "A simple laser gun, found in the station's Armory."
+	steal_hint = "Простой лазерный карабин, что может быть найден в оружейной."
 
 /datum/objective_item/steal/spy/laser_gun/check_special_completion(obj/item/thing)
 	return thing.type == /obj/item/gun/energy/laser
@@ -808,7 +809,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 		return add_item_to_steal(src, /obj/item/gun/energy/laser)
 
 /datum/objective_item/steal/spy/shotgun
-	name = "riot shotgun"
+	name = "служебный дробовик"
 	targetitem = /obj/item/gun/ballistic/shotgun/riot
 	excludefromjob = list(
 		JOB_DETECTIVE,
@@ -819,13 +820,13 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 	exists_on_map = TRUE
 	difficulty = 3
-	steal_hint = "A shotgun found in the station's Armory for riot suppression. Doesn't miss."
+	steal_hint = "Служебный дробовик для подавления бунтов, что может быть найден в оружейной."
 
 /obj/item/gun/ballistic/shotgun/riot/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/gun/ballistic/shotgun/riot)
 
 /datum/objective_item/steal/spy/temp_gun
-	name = "security's temperature gun"
+	name = "температурная винтовка СБ"
 	targetitem = /obj/item/gun/energy/temperature/security
 	excludefromjob = list(
 		JOB_DETECTIVE,
@@ -836,13 +837,13 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 	exists_on_map = TRUE
 	difficulty = 2 // lowered for the meme
-	steal_hint = "Security's TRUSTY temperature gun, found in the station's Armory."
+	steal_hint = "Надёжная температурная винтовка СБ, что может быть найдена в оружейной."
 
 /obj/item/gun/energy/temperature/security/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/gun/energy/temperature/security)
 
 /datum/objective_item/steal/spy/stamp
-	name = "head of staff's stamp"
+	name = "штамп главы"
 	targetitem = /obj/item/stamp/head
 	excludefromjob = list(
 		JOB_CAPTAIN,
@@ -855,13 +856,13 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 	exists_on_map = TRUE
 	difficulty = 1
-	steal_hint = "A stamp owned by a head of staff, from their offices."
+	steal_hint = "Штамп, принадлежащий главе отдела, что может быть найдена в их офисе."
 
 /obj/item/stamp/head/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/stamp/head)
 
 /datum/objective_item/steal/spy/sunglasses
-	name = "some sunglasses"
+	name = "какие-нибудь солнцезащитные очки"
 	targetitem = /obj/item/clothing/glasses/sunglasses
 	excludefromjob = list(
 		JOB_CAPTAIN,
@@ -876,55 +877,54 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 		JOB_WARDEN,
 	)
 	difficulty = 1
-	steal_hint = "A pair of sunglasses. Lawyers often have a few pairs, as do some heads of staff. \
-		You can also obtain a pair from dissassembling hudglasses."
+	steal_hint = "Пара солнцезащитных очков. У юристов обычно есть несколько штук, как и у некоторых глав. Также их можно получить, разобрав HUD-очки"
 
 /datum/objective_item/steal/spy/ce_modsuit
-	name = "chief engineer's advanced MOD control unit"
+	name = "продвинутый МОД-костюм главного инженера"
 	targetitem = /obj/item/mod/control/pre_equipped/advanced
 	excludefromjob = list(JOB_CHIEF_ENGINEER)
 	exists_on_map = TRUE
 	difficulty = 2
-	steal_hint = "An advanced version of the standard Engineering MODsuit commonly worn by the Chief Engineer."
+	steal_hint = "Продвинутая версия стандартного инженерного МОД-костюма. Можно найти у главного инженера или в его кабинете."
 
 /obj/item/mod/control/pre_equipped/advanced/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/mod/control/pre_equipped/advanced)
 
 /datum/objective_item/steal/spy/rd_modsuit
-	name = "research director's research MOD control unit"
+	name = "МОД-костюм директора исследований"
 	targetitem = /obj/item/mod/control/pre_equipped/research
 	excludefromjob = list(JOB_RESEARCH_DIRECTOR)
 	exists_on_map = TRUE
 	difficulty = 2
-	steal_hint = "A bulky MODsuit commonly worn by the Research Director to protect themselves from the hazards of their work."
+	steal_hint = "Громоздкий МОД-костюм директора исследований в опасных условиях на рабочем месте. Можно найти у директора исследований или в его кабинете."
 
 /obj/item/mod/control/pre_equipped/research/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/mod/control/pre_equipped/research)
 
 /datum/objective_item/steal/spy/cmo_modsuit
-	name = "chief medical officer's rescure MOD control unit"
+	name = "МОД-костюм главного врача"
 	targetitem = /obj/item/mod/control/pre_equipped/rescue
 	excludefromjob = list(JOB_CHIEF_MEDICAL_OFFICER)
 	exists_on_map = TRUE
 	difficulty = 2
-	steal_hint = "A MODsuit sometimes equipped by the Chief Medical Officer to perform rescue opperations in hazardous environments."
+	steal_hint = "МОД-костюм, который главный врач иногда использует для спасательных операций в опасных условиях."
 
 /obj/item/mod/control/pre_equipped/rescue/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/mod/control/pre_equipped/rescue)
 
 /datum/objective_item/steal/spy/hos_modsuit
-	name = "head of security's safeguard MOD control unit"
+	name = "МОД-костюм главы службы безопасности"
 	targetitem = /obj/item/mod/control/pre_equipped/safeguard
 	excludefromjob = list(JOB_HEAD_OF_SECURITY)
 	exists_on_map = TRUE
 	difficulty = 2
-	steal_hint = "An advanced MODsuit sometimes worn by the Head of Security when needing to detain hostiles invading the station."
+	steal_hint = "Продвинутый МОД-костюм, который глава службы безопасности иногда использует для задержания враждебно настроенных нарушителей на станции."
 
 /obj/item/mod/control/pre_equipped/safeguard/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/mod/control/pre_equipped/safeguard)
 
 /datum/objective_item/steal/spy/stun_baton
-	name = "stun baton"
+	name = "оглушающая дубинка"
 	targetitem = /obj/item/melee/baton/security
 	excludefromjob = list(
 		JOB_CAPTAIN,
@@ -935,13 +935,13 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 		JOB_WARDEN,
 	)
 	difficulty = 2
-	steal_hint = "Steal any stun baton from Security."
+	steal_hint = "Украдите любую оглушающую дубинку у офицера службы безопасности. Или найдите в бриге."
 
 /datum/objective_item/steal/spy/stun_baton/check_special_completion(obj/item/thing)
 	return !istype(thing, /obj/item/melee/baton/security/cattleprod)
 
 /datum/objective_item/steal/spy/det_baton
-	name = "detective's baton"
+	name = "дубинка детектива"
 	targetitem = /obj/item/melee/baton
 	excludefromjob = list(
 		JOB_CAPTAIN,
@@ -953,7 +953,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 	exists_on_map = TRUE
 	difficulty = 2
-	steal_hint = "The detective's old wooden truncheon, commonly found on their person for self defense."
+	steal_hint = "Старая дубинка детектива, обычно при нём для самообороны."
 
 /datum/objective_item/steal/spy/det_baton/check_special_completion(obj/item/thing)
 	return thing.type == /obj/item/melee/baton
@@ -963,12 +963,12 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 		return add_item_to_steal(src, /obj/item/melee/baton)
 
 /datum/objective_item/steal/spy/captain_sabre_sheathe
-	name = "captain's sabre sheathe"
+	name = "ножны капитанской сабли"
 	targetitem = /obj/item/storage/belt/sheath/sabre
 	excludefromjob = list(JOB_CAPTAIN)
 	exists_on_map = TRUE
 	difficulty = 3
-	steal_hint = "The sheathe for the captain's sabre, found in their closet or strapped to their waist at all times."
+	steal_hint = "Ножны для капитанской сабли. Их можно найти в гардеробе капитана или на его поясе — он носит их постоянно."
 
 /obj/item/storage/belt/sheath/sabre/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/storage/belt/sheath/sabre)

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -138,7 +138,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	item_owner = list(JOB_BARTENDER)
 	exists_on_map = TRUE
 	difficulty = 2
-	steal_hint = "Двухствольный дробовик, обычно находящийся у бармена. Если его нет у бармена, то можете найти в подсобке бара."
+	steal_hint = "Двуствольный дробовик, обычно находящийся у бармена. Если его нет у бармена, то можете найти в подсобке бара."
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/gun/ballistic/shotgun/doublebarrel)
@@ -214,7 +214,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	item_owner = list(JOB_MIME)
 	exists_on_map = TRUE
 	difficulty = 1
-	steal_hint = "Маска мима. Она всегда должен быть на лице мима."
+	steal_hint = "Маска мима. Она всегда должна быть на лице мима."
 
 /obj/item/clothing/mask/gas/mime/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/clothing/mask/gas/mime)
@@ -239,7 +239,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	item_owner = list(JOB_COOK)
 	exists_on_map = TRUE
 	difficulty = 1
-	steal_hint = "Искусственные итальянские усы шеф-повара, найденные либо на лице, либо в мусорном ведре, в зависимости от того, кто дежурит."
+	steal_hint = "Искусственные итальянские усы шеф-повара, найденные либо на лице, либо в мусорном ведре, в зависимости от того, кто за работой."
 
 /obj/item/clothing/mask/fakemoustache/italian/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/clothing/mask/fakemoustache/italian)
@@ -293,7 +293,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 	exists_on_map = TRUE
 	difficulty = 3
-	steal_hint = "Оружие самообороны, стандартное для всех глав отделов, за исключением начальника службы безопасности. Редко находится не при владельце."
+	steal_hint = "Оружие самообороны, стандартное для всех глав отделов, за исключением главы службы безопасности. Редко находится не при владельце."
 
 /datum/objective_item/steal/traitor/telebaton/check_special_completion(obj/item/thing)
 	return thing.type == /obj/item/melee/baton/telescopic
@@ -342,7 +342,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	exists_on_map = TRUE
 	difficulty = 4
 	steal_hint = "Запасная ID-карта самого главного на этой станции. \
-			Если поблизости нет официального капитана, вы можете найти её на груди исполняющего обязанности капитана - одного из глав отдела."
+		Если поблизости нет официального капитана, вы можете найти её на груди исполняющего обязанности капитана - одного из глав отдела."
 
 /obj/item/card/id/advanced/gold/captains_spare/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/card/id/advanced/gold/captains_spare)
@@ -351,25 +351,25 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 
 // Will always generate even with no Captain due to its security and temptation to use it
 /datum/objective_item/steal/caplaser
-	name = "капитанский антикварный лазерный пистолет"
+	name = "капитанское антикварное лазерное оружие"
 	targetitem = /obj/item/gun/energy/laser/captain
 	excludefromjob = list(JOB_CAPTAIN)
 	exists_on_map = TRUE
 	difficulty = 4
-	steal_hint = "Самозарядный лазерный пистолет, что может быть найден в витрине в каюте капитана. \
+	steal_hint = "Самозарядное антикварное лазерное оружие, что может быть найдено в витрине в каюте капитана. \
 		Его вскрытие может вызвать тревогу системы безопасности, поэтому будьте осторожны."
 
 /obj/item/gun/energy/laser/captain/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/gun/energy/laser/captain)
 
 /datum/objective_item/steal/hoslaser
-	name = "персональный лазерный пистолет главы службы безопасности"
+	name = "персональное лазерное оружие главы службы безопасности"
 	targetitem = /obj/item/gun/energy/e_gun/hos
 	excludefromjob = list(JOB_HEAD_OF_SECURITY)
 	item_owner = list(JOB_HEAD_OF_SECURITY)
 	exists_on_map = TRUE
 	difficulty = 4
-	steal_hint = "Уникальный трехрежимный лазерный пистолет главы службы безопасности. \
+	steal_hint = "Уникальное трехрежимное лазерное оружие главы службы безопасности. \
 		Всегда находится при нём, если он жив, но в противном случае может быть найден в его шкафчике."
 
 /obj/item/gun/energy/e_gun/hos/add_stealing_item_objective()
@@ -456,7 +456,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	targetitem = /obj/item/disk/nuclear
 	excludefromjob = list(JOB_CAPTAIN)
 	difficulty = 5
-	steal_hint = "Вы знаете что за диск. Постоянно находится при капитане (возможно). \
+	steal_hint = "Вы знаете ЭТОТ диск. Постоянно находится при капитане (возможно). \
 		Его трудно не заметить, но если вы не можете его найти, у главы службы безопасности и капитана есть устройства, позволяющие отследить его точное местоположение."
 
 /obj/item/disk/nuclear/add_stealing_item_objective()
@@ -472,13 +472,13 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	item_owner = list(JOB_HEAD_OF_SECURITY)
 	exists_on_map = TRUE
 	difficulty = 4
-	steal_hint = "Абляционный плащ, что может быть найден в оружейной."
+	steal_hint = "Абляционный плащ, что может быть найден на полках в оружейной брига."
 
 /obj/item/clothing/suit/hooded/ablative/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/clothing/suit/hooded/ablative)
 
 /datum/objective_item/steal/reactive
-	name = "реактивную телепортирующую броню"
+	name = "реактивную телепортационную броню"
 	targetitem = /obj/item/clothing/suit/armor/reactive/teleport
 	excludefromjob = list(JOB_RESEARCH_DIRECTOR)
 	item_owner = list(JOB_RESEARCH_DIRECTOR)
@@ -526,7 +526,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	item_owner = list(JOB_RESEARCH_DIRECTOR, JOB_SCIENTIST)
 	exists_on_map = TRUE
 	difficulty = 4
-	steal_hint = "Жесткий диск главного исследовательского сервера. Находится в серверной исследований и разработок."
+	steal_hint = "Жесткий диск из мастер-сервера исследовательского отдела. Находится в серверной отдела исследований и разработок."
 
 /obj/item/computer_disk/hdd_theft/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/computer_disk/hdd_theft)
@@ -608,8 +608,8 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	excludefromjob = list(JOB_CHIEF_ENGINEER, JOB_STATION_ENGINEER, JOB_ATMOSPHERIC_TECHNICIAN)
 	exists_on_map = TRUE
 	difficulty = 4
-	steal_hint = "Черный ящик данных станции, доступный исключительно в телекоммуникационных сетях."
-	destruction_method = "Слишком крепкий, чтобы его можно было уничтожить обычными средствами - его нужно стереть в порошок с помощью суперматерии или сжечь в крематории часовни."
+	steal_hint = "Черный ящик данных станции, доступный исключительно в телекоммуникационной."
+	destruction_method = "Слишком крепкий, чтобы его можно было уничтожить обычными средствами - его нужно стереть в порошок с помощью суперматерии или сжечь в крематории церкви."
 
 /obj/item/blackbox/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/blackbox)
@@ -630,28 +630,28 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	return add_item_to_steal(src, /obj/item/clothing/gloves/color/yellow)
 
 /datum/objective_item/steal/traitor/moth_plush
-	name = "плюшевая милая моль"
+	name = "милая плюшевая моль"
 	targetitem = /obj/item/toy/plush/moth
 	excludefromjob = list(JOB_PSYCHOLOGIST, JOB_PARAMEDIC, JOB_CHEMIST, JOB_MEDICAL_DOCTOR, JOB_CHIEF_MEDICAL_OFFICER, JOB_CORONER)
 	exists_on_map = TRUE
 	difficulty = 1
-	steal_hint = "Плюшевая моль. Также может быть найдена у психолога, что лечит душевные травмы этой молью."
+	steal_hint = "Плюшевая моль. Может быть найдена у психолога, что лечит душевные травмы этой молью."
 
 /obj/item/toy/plush/moth/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/toy/plush/moth)
 
 /datum/objective_item/steal/traitor/lizard_plush
-	name = "плюшевая милая ящерица"
+	name = "милая плюшевая ящерица"
 	targetitem = /obj/item/toy/plush/lizard_plushie
 	exists_on_map = TRUE
 	difficulty = 1
-	steal_hint = "Плюшевая ящерица. Также может быть найдена в технических тоннелях."
+	steal_hint = "Плюшевая ящерица. Может быть найдена в технических тоннелях."
 
 /obj/item/toy/plush/lizard_plushie/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/toy/plush/lizard_plushie)
 
 /datum/objective_item/steal/traitor/denied_stamp
-	name = "штамп отклонения снабжения"
+	name = "штамп \"отклонено\" отдела снабжения"
 	targetitem = /obj/item/stamp/denied
 	excludefromjob = list(JOB_CARGO_TECHNICIAN, JOB_QUARTERMASTER, JOB_SHAFT_MINER)
 	exists_on_map = TRUE
@@ -662,7 +662,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	return add_item_to_steal(src, /obj/item/stamp/denied)
 
 /datum/objective_item/steal/traitor/granted_stamp
-	name = "штамп подтверждения снабжения"
+	name = "штамп \"одобрено\" отдела снабжения"
 	targetitem = /obj/item/stamp/granted
 	excludefromjob = list(JOB_CARGO_TECHNICIAN, JOB_QUARTERMASTER, JOB_SHAFT_MINER)
 	exists_on_map = TRUE
@@ -736,7 +736,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	excludefromjob = list(JOB_RESEARCH_DIRECTOR)
 	exists_on_map = TRUE
 	difficulty = 3
-	steal_hint = "Хедкраб директора исследований Ламарр. Может быть найден в кабинете директора исследований."
+	steal_hint = "Ламарр, хедкраб директора исследований. Может быть найден в кабинете директора исследований."
 
 /obj/item/clothing/mask/facehugger/lamarr/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/clothing/mask/facehugger/lamarr)
@@ -772,7 +772,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 	exists_on_map = TRUE
 	difficulty = 2
-	steal_hint = "Двухрежимный энергетический карабин, что может быть найден в оружейной. Также может быть у некоторых глав для их персональной защиты."
+	steal_hint = "Двухрежимный энергетический карабин, что может быть найден в оружейной брига. Также может быть у некоторых глав для их персональной защиты."
 
 /datum/objective_item/steal/spy/energy_gun/check_special_completion(obj/item/thing)
 	return thing.type == /obj/item/gun/energy/e_gun
@@ -798,7 +798,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 	exists_on_map = TRUE
 	difficulty = 3
-	steal_hint = "Простой лазерный карабин, что может быть найден в оружейной."
+	steal_hint = "Простой лазерный карабин, что может быть найден в оружейной брига."
 
 /datum/objective_item/steal/spy/laser_gun/check_special_completion(obj/item/thing)
 	return thing.type == /obj/item/gun/energy/laser
@@ -819,7 +819,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 	exists_on_map = TRUE
 	difficulty = 3
-	steal_hint = "Служебный дробовик для подавления бунтов, что может быть найден в оружейной."
+	steal_hint = "Служебный дробовик для подавления бунтов, что может быть найден в оружейной брига."
 
 /obj/item/gun/ballistic/shotgun/riot/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/gun/ballistic/shotgun/riot)
@@ -836,7 +836,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	)
 	exists_on_map = TRUE
 	difficulty = 2 // lowered for the meme
-	steal_hint = "Надёжная температурная винтовка СБ, что может быть найдена в оружейной."
+	steal_hint = "Надёжная температурная винтовка службы безопасности, что может быть найдена в оружейной брига."
 
 /obj/item/gun/energy/temperature/security/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/gun/energy/temperature/security)
@@ -876,7 +876,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 		JOB_WARDEN,
 	)
 	difficulty = 1
-	steal_hint = "Пара солнцезащитных очков. У юристов обычно есть несколько штук, как и у некоторых глав. Также их можно получить, разобрав HUD-очки."
+	steal_hint = "Пара солнцезащитных очков. У юристов обычно есть несколько штук, как и у некоторых глав. Также их можно получить, разобрав ИЛС-очки."
 
 /datum/objective_item/steal/spy/ce_modsuit
 	name = "продвинутый МОД-костюм главного инженера"
@@ -895,7 +895,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	excludefromjob = list(JOB_RESEARCH_DIRECTOR)
 	exists_on_map = TRUE
 	difficulty = 2
-	steal_hint = "Громоздкий МОД-костюм директора исследований в опасных условиях на рабочем месте. Можно найти у директора исследований или в его кабинете."
+	steal_hint = "Громоздкий МОД-костюм директора исследований для работы в опасных условиях. Можно найти у директора исследований или в его кабинете."
 
 /obj/item/mod/control/pre_equipped/research/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/mod/control/pre_equipped/research)

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -486,7 +486,7 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	exists_on_map = TRUE
 	difficulty = 3
 	steal_hint = "Специальная броня, что может быть у директора исследований. \
-		Также может быть найдена в шкафчике."."
+		Также может быть найдена в шкафчике в кабинете директора исследований."
 
 /obj/item/clothing/suit/armor/reactive/teleport/add_stealing_item_objective()
 	return add_item_to_steal(src, /obj/item/clothing/suit/armor/reactive/teleport)


### PR DESCRIPTION
## Что этот PR делает

Переводит цели предателей на русский. В охапку доперевёл цели что были дополнительными у предателей (их можно дать через педалькуе-кнопки через ТП)

## Почему это хорошо для игры

Итоги раунда с меньшим количеством английского языка

## Изображения изменений

<img width="402" height="266" alt="image" src="https://github.com/user-attachments/assets/0c0e7713-8641-490a-816b-a603dd7d6e7b" />


## Тестирование

лок алка

## Changelog

:cl:
translation: Переведены не переведённые цели предателей.
/:cl:
