### PR TITLE
Partial revert of Cyberiad Ghetto Rework

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -228,8 +228,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
 "adv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/machinery/light/small/directional/east,
-/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "adz" = (
@@ -255,7 +257,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "adQ" = (
-/turf/open/floor/bamboo,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
 "aec" = (
 /turf/open/floor/plating,
@@ -427,10 +432,13 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/station/science/server)
 "agH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
-/turf/open/indestructible/plating,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "agK" = (
 /obj/structure/lattice,
@@ -441,10 +449,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
 "agO" = (
-/obj/effect/spawner/random/trash/cigbutt,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood/parquet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/grimy,
 /area/station/maintenance/ghetto/fore/starboard)
 "agU" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -454,9 +461,12 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "agZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
 /obj/effect/mapping_helpers/broken_floor,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/fore/starboard)
 "ahc" = (
 /obj/machinery/door/window/brigdoor/left/directional/north{
@@ -597,8 +607,7 @@
 /area/station/maintenance/department/electrical/ghetto)
 "ait" = (
 /obj/machinery/space_heater,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "aiv" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -877,10 +886,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
-"alV" = (
-/obj/structure/fluff/tram_rail/electric/anchor,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/fore/starboard)
 "alX" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -951,10 +956,10 @@
 /turf/open/floor/iron,
 /area/station/security/lockers)
 "amK" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/spawner/random/trash/graffiti,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "amL" = (
 /obj/machinery/status_display/evac/directional/north,
 /obj/machinery/camera/directional/north{
@@ -964,12 +969,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "amM" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/table,
-/obj/item/wrench,
-/obj/item/multitool,
-/obj/item/pen/screwdriver,
-/turf/open/floor/iron/dark,
+/obj/machinery/door/airlock/silver,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/herringbone,
 /area/station/maintenance/ghetto/central/fore)
 "amN" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -1442,12 +1446,6 @@
 /obj/structure/flora/rock/pile,
 /turf/open/floor/grass,
 /area/station/commons/dorms)
-"ato" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto/aft)
 "atx" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
 	dir = 1
@@ -1633,10 +1631,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard/west)
 "avR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/steam_vent,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "awa" = (
@@ -1945,7 +1940,7 @@
 /area/station/engineering/engine_smes)
 "azb" = (
 /obj/machinery/vending/clothing,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "azj" = (
@@ -1983,17 +1978,21 @@
 /obj/item/razor{
 	pixel_x = 8
 	},
-/obj/machinery/light/small/dim/directional/west,
+/obj/machinery/light/small/directional/west{
+	name = "maintenance light";
+	nightshift_allowed = 0;
+	nightshift_enabled = 1
+	},
 /obj/item/radio/intercom/directional/west,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/small,
 /area/station/security/interrogation/ghetto)
 "azn" = (
-/obj/machinery/transport/power_rectifier,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/machinery/atmospherics/components/tank/air/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "azs" = (
 /obj/effect/landmark/start/captain,
 /turf/open/floor/carpet/blue,
@@ -2102,15 +2101,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
-"aAu" = (
-/obj/structure/fluff/tram_rail/electric,
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic,
-/obj/structure/chair/sofa/bench/tram/right{
-	dir = 8
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
 "aAw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/smooth,
@@ -2449,15 +2439,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
-"aEx" = (
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/port/greater)
 "aEC" = (
 /obj/structure/sign/warning/radiation/directional/north,
 /turf/open/floor/engine,
@@ -2494,12 +2475,10 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/maintenance/ghetto/starboard)
 "aEU" = (
-/obj/machinery/door/airlock/medical,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/barricade/wooden/crude,
-/obj/machinery/door/poddoor/shutters,
-/turf/open/floor/iron/white/textured,
-/area/station/security/medical)
+/obj/structure/bookcase,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "aFl" = (
 /obj/structure/fluff/paper/stack{
 	dir = 4
@@ -2720,9 +2699,9 @@
 "aIa" = (
 /obj/structure/closet,
 /obj/item/paper/crumpled,
-/obj/effect/spawner/random/maintenance/three,
-/turf/open/floor/plating,
-/area/station/maintenance/port/greater)
+/obj/effect/spawner/random/maintenance/six,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "aIe" = (
 /obj/structure/chair/office/light,
 /obj/structure/railing/corner{
@@ -2785,17 +2764,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
-"aIO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 9
-	},
-/obj/machinery/button/door/directional/east{
-	id = "service_station_shutters";
-	name = "Service Station Shutter Control"
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
 "aIW" = (
 /obj/item/reagent_containers/chem_pack,
 /obj/item/reagent_containers/chem_pack,
@@ -2837,13 +2805,6 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
-"aJH" = (
-/obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood/parquet,
-/area/station/service/bar/backroom/ghetto)
 "aJS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/glass,
@@ -2939,13 +2900,6 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/wood,
 /area/station/maintenance/aft)
-"aLp" = (
-/obj/structure/railing/platform/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
 "aLu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3164,9 +3118,9 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "aNW" = (
-/obj/effect/turf_decal/siding/wood/corner,
-/turf/open/floor/carpet,
-/area/station/service/library)
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron/freezer,
+/area/station/maintenance/ghetto/fore/starboard)
 "aNY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/newscaster/directional/north,
@@ -3542,16 +3496,6 @@
 	dir = 8
 	},
 /area/station/engineering/atmos/project)
-"aSl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
 "aSr" = (
 /obj/machinery/door/airlock/research/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -3591,8 +3535,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/aft)
 "aTb" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/noslip/tram,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "aTc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -3654,11 +3598,13 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "aTF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/directional/west,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
-/obj/effect/spawner/random/trash/graffiti,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "aTJ" = (
 /obj/structure/chair{
@@ -3671,11 +3617,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "aTK" = (
-/obj/structure/fluff/tram_rail/electric,
-/obj/structure/transport/linear/tram,
-/obj/structure/tram,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/security/ghetto/aft)
 "aTM" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
@@ -3725,9 +3669,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "aUb" = (
-/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/area/station/maintenance/department/medical/ghetto)
 "aUo" = (
 /obj/structure/sink/directional/east,
 /obj/structure/mirror/directional/west,
@@ -4008,14 +3952,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "aXp" = (
-/obj/effect/spawner/random/trash/cigbutt,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/parquet,
+/obj/structure/chair/office,
+/turf/open/floor/iron/grimy,
 /area/station/maintenance/ghetto/fore/starboard)
 "aXv" = (
 /turf/open/floor/iron,
@@ -4155,11 +4093,10 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "aYG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "aYN" = (
 /obj/machinery/atmospherics/components/tank/air{
@@ -4201,12 +4138,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
-"aZl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
 "aZx" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -4315,10 +4246,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"baO" = (
-/obj/effect/spawner/random/trash/graffiti,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/fore/starboard)
 "baR" = (
 /obj/structure/rack,
 /turf/open/floor/pod,
@@ -4328,11 +4255,13 @@
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
 "baW" = (
-/obj/structure/chair/stool{
-	dir = 4
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/turf/open/floor/iron/cafeteria,
 /area/station/commons/locker)
 "baY" = (
 /obj/machinery/vatgrower,
@@ -4355,13 +4284,9 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "bbf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/carpet/royalblack,
 /area/station/maintenance/ghetto/fore/starboard)
 "bbk" = (
 /obj/machinery/door/airlock/maintenance,
@@ -4400,12 +4325,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/storage)
 "bcn" = (
-/obj/machinery/door/airlock/security,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "bct" = (
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
@@ -4639,12 +4564,9 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/security/ghetto)
 "bfG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood/parquet,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/grimy,
 /area/station/maintenance/ghetto/fore/starboard)
 "bfK" = (
 /obj/structure/table/reinforced,
@@ -4696,8 +4618,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "bgA" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/obj/structure/grille,
+/turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "bgE" = (
 /turf/open/openspace,
@@ -4733,18 +4655,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
-"bgP" = (
-/obj/machinery/transport/guideway_sensor{
-	pixel_x = -12
-	},
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 1
-	},
-/obj/machinery/atmos_shield_gen/active{
-	dir = 4
-	},
-/turf/open/indestructible/tram,
-/area/station/maintenance/ghetto/fore/starboard)
 "bgS" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -4767,13 +4677,8 @@
 "bhg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/small/directional/west,
-/obj/structure/railing/corner/end{
-	dir = 4
-	},
-/obj/structure/railing/corner/end/flip{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor/iron,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "bhl" = (
 /obj/effect/spawner/random/structure/chair_maintenance{
@@ -4876,10 +4781,13 @@
 /turf/open/floor/iron/dark/small,
 /area/station/commons/vacant_room/commissary)
 "bir" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/iron,
-/area/station/commons/locker)
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "biw" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -4891,15 +4799,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "biy" = (
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "biB" = (
 /obj/machinery/door/airlock/maintenance,
@@ -4907,14 +4810,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "biC" = (
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 1
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
 	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "biJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -5016,11 +4917,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "bjm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard/west)
 "bjq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5129,11 +5031,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bkB" = (
-/obj/structure/table,
-/obj/item/newspaper,
-/obj/item/cigarette/pipe,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/structure/table/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "bkE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5141,15 +5043,17 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "bkN" = (
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic,
-/obj/structure/sign/tram_plate/directional/south,
-/obj/structure/closet/emcloset,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/light/small/directional/south,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "bkP" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
@@ -5168,13 +5072,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "bll" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/sign/calendar/directional/north,
-/turf/open/floor/wood/parquet,
+/obj/structure/table/wood,
+/obj/item/folder,
+/obj/item/pen,
+/turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "blo" = (
 /obj/machinery/conveyor{
@@ -5276,9 +5177,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "bmk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -5348,9 +5246,13 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "bnC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/department/medical/ghetto/central)
 "bnD" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -5415,15 +5317,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/gravity_generator)
-"boU" = (
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/turf/open/indestructible/tram,
-/area/station/maintenance/ghetto/fore/starboard)
 "boY" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/yellow{
@@ -5628,12 +5521,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
-"bqT" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/rack,
-/obj/item/storage/belt/utility,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
 "bqY" = (
 /turf/closed/wall,
 /area/station/maintenance/department/medical/ghetto)
@@ -5751,12 +5638,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "brP" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "brQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/corporate{
@@ -5815,9 +5705,17 @@
 /turf/open/floor/wood/parquet,
 /area/station/hallway/secondary/service)
 "bsA" = (
-/obj/effect/spawner/random/structure/girder,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/dark_green/anticorner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "bsI" = (
 /obj/effect/turf_decal/trimline/dark_blue/line,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -6352,7 +6250,6 @@
 /area/station/maintenance/ghetto/starboard)
 "bzp" = (
 /obj/machinery/vending/coffee,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "bzq" = (
@@ -6379,16 +6276,12 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "bzM" = (
-/obj/structure/railing{
-	dir = 4
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
 	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/textured,
+/turf/open/floor/iron,
 /area/station/commons/locker)
 "bzO" = (
 /obj/machinery/door/firedoor,
@@ -6473,6 +6366,7 @@
 "bBs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/fore)
@@ -6671,16 +6565,11 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "bDA" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/camera/directional/south{
-	c_tag = "Public Shuttle - Reception Point"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/dock)
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/ghetto/fore/starboard)
 "bDC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -6897,14 +6786,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "bFX" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/spawner/random/trash/cigbutt,
+/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "bFY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
 /area/station/hallway/secondary/dock)
 "bFZ" = (
 /obj/machinery/door/poddoor{
@@ -6923,10 +6814,9 @@
 "bGg" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/wood/tile,
+/obj/effect/mapping_helpers/airlock/access/any/service/library,
+/turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
 "bGi" = (
 /turf/closed/wall,
@@ -7109,13 +6999,16 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "bJy" = (
-/obj/item/stack/spacecash/c10{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/station/commons/locker/ghetto)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/sparsegrass/style_3,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/grass/jungle/b/style_random,
+/obj/structure/marker_beacon/lime,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/port)
 "bJE" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/yellow{
@@ -7141,11 +7034,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "bJM" = (
-/obj/structure/stairs/east{
-	dir = 2
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto/morgue)
 "bJQ" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 2";
@@ -7159,11 +7052,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/holding_cell)
-"bJR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/dead_body_placer,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto/morgue)
 "bJW" = (
 /obj/machinery/computer/atmos_alert/station_only,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
@@ -7201,14 +7089,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "bKA" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
-	},
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/floor/grass,
-/area/station/maintenance/department/security/ghetto/aft)
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "bKD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -7350,14 +7233,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "bMl" = (
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/department/security/ghetto/aft)
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
 "bMs" = (
-/obj/structure/transport/linear/tram,
-/obj/structure/tram,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/spawner/random/structure/table,
+/obj/effect/spawner/random/engineering/flashlight,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port/greater)
 "bMt" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
@@ -7412,12 +7300,18 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "bMW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "bNj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7624,16 +7518,10 @@
 "bPD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/fore)
-"bPJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
 "bPK" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -7699,14 +7587,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "bQs" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Library"
-	},
-/turf/open/floor/wood,
-/area/station/service/library)
+/obj/structure/bed/maint,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/medical/minor_healing,
+/turf/open/floor/iron,
+/area/station/maintenance/department/medical/ghetto)
 "bQA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7917,21 +7802,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bTl" = (
-/obj/machinery/transport/crossing_signal/northwest,
-/obj/machinery/transport/guideway_sensor{
-	dir = 1;
-	pixel_x = -12;
-	pixel_y = 20
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/atmos_shield_gen/active{
-	dir = 4
-	},
-/obj/machinery/atmos_shield_gen/active{
-	dir = 8
-	},
-/turf/open/indestructible/tram,
-/area/station/maintenance/ghetto/port/greater)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/medical/ghetto/morgue)
 "bTH" = (
 /turf/closed/wall,
 /area/station/maintenance/starboard/aft)
@@ -8090,10 +7964,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/gravity_generator)
 "bWl" = (
-/obj/effect/spawner/random/structure/tank_holder,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto/aft)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "bWr" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -8126,13 +8002,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"bWM" = (
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
 "bWQ" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/table/wood,
@@ -8148,6 +8017,7 @@
 	pixel_x = 7;
 	pixel_y = 5
 	},
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/wood,
 /area/station/service/bar/backroom/ghetto)
 "bWR" = (
@@ -8604,11 +8474,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
-"cby" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/iron/dark/smooth_edge,
-/area/station/service/bar/backroom/ghetto)
 "cbH" = (
 /obj/structure/chair/stool{
 	dir = 4
@@ -8657,10 +8522,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "cca" = (
-/obj/effect/spawner/random/trash/cigbutt,
+/obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/starboard)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "ccg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -8811,10 +8677,14 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "ceM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/girder,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "ceO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
@@ -8873,22 +8743,23 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"cgg" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
 "cgh" = (
 /obj/structure/table,
 /obj/item/key/janitor,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "cgj" = (
-/obj/effect/spawner/random/medical/minor_healing,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/plating,
-/area/station/hallway/secondary/dock)
+/area/station/maintenance/department/security/ghetto/aft)
 "cgk" = (
 /obj/machinery/turretid{
 	control_area = "/area/station/ai_monitored/turret_protected/ai_upload";
@@ -9022,9 +8893,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "chI" = (
-/obj/machinery/firealarm/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/door/airlock,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "chM" = (
 /obj/effect/spawner/random/structure/girder,
@@ -9088,6 +8960,7 @@
 	pixel_y = 6
 	},
 /obj/item/healthanalyzer,
+/obj/machinery/light/cold/directional/south,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
@@ -9121,14 +8994,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "ciP" = (
-/obj/item/kirbyplants/random{
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/turf/open/floor/wood/parquet,
-/area/station/service/bar/backroom/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/maintenance/department/security/ghetto/aft)
 "ciR" = (
 /obj/machinery/bci_implanter,
 /obj/machinery/light/directional/west,
@@ -9148,12 +9017,14 @@
 	},
 /area/station/hallway/secondary/entry)
 "ciW" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/directional/south,
-/obj/structure/sign/departments/engineering/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "cjc" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -9422,14 +9293,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "cll" = (
-/obj/effect/turf_decal/tile/neutral/tram,
-/obj/structure/transport/linear/tram,
-/obj/effect/landmark/transport/nav_beacon/tram/nav/tramstation/main,
-/obj/effect/landmark/transport/nav_beacon/tram/platform/cyberiad/central,
-/obj/structure/thermoplastic/light,
-/obj/machinery/light/floor/transport,
-/turf/open/indestructible/tram/plate,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "clp" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -9775,8 +9643,15 @@
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "cqh" = (
-/turf/closed/wall/rust,
-/area/station/maintenance/department/medical/ghetto)
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/entertainment/drugs,
+/obj/machinery/door/window/right/directional/south{
+	name = "Ghetto Pharmacy";
+	req_access = list("pharmacy")
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto/central)
 "cqq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood/corner,
@@ -9789,10 +9664,11 @@
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "cqr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron_dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/station/maintenance/ghetto/starboard)
 "cqz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10085,13 +9961,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "cuf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "cui" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/cable,
@@ -10147,10 +10021,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
-"cuH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/bamboo,
-/area/station/service/library/artgallery)
 "cuJ" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -10283,6 +10153,7 @@
 "cwa" = (
 /obj/effect/turf_decal/trimline/white/line,
 /obj/machinery/camera/directional/south{
+	dir = 5;
 	c_tag = "Kitchen - Backroom Lower Floor East"
 	},
 /turf/open/floor/iron/white/corner{
@@ -10338,11 +10209,14 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "cwC" = (
-/obj/structure/fence/cut/medium{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth_half,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "cwE" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -10416,12 +10290,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage/ghetto/depot)
 "cxT" = (
-/obj/effect/spawner/random/trash/graffiti{
-	spawn_loot_chance = 50
-	},
-/obj/machinery/light/small/directional/west,
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/area/station/maintenance/department/medical/ghetto)
 "cxU" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -10538,11 +10409,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical/ghetto)
-"czp" = (
-/obj/structure/sign/warning/vacuum/directional/west,
-/obj/effect/spawner/random/structure/tank_holder,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
 "czs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general{
 	dir = 5
@@ -10835,11 +10701,9 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "cDt" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/dock)
+/obj/effect/spawner/random/engineering/tank,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port/greater)
 "cDv" = (
 /turf/open/floor/iron/stairs/right{
 	dir = 8
@@ -10946,10 +10810,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "cEI" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/spawner/random/trash/grime,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
+/area/station/maintenance/department/medical/ghetto/central)
 "cEJ" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/engine,
@@ -10991,12 +10859,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/gravity_generator)
-"cFe" = (
-/obj/machinery/light/small/directional/east,
-/obj/effect/spawner/random/engineering/atmospherics_portable,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
 "cFg" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -11086,10 +10948,13 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "cGn" = (
-/obj/effect/turf_decal/tile/neutral/tram,
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/indestructible/tram/plate,
-/area/station/maintenance/ghetto/port/greater)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/door/airlock,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto/morgue)
 "cGq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -11167,10 +11032,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "cHg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/barricade/wooden/crude,
+/obj/structure/barricade/wooden,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/fore)
+/area/station/maintenance/ghetto/fore/starboard)
 "cHj" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -11207,9 +11075,7 @@
 /turf/open/floor/iron/grimy,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "cHG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
 "cHH" = (
@@ -11311,31 +11177,31 @@
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "cIM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance/two,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/port)
 "cIN" = (
 /obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/carpet/black,
 /area/station/service/bar)
 "cIS" = (
-/turf/open/floor/wood,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "cIU" = (
 /obj/structure/rack,
 /obj/item/tank/jetpack/carbondioxide,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/command/storage/eva)
 "cJf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/turf/open/floor/iron,
+/area/station/maintenance/department/medical/ghetto)
 "cJj" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
@@ -11350,11 +11216,10 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/storage)
 "cJl" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/iron/stairs/left,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/light/small/directional/east,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "cJm" = (
 /turf/closed/wall,
 /area/station/medical/surgery/fore)
@@ -11486,9 +11351,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "cKv" = (
-/obj/machinery/digital_clock,
-/turf/closed/wall,
-/area/station/maintenance/ghetto/port/greater)
+/obj/structure/bed/maint,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "cKC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -11501,7 +11368,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/area/station/maintenance/ghetto/port)
 "cKJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/sink/directional/east,
@@ -11560,11 +11427,11 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "cLy" = (
+/obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
+/obj/structure/curtain/bounty,
+/obj/item/bedsheet/brown,
+/turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "cLH" = (
 /obj/structure/barricade/wooden,
@@ -11606,12 +11473,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
-"cMc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/station/commons/locker/ghetto)
 "cMf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11719,19 +11580,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "cMT" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/sign/poster/random/directional/east,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/dock)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "cMU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -11854,10 +11708,10 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "cOC" = (
-/obj/structure/fluff/tram_rail/electric,
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/port/greater)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/maintenance/department/medical/ghetto)
 "cOM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12179,12 +12033,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "cSQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/holopad,
-/turf/open/floor/carpet,
-/area/station/commons/locker/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "cSR" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -12208,28 +12062,20 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "cTk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/effect/spawner/random/structure/crate,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/area/station/maintenance/ghetto/port)
 "cTu" = (
-/obj/structure/table,
-/obj/item/storage/backpack{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/storage/backpack,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/obj/structure/sign/map/right{
-	pixel_y = -32
-	},
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
+/obj/effect/turf_decal/tile/dark_green,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "cTB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -12360,12 +12206,12 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/cargo/bitrunning/den)
 "cUx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/fore)
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/mob/living/basic/cockroach,
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "cUz" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law{
@@ -12564,15 +12410,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
-"cWP" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/textured_half,
-/area/station/commons/locker)
 "cWQ" = (
 /obj/machinery/computer/prisoner/gulag_teleporter_computer,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -12581,13 +12418,12 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "cWR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/item/kirbyplants/random,
+/obj/effect/spawner/random/trash/graffiti{
+	spawn_loot_chance = 50
 	},
-/obj/machinery/requests_console/auto_name/directional/west,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "cWS" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/misc/grass,
@@ -12601,13 +12437,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"cXa" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/effect/spawner/random/decoration,
-/turf/open/floor/iron,
-/area/station/maintenance/department/medical/ghetto)
 "cXd" = (
 /obj/machinery/light/directional/north,
 /obj/effect/spawner/random/vending/colavend,
@@ -12792,8 +12621,16 @@
 /turf/open/floor/carpet/black,
 /area/station/maintenance/starboard/fore)
 "cYY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor/iron_dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "cYZ" = (
 /obj/structure/easel,
@@ -12908,13 +12745,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "cZT" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
+/obj/structure/table/wood,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "cZU" = (
 /obj/structure/table/optable{
 	desc = "A cold, hard place for your final rest.";
@@ -13145,13 +12979,6 @@
 "dcs" = (
 /turf/closed/wall,
 /area/station/engineering/atmos)
-"dct" = (
-/obj/structure/fence/door,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
 "dcy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -13368,13 +13195,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "dfX" = (
-/obj/structure/table/wood/fancy/blue,
-/obj/structure/sign/painting/library_secure{
-	pixel_y = -32
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/door/window/left/directional/north,
-/turf/open/floor/wood/tile,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/sepia,
 /area/station/service/library/artgallery)
 "dgb" = (
 /obj/structure/table,
@@ -13468,13 +13293,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "dhq" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "dhv" = (
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
@@ -13533,10 +13356,7 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "dhZ" = (
-/obj/structure/transport/linear/tram,
-/obj/structure/tram/split,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/indestructible/plating,
+/turf/closed/wall/rust,
 /area/station/maintenance/ghetto/central/fore)
 "dib" = (
 /obj/item/target/clown,
@@ -13552,14 +13372,12 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/medical/break_room)
 "dif" = (
-/obj/effect/turf_decal/tile/neutral/tram,
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic,
-/obj/structure/chair/sofa/bench/tram/left{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/turf/open/indestructible/tram/plate,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/iv_drip,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "dii" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13578,7 +13396,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "dip" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13601,14 +13419,12 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "diB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+/obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "diG" = (
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/plating/airless,
@@ -13832,9 +13648,6 @@
 "dkL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "dkM" = (
@@ -13849,9 +13662,11 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/port)
 "dkO" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/atmospherics/components/unary/outlet_injector/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "dkQ" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/effect/turf_decal/stripes/corner{
@@ -14074,10 +13889,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "dmZ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood/parquet,
+/obj/structure/table/wood,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "dna" = (
 /turf/closed/wall,
@@ -14114,16 +13927,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
 "dnQ" = (
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 8
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/obj/machinery/camera/directional/north{
-	c_tag = "Locker Room Lower Floor"
-	},
-/obj/structure/sign/departments/tram/directional/north,
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "doe" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/item/paper/crumpled,
@@ -14153,14 +13961,12 @@
 /turf/open/misc/grass,
 /area/station/security/prison/garden)
 "dow" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "service_station_shutters";
-	name = "Service Station Shutters"
-	},
-/obj/structure/fence{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/crate_loot,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/ghetto/central/fore)
 "doz" = (
 /turf/open/space/basic,
@@ -14316,13 +14122,9 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/department/security/ghetto)
 "dqr" = (
-/obj/effect/spawner/random/trash/cigbutt,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/port/greater)
 "dqU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14487,11 +14289,14 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "dsx" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth_half,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/spawner/random/trash/grime,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "dsD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
@@ -14528,13 +14333,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "dsP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/spawner/random/structure/closet_private,
-/turf/open/floor/iron/dark,
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "dsQ" = (
 /obj/structure/railing{
@@ -14598,7 +14399,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/table_or_rack,
 /obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "dtX" = (
 /obj/structure/kitchenspike,
@@ -14725,12 +14526,14 @@
 /turf/closed/wall,
 /area/station/medical/medbay/lobby)
 "dvm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/barricade,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto/central)
 "dvv" = (
 /obj/machinery/door/window/brigdoor/left/directional/east{
 	name = "Secure Creature Pen";
@@ -14761,7 +14564,7 @@
 "dvA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/bathroom,
+/obj/machinery/door/airlock,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
@@ -14772,11 +14575,12 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "dvK" = (
-/obj/machinery/atmospherics/components/tank/air/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "dvQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14784,28 +14588,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "dwb" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/tram/warning{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/tram/mid_joiner{
-	dir = 1
-	},
-/obj/structure/rack,
-/obj/item/chair/plastic{
-	pixel_y = 8
-	},
-/obj/item/chair/plastic{
-	pixel_y = 14
-	},
-/obj/item/chair/plastic{
-	pixel_y = 19
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 1
-	},
-/area/station/service/bar/backroom/ghetto)
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "dwg" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
@@ -15051,11 +14843,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical/ghetto)
 "dzN" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/random/maintenance/two,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "dzQ" = (
 /obj/structure/railing{
 	dir = 1
@@ -15228,12 +15019,12 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "dBQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/maint,
-/obj/effect/spawner/random/bedsheet/any,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "dBT" = (
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/wood/large,
@@ -15460,12 +15251,14 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/gravity_generator)
 "dEP" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/machinery/stasis,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/obj/effect/spawner/random/medical/minor_healing,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "dEY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -15497,15 +15290,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"dFG" = (
-/obj/structure/bed,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain/bounty,
-/obj/item/bedsheet/brown,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/wood,
-/area/station/maintenance/ghetto/fore/starboard)
 "dFH" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -15527,10 +15311,14 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
 "dFI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/port/fore)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 1
+	},
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "dFK" = (
 /turf/open/openspace,
 /area/station/service/library)
@@ -15570,11 +15358,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "dGe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/area/station/maintenance/ghetto/port/greater)
 "dGf" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
@@ -15583,12 +15369,17 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "dGn" = (
-/obj/structure/fence{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "dGo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/siding/wood{
@@ -15617,10 +15408,9 @@
 /turf/open/floor/carpet,
 /area/station/service/library)
 "dGC" = (
-/obj/machinery/door/airlock/engineering,
+/obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "dGF" = (
@@ -15647,16 +15437,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"dGV" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 5
-	},
-/obj/structure/flora/rock/pile/jungle/style_5,
-/obj/structure/railing{
-	dir = 5
-	},
-/turf/open/floor/grass,
-/area/station/maintenance/department/security/ghetto/aft)
 "dGY" = (
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
@@ -15773,14 +15553,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"dIH" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/cold/directional/south,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
 "dIJ" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/effect/decal/cleanable/dirt,
@@ -15870,12 +15642,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/prison/ghetto)
 "dJQ" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/structure/table,
+/obj/effect/spawner/random/mod/maint,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "dJU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -15933,11 +15702,13 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/checkpoint/medical)
 "dKD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/aft)
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/random/dead,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "dKE" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/maintenance,
@@ -16046,13 +15817,6 @@
 /obj/effect/turf_decal/tile/green/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"dLw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
 "dLz" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -16124,6 +15888,7 @@
 "dNb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
@@ -16289,12 +16054,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
 "dPX" = (
+/obj/structure/closet/secure_closet/personal,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "dQe" = (
 /obj/machinery/door/airlock/maintenance,
@@ -16387,8 +16149,10 @@
 /turf/open/floor/wood/parquet,
 /area/station/hallway/secondary/service)
 "dRE" = (
-/obj/structure/fluff/tram_rail/end,
-/turf/open/indestructible/plating,
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "dRK" = (
 /obj/effect/turf_decal/stripes/line{
@@ -16570,16 +16334,11 @@
 /area/station/maintenance/department/prison)
 "dUG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 8
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 1
 	},
-/obj/structure/chair/comfy/teal{
-	dir = 4
-	},
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "dUK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
@@ -16648,11 +16407,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/hydroponics/ghetto)
-"dVQ" = (
-/obj/effect/spawner/random/trash/bucket,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
 "dVT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16846,11 +16600,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "dXW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/medical/ghetto/morgue)
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "dXY" = (
 /obj/structure/railing{
 	dir = 4
@@ -16930,11 +16685,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "dZt" = (
-/obj/structure/fluff/tram_rail/electric,
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic/light,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "dZC" = (
 /obj/structure/table,
 /obj/item/toy/crayon/spraycan,
@@ -16945,11 +16700,14 @@
 /turf/open/floor/iron/stairs/medium,
 /area/station/hallway/secondary/exit/departure_lounge)
 "dZS" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/machinery/door/airlock/multi_tile{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto/central)
 "dZX" = (
 /obj/item/ammo_casing/rebar/paperball{
 	pixel_x = 11;
@@ -16992,7 +16750,9 @@
 /turf/open/floor/plating,
 /area/station/science/lab)
 "eag" = (
-/turf/open/floor/catwalk_floor/iron_dark,
+/obj/effect/spawner/random/trash/hobo_squat,
+/obj/structure/sign/directions/dorms/directional/north,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "ean" = (
 /obj/structure/plasticflaps/opaque,
@@ -17133,15 +16893,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/trash)
 "ebI" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain/cloth/fancy/mechanical{
+	id = "ghetto_theatre";
+	name = "Curtains"
 	},
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "ebN" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -17217,13 +16975,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "ecD" = (
-/obj/effect/turf_decal/tile/neutral/tram,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line,
-/turf/open/indestructible/tram/plate,
-/area/station/maintenance/ghetto/port/greater)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "ecP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/south,
@@ -17284,12 +17040,14 @@
 /turf/open/floor/iron/kitchen/small,
 /area/station/service/kitchen/kitchen_backroom/ghetto)
 "edF" = (
-/obj/structure/fluff/tram_rail/electric,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "edG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -17316,8 +17074,14 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "edP" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor/iron_dark,
+/turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "edY" = (
 /obj/machinery/computer/operating{
@@ -17699,8 +17463,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/sorting)
 "ejp" = (
-/obj/machinery/transport/power_rectifier,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/frame/computer,
+/obj/item/stack/cable_coil,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "ejr" = (
@@ -17983,10 +17747,12 @@
 	},
 /area/station/security/checkpoint/customs)
 "end" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/area/station/maintenance/department/medical/ghetto)
 "eng" = (
 /turf/closed/wall,
 /area/station/medical/paramedic)
@@ -18088,12 +17854,9 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/central/aft)
 "eox" = (
-/obj/machinery/door/airlock/medical,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/structure/barricade/wooden,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "eoG" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -18278,13 +18041,6 @@
 /obj/item/flashlight/flare/candle,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
-"erm" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/rack,
-/obj/effect/spawner/random/mod/maint,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
 "err" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/yellow{
@@ -18362,9 +18118,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "esN" = (
-/obj/effect/turf_decal/tile/neutral/tram,
-/turf/open/indestructible/tram/plate,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/machinery/light/small/directional/west,
+/obj/structure/table,
+/obj/effect/spawner/random/medical/minor_healing,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "esV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 8
@@ -18425,12 +18183,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"eup" = (
-/obj/structure/fluff/tram_rail/electric/anchor{
-	dir = 1
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/port/greater)
 "euv" = (
 /obj/effect/turf_decal/tile/dark/half,
 /turf/open/floor/iron,
@@ -18787,12 +18539,6 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron,
 /area/station/security/office)
-"eAc" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/port)
 "eAf" = (
 /obj/item/radio/intercom/chapel/directional/east,
 /obj/structure/chair,
@@ -18906,13 +18652,15 @@
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "eBh" = (
-/obj/structure/railing/corner,
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/textured,
-/area/station/commons/locker)
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "eBj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/molten_object/large,
@@ -18928,19 +18676,12 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/fore)
 "eBA" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/trimline/tram/filled/line{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 1
-	},
-/obj/machinery/button/transport/tram/directional/north{
-	id = 3
-	},
-/obj/machinery/transport/destination_sign/indicator/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "eBC" = (
 /obj/structure/table,
@@ -18961,12 +18702,15 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
 "eBD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/aft)
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port/greater)
 "eBF" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/floodlight_frame/completed,
@@ -19050,22 +18794,22 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
 "eCW" = (
-/obj/structure/sign/directions/arrival/directional/north{
-	dir = 8
+/obj/structure/firelock_frame{
+	anchored = 1
 	},
-/obj/structure/railing/platform/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "eCX" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/service/bar,
-/obj/machinery/door/airlock/maintenance,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/service/bar/backroom/ghetto)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/stasis{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "eDc" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -19089,15 +18833,9 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "eDv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "eDw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -19128,16 +18866,10 @@
 /turf/open/floor/stone,
 /area/station/service/hydroponics)
 "eDR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/remains/human,
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/spawner/structure/window,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto/central)
 "eDS" = (
 /obj/effect/turf_decal/loading_area,
 /obj/item/radio/intercom/directional/north,
@@ -19220,10 +18952,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
 "eFw" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port)
 "eFx" = (
@@ -19686,13 +19415,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics/ghetto)
-"eKm" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/engineering/flashlight,
-/obj/item/stock_parts/power_store/cell/empty,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/aft)
 "eKq" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/port/fore)
@@ -19761,8 +19483,7 @@
 /area/station/maintenance/starboard/aft)
 "eLo" = (
 /obj/effect/spawner/random/trash/garbage,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/fore)
 "eLF" = (
 /obj/machinery/light/directional/east,
@@ -19839,7 +19560,6 @@
 "eME" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "eMH" = (
@@ -19935,10 +19655,13 @@
 /turf/open/floor/iron/telecomms,
 /area/station/tcommsat/server)
 "eNS" = (
-/obj/machinery/door/airlock/public,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/spawner/random/trash/garbage,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "eNU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -20188,14 +19911,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"eRQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/light/small/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/fore)
 "eRT" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -20231,8 +19946,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "eSj" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/indestructible/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/grimy,
 /area/station/maintenance/ghetto/fore/starboard)
 "eSk" = (
 /obj/effect/turf_decal/siding/dark{
@@ -20314,27 +20031,14 @@
 /area/station/maintenance/ghetto/sorting)
 "eTx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto/central)
 "eTz" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"eTC" = (
-/obj/structure/railing,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/catwalk_floor/iron,
-/area/station/maintenance/ghetto/port/greater)
 "eTD" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 8;
@@ -20351,11 +20055,9 @@
 /area/station/maintenance/port)
 "eTK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/knife,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/table/wood,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "eTT" = (
 /obj/machinery/portable_atmospherics/scrubber,
@@ -20363,18 +20065,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/engine,
 /area/station/science/lower)
-"eUc" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/emergency,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/obj/structure/sign/map/left{
-	pixel_y = -32
-	},
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
 "eUd" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -20538,11 +20228,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "eWi" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "eWk" = (
 /obj/structure/railing{
 	dir = 8
@@ -20851,11 +20545,18 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "faT" = (
-/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto/morgue)
+/area/station/maintenance/ghetto/central/fore)
 "faU" = (
 /obj/structure/showcase/cyborg/old{
 	dir = 4;
@@ -20887,15 +20588,8 @@
 	},
 /area/station/engineering/atmos)
 "fbp" = (
-/obj/machinery/light/small/directional/north,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/effect/spawner/random/entertainment/wallet_storage,
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/turf/open/floor/wood/large,
+/area/station/maintenance/ghetto/port)
 "fbw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -20970,12 +20664,8 @@
 /area/station/medical/virology)
 "fcz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/effect/spawner/random/medical/minor_healing,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto/central)
 "fcC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue,
@@ -21097,13 +20787,11 @@
 /turf/open/floor/iron/telecomms,
 /area/station/tcommsat/server)
 "fei" = (
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 1
+/obj/structure/fermenting_barrel{
+	desc = "A dried up barrel of what appeared to once have been full of wine.";
+	name = "cask"
 	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "fer" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21135,8 +20823,6 @@
 "feT" = (
 /obj/structure/bed/medical/emergency,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
 "feV" = (
@@ -21284,18 +20970,6 @@
 	dir = 8
 	},
 /area/station/service/chapel)
-"fgH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto/aft)
 "fgR" = (
 /obj/effect/turf_decal/trimline/tram/line,
 /obj/structure/cable,
@@ -21334,12 +21008,12 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "fgZ" = (
-/obj/structure/holosign/barrier/atmos/tram,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/port/greater)
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "fhe" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -21537,9 +21211,12 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "fjr" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth_large,
-/area/station/maintenance/ghetto/central/fore)
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "fjs" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/storage_shared)
@@ -21586,13 +21263,10 @@
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "fjE" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron/stairs/right{
-	color = "#9a9a9a"
-	},
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/effect/turf_decal/tile/dark_green/anticorner,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "fjH" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmoslock";
@@ -21753,14 +21427,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage/ghetto)
 "flF" = (
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/mess,
-/turf/open/floor/iron,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "flM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21884,12 +21552,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "fmY" = (
-/obj/machinery/firealarm/directional/north,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/dark/side{
-	dir = 5
-	},
-/area/station/hallway/secondary/dock)
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "fnc" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -21918,7 +21583,7 @@
 /area/station/service/library)
 "fnE" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/fore)
 "fnG" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
@@ -22109,11 +21774,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
 "fqD" = (
-/obj/structure/fluff/tram_rail/end{
-	dir = 4
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/port/greater)
+/turf/open/floor/iron,
+/area/station/maintenance/department/security/ghetto/aft)
 "fqE" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/airalarm/directional/west,
@@ -22254,12 +21916,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
-"frZ" = (
-/obj/structure/chair/sofa/bench/right{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/aft)
 "fse" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22419,9 +22075,11 @@
 /area/station/engineering/hallway)
 "fuc" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/area/station/maintenance/ghetto/port)
 "fuk" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -22488,12 +22146,10 @@
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "fuM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron,
-/area/station/commons/locker)
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/bookcase/random,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "fuT" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -22926,7 +22582,13 @@
 /turf/open/floor/plating,
 /area/station/engineering/hallway/west)
 "fzZ" = (
-/turf/open/openspace,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/structure/table,
+/obj/item/toy/gun,
+/turf/open/floor/iron,
 /area/station/commons/locker)
 "fAb" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
@@ -22986,17 +22648,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"fAS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 1
-	},
-/obj/machinery/transport/crossing_signal/northwest,
-/obj/machinery/atmos_shield_gen/active{
-	dir = 8
-	},
-/turf/open/indestructible/tram,
-/area/station/maintenance/ghetto/fore/starboard)
 "fAT" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -23422,8 +23073,10 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "fFu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "fFB" = (
 /obj/machinery/conveyor{
@@ -23503,22 +23156,15 @@
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "fGs" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
-"fGv" = (
-/obj/machinery/photocopier/prebuilt,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/dock)
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "fGz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23636,14 +23282,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "fHp" = (
-/obj/effect/spawner/random/engineering/canister,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bookcase,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "fHt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood/parquet,
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/fore/starboard)
 "fHC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23765,12 +23413,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "fIL" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 1
 	},
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "fIQ" = (
 /obj/item/coin/gold,
 /obj/machinery/computer/slot_machine,
@@ -23895,14 +23545,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "fKu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/machinery/door/airlock,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/spawner/random/structure/barricade,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "fKw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24030,9 +23679,11 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/theater)
 "fLV" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard/west)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "fLX" = (
 /obj/effect/turf_decal/tile/green/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -24338,13 +23989,11 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
 "fQm" = (
-/obj/machinery/door/airlock/medical,
-/obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/starboard)
 "fQy" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 4
@@ -24371,13 +24020,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/service/chapel/monastery)
-"fQQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/fore/starboard)
 "fQS" = (
 /obj/effect/landmark/firealarm_sanity,
 /turf/open/openspace,
@@ -24423,8 +24065,10 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "fRD" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/catwalk_floor/iron_dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "fRG" = (
 /obj/structure/table/wood/poker,
@@ -24700,9 +24344,18 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
 "fUE" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
+	color = "#ff0000";
+	name = "Scrubbers multi deck pipe adapter";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
+	color = "#0000ff";
+	name = "Supply multi deck pipe adapter";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "fUI" = (
 /obj/structure/closet,
 /obj/item/poster/random_contraband,
@@ -24813,8 +24466,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "fWl" = (
-/turf/closed/wall/rust,
-/area/station/commons/locker/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "fWn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25017,9 +24680,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
 "fYU" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/starboard)
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port/greater)
 "fYY" = (
 /obj/structure/railing/corner,
 /turf/open/floor/grass,
@@ -25050,9 +24713,9 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/upper)
 "fZq" = (
-/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "fZs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -25085,20 +24748,26 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "fZI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 8
 	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/port/greater)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "fZJ" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/crayon/spraycan{
+	pixel_x = 3;
+	pixel_y = 6
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/item/chisel{
+	pixel_x = -4;
+	pixel_y = 4
 	},
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "fZP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -25123,15 +24792,13 @@
 /turf/open/floor/wood/parquet,
 /area/station/hallway/secondary/service)
 "gag" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/graffiti{
+	spawn_loot_chance = 50
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
 "gaj" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating,
@@ -25190,16 +24857,16 @@
 /turf/open/floor/iron,
 /area/station/security/range)
 "gaR" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/table,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
+/area/station/maintenance/ghetto/port/greater)
 "gaS" = (
-/obj/structure/chair/stool{
-	dir = 8
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
+/obj/machinery/washing_machine,
+/turf/open/floor/iron/cafeteria,
 /area/station/commons/locker)
 "gaU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -25306,12 +24973,18 @@
 /turf/open/floor/stone,
 /area/station/maintenance/ghetto/starboard)
 "gcf" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/item/cigbutt,
+/obj/item/cigbutt{
+	pixel_y = 11;
+	pixel_x = -9
 	},
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
+/obj/effect/decal/cleanable/ash{
+	pixel_x = 2;
+	pixel_y = 9
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "gcr" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -25606,19 +25279,6 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"gga" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/tram/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/tram/mid_joiner{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 1
-	},
-/area/station/service/bar/backroom/ghetto)
 "ggc" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -25904,12 +25564,9 @@
 /turf/open/openspace,
 /area/station/service/kitchen/kitchen_backroom)
 "gkh" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/structure/sign/directions/arrival/directional/west,
 /turf/open/floor/iron,
-/area/station/hallway/secondary/dock)
+/area/station/maintenance/ghetto/port)
 "gkn" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
@@ -26012,9 +25669,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
 "glK" = (
+/obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/fore)
+/obj/structure/destructible/cult/item_dispenser/archives/library,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "glP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -26054,13 +25713,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "gmH" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/barricade,
+/turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "gmK" = (
 /obj/machinery/newscaster/directional/north,
@@ -26374,10 +26031,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "gqH" = (
-/obj/structure/table,
-/obj/item/paper,
-/turf/open/floor/iron/dark/side,
-/area/station/hallway/secondary/dock)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "gqL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26404,37 +26062,31 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "gqX" = (
-/obj/structure/chair{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/tram/warning{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/tram/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/tram/mid_joiner{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/sign/warning/directional/south,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/dock)
+/obj/machinery/vending/wardrobe/bar_wardrobe,
+/obj/machinery/status_display/evac/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/smooth_corner,
+/area/station/service/bar/backroom/ghetto)
 "grg" = (
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic,
-/obj/structure/chair/sofa/bench/tram/left{
-	dir = 1
-	},
-/obj/machinery/computer/tram_controls/split/directional/south,
-/turf/open/indestructible/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "grk" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 9
-	},
-/obj/structure/flora/rock/pile/jungle/style_5,
-/obj/structure/railing{
-	dir = 9
-	},
-/turf/open/floor/grass,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/frame/computer,
+/turf/open/floor/iron,
 /area/station/maintenance/department/security/ghetto/aft)
 "grl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26470,8 +26122,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "grQ" = (
-/obj/structure/fluff/tram_rail/electric,
-/turf/open/indestructible/plating,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "grU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26609,14 +26267,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "gtv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/multi_tile,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/barricade/wooden,
 /turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
+/area/station/maintenance/department/medical/ghetto/central)
 "gtG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/splatter/oil,
@@ -26664,10 +26321,12 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "gup" = (
-/obj/effect/spawner/random/trash/garbage,
+/obj/structure/chair{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "gur" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -26676,11 +26335,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
 "guA" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/central/fore)
+/obj/structure/bookcase/random,
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "guC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26690,15 +26347,6 @@
 /area/station/maintenance/ghetto/central)
 "guN" = (
 /turf/closed/wall,
-/area/station/maintenance/ghetto/central/fore)
-"guU" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/rack,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_y = 4
-	},
-/obj/item/stack/sheet/iron/fifty,
-/turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/central/fore)
 "gve" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -26748,6 +26396,10 @@
 /area/station/engineering/atmos)
 "gwo" = (
 /obj/machinery/light/small/directional/south,
+/obj/machinery/camera/directional/east{
+	c_tag = "Library - South";
+	dir = 2
+	},
 /turf/open/floor/wood,
 /area/station/service/library)
 "gwp" = (
@@ -26789,18 +26441,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "gwH" = (
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 1
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 1
-	},
-/obj/machinery/button/transport/tram/directional/north{
-	id = 2
-	},
-/obj/machinery/transport/destination_sign/indicator/directional/north,
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron,
-/area/station/maintenance/ghetto/central/fore)
+/area/station/commons/locker)
 "gwK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26884,16 +26530,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "gxJ" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/structure/closet/crate/trashcart/laundry,
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/camera/directional/south{
-	c_tag = "Locker Room Lower Floor - Laundry"
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "gxS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow,
@@ -26920,19 +26562,12 @@
 /turf/open/floor/wood,
 /area/station/maintenance/aft)
 "gyg" = (
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/transport/crossing_signal/northwest,
-/obj/machinery/atmos_shield_gen/active{
-	dir = 8
-	},
-/turf/open/indestructible/tram,
-/area/station/maintenance/ghetto/fore/starboard)
-"gyB" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "gyK" = (
 /obj/machinery/gibber,
@@ -27171,20 +26806,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "gBP" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/tram/warning{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/tram/mid_joiner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/tram/mid_joiner{
-	dir = 8
-	},
-/obj/machinery/vending/wardrobe/bar_wardrobe,
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron/dark/smooth_corner,
-/area/station/service/bar/backroom/ghetto)
+/obj/machinery/photocopier/prebuilt,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "gBR" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -27201,8 +26825,10 @@
 /turf/open/floor/carpet,
 /area/station/commons/vacant_room/office)
 "gCc" = (
-/obj/effect/spawner/random/trash/graffiti,
-/turf/open/floor/iron,
+/obj/structure/easel,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/canvas/twentythree_twentythree,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "gCj" = (
 /obj/machinery/light/directional/north,
@@ -27258,10 +26884,10 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "gCL" = (
-/obj/effect/turf_decal/tile/neutral/tram,
-/obj/effect/landmark/transport/nav_beacon/tram/platform/cyberiad/west,
-/turf/open/indestructible/tram/plate,
-/area/station/maintenance/ghetto/port/greater)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron,
+/area/station/maintenance/department/security/ghetto/aft)
 "gCM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -27356,24 +26982,26 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay/ghetto)
 "gEh" = (
-/obj/structure/transport/linear/tram,
-/obj/structure/tram/split,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/dark_green/half{
 	dir = 1
 	},
-/obj/machinery/transport/destination_sign/split/north,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "gEj" = (
-/obj/effect/turf_decal/siding/white{
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "gEm" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood/parquet,
@@ -27606,7 +27234,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/sign/warning/vacuum/directional/north,
+/obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "gHv" = (
@@ -27768,14 +27396,14 @@
 /area/station/engineering/storage/tech)
 "gIC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 8
-	},
-/obj/structure/chair/comfy/teal{
+/obj/structure/chair/office{
 	dir = 4
 	},
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/grimy,
+/area/station/maintenance/ghetto/fore/starboard)
 "gIH" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/iron/dark,
@@ -27815,14 +27443,12 @@
 /turf/open/floor/iron/grimy,
 /area/station/hallway/secondary/entry)
 "gJe" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clipboard,
+/obj/item/folder/red,
+/turf/open/floor/carpet,
+/area/station/maintenance/ghetto/fore/starboard)
 "gJq" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -28145,6 +27771,7 @@
 /obj/effect/turf_decal/trimline/tram/warning,
 /obj/effect/turf_decal/trimline/tram/mid_joiner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/service/bar/backroom/ghetto)
@@ -28579,7 +28206,7 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/spawner/random/maintenance/four,
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "gQF" = (
 /obj/structure/disposalpipe/segment{
@@ -28723,15 +28350,18 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "gTC" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/tram/warning{
-	dir = 8
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
 	},
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 8
-	},
-/area/station/service/bar/backroom/ghetto)
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/ghetto/port)
 "gTU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29159,8 +28789,6 @@
 /area/station/medical/surgery/aft)
 "gZc" = (
 /obj/structure/closet,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "gZj" = (
@@ -29263,12 +28891,6 @@
 "had" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/ghetto/port)
-"hae" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
 "hah" = (
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
@@ -29371,14 +28993,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "hbM" = (
-/obj/structure/transport/linear/tram,
-/obj/structure/tram,
-/obj/machinery/transport/tram_controller,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/space_heater/improvised_chem_heater,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "hbO" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -29619,19 +29237,13 @@
 /obj/structure/sign/warning/electric_shock/directional/west,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
-"hfE" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
 "hfG" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "hfN" = (
-/obj/structure/frame,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto/central)
 "hfO" = (
 /obj/effect/landmark/navigate_destination/dockescpod4,
 /obj/machinery/door/airlock/external,
@@ -29843,11 +29455,13 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "hhW" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/barricade/wooden/crude,
-/obj/machinery/door/poddoor/shutters,
-/turf/open/floor/plating,
-/area/station/security/medical)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "hhY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -29856,14 +29470,14 @@
 /turf/open/floor/iron/large,
 /area/station/security/checkpoint/arrivals)
 "hia" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/caution/stand_clear/white{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/indestructible/tram,
-/area/station/maintenance/ghetto/port/greater)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "hif" = (
 /obj/item/gun/ballistic/shotgun/toy/crossbow,
 /turf/open/floor/plating,
@@ -30103,17 +29717,10 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "hll" = (
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "hlo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30234,10 +29841,10 @@
 /turf/open/floor/iron/kitchen_coldroom/dark,
 /area/station/service/kitchen/coldroom/ghetto)
 "hmU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "hmV" = (
@@ -30357,11 +29964,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "hnY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/station/commons/locker/ghetto)
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "hnZ" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -30449,17 +30056,9 @@
 	},
 /area/station/maintenance/starboard/fore)
 "hoU" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/tram/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/tram/mid_joiner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 8
-	},
-/area/station/service/bar/backroom/ghetto)
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "hoZ" = (
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/carpet/royalblack,
@@ -30634,10 +30233,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
 "hrl" = (
-/obj/structure/table,
-/obj/item/toy/gun,
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
 /area/station/commons/locker)
 "hru" = (
 /obj/structure/rack,
@@ -30685,9 +30284,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "hsa" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/commons/locker/ghetto)
+/obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/item/food/grown/tomato{
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/port)
 "hsc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -30916,17 +30519,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage/ghetto)
 "hvt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/engineering,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
+/obj/structure/table/wood/fancy/blue,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/door/window/left/directional/north,
+/obj/structure/sign/painting/library_secure{
+	pixel_y = -32
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
+/turf/open/floor/wood/tile,
+/area/station/service/library/artgallery)
 "hvB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31068,6 +30668,7 @@
 "hxb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/fore)
@@ -31087,12 +30688,8 @@
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
 "hxj" = (
-/obj/structure/table,
-/obj/item/radio{
-	icon_state = "radio"
-	},
-/obj/structure/sign/directions/dorms/directional/north,
-/turf/open/floor/iron,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "hxl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31411,9 +31008,11 @@
 /turf/open/floor/asphalt,
 /area/station/maintenance/ghetto/garden)
 "hBs" = (
-/obj/structure/fence/door,
-/turf/open/floor/iron/smooth_half,
-/area/station/maintenance/ghetto/central/fore)
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/service/library)
 "hBy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31421,10 +31020,15 @@
 /turf/open/floor/iron/grimy,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "hBH" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/crate,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "hBI" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/caution/stand_clear{
@@ -31502,11 +31106,12 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/gravity_generator)
 "hCs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/medical/anchored{
+	dir = 1
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/area/station/maintenance/department/medical/ghetto/central)
 "hCw" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/wood,
@@ -31546,11 +31151,11 @@
 /turf/open/floor/wood/large,
 /area/station/service/theater)
 "hCO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard/west)
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/iron/sepia,
+/area/station/service/library/artgallery)
 "hCT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31664,14 +31269,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/station/command/heads_quarters/captain/private)
-"hDQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
 "hDR" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -31835,10 +31432,6 @@
 /obj/machinery/iv_drip,
 /obj/item/reagent_containers/blood,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/camera/directional/south{
-	c_tag = "Brig - Lower Floor - Infirmary"
-	},
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
 "hFc" = (
@@ -31851,11 +31444,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
-"hFo" = (
-/obj/structure/cable,
-/obj/structure/sign/warning/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central/fore)
 "hFx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31964,13 +31552,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/blueshield)
-"hGt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/starboard)
 "hGH" = (
 /obj/machinery/conveyor/inverted{
 	dir = 6;
@@ -32058,10 +31639,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "hHz" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "hHC" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency{
@@ -32155,14 +31738,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"hID" = (
-/obj/structure/fluff/tram_rail/electric,
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic,
-/obj/structure/chair/sofa/bench/tram/left,
-/obj/machinery/computer/tram_controls/split/directional/north,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
 "hIG" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -32588,12 +32163,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"hOf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet/royalblack,
-/area/station/maintenance/ghetto/fore/starboard)
 "hOg" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -32616,10 +32185,12 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
 "hOk" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/turf/open/floor/wood/parquet,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/public,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/barricade/wooden/crude,
+/obj/structure/barricade/wooden,
+/turf/open/floor/iron/grimy,
 /area/station/maintenance/ghetto/fore/starboard)
 "hOm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32652,15 +32223,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"hOv" = (
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
 "hOB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32691,14 +32253,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
-"hOR" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/turf_decal/siding/white,
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/obj/structure/cable,
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
 "hOY" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -32741,8 +32295,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
 "hPH" = (
-/turf/open/floor/carpet,
-/area/station/commons/locker/ghetto)
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/plastic,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "hPO" = (
 /turf/closed/wall,
 /area/station/cargo/sorting)
@@ -32773,29 +32331,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/starboard)
-"hQg" = (
-/obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/wood/parquet,
-/area/station/service/bar/backroom/ghetto)
 "hQm" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "hQo" = (
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 1
+/obj/effect/spawner/random/structure/crate,
+/obj/effect/turf_decal/bot_white,
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/caution_sign,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/ghetto/port/greater)
 "hQL" = (
 /obj/structure/flora/grass/jungle/a/style_random,
@@ -32903,13 +32450,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"hRQ" = (
-/obj/effect/turf_decal/tile/neutral/tram,
-/obj/effect/landmark/transport/transport_id/tramstation/line_1,
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic/light,
-/turf/open/indestructible/tram/plate,
-/area/station/maintenance/ghetto/central/fore)
 "hSa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -33071,9 +32611,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
 "hTS" = (
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance/two,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/corner,
-/turf/open/floor/iron,
+/turf/open/floor/iron/white/herringbone,
 /area/station/maintenance/ghetto/central/fore)
 "hUa" = (
 /obj/machinery/camera/directional/north{
@@ -33106,21 +32647,14 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/theater)
 "hUx" = (
-/obj/structure/chair/comfy/black{
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
-"hUy" = (
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "hUE" = (
 /turf/closed/wall,
@@ -33186,9 +32720,10 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/aft)
 "hVb" = (
-/obj/structure/fluff/tram_rail/floor,
-/turf/open/indestructible/tram,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "hVc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33411,15 +32946,10 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "hYO" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/clothing/costume,
-/obj/machinery/light/small/directional/south,
-/obj/item/toy/foamblade,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "hYU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33518,12 +33048,15 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/ghetto/port)
 "hZr" = (
-/obj/structure/chair/wood{
+/obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "hZs" = (
 /obj/structure/closet/wardrobe/miner,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
@@ -33595,12 +33128,9 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/aft)
 "iat" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/sign/warning/no_smoking/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/machinery/holopad,
+/turf/open/floor/iron,
+/area/station/commons/locker)
 "iax" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -33818,21 +33348,21 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/central)
 "idE" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/textured,
+/obj/structure/table,
+/obj/item/toy/cards/deck,
+/obj/effect/spawner/random/entertainment/dice,
+/turf/open/floor/iron,
 /area/station/commons/locker)
 "idF" = (
-/obj/effect/turf_decal/tile/neutral/tram,
-/turf/open/indestructible/tram/plate,
-/area/station/maintenance/ghetto/port/greater)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "idP" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
@@ -34040,11 +33570,12 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/fore)
 "igO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm/directional/south,
-/obj/effect/spawner/random/maintenance/two,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/area/station/maintenance/ghetto/port)
 "ihc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass,
@@ -34069,14 +33600,11 @@
 /turf/open/floor/engine/cult,
 /area/station/service/library)
 "ihB" = (
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/turf_decal/tile/dark_green,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "ihI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -34187,11 +33715,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/arrivals)
-"iiL" = (
-/obj/effect/spawner/random/trash/bin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
 "iiO" = (
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
@@ -34245,15 +33768,9 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/atmos)
 "ijm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "ijq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34473,13 +33990,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/processing)
-"imh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
 "imo" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -34619,9 +34129,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
-"iox" = (
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/fore)
 "ioz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -34704,11 +34211,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "ipw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
 	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/port/greater)
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "ipy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34759,15 +34269,12 @@
 /turf/closed/wall,
 /area/station/commons/dorms/apartment1)
 "iqc" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/obj/structure/table/glass,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/glasses/hud/health,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "iqj" = (
 /obj/effect/spawner/random/structure/barricade,
 /turf/open/floor/plating,
@@ -34780,9 +34287,11 @@
 /turf/open/floor/iron/stairs/right,
 /area/station/security/holding_cell)
 "iqs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/firealarm_sanity,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto/central)
 "iqu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -34794,15 +34303,10 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "iqH" = (
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
-/area/station/maintenance/ghetto/central/fore)
+/area/station/maintenance/ghetto/fore/starboard)
 "iqM" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -34837,12 +34341,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "iqU" = (
-/obj/structure/fence/post{
-	dir = 4
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 8
 	},
-/obj/structure/sign/warning/electric_shock,
-/turf/open/floor/iron/smooth_half,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "ira" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35183,12 +34687,10 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/nanotrasen_representative)
 "ivj" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
+/obj/structure/noticeboard/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/port)
 "ivw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/structure/closet/crate/preopen,
@@ -35261,12 +34763,12 @@
 /turf/open/floor/iron,
 /area/station/science/research)
 "iwo" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/random,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "iwq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35356,9 +34858,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "iyj" = (
-/obj/structure/fluff/tram_rail/electric,
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/indestructible/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "iym" = (
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -35634,13 +35139,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "iCy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance/two,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "iCz" = (
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
@@ -35722,19 +35226,18 @@
 /turf/open/floor/engine/cult,
 /area/station/service/library)
 "iDA" = (
-/obj/structure/fluff/tram_rail/electric,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/turf/open/floor/iron/stairs/right{
+	dir = 1
 	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/area/station/maintenance/ghetto/port)
 "iDR" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/carpet/black,
 /area/station/maintenance/ghetto/fore/starboard)
 "iDY" = (
-/obj/structure/chair/office,
-/turf/open/floor/iron/dark,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "iEh" = (
 /obj/structure/cable,
@@ -35784,10 +35287,6 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
-"iEC" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron/smooth_large,
-/area/station/maintenance/ghetto/central/fore)
 "iEL" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/syringe/contraband/bath_salts{
@@ -35810,9 +35309,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/small,
 /area/station/security/interrogation/ghetto)
-"iET" = (
-/turf/open/floor/noslip/tram,
-/area/station/maintenance/ghetto/port/greater)
 "iEU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -35883,15 +35379,9 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/aft)
 "iFL" = (
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic,
-/obj/structure/chair/sofa/bench/tram/right{
-	dir = 4
-	},
-/turf/open/indestructible/plating,
+/obj/effect/spawner/random/trash/grille_or_waste,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "iFM" = (
 /obj/machinery/conveyor{
@@ -36551,7 +36041,6 @@
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white/corner,
 /area/station/service/kitchen/kitchen_backroom/ghetto)
 "iNx" = (
@@ -36727,10 +36216,11 @@
 /turf/open/floor/iron/white,
 /area/station/common/cryopods)
 "iPz" = (
-/obj/effect/spawner/random/trash/cigbutt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/structure/sign/poster/contraband/random/directional/north,
+/obj/machinery/light/small/broken/directional/north,
+/obj/effect/turf_decal/tile/dark/opposingcorners,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/port)
 "iPC" = (
 /obj/structure/table/glass,
 /obj/machinery/camera/directional/north{
@@ -36955,13 +36445,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
-"iSB" = (
-/obj/structure/chair/sofa/bench/left{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/aft)
 "iSE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37010,10 +36493,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "iTk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto/central)
 "iTo" = (
 /obj/effect/spawner/random/trash,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -37275,6 +36761,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
 	},
@@ -37489,14 +36976,20 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "iYM" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/trimline/tram/warning{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/tram/mid_joiner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/tram/mid_joiner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/tram/warning{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 4
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
 	},
 /area/station/service/bar/backroom/ghetto)
 "iYN" = (
@@ -37895,12 +37388,6 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/station/security/prison)
-"jdT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/port/fore)
 "jdV" = (
 /obj/structure/statue/station_map/cyberiad/e,
 /turf/open/floor/iron,
@@ -37941,7 +37428,6 @@
 /area/station/science/xenobiology)
 "jef" = (
 /obj/machinery/vending/autodrobe,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "jek" = (
@@ -38206,10 +37692,11 @@
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "jhh" = (
-/obj/machinery/firealarm/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/aft)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "jhn" = (
 /obj/structure/table,
 /obj/item/toy/figure/prisoner,
@@ -38281,13 +37768,11 @@
 /turf/open/floor/wood/tile,
 /area/station/service/lawoffice)
 "jiq" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/paper/stack{
-	dir = 4
-	},
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "jir" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /obj/machinery/status_display/ai/directional/south,
@@ -38327,13 +37812,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/engineering/lobby)
-"jiW" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
 "jja" = (
 /obj/machinery/atmospherics/components/binary/pump/off/supply/hidden/layer4{
 	dir = 4
@@ -38449,14 +37927,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/trash)
-"jkC" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/structure/sign/warning/no_smoking/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
 "jkD" = (
 /obj/item/reagent_containers/cup/bucket{
 	pixel_x = -8;
@@ -38547,12 +38017,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
 "jmc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/parquet,
+/obj/structure/displaycase_chassis,
+/turf/open/floor/wood/large,
 /area/station/maintenance/ghetto/fore/starboard)
 "jmq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38687,12 +38153,6 @@
 /obj/effect/turf_decal/tile/purple/half,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
-"jnN" = (
-/obj/structure/chair/sofa/bench{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
 "jnP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
 	dir = 4
@@ -38736,13 +38196,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/plating,
 /area/station/security/interrogation/ghetto)
-"joZ" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/iron,
-/area/station/maintenance/department/medical/ghetto)
 "jpd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -38864,13 +38317,11 @@
 /turf/open/floor/carpet/red,
 /area/station/maintenance/department/security/ghetto)
 "jrj" = (
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/indestructible/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "jro" = (
 /obj/structure/cable,
@@ -39264,11 +38715,8 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/upper)
 "jwV" = (
-/obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/iron/dark/side{
-	dir = 10
-	},
-/area/station/hallway/secondary/dock)
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "jwX" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1
@@ -39290,14 +38738,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "jxf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/medical,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable,
-/obj/effect/spawner/random/structure/barricade,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto/morgue)
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "jxh" = (
 /obj/structure/railing/platform/corner{
 	dir = 8
@@ -39375,10 +38822,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
 "jxY" = (
-/obj/item/chair/stool,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood/parquet,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "jyh" = (
 /obj/structure/table/reinforced,
@@ -39622,11 +39069,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/prison/ghetto)
 "jAV" = (
-/obj/structure/chair/office,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/hallway/secondary/dock)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto/central)
 "jAW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/structure/girder,
@@ -39648,11 +39094,13 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "jBp" = (
-/obj/structure/frame,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/dark_green,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "jBr" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
@@ -39819,11 +39267,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "jEs" = (
-/obj/item/stack/sheet/cardboard{
-	amount = 10
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "jEt" = (
 /obj/machinery/door/poddoor/shutters/window/preopen{
 	dir = 1;
@@ -39967,17 +39416,9 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "jFO" = (
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 1
-	},
-/obj/structure/sign/directions/arrival/directional/north{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "jFP" = (
 /obj/structure/table,
@@ -39994,7 +39435,7 @@
 /turf/closed/wall,
 /area/station/security/checkpoint/medical)
 "jGc" = (
-/obj/structure/chair/wood{
+/obj/effect/spawner/random/entertainment/arcade{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -40162,12 +39603,15 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/station/hallway/secondary/dock)
 "jHI" = (
-/obj/structure/chair/sofa/bench/right{
-	dir = 4
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/office{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/aft)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/firealarm_sanity,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "jHK" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -40221,17 +39665,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "jIb" = (
-/obj/structure/railing/corner{
-	dir = 8
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/textured,
-/area/station/commons/locker)
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "jIc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -40269,7 +39707,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "jIM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -40299,11 +39737,12 @@
 /turf/closed/wall/rust,
 /area/station/service/hydroponics/ghetto)
 "jJg" = (
-/obj/effect/turf_decal/tile/neutral/tram,
-/obj/structure/transport/linear/tram,
-/obj/structure/tram,
-/turf/open/indestructible/tram/plate,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/maint,
+/obj/effect/spawner/random/bedsheet/any,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "jJh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/cable_coil,
@@ -40435,20 +39874,21 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "jKp" = (
-/obj/structure/railing/corner,
-/obj/effect/spawner/random/trash/cigbutt,
+/obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/turf_decal/tile/dark_green/half,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "jKq" = (
-/obj/item/toy/cards/deck{
-	pixel_x = -9;
-	pixel_y = 13
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plating,
-/area/station/commons/locker/ghetto)
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "jKr" = (
 /obj/effect/turf_decal/siding/dark,
 /obj/structure/railing{
@@ -40766,7 +40206,6 @@
 /area/station/engineering/gravity_generator)
 "jPb" = (
 /obj/machinery/light/small/directional/east,
-/obj/machinery/firealarm/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "jPd" = (
@@ -41027,7 +40466,6 @@
 /area/station/maintenance/port/aft)
 "jTv" = (
 /obj/structure/closet/wardrobe/white,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "jTy" = (
@@ -41426,13 +40864,6 @@
 "jXZ" = (
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
-"jYi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 1
-	},
-/turf/open/indestructible/tram,
-/area/station/maintenance/ghetto/fore/starboard)
 "jYl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41524,20 +40955,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"jZk" = (
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/spawner/random/trash/cigbutt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/central/fore)
 "jZm" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "maints1"
@@ -41802,17 +41219,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "kbJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/ghetto/aft)
+/obj/structure/closet/crate/trashcart,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/port)
 "kbS" = (
 /obj/effect/spawner/random/aimodule/harmful,
 /obj/structure/table/wood/fancy/blue,
@@ -41865,11 +41276,15 @@
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/command/nuke_storage)
 "kdc" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "kdj" = (
 /obj/structure/table,
 /obj/item/flatpack{
@@ -41904,13 +41319,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "kdL" = (
-/obj/structure/transport/linear/tram,
-/obj/structure/tram/alt/titanium,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "kdO" = (
 /obj/item/kirbyplants/random/dead,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -41947,10 +41362,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "keb" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/bedsheet/orange,
+/obj/item/clothing/under/syndicate/tacticool{
+	pixel_x = -1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "kej" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/food_or_drink,
@@ -42005,29 +41424,6 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"keV" = (
-/obj/structure/bed,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/bedsheet/orange,
-/obj/item/clothing/under/syndicate/tacticool{
-	pixel_x = -1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
-"keX" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
 "kfl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42095,13 +41491,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "kfN" = (
-/obj/structure/closet,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/obj/structure/cable,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "kgb" = (
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
@@ -42475,8 +41868,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "klx" = (
-/turf/closed/wall,
-/area/station/hallway/primary/starboard/west)
+/obj/structure/sign/warning/vacuum/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "kly" = (
 /obj/structure/flora/bush/jungle/b/style_random,
 /turf/open/floor/asphalt,
@@ -42642,9 +42039,12 @@
 /area/station/maintenance/aft)
 "knh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/cold/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
+/obj/structure/table,
+/obj/effect/turf_decal/tile/dark_green,
+/obj/machinery/light/small/directional/east,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "knr" = (
 /obj/machinery/papershredder,
 /turf/open/floor/plating,
@@ -42942,14 +42342,11 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/dronefabricator)
 "kqT" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/port)
 "krr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
@@ -42997,9 +42394,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "krR" = (
-/obj/structure/grille/broken,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/chair/sofa/right/brown{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/station/service/library/artgallery)
 "krW" = (
 /obj/structure/sign/warning/test_chamber/directional/east,
 /obj/structure/lattice/catwalk,
@@ -43400,11 +42799,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/prison)
 "kwg" = (
-/obj/structure/chair/stool{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood/parquet,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/fore/starboard)
 "kwo" = (
 /obj/effect/decal/cleanable/dirt,
@@ -43551,19 +42950,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
-"kyA" = (
-/obj/structure/chair/sofa/bench/right{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
-"kyG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
 "kyQ" = (
 /obj/structure/frame/computer{
 	dir = 4
@@ -43571,11 +42957,12 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/aft)
 "kyW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/closet,
+/obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
-/obj/structure/sign/poster/contraband/random/directional/west,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "kzc" = (
 /turf/closed/wall,
@@ -43651,12 +43038,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "kAg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/wood/parquet,
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/pai_card,
+/turf/open/floor/carpet,
 /area/station/maintenance/ghetto/fore/starboard)
 "kAj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43727,14 +43112,11 @@
 /turf/open/floor/carpet,
 /area/station/service/library)
 "kBo" = (
-/obj/structure/table,
-/obj/item/clothing/head/soft{
-	pixel_x = -2;
-	pixel_y = 3
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/station/commons/locker)
 "kBq" = (
 /obj/structure/spider/stickyweb,
@@ -43884,11 +43266,9 @@
 /turf/open/floor/carpet/green,
 /area/station/commons/dorms/apartment1)
 "kCp" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/structure/railing,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/glass/reinforced,
 /area/station/hallway/secondary/dock)
 "kCs" = (
 /obj/structure/closet,
@@ -44005,17 +43385,10 @@
 /turf/open/floor/carpet,
 /area/station/service/library/ghetto)
 "kDI" = (
-/obj/machinery/light/small/directional/west,
-/obj/structure/table,
-/obj/structure/bedsheetbin/empty,
-/obj/effect/turf_decal/tile/neutral/opposingcorners{
+/turf/open/floor/iron/stairs/left{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/commons/locker/ghetto)
+/area/station/maintenance/ghetto/port)
 "kDK" = (
 /obj/machinery/firealarm/directional/east,
 /obj/structure/closet/secure_closet/brig,
@@ -44134,9 +43507,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "kEC" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
+/obj/structure/table,
+/obj/machinery/light/small/directional/south,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/freezer,
 /area/station/maintenance/ghetto/fore/starboard)
 "kEI" = (
 /obj/structure/table/wood,
@@ -44409,6 +43783,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/wood,
 /area/station/service/library)
 "kHC" = (
@@ -44605,7 +43980,6 @@
 /area/station/service/lawoffice)
 "kJJ" = (
 /obj/structure/closet/emcloset,
-/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "kJW" = (
@@ -44681,10 +44055,11 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "kKl" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/turf/open/floor/iron/white/diagonal,
-/area/station/maintenance/ghetto/port/greater)
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto/central)
 "kKo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -44869,13 +44244,12 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
 "kMf" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 8
-	},
+/obj/structure/closet/secure_closet/personal,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "kMh" = (
 /obj/effect/turf_decal/tile/purple/half{
@@ -44893,10 +44267,9 @@
 /turf/open/floor/iron,
 /area/station/security/range)
 "kMB" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/full,
-/turf/open/floor/iron/textured_large,
-/area/station/hallway/secondary/dock)
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/port)
 "kMD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -44978,12 +44351,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/security/prison)
-"kNT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/commons/locker)
 "kNW" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -45186,12 +44553,12 @@
 /turf/open/floor/wood,
 /area/station/service/library/ghetto)
 "kQH" = (
-/obj/structure/holosign/barrier/atmos/tram,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
 	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/sepia,
+/area/station/service/library/artgallery)
 "kQI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -45323,9 +44690,9 @@
 /area/station/security/prison/visit)
 "kSb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "kSe" = (
@@ -45622,13 +44989,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
 "kWv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/carpet,
+/obj/machinery/vending/coffee,
+/turf/open/floor/wood,
 /area/station/service/library)
 "kWw" = (
 /obj/structure/table/wood,
@@ -45637,14 +44999,11 @@
 /turf/open/floor/wood,
 /area/station/service/library/ghetto)
 "kWG" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/structure/table,
-/obj/effect/spawner/random/clothing/kittyears_or_rabbitears,
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/turf/open/floor/wood/large,
+/area/station/maintenance/ghetto/port)
 "kWL" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/caution/stand_clear{
@@ -45709,10 +45068,10 @@
 /turf/open/floor/plating,
 /area/station/service/cafeteria)
 "kXr" = (
-/obj/structure/fluff/tram_rail/end{
-	dir = 1
-	},
-/turf/open/indestructible/plating,
+/obj/structure/bookcase/random/adult,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/fore/starboard)
 "kXt" = (
 /obj/structure/rack,
@@ -45720,10 +45079,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "kXD" = (
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/turf/open/indestructible/plating,
+/obj/structure/ladder,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "kXE" = (
 /obj/structure/toilet{
@@ -46249,11 +45607,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "lek" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/trinary/mixer/flipped{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/rack,
+/obj/effect/spawner/random/mod/maint,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "les" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46397,10 +45753,12 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "lgp" = (
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/service/bar/backroom/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "lgs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1,
 /obj/effect/turf_decal/tile/yellow,
@@ -46410,14 +45768,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
-"lgw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/directional/south,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
 "lgF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46535,14 +45885,6 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/maintenance/department/security/ghetto/fore)
-"lih" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
 "lim" = (
 /obj/machinery/vending/dinnerware,
 /obj/machinery/firealarm/directional/south,
@@ -46759,9 +46101,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/fore)
 "llw" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "llD" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
@@ -46918,8 +46262,6 @@
 /area/station/cargo/drone_bay/ghetto)
 "lni" = (
 /obj/effect/spawner/random/trash/mess,
-/obj/machinery/light/small/directional/south,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "lnl" = (
@@ -47000,15 +46342,12 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "lob" = (
-/obj/structure/bed{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/machinery/light/small/directional/west,
-/obj/item/bedsheet/black{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/station/maintenance/ghetto/fore/starboard)
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "loc" = (
 /obj/structure/chair/comfy/teal{
 	dir = 8
@@ -47202,7 +46541,8 @@
 	},
 /area/station/service/kitchen/kitchen_backroom/ghetto)
 "lqd" = (
-/obj/effect/spawner/random/trash/mess,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "lqi" = (
@@ -47231,11 +46571,13 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical/ghetto/morgue)
 "lqt" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp{
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/backroom/ghetto)
 "lqy" = (
@@ -47331,15 +46673,13 @@
 /turf/open/floor/iron/kitchen_coldroom/dark,
 /area/station/service/kitchen/coldroom/ghetto)
 "lrf" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/siding/white/corner,
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/obj/machinery/incident_display/tram/directional/north{
-	name = "счетчик премий Дарвина";
-	desc = "Дисплей, на котором отображается количество вмятин, которые необходимо исправить после окончания смены."
-	},
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
+/obj/machinery/light/small/directional/west,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/grass/jungle/b/style_random,
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/port)
 "lri" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47405,9 +46745,16 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
 "lrH" = (
-/turf/open/indestructible/tram,
-/area/station/maintenance/ghetto/port/greater)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "lrM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable,
 /obj/machinery/duct,
@@ -47500,16 +46847,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
-"lsH" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external/glass,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central/fore)
 "lsJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/decal/cleanable/dirt,
@@ -47646,10 +46983,6 @@
 /obj/structure/sign/poster/random/directional/east,
 /turf/closed/wall,
 /area/station/maintenance/port)
-"lus" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/noslip/tram,
-/area/station/maintenance/ghetto/fore/starboard)
 "luu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -47840,11 +47173,7 @@
 "lwX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard,
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port/greater)
 "lxv" = (
@@ -47896,17 +47225,12 @@
 /turf/open/floor/wood/parquet/amaranth,
 /area/station/maintenance/ghetto/fore/starboard)
 "lxO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/grenade/smokebomb,
-/obj/item/clothing/glasses/sunglasses,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/bed{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/item/instrument/guitar,
-/turf/open/floor/iron/dark,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "lxT" = (
 /obj/machinery/recharge_station,
@@ -48183,10 +47507,12 @@
 /turf/open/floor/iron/smooth,
 /area/station/medical/chemistry/ghetto)
 "lBG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/smooth_large,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto/central)
 "lBQ" = (
 /obj/structure/table/wood,
 /obj/item/clothing/gloves/latex/nitrile{
@@ -48362,15 +47688,16 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "lEK" = (
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/duct,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/backroom/ghetto)
@@ -48690,11 +48017,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "lIH" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark/side{
-	dir = 9
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
-/area/station/hallway/secondary/dock)
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "lIJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/general/visible,
 /obj/item/wrench,
@@ -48767,10 +48094,7 @@
 "lJB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/cable_coil/thirty,
-/obj/structure/railing/corner/end{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor/iron,
+/turf/open/floor/iron,
 /area/station/maintenance/ghetto/port/greater)
 "lJL" = (
 /obj/structure/table/wood,
@@ -48877,6 +48201,7 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/cargo/bitrunning/den)
 "lKG" = (
+/obj/effect/spawner/random/engineering/atmospherics_portable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -48908,12 +48233,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port/aft)
 "lLj" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance/two,
-/obj/effect/turf_decal/siding/white,
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
+/obj/structure/marker_beacon/burgundy,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "lLm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49047,11 +48369,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "lMD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "lMF" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -49360,7 +48682,12 @@
 /obj/item/bikehorn{
 	pixel_y = -4
 	},
-/obj/machinery/light/small/dim/directional/east,
+/obj/machinery/light/small/directional/east{
+	name = "maintenance light";
+	nightshift_allowed = 0;
+	nightshift_enabled = 1;
+	nightshift_light_power = 0.4
+	},
 /obj/item/bikehorn/rubberducky{
 	pixel_x = 6;
 	pixel_y = 4
@@ -49404,10 +48731,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/duct,
-/obj/machinery/firealarm/directional/east,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/backroom/ghetto)
 "lQJ" = (
@@ -49422,10 +48749,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "lQX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/box,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/clothing/neck/stethoscope,
+/turf/open/floor/iron,
+/area/station/maintenance/department/medical/ghetto)
 "lRd" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
@@ -49503,14 +48831,13 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/electrical/ghetto)
 "lSJ" = (
-/obj/effect/turf_decal/tile/neutral/tram,
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic,
-/obj/structure/chair/sofa/bench/tram/left{
-	dir = 4
-	},
-/turf/open/indestructible/tram/plate,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/light/small/directional/south,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "lSM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49521,10 +48848,15 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "lTn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/door/firedoor,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "lTt" = (
 /obj/structure/disposalpipe/segment{
@@ -49560,12 +48892,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
-"lTM" = (
-/obj/machinery/vending/cigarette,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/fore/starboard)
 "lTO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/mapping_helpers/broken_floor,
@@ -49728,8 +49054,8 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen/kitchen_backroom/ghetto)
 "lVD" = (
-/obj/structure/fluff/tram_rail/electric/anchor,
-/turf/open/indestructible/plating,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "lVF" = (
 /obj/structure/closet/emcloset,
@@ -50120,16 +49446,8 @@
 /turf/open/floor/wood/large,
 /area/station/service/theater)
 "mai" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "mak" = (
 /obj/effect/turf_decal/stripes/line{
@@ -50220,9 +49538,18 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "mbC" = (
-/obj/structure/fluff/tram_rail/electric,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "mbG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50464,16 +49791,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"mdX" = (
-/obj/machinery/door/airlock/engineering,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
 "mes" = (
 /obj/machinery/autolathe,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -50718,12 +50035,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
 /area/station/commons/storage/emergency)
-"mhz" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron/stairs/right,
-/area/station/maintenance/ghetto/central/fore)
 "mhA" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/trash/janitor_supplies,
@@ -51070,12 +50381,10 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/central)
 "mmk" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
+/obj/structure/chair/office{
+	dir = 8
 	},
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/grimy,
 /area/station/maintenance/ghetto/fore/starboard)
 "mmm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -51180,9 +50489,10 @@
 /turf/open/floor/iron/kitchen/small,
 /area/station/service/kitchen/kitchen_backroom/ghetto)
 "mpa" = (
-/obj/structure/fluff/tram_rail/electric,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/port/greater)
+/obj/item/chair,
+/obj/effect/turf_decal/tile/dark/opposingcorners,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/port)
 "mpf" = (
 /obj/machinery/firealarm/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -51414,6 +50724,7 @@
 "mrw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -51501,11 +50812,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/engineering/storage)
-"msN" = (
-/obj/item/chair/wood,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
 "msO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -51530,10 +50836,15 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "mtl" = (
-/obj/structure/fence/door,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth_half,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/turf_decal/tile/dark_green,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "mtm" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -51628,8 +50939,8 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
 "muS" = (
-/obj/structure/sign/departments/medbay/alt/directional/south,
-/turf/open/floor/iron/dark,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "muX" = (
 /obj/machinery/light/small/dim/directional/south,
@@ -51714,8 +51025,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "mvv" = (
+/obj/structure/closet/secure_closet/personal{
+	anchored = 1
+	},
 /obj/item/radio/intercom/directional/south,
-/turf/closed/wall,
+/turf/open/floor/iron,
 /area/station/maintenance/port)
 "mvz" = (
 /obj/structure/rack,
@@ -51874,17 +51188,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"myA" = (
-/obj/machinery/washing_machine,
-/obj/structure/sign/clock/directional/north,
-/obj/effect/turf_decal/tile/neutral/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/commons/locker/ghetto)
 "myC" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -52058,12 +51361,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage/ghetto/depot)
 "mAt" = (
-/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/iron/dark,
+/obj/item/knife,
+/turf/open/floor/carpet/royalblack,
 /area/station/maintenance/ghetto/fore/starboard)
 "mAw" = (
 /obj/effect/spawner/structure/window,
@@ -52541,9 +51842,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port/aft)
 "mFY" = (
-/obj/structure/transport/linear/public,
-/turf/open/floor/plating/elevatorshaft,
-/area/station/maintenance/ghetto/starboard)
+/obj/structure/table/wood/fancy/blue,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/door/window/right/directional/north,
+/obj/structure/sign/painting/library_secure{
+	pixel_y = -32
+	},
+/turf/open/floor/wood/tile,
+/area/station/service/library/artgallery)
 "mFZ" = (
 /obj/structure/closet/secure_closet/freezer/empty/open,
 /obj/effect/spawner/random/maintenance,
@@ -52565,15 +51871,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
-"mGq" = (
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/fore/starboard)
 "mGt" = (
 /obj/structure/closet/secure_closet/freezer/empty/open,
 /obj/item/reagent_containers/condiment/sugar{
@@ -52756,12 +52053,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "mIo" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/structure/closet,
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/port)
 "mIp" = (
 /obj/structure/table/wood,
 /obj/item/cane{
@@ -53471,11 +52765,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "mRC" = (
-/obj/structure/sign/plaques/kiddie/library{
-	pixel_y = 32
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
-/area/station/hallway/primary/starboard/west)
+/area/station/maintenance/department/security/ghetto/aft)
 "mRL" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -53688,26 +52983,10 @@
 /obj/effect/spawner/random/structure/tank_holder,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/starboard)
-"mUg" = (
-/obj/structure/hedge,
-/obj/structure/window/spawner/directional/west,
-/obj/structure/window/spawner/directional/south,
-/obj/structure/window/spawner/directional/north,
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/port/greater)
 "mUu" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/fore)
-"mUv" = (
-/obj/structure/sign/painting/library_secure{
-	pixel_y = 32
-	},
-/obj/effect/spawner/random/decoration/statue{
-	spawn_loot_chance = 35
-	},
-/turf/open/floor/wood/tile,
-/area/station/service/library/artgallery)
 "mUy" = (
 /obj/structure/railing,
 /obj/structure/flora/bush/grassy,
@@ -53736,13 +53015,10 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "mVb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/sign/directions/dorms/directional/north{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "mVe" = (
 /obj/effect/landmark/start/cargo_technician,
@@ -53805,10 +53081,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "mVY" = (
-/obj/machinery/holopad,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/wood/parquet,
-/area/station/service/bar/backroom/ghetto)
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet,
+/area/station/service/library)
 "mWc" = (
 /obj/structure/cable,
 /turf/open/floor/circuit/green,
@@ -54013,12 +53289,9 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
 "mYD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/displaycase_chassis,
+/turf/open/floor/wood/large,
 /area/station/maintenance/ghetto/fore/starboard)
 "mYF" = (
 /turf/open/floor/iron/dark,
@@ -54092,15 +53365,14 @@
 /area/station/science/xenobiology)
 "mZy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+/obj/effect/turf_decal/tile/dark_green{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/cold/directional/east,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "mZE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small/directional/west,
@@ -54149,15 +53421,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/mechbay)
-"nam" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/structure/table,
-/obj/machinery/coffeemaker{
-	pixel_y = 11
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
 "naq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -54411,7 +53674,6 @@
 /area/station/science/server)
 "ndY" = (
 /obj/machinery/vending/cola/red,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "ndZ" = (
@@ -54507,15 +53769,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "nfi" = (
-/obj/machinery/washing_machine,
-/obj/effect/turf_decal/tile/neutral/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/glass_shards/mini,
 /turf/open/floor/iron,
-/area/station/commons/locker/ghetto)
+/area/station/maintenance/ghetto/port)
 "nfl" = (
 /obj/structure/stairs/wood,
 /turf/open/floor/wood,
@@ -54543,17 +53801,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/port/aft)
-"nfN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/textured_corner{
-	dir = 4
-	},
-/area/station/commons/locker)
 "nfS" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
@@ -54762,10 +54009,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "niz" = (
-/obj/structure/fluff/tram_rail/floor{
-	dir = 1
-	},
-/turf/open/indestructible/tram,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "niE" = (
 /turf/open/floor/catwalk_floor,
@@ -54826,17 +54073,16 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
 "njv" = (
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 1
+/obj/effect/turf_decal/tile/dark_green/anticorner{
+	dir = 8
 	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 1
-	},
-/obj/structure/railing{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/iv_drip,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "njy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54934,11 +54180,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"nkx" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/aft)
 "nkz" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/item/clothing/mask/balaclava,
@@ -55003,17 +54244,19 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "nlo" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood/parquet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/public,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/barricade/wooden/crude,
+/obj/structure/barricade/wooden,
+/turf/open/floor/iron/grimy,
 /area/station/maintenance/ghetto/fore/starboard)
 "nlp" = (
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood/parquet,
+/obj/structure/table_frame/wood,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "nlr" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
@@ -55292,17 +54535,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port/aft)
-"non" = (
-/obj/structure/chair/stool{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
 "noo" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 5
@@ -55328,18 +54560,21 @@
 /turf/open/floor/iron/smooth,
 /area/station/commons/toilet/restrooms)
 "noF" = (
-/obj/structure/table/wood,
-/obj/item/coin/gold,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/airalarm/directional/south,
+/obj/effect/spawner/random/medical/minor_healing,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "noM" = (
-/obj/effect/turf_decal/siding/white,
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/food/grown/tomato,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "noO" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/yellow{
@@ -55460,6 +54695,7 @@
 "nqa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
@@ -55562,11 +54798,14 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/aft)
 "nrj" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/machinery/iv_drip,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "nrl" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 3";
@@ -55634,11 +54873,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "nrU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/dark,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "nsh" = (
 /obj/machinery/light/directional/south,
@@ -55777,12 +55014,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "nuf" = (
-/obj/structure/hedge,
-/obj/structure/window/spawner/directional/east,
-/obj/structure/window/spawner/directional/south,
-/obj/structure/window/spawner/directional/north,
-/turf/open/floor/grass,
-/area/station/maintenance/ghetto/port/greater)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "nuu" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -55876,13 +55113,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
-"nvH" = (
-/obj/structure/fluff/tram_rail/electric,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/port/greater)
 "nvN" = (
 /obj/machinery/vending/wardrobe/law_wardrobe,
 /obj/machinery/button/door/directional/east{
@@ -55982,13 +55212,6 @@
 "nwJ" = (
 /turf/closed/wall,
 /area/station/security/checkpoint/arrivals)
-"nwL" = (
-/obj/structure/table,
-/obj/effect/spawner/random/bureaucracy/pen,
-/turf/open/floor/iron/dark/side{
-	dir = 6
-	},
-/area/station/hallway/secondary/dock)
 "nwN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56059,15 +55282,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "nxO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "nxS" = (
 /obj/structure/cable,
 /obj/machinery/light_switch/directional/east,
@@ -56134,15 +55351,8 @@
 /turf/open/floor/iron,
 /area/station/security/lockers)
 "nzm" = (
-/obj/item/instrument/saxophone,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/fore/starboard)
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "nzt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/decal/cleanable/dirt,
@@ -56170,12 +55380,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "nzO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/sign/poster/contraband/random/directional/west,
+/obj/structure/bookcase/random/fiction,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "nzQ" = (
 /obj/structure/table,
@@ -56193,16 +55400,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "nAe" = (
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/cigbutt,
+/obj/effect/turf_decal/delivery,
+/obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/maintenance/ghetto/central/fore)
+/area/station/maintenance/department/medical/ghetto)
 "nAh" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -56548,11 +55750,6 @@
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
-"nDY" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron/textured,
-/area/station/commons/locker)
 "nEe" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -56640,13 +55837,10 @@
 /area/station/maintenance/starboard/upper)
 "nFI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/camera/directional/south{
-	c_tag = "Tram Station - Central Control Room"
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
+/obj/item/chair/wood,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
 "nFL" = (
 /turf/open/floor/carpet,
 /area/station/maintenance/aft)
@@ -56659,10 +55853,10 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "nGh" = (
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
+/obj/structure/tank_holder/extinguisher,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/wood/tile,
+/area/station/service/library/artgallery)
 "nGm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -56747,12 +55941,9 @@
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/port/fore)
 "nGW" = (
-/obj/machinery/door/poddoor{
-	elevator_mode = 1;
-	transport_linked_id = "tram_hall_lift";
-	name = "Elevator Door"
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/effect/turf_decal/delivery/white,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard/west)
 "nHf" = (
@@ -56854,10 +56045,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
 "nIg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/railing,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
-/area/station/maintenance/ghetto/central/fore)
+/area/station/maintenance/ghetto/fore/starboard)
 "nIh" = (
 /obj/structure/rack,
 /obj/item/extinguisher,
@@ -56868,7 +56061,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "nIo" = (
@@ -57124,10 +56316,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "nMs" = (
-/obj/effect/turf_decal/tile/neutral/tram,
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/indestructible/tram/plate,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/structure/holosign/barrier/atmos,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "nMx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57259,16 +56450,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/engine,
 /area/station/science/lower)
-"nNL" = (
-/obj/machinery/door/airlock/multi_tile/public/glass,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white/diagonal,
-/area/station/maintenance/ghetto/port/greater)
 "nNM" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron,
@@ -57392,16 +56573,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
-"nPf" = (
-/obj/structure/transport/linear/tram/corner/northeast,
-/obj/structure/tram/spoiler{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
 "nPg" = (
 /obj/structure/chair/wood,
 /obj/effect/mapping_helpers/broken_floor,
@@ -57448,13 +56619,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/storage)
 "nPy" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
+/area/station/maintenance/department/medical/ghetto/central)
 "nPO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57549,19 +56721,10 @@
 /turf/open/floor/iron/half,
 /area/station/commons/dorms)
 "nQP" = (
-/obj/structure/table,
-/obj/item/storage/wallet,
-/obj/item/storage/wallet{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
+/obj/structure/bookcase,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "nQS" = (
 /obj/structure/table/wood/poker,
 /obj/item/clothing/head/fedora,
@@ -57596,13 +56759,10 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/fore)
 "nRp" = (
-/obj/structure/table/wood/fancy/blue,
-/obj/structure/sign/painting/library_secure{
-	pixel_y = -32
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/door/window/right/directional/north,
-/turf/open/floor/wood/tile,
+/turf/open/floor/iron/sepia,
 /area/station/service/library/artgallery)
 "nRr" = (
 /obj/structure/table,
@@ -57647,12 +56807,13 @@
 /turf/open/floor/iron/airless,
 /area/station/science/ordnance/bomb)
 "nRY" = (
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	dir = 4
-	},
-/obj/structure/sign/departments/tram/directional/north,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard/west)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/dark_green/half,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "nSf" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -57822,10 +56983,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "nTL" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/maintenance/three,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/fore)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "nTM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -57892,12 +57053,9 @@
 /turf/open/floor/wood/large,
 /area/station/service/theater)
 "nUz" = (
-/obj/structure/sign/warning/directional/west,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "nUC" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/structure/chair/comfy/brown{
@@ -57937,18 +57095,16 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "nVs" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/area/station/maintenance/department/medical/ghetto)
 "nVy" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -57976,11 +57132,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "nVV" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/structure/flora/tree/jungle/small/style_5,
-/obj/structure/railing,
-/turf/open/floor/grass,
-/area/station/maintenance/department/security/ghetto/aft)
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/closet,
+/obj/effect/spawner/random/clothing/kittyears_or_rabbitears,
+/obj/item/clothing/under/rank/civilian/lawyer/black/skirt,
+/obj/item/clothing/under/suit/black,
+/turf/open/floor/iron/cafeteria,
+/area/station/commons/locker)
 "nVX" = (
 /obj/structure/sign/warning/vacuum/directional/west,
 /obj/machinery/light/small/directional/west,
@@ -58277,7 +57438,7 @@
 /area/station/maintenance/department/engine)
 "nZH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/airlock,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
@@ -58299,12 +57460,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "oad" = (
-/obj/structure/fluff/tram_rail/electric,
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic,
-/obj/structure/chair/sofa/bench/tram/right,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/structure/closet/secure_closet/medical1,
+/obj/structure/extinguisher_cabinet{
+	dir = 4;
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "oah" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/dock)
@@ -58374,15 +57537,12 @@
 /turf/open/floor/plating,
 /area/station/service/hydroponics)
 "obg" = (
-/obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Laundry Room"
-	},
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "obj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -58482,27 +57642,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/aft)
-"obZ" = (
-/obj/machinery/door/airlock/multi_tile/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/fore/starboard)
 "ocb" = (
-/obj/machinery/transport/guideway_sensor{
-	dir = 1;
-	pixel_x = -12;
-	pixel_y = 20
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
 	},
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/atmos_shield_gen/active{
-	dir = 4
-	},
-/turf/open/indestructible/tram,
-/area/station/maintenance/ghetto/fore/starboard)
+/turf/open/floor/iron/sepia,
+/area/station/service/library/artgallery)
 "oce" = (
 /obj/effect/turf_decal/siding/wideplating_new/light,
 /obj/item/trash/bee,
@@ -58550,17 +57695,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
-"ocx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron/textured_corner{
-	dir = 1
-	},
-/area/station/commons/locker)
 "ocB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59021,7 +58155,8 @@
 /turf/open/floor/iron,
 /area/station/security/range)
 "oiH" = (
-/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto/fore)
@@ -59529,15 +58664,8 @@
 /turf/open/floor/iron/white/corner,
 /area/station/service/kitchen/kitchen_backroom/ghetto)
 "ooM" = (
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/graffiti,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/structure/chair/office,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "ooW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59689,10 +58817,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "oqy" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/maintenance/department/medical/ghetto)
 "oqA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/smooth,
@@ -59710,8 +58839,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "oqJ" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "oqL" = (
 /obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
@@ -59862,10 +58991,7 @@
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
 "oss" = (
-/obj/structure/chair/sofa/bench/right{
-	dir = 8
-	},
-/obj/effect/landmark/start/hangover,
+/obj/effect/spawner/random/structure/barricade,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "ost" = (
@@ -59904,10 +59030,13 @@
 /turf/open/water,
 /area/station/maintenance/ghetto/garden)
 "osL" = (
-/obj/structure/stairs/south,
-/obj/effect/landmark/firealarm_sanity,
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/obj/machinery/door/airlock/public/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/any/service/library,
+/turf/open/floor/iron/dark,
+/area/station/service/library/artgallery)
 "osV" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags{
@@ -60264,13 +59393,15 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "oxq" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
-	dir = 1
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/parquet,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/spawner/random/trash/graffiti{
+	spawn_loot_chance = 50
+	},
+/turf/open/floor/iron/grimy,
 /area/station/maintenance/ghetto/fore/starboard)
 "oxu" = (
 /obj/machinery/suit_storage_unit/security,
@@ -60371,15 +59502,26 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical/ghetto)
 "oyv" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/obj/structure/bed{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/item/bedsheet/black{
+	dir = 1
+	},
+/turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "oyA" = (
-/obj/structure/chair/sofa/bench/left{
+/obj/effect/turf_decal/tile/dark_green{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/aft)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "oyJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -60437,13 +59579,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/security/holding_cell)
-"ozK" = (
-/obj/effect/spawner/random/trash/grime,
-/obj/machinery/camera/directional/south{
-	c_tag = "Tram Station - East"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
 "ozY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/newscaster/directional/north,
@@ -60686,18 +59821,13 @@
 /turf/open/floor/carpet/red,
 /area/station/maintenance/department/security/ghetto)
 "oCT" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/tram/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/tram/mid_joiner{
-	dir = 1
-	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 1
-	},
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/obj/machinery/duct,
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
 /area/station/service/bar/backroom/ghetto)
 "oCX" = (
 /turf/open/floor/carpet/orange,
@@ -60865,16 +59995,15 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "oEX" = (
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic/light,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/indestructible/plating,
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "oEZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/station/service/bar/backroom/ghetto)
 "oFe" = (
@@ -61329,9 +60458,10 @@
 /turf/open/floor/wood/tile,
 /area/station/service/lawoffice)
 "oKO" = (
-/obj/effect/turf_decal/tile/neutral/tram,
-/obj/effect/landmark/transport/nav_beacon/tram/platform/cyberiad/east,
-/turf/open/indestructible/tram/plate,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "oKP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -61559,8 +60689,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "oNQ" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/indestructible/plating,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "oOa" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
@@ -61660,18 +60791,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
-"oPg" = (
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	dir = 1
-	},
-/obj/machinery/button/elevator/directional/north{
-	id = "tram_hall_lift"
-	},
-/obj/machinery/lift_indicator/directional/north{
-	linked_elevator_id = "tram_hall_lift"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard/west)
 "oPj" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -61712,10 +60831,11 @@
 /turf/open/floor/plating,
 /area/station/security/lockers)
 "oPU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/aft)
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "oPZ" = (
 /obj/effect/spawner/random/maintenance,
 /obj/machinery/light/directional/south,
@@ -61965,25 +61085,19 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/storage)
 "oSW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "oSX" = (
 /obj/structure/cable,
 /obj/machinery/light_switch/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/command/teleporter)
-"oTa" = (
-/obj/structure/railing/platform/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
 "oTc" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Research - Xenobiology Pens Observation North";
@@ -62175,11 +61289,6 @@
 "oVL" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
-"oVO" = (
-/obj/structure/holosign/barrier/atmos/tram,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/fore/starboard)
 "oVR" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/deepfryer,
@@ -62570,10 +61679,9 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "paO" = (
-/obj/effect/spawner/random/trash/mess,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/effect/decal/cleanable/food/tomato_smudge,
+/turf/open/floor/wood/large,
+/area/station/maintenance/ghetto/port)
 "paU" = (
 /obj/structure/chair/stool/bar{
 	dir = 4
@@ -62827,13 +61935,8 @@
 /turf/open/misc/grass,
 /area/station/security/prison/garden)
 "peu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/effect/turf_decal/siding/wood,
 /obj/effect/landmark/navigate_destination/library,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
 /turf/open/floor/carpet,
 /area/station/service/library)
 "pex" = (
@@ -62922,18 +62025,10 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "pfs" = (
-/obj/machinery/light/small/directional/east,
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/tile/neutral/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
-	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/commons/locker/ghetto)
+/area/station/maintenance/ghetto/port)
 "pfw" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/stairs/right,
@@ -62966,13 +62061,9 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "pfM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/wood/parquet,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/grimy,
 /area/station/maintenance/ghetto/fore/starboard)
 "pgc" = (
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -63196,13 +62287,14 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "piL" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
-	dir = 8
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 1
 	},
-/obj/item/kirbyplants/random/dead,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "piQ" = (
 /obj/structure/chair/sofa/right/brown{
 	dir = 1
@@ -63215,11 +62307,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"piT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/aft)
 "pja" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -63265,16 +62352,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
 "pjD" = (
-/obj/structure/sign/painting/library_secure{
-	pixel_x = -32
-	},
-/obj/structure/sign/painting/library_secure{
-	pixel_y = 32
-	},
+/obj/structure/table/wood/fancy,
+/obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/spawner/random/decoration/statue{
 	spawn_loot_chance = 35
 	},
-/obj/machinery/light/directional/west,
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
 "pjP" = (
@@ -63326,7 +62408,8 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "pkk" = (
-/obj/effect/landmark/start/bartender,
+/obj/effect/landmark/event_spawn,
+/obj/machinery/holopad,
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/backroom/ghetto)
 "pkn" = (
@@ -63383,22 +62466,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
-"pkM" = (
-/obj/machinery/transport/crossing_signal/northwest,
-/obj/machinery/transport/guideway_sensor{
-	pixel_x = -12
-	},
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 1
-	},
-/obj/machinery/atmos_shield_gen/active{
-	dir = 8
-	},
-/obj/machinery/atmos_shield_gen/active{
-	dir = 4
-	},
-/turf/open/indestructible/tram,
-/area/station/maintenance/ghetto/port/greater)
 "pkT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -63450,6 +62517,7 @@
 	dir = 4
 	},
 /obj/structure/sink/kitchen/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
@@ -63622,11 +62690,14 @@
 /turf/open/floor/iron/diagonal,
 /area/station/commons/dorms)
 "pna" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/transport/power_rectifier,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "pnf" = (
 /obj/structure/rack,
 /obj/machinery/light/small/directional/north,
@@ -63787,11 +62858,20 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "ppD" = (
-/obj/structure/table,
-/obj/effect/spawner/random/entertainment/dice,
-/obj/item/lipstick/random,
-/turf/open/floor/iron,
-/area/station/commons/locker)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/tram/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/tram/mid_joiner{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
+/area/station/service/bar/backroom/ghetto)
 "ppE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/hangover,
@@ -63887,11 +62967,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "pqG" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "pqR" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -64004,9 +63083,6 @@
 /obj/structure/sign/painting/library{
 	pixel_x = -32
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
 "psw" = (
@@ -64041,11 +63117,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "ptb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/machinery/button/curtain{
+	name = "Privacy Curtains";
+	id = "ghetto_theatre";
+	pixel_y = -26
 	},
-/turf/open/floor/carpet,
-/area/station/commons/locker/ghetto)
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/port)
 "pte" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance,
@@ -64684,14 +63764,10 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "pAQ" = (
-/obj/structure/closet,
-/obj/item/clothing/under/suit/black/skirt,
-/obj/item/clothing/under/suit/black,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/obj/structure/cable,
+/obj/structure/broken_flooring/pile/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "pBm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -64974,25 +64050,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
-"pDH" = (
-/obj/effect/turf_decal/trimline/tram/warning{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/tram/mid_joiner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/tram/mid_joiner{
-	dir = 1
-	},
-/obj/structure/reagent_dispensers/beerkeg,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 8
-	},
-/area/station/service/bar/backroom/ghetto)
 "pDI" = (
 /obj/structure/closet/wardrobe/mixed,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "pDJ" = (
@@ -65016,15 +64075,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
-"pDZ" = (
-/obj/structure/sign/painting/library_secure{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/wood/tile,
-/area/station/service/library/artgallery)
 "pEl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
 /obj/effect/turf_decal/trimline/dark_red/line{
@@ -65134,13 +64184,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
-"pEZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/ghetto/central/fore)
 "pFd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/decal/cleanable/dirt,
@@ -65161,12 +64204,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "pFu" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/siding/white/corner,
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/dark_green/half{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "pFA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -65209,12 +64252,20 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "pFX" = (
-/obj/structure/fluff/tram_rail/electric,
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic/light,
-/obj/item/radio/intercom/directional/north,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/structure/table/glass,
+/obj/machinery/light/small/directional/south,
+/obj/item/reagent_containers/cup/mortar{
+	pixel_x = 3
+	},
+/obj/item/extinguisher/crafted{
+	pixel_y = 9;
+	pixel_x = 3
+	},
+/obj/item/pestle{
+	pixel_x = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "pGi" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -65434,11 +64485,6 @@
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"pIQ" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
 "pJa" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -65547,10 +64593,16 @@
 /turf/open/floor/iron,
 /area/station/science/research)
 "pKB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "pKC" = (
 /obj/machinery/holopad,
@@ -65762,9 +64814,12 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "pNk" = (
-/obj/structure/fluff/tram_rail/floor,
-/turf/open/indestructible/tram,
-/area/station/maintenance/ghetto/port/greater)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "pNn" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -65827,8 +64882,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "pNU" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 1
+	},
 /turf/open/floor/carpet/black,
 /area/station/maintenance/ghetto/fore/starboard)
 "pNV" = (
@@ -66443,11 +65499,14 @@
 /turf/closed/wall,
 /area/station/maintenance/ghetto/port/aft)
 "pVq" = (
-/obj/effect/spawner/random/vending/snackvend,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/status_display/ai/directional/south,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/grass/jungle/b/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/port)
 "pVF" = (
 /obj/structure/spacevine{
 	can_spread = 0;
@@ -66651,12 +65710,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical/ghetto/morgue)
-"pYa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
 "pYc" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
@@ -66741,10 +65794,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "pZB" = (
-/obj/effect/turf_decal/siding/white,
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "pZC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
@@ -66755,15 +65810,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "pZE" = (
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 1
+/obj/effect/decal/cleanable/food/tomato_smudge,
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/machinery/light/floor,
+/turf/open/floor/wood/large,
+/area/station/maintenance/ghetto/port)
 "pZF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -66835,11 +65888,14 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "qas" = (
-/obj/structure/chair/sofa/bench/right{
+/obj/structure/table/wood,
+/obj/item/book/random,
+/obj/item/taperecorder,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/fore/starboard)
 "qau" = (
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -66857,12 +65913,11 @@
 /turf/open/floor/pod,
 /area/station/maintenance/ghetto/storage)
 "qaD" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "qaE" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/machinery/light_switch/directional/west,
@@ -66916,34 +65971,18 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/storage/primary)
 "qbI" = (
-/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/effect/spawner/random/clothing/costume,
-/obj/effect/spawner/random/clothing/bowler_or_that,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/iron/dark,
+/obj/structure/showcase/machinery/tv/broken,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "qbN" = (
-/obj/structure/sign/directions/medical/directional/west{
-	pixel_y = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/structure/crate,
+/obj/structure/sign/directions/medical/directional/west,
 /obj/structure/cable,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/sign/directions/security/directional/west{
-	pixel_y = -4
-	},
-/turf/open/floor/iron/stairs/left{
-	color = "#9a9a9a"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "qbQ" = (
 /turf/open/floor/iron/white,
@@ -67010,9 +66049,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/prison/ghetto)
 "qdj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/showcase/machinery/tv/broken,
-/turf/open/floor/plating,
+/turf/open/floor/iron/freezer,
 /area/station/maintenance/ghetto/fore/starboard)
 "qdr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -67226,11 +66263,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"qgF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/banner/medical/mundane,
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
 "qgL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -67259,10 +66291,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/ghetto/fore/starboard)
 "qhd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/bookcase,
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "qhf" = (
 /obj/structure/sign/warning/electric_shock/directional/east,
 /obj/structure/lattice,
@@ -67581,8 +66613,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "qli" = (
-/obj/structure/railing,
-/turf/open/floor/catwalk_floor/iron,
+/obj/effect/spawner/random/trash/graffiti,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "qll" = (
 /obj/structure/sign/warning/secure_area/directional/east,
@@ -67733,12 +66766,10 @@
 /turf/open/floor/carpet/black,
 /area/station/maintenance/ghetto/fore/starboard)
 "qnq" = (
-/obj/structure/fluff/tram_rail/electric,
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic,
-/obj/structure/closet/firecloset/full,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/structure/table/glass,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto/central)
 "qnC" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -67788,13 +66819,10 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "qox" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance/two,
-/obj/machinery/camera/directional/south{
-	c_tag = "Tram Station - West"
-	},
+/obj/structure/table/glass,
+/obj/effect/spawner/random/engineering/flashlight,
 /turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/area/station/maintenance/department/medical/ghetto)
 "qoy" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/records/medical/laptop{
@@ -67869,17 +66897,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard/west)
 "qpw" = (
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 1
-	},
-/obj/structure/sign/directions/arrival/directional/north{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/grimy,
+/area/station/maintenance/ghetto/fore/starboard)
 "qpy" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -68170,10 +67191,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "qul" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/department/medical/ghetto)
+/obj/machinery/door/airlock,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/welded,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto/central)
 "qup" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -68183,7 +67206,9 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "quE" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "quH" = (
@@ -68288,13 +67313,9 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage)
 "qvJ" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/spawner/random/trash/garbage,
-/obj/machinery/digital_clock/directional/north,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "qwo" = (
 /obj/structure/table,
 /obj/item/clipboard{
@@ -68361,12 +67382,13 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "qxb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/storage/medkit/regular,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "qxg" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/stripes/line,
@@ -68475,24 +67497,13 @@
 /turf/open/floor/pod,
 /area/station/maintenance/ghetto/storage)
 "qyp" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/spawner/random/trash/hobo_squat,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
-"qyx" = (
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/transport/tram_controller/tcomms,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
-"qyA" = (
-/obj/structure/sign/painting/library{
-	pixel_x = -32
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 1
 	},
-/obj/item/kirbyplants/random,
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/light/directional/west,
-/turf/open/floor/wood/tile,
-/area/station/service/library/artgallery)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "qyB" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/camera/directional/west{
@@ -68601,11 +67612,6 @@
 	},
 /turf/open/floor/iron/kitchen/small,
 /area/station/service/kitchen/kitchen_backroom/ghetto)
-"qzJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron,
-/area/station/maintenance/ghetto/port/greater)
 "qzN" = (
 /turf/open/floor/iron/dark,
 /area/station/construction)
@@ -68796,13 +67802,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
-"qCq" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
 "qCv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -68869,7 +67868,11 @@
 /area/station/science/server)
 "qDl" = (
 /obj/structure/table/glass,
+/obj/machinery/camera/directional/south{
+	c_tag = "Brig - Lower Floor - Infirmary"
+	},
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
 "qDy" = (
@@ -69033,11 +68036,9 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical/ghetto/morgue)
 "qFZ" = (
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/obj/effect/spawner/random/entertainment,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "qGd" = (
 /obj/structure/railing{
@@ -69270,12 +68271,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/magistrate)
-"qJn" = (
-/obj/structure/chair/sofa/bench/right{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
 "qJs" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -69491,10 +68486,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "qMz" = (
-/obj/structure/cable,
-/obj/machinery/holopad,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/service/bar/backroom/ghetto)
+/obj/machinery/light/small/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/medical/ghetto/morgue)
 "qMA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -69696,21 +68692,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "qPh" = (
-/obj/structure/sign/directions/dorms/directional/north{
-	dir = 4;
-	pixel_y = 37
-	},
-/obj/structure/sign/directions/evac/directional/north{
-	dir = 4;
-	pixel_y = 28
-	},
-/obj/structure/railing/platform/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/dark_green/anticorner,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
+/obj/structure/bed/maint,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "qPl" = (
 /obj/structure/railing/corner{
 	dir = 1;
@@ -69756,10 +68743,13 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "qPF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/door/airlock,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "qPH" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -69823,15 +68813,9 @@
 /turf/open/openspace,
 /area/station/science/xenobiology)
 "qQP" = (
-/obj/structure/transport/linear/tram/corner/northwest,
-/obj/structure/tram/spoiler{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "qQR" = (
 /obj/machinery/power/solar_control{
 	dir = 1;
@@ -69973,10 +68957,8 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "qSN" = (
-/obj/structure/chair/sofa/bench/right{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "qSP" = (
 /obj/machinery/camera/directional/north{
@@ -70039,18 +69021,15 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/upper)
 "qTw" = (
-/obj/structure/railing{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/light/directional/west,
+/obj/machinery/camera/directional/west{
+	c_tag = "Starboard Primary Hallway 4"
 	},
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/area/station/hallway/primary/starboard/west)
 "qTA" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -70080,11 +69059,6 @@
 /obj/machinery/photocopier/prebuilt,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"qTT" = (
-/obj/effect/spawner/random/structure/closet_empty/crate,
-/obj/effect/spawner/random/maintenance/five,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/aft)
 "qTY" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -70152,12 +69126,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "qVj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/department/medical/ghetto)
+/turf/closed/wall,
+/area/station/maintenance/department/medical/ghetto/central)
 "qVo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70405,12 +69375,9 @@
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
 "qXA" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/structure/sign/poster/contraband/random/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "qXI" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/structure/table/reinforced,
@@ -70693,12 +69660,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical/ghetto)
 "rbr" = (
-/obj/structure/railing/platform/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "rbt" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
@@ -70737,28 +69704,21 @@
 	},
 /area/station/cargo/storage)
 "rbQ" = (
-/obj/effect/decal/cleanable/glass,
-/obj/machinery/light/small/directional/north,
-/obj/structure/sign/directions/medical/directional/north{
-	pixel_y = 37
+/obj/machinery/light/small/directional/south{
+	name = "maintenance light";
+	nightshift_allowed = 0;
+	nightshift_enabled = 1
 	},
-/obj/structure/sign/directions/security/directional/north{
-	pixel_y = 28
-	},
+/obj/structure/ladder,
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/area/station/maintenance/department/prison)
 "rcb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/washing_machine,
 /turf/open/floor/plating,
 /area/station/security/interrogation/ghetto)
-"rcd" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
 "rcg" = (
 /obj/structure/chair/sofa/right/brown,
 /obj/effect/turf_decal/siding/brown{
@@ -70798,9 +69758,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "rcM" = (
-/obj/effect/spawner/random/trash/ghetto_containers,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "rcZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -71063,9 +70023,10 @@
 /turf/open/floor/wood/parquet,
 /area/station/security/courtroom)
 "rfJ" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/obj/structure/sign/warning/docking/directional/west,
+/obj/machinery/light/small/red/directional/west,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/ghetto/central/fore)
 "rfN" = (
 /obj/effect/turf_decal/trimline/white/line{
@@ -71094,11 +70055,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "rgw" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/brigdoor/right/directional/north,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/textured_large,
-/area/station/hallway/secondary/dock)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/glass,
+/obj/structure/chem_separator{
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/cup/glass/trophy{
+	pixel_y = 15;
+	pixel_x = 5
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "rgy" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -71116,6 +70083,7 @@
 /obj/item/mop,
 /obj/machinery/light/small/blacklight/directional/east,
 /obj/structure/table,
+/obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 1
@@ -71254,14 +70222,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rhY" = (
-/obj/machinery/light/small/directional/north,
-/obj/structure/sign/clock/directional/north,
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/obj/structure/cable,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "rib" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -71269,12 +70233,6 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"rik" = (
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/dock)
 "rip" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/red{
@@ -71350,11 +70308,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
-"rjl" = (
-/obj/structure/holosign/barrier/atmos/tram,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/port/greater)
 "rjm" = (
 /obj/item/soap/nanotrasen,
 /obj/structure/curtain/cloth/fancy,
@@ -71456,13 +70409,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/service/kitchen/kitchen_backroom/ghetto)
 "rku" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/item/storage/box/masks,
-/obj/item/clothing/neck/stethoscope,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "rky" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -71666,14 +70616,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/grass,
 /area/station/maintenance/ghetto/garden)
-"rna" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/maint,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
 "rnb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/right/directional/west{
@@ -71767,13 +70709,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "rnJ" = (
-/obj/effect/turf_decal/tile/neutral/tram,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line,
-/turf/open/indestructible/tram/plate,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/machinery/light/small/directional/north,
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/iron,
+/area/station/maintenance/department/medical/ghetto)
 "rnL" = (
 /obj/effect/landmark/start/hangover,
 /obj/structure/railing{
@@ -71826,32 +70766,25 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port/greater)
 "roB" = (
-/obj/effect/turf_decal/tile/neutral/tram,
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic/light,
-/obj/machinery/light/floor/transport,
-/turf/open/indestructible/tram/plate,
-/area/station/maintenance/ghetto/central/fore)
-"roD" = (
-/obj/effect/turf_decal/trimline/tram/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/tram/corner{
-	dir = 1
-	},
-/obj/structure/sign/poster/random/directional/east,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
-"roH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/item/paper/crumpled/bloody,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/parquet,
+/obj/structure/urinal{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
+"roD" = (
+/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
+"roH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/fore/starboard)
 "roI" = (
 /obj/structure/table/wood,
@@ -71867,12 +70800,11 @@
 /area/station/security/mechbay)
 "roP" = (
 /obj/structure/table/wood/fancy,
+/obj/machinery/door/window/left/directional/south,
 /obj/structure/sign/painting/large/library{
 	dir = 1;
 	pixel_x = -32
 	},
-/obj/machinery/door/window/left/directional/south,
-/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
 "roQ" = (
@@ -71895,14 +70827,11 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "roX" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/radio/intercom/directional/south,
-/obj/item/storage/backpack/satchel/leather/withwallet,
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/directional/south,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/port)
 "rpc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/broken_flooring/corner/directional/south,
@@ -71935,7 +70864,6 @@
 /area/station/science/xenobiology)
 "rpF" = (
 /obj/structure/closet/wardrobe/black,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "rpJ" = (
@@ -72116,12 +71044,15 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "rrP" = (
-/turf/open/floor/carpet/royalblack,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/open/floor/iron/freezer,
 /area/station/maintenance/ghetto/fore/starboard)
 "rrQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "rrW" = (
 /turf/open/floor/engine/n2,
@@ -72227,12 +71158,9 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "rti" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "rtm" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/yellow{
@@ -72298,7 +71226,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "rtR" = (
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "rtT" = (
 /obj/machinery/light/small/directional/west,
@@ -72928,13 +71857,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "rDq" = (
-/obj/machinery/newscaster/directional/north,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/chair/stool,
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/grimy,
+/area/station/maintenance/ghetto/fore/starboard)
 "rDD" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/decal/cleanable/dirt,
@@ -73101,10 +72031,6 @@
 /area/station/security/prison/ghetto)
 "rFH" = (
 /obj/structure/transport/linear/public,
-/obj/effect/abstract/elevator_music_zone{
-	linked_elevator_id = "cargo_elevator";
-	range = 2
-	},
 /obj/effect/landmark/transport/transport_id{
 	specific_transport_id = "cargo_elevator"
 	},
@@ -73152,9 +72078,7 @@
 /area/station/service/chapel/office)
 "rGt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/plumbed{
-	dir = 1
-	},
+/obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/delivery/white{
 	color = "#52B4E9"
 	},
@@ -73296,13 +72220,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "rIX" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/iron/grimy,
+/area/station/maintenance/ghetto/fore/starboard)
 "rIZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -73650,13 +72570,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "rMx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/mapping_helpers/broken_floor,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/parquet,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/fore/starboard)
 "rML" = (
 /obj/effect/turf_decal/siding/yellow/end,
@@ -73893,17 +72808,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "rPQ" = (
-/obj/structure/transport/linear/public,
-/obj/effect/landmark/transport/transport_id{
-	specific_transport_id = "tram_hall_lift"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/effect/abstract/elevator_music_zone{
-	linked_elevator_id = "tram_hall_lift";
-	range = 2
-	},
-/obj/machinery/light/floor/transport,
-/turf/open/floor/plating/elevatorshaft,
-/area/station/maintenance/ghetto/starboard)
+/turf/open/floor/wood/tile,
+/area/station/service/library/artgallery)
 "rPX" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/tile,
@@ -73915,10 +72824,12 @@
 /turf/open/floor/wood,
 /area/station/service/kitchen/abandoned)
 "rQm" = (
-/obj/effect/spawner/random/trash,
-/obj/structure/sign/departments/tram/directional/west,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/item/chair{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/dark/opposingcorners,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/port)
 "rQp" = (
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
@@ -73935,6 +72846,7 @@
 /area/station/engineering/lobby)
 "rQB" = (
 /obj/machinery/light/small/directional/north,
+/obj/effect/spawner/random/engineering/canister,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -74105,24 +73017,17 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
 "rSO" = (
-/obj/effect/turf_decal/trimline/tram/mid_joiner{
+/obj/structure/chair/sofa/left/brown{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/tram/warning{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/tram/mid_joiner,
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 4
-	},
-/area/station/service/bar/backroom/ghetto)
+/turf/open/floor/wood/tile,
+/area/station/service/library/artgallery)
 "rST" = (
-/obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/cold/directional/east,
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto)
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto/central)
 "rTb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -74225,8 +73130,9 @@
 /turf/open/floor/iron,
 /area/station/security/lockers)
 "rTY" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "rTZ" = (
 /obj/effect/turf_decal/delivery,
@@ -74338,21 +73244,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "rVg" = (
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 1
-	},
-/obj/structure/sign/directions/dorms/directional/north{
-	dir = 4;
-	pixel_y = 37
-	},
-/obj/structure/sign/directions/evac/directional/north{
-	dir = 4;
-	pixel_y = 28
-	},
-/turf/open/floor/iron,
+/obj/effect/spawner/random/structure/crate,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "rVq" = (
 /obj/structure/table/wood,
@@ -74447,9 +73341,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "rWy" = (
-/obj/structure/railing,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "rWA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
 	dir = 9
@@ -74710,7 +73608,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "rYU" = (
-/turf/open/floor/noslip/tram,
+/mob/living/basic/cockroach,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "rYX" = (
 /obj/effect/spawner/structure/window,
@@ -74731,11 +73631,6 @@
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/science/lower)
-"rZo" = (
-/obj/structure/chair/sofa/bench/left,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
 "rZq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -74805,11 +73700,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "say" = (
-/obj/machinery/door/airlock/medical,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto/central)
 "saE" = (
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
@@ -74955,17 +73849,10 @@
 "sca" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/maintenance/ghetto/port)
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "scc" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/entertainment/money_small,
@@ -75153,8 +74040,8 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
 "sdI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
@@ -75163,9 +74050,12 @@
 /turf/closed/wall,
 /area/station/medical/paramedic)
 "sdN" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "sdQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -75340,12 +74230,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/sorting)
 "sgD" = (
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/structure/lattice/catwalk,
+/obj/effect/turf_decal/arrows,
+/turf/open/space/basic,
+/area/space/nearstation)
 "sgT" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron/white,
@@ -75438,8 +74326,8 @@
 	},
 /area/station/commons/storage/primary)
 "shU" = (
-/obj/item/kirbyplants/random/dead,
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "shW" = (
 /obj/machinery/camera/directional/north{
@@ -75504,8 +74392,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "siP" = (
@@ -75535,15 +74422,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
-"siU" = (
-/obj/effect/turf_decal/trimline/tram/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/tram/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
 "sjf" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -75629,11 +74507,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
-"sjP" = (
-/obj/effect/spawner/random/trash/mopbucket,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
 "sjT" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/prisoner,
@@ -75992,9 +74865,6 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance/office)
 "sof" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -76012,13 +74882,15 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "soo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/departments/tram/directional/north,
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/starboard)
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port/greater)
 "sop" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -76071,12 +74943,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library/ghetto)
 "soN" = (
-/obj/effect/spawner/random/trash/box,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral,
-/obj/item/radio/intercom/directional/east,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/turf_decal/tile/dark/opposingcorners,
 /turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/area/station/maintenance/ghetto/port)
 "soV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -76189,8 +75059,8 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "sqn" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "sqp" = (
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -76378,8 +75248,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "ssl" = (
-/obj/structure/closet/emcloset,
-/obj/structure/sign/warning/vacuum/directional/east,
+/obj/structure/sign/directions/security/directional/north{
+	pixel_y = 39
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "sss" = (
@@ -76408,15 +75281,15 @@
 /turf/open/floor/iron/large,
 /area/station/security/courtroom)
 "stc" = (
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
+/obj/item/paper/fluff/jobs/prisoner/letter{
+	pixel_x = -8;
+	pixel_y = 9
 	},
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic,
-/obj/structure/chair/sofa/bench/tram/right{
-	dir = 1
+/obj/item/restraints/handcuffs{
+	pixel_x = 4;
+	pixel_y = -3
 	},
-/turf/open/indestructible/plating,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "std" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -76517,11 +75390,11 @@
 /area/station/engineering/supermatter/room)
 "suj" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/garbage,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "suk" = (
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/ghetto/starboard)
@@ -76557,19 +75430,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "suR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/fore/starboard)
-"suV" = (
-/obj/structure/table,
-/obj/item/pai_card,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/dock)
+/turf/open/floor/carpet/royalblack,
+/area/station/maintenance/ghetto/fore/starboard)
 "svg" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/door/airlock/medical/glass,
@@ -76627,12 +75490,8 @@
 /turf/open/misc/grass,
 /area/station/security/prison/garden)
 "svx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/sign/poster/random/directional/west,
-/turf/open/floor/iron,
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "svz" = (
 /obj/structure/table/wood,
@@ -76718,12 +75577,12 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "swu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto/central)
 "swA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -76817,13 +75676,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
 "sxF" = (
-/obj/structure/transport/linear/tram,
-/obj/structure/tram,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/storage/medkit/regular,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "sxR" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -76974,11 +75831,9 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "sAw" = (
-/obj/structure/fluff/tram_rail/electric,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/indestructible/plating,
+/obj/machinery/firealarm/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "sAC" = (
 /obj/structure/disposalpipe/segment{
@@ -77128,14 +75983,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "sCV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "sCY" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/computer/atmos_control/ordnancemix{
@@ -77349,15 +76202,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "sEw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/airlock,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/spawner/random/structure/barricade,
-/turf/open/floor/plating,
+/turf/open/floor/carpet/royalblack,
 /area/station/maintenance/ghetto/fore/starboard)
 "sEA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -77474,7 +76323,6 @@
 /area/station/maintenance/fore)
 "sGD" = (
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "sGN" = (
@@ -77492,13 +76340,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
-"sGQ" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
 "sGV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -77545,10 +76386,11 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "sHr" = (
-/obj/machinery/airalarm/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/sepia,
+/area/station/service/library/artgallery)
 "sHs" = (
 /obj/effect/turf_decal/tile/purple/half,
 /turf/open/floor/iron/white,
@@ -77731,13 +76573,6 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
-"sJJ" = (
-/obj/structure/fence/post{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/smooth_half,
-/area/station/maintenance/ghetto/central/fore)
 "sJK" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -77752,14 +76587,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "sJU" = (
-/obj/effect/turf_decal/trimline/tram/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/tram/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/barricade,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto/morgue)
 "sKd" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard/west)
@@ -77787,7 +76622,6 @@
 "sKq" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
-/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "sKy" = (
@@ -77891,13 +76725,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/magistrate)
-"sMr" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
-/area/station/maintenance/department/medical/ghetto)
 "sMw" = (
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/fore)
@@ -77984,10 +76811,11 @@
 /turf/open/floor/iron/kitchen_coldroom/dark,
 /area/station/service/kitchen/coldroom/ghetto)
 "sOh" = (
-/obj/structure/grille/broken,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/camera/directional/east{
+	c_tag = "Library - East"
+	},
+/turf/open/openspace,
+/area/station/service/library)
 "sOi" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/wood{
@@ -78042,7 +76870,6 @@
 "sPc" = (
 /obj/structure/table/wood/fancy,
 /obj/machinery/door/window/right/directional/south,
-/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
 "sPh" = (
@@ -78165,10 +76992,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
-"sQw" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
 "sQS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -78246,14 +77069,19 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/sorting)
 "sRw" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/sign/directions/security/directional/north{
+	pixel_y = 8;
+	pixel_x = 32
 	},
-/obj/structure/flora/rock/pile/jungle/style_3,
-/obj/structure/railing{
-	dir = 10
+/obj/structure/sign/directions/medical/directional/east,
+/obj/structure/sign/directions/arrival/directional/south{
+	pixel_y = -8;
+	pixel_x = 32
 	},
-/turf/open/floor/grass,
+/turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "sRz" = (
 /obj/structure/bed,
@@ -78287,12 +77115,10 @@
 /turf/open/floor/carpet/red,
 /area/station/commons/dorms/apartment1)
 "sRN" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "sRV" = (
 /obj/effect/turf_decal/tile/neutral/anticorner{
@@ -78331,15 +77157,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
-"sSH" = (
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/dock)
 "sSO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -78367,11 +77184,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "sTc" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "service_station_shutters";
-	name = "Service Station Shutters"
+/obj/effect/decal/remains/human,
+/obj/item/reagent_containers/cup/glass/bottle/wine{
+	desc = "A fine bottle of amontillado wine. Yes, for the love of god!";
+	name = "bottle of amontillado wine";
+	pixel_x = 8
 	},
-/turf/open/floor/noslip/tram,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "sTj" = (
 /obj/structure/railing/corner{
@@ -78463,20 +77282,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "sUv" = (
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 8
 	},
-/obj/structure/holosign/barrier/atmos/tram,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/port/greater)
-"sUA" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/table,
-/obj/item/lightreplacer,
-/obj/item/clothing/mask/gas,
-/obj/structure/sign/clock/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "sUJ" = (
 /obj/structure/chair/pew{
 	dir = 1
@@ -78496,10 +77308,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto)
 "sUP" = (
-/obj/effect/turf_decal/tile/neutral/tram,
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic/light,
-/turf/open/indestructible/tram/plate,
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "sUR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -78551,14 +77361,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "sVm" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/obj/structure/sign/departments/cargo/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "sVs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -78844,13 +77652,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
 "sZN" = (
-/obj/machinery/requests_console/auto_name/directional/north,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/obj/structure/chair/stool,
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "sZW" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/trash)
@@ -78873,7 +77682,6 @@
 "tay" = (
 /obj/machinery/firealarm/directional/north,
 /obj/effect/spawner/random/clothing/wardrobe_closet_colored,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "taM" = (
@@ -78897,20 +77705,19 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "taY" = (
-/obj/structure/fluff/tram_rail/floor{
-	dir = 1
-	},
-/turf/open/indestructible/tram,
-/area/station/maintenance/ghetto/port/greater)
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "tbg" = (
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/graffiti,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/herringbone,
 /area/station/maintenance/ghetto/central/fore)
 "tbh" = (
 /obj/structure/table,
@@ -79027,11 +77834,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"tcU" = (
-/obj/effect/spawner/random/trash/garbage,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
 "tda" = (
 /obj/machinery/recharger,
 /obj/structure/table,
@@ -79090,12 +77892,13 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "tdR" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "tef" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -79179,11 +77982,14 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "teR" = (
-/obj/effect/turf_decal/trimline/white/filled/warning{
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard/west)
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "tfg" = (
 /obj/effect/turf_decal/siding/wood/amaranth/corner{
 	dir = 8
@@ -79231,12 +78037,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "tfY" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/door/airlock/public/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
+/turf/open/floor/carpet,
+/area/station/service/library)
 "tgj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -79265,8 +78076,8 @@
 /area/station/medical/psychology)
 "tgE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
@@ -79366,7 +78177,7 @@
 /area/station/service/library/ghetto)
 "tiq" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "tit" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
@@ -79650,13 +78461,9 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "tlu" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/obj/effect/spawner/random/structure/furniture_parts,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/port)
 "tlA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -79677,10 +78484,6 @@
 /obj/structure/lattice,
 /turf/open/space/openspace,
 /area/space/nearstation)
-"tlT" = (
-/obj/effect/spawner/random/structure/girder,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/aft)
 "tlX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -79705,9 +78508,9 @@
 "tmy" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/mirror/directional/west,
 /obj/structure/sink/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/mirror/broken/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "tmz" = (
@@ -79738,13 +78541,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "tmJ" = (
-/obj/effect/turf_decal/trimline/tram/filled/line{
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/soap,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port/greater)
 "tmK" = (
@@ -80252,12 +79053,6 @@
 /obj/effect/landmark/navigate_destination/bridge,
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"trz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/fore)
 "trD" = (
 /obj/structure/chair{
 	dir = 8
@@ -80291,13 +79086,14 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "trT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/stairs{
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
 	},
-/area/station/maintenance/ghetto/port/greater)
+/obj/effect/spawner/random/structure/table,
+/obj/effect/spawner/random/entertainment/musical_instrument,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/port)
 "tsi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -80336,12 +79132,6 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"tsu" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/fore/starboard)
 "tsz" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/landmark/blobstart,
@@ -80369,16 +79159,9 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/science/server)
 "tsU" = (
-/obj/item/coin/iron{
-	pixel_y = -5
-	},
-/obj/item/coin/plasma{
-	pixel_x = 3;
-	pixel_y = -2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/station/commons/locker/ghetto)
+/obj/structure/table/glass,
+/turf/open/floor/iron,
+/area/station/maintenance/department/medical/ghetto)
 "tsW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -80601,7 +79384,6 @@
 /area/station/command/heads_quarters/hos)
 "tuO" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "tuR" = (
@@ -80712,14 +79494,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "tvU" = (
-/obj/structure/chair/stool/directional/west,
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "tvY" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -80761,9 +79540,17 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "twt" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/item/food/grown/tomato{
+	pixel_x = 6;
+	pixel_y = -1
+	},
+/obj/item/food/grown/tomato{
+	pixel_x = -2;
+	pixel_y = 5
+	},
 /turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/area/station/maintenance/ghetto/port)
 "tww" = (
 /obj/machinery/door/airlock/engineering/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -80855,7 +79642,6 @@
 /area/station/engineering/storage)
 "txK" = (
 /obj/structure/closet/wardrobe/grey,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "txL" = (
@@ -81116,8 +79902,11 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/gravity_generator)
 "tCq" = (
-/turf/closed/wall,
-/area/station/commons/locker/ghetto)
+/obj/structure/rack,
+/obj/effect/spawner/random/clothing/costume,
+/obj/effect/turf_decal/tile/dark/opposingcorners,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/port)
 "tCv" = (
 /turf/closed/wall,
 /area/station/security/warden)
@@ -81247,11 +80036,6 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/fore)
-"tEj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/aft)
 "tEo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -81683,14 +80467,12 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "tJE" = (
-/obj/machinery/door/poddoor/preopen{
-	elevator_mode = 1;
-	transport_linked_id = "tram_hall_lift";
-	name = "Elevator Door"
+/obj/structure/sign/painting/library{
+	pixel_x = -32
 	},
-/obj/effect/turf_decal/delivery/white,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/starboard)
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood/tile,
+/area/station/service/library/artgallery)
 "tJN" = (
 /obj/structure/rack,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -82042,18 +80824,22 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/aft)
 "tNV" = (
-/obj/machinery/button/elevator/directional/east{
-	id = "tram_hall_lift"
+/obj/effect/turf_decal/trimline/tram/mid_joiner{
+	dir = 8
 	},
-/obj/machinery/lift_indicator/directional/east{
-	linked_elevator_id = "tram_hall_lift"
+/obj/effect/turf_decal/trimline/tram/warning{
+	dir = 10
 	},
-/obj/effect/turf_decal/trimline/white/filled/corner{
+/obj/effect/turf_decal/trimline/tram/mid_joiner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark/smooth_corner{
 	dir = 4
 	},
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/starboard)
+/area/station/service/bar/backroom/ghetto)
 "tNX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -82084,10 +80870,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
 "tOg" = (
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/turf/open/indestructible/plating,
+/turf/open/floor/iron/grimy,
 /area/station/maintenance/ghetto/fore/starboard)
 "tOj" = (
 /obj/structure/closet/crate/bin,
@@ -82358,11 +81141,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
 "tSi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/carpet,
-/area/station/commons/locker/ghetto)
+/obj/effect/spawner/random/trash/graffiti{
+	spawn_loot_chance = 50
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "tSk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -82401,8 +81185,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
 /obj/structure/showcase/machinery/tv/broken{
-	name = "зомбоящик";
-	desc = "Слегка потрепанный телевизор. Различные агитационные ролики Nanotrasen воспроизводятся по кругу, сопровождаемые НЕ веселой мелодией."
+	desc = "Слегка потрепанный телевизор. Различные агитационные ролики Nanotrasen воспроизводятся по кругу, сопровождаемые НЕ веселой мелодией.";
+	name = "зомбоящик"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/small,
@@ -82421,19 +81205,20 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
 "tSS" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/structure/flora/tree/jungle/small/style_4,
-/obj/structure/railing,
-/turf/open/floor/grass,
-/area/station/maintenance/department/security/ghetto/aft)
-"tSU" = (
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic/light,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
+"tSU" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/table/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron,
+/area/station/maintenance/department/medical/ghetto)
 "tTc" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -82444,11 +81229,9 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "tTo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/effect/spawner/random/medical/injector,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "tTq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -82480,9 +81263,11 @@
 /turf/open/floor/plating,
 /area/station/commons/storage/emergency)
 "tTU" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/crate,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/iron,
+/area/station/maintenance/department/security/ghetto/aft)
 "tUe" = (
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -82882,12 +81667,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
-"tXU" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/central/fore)
 "tXV" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
@@ -83139,10 +81918,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
-"ubd" = (
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
 "ubf" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/conveyor{
@@ -83257,12 +82032,10 @@
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/entry)
 "ucW" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/ghetto/fore/starboard)
 "ucY" = (
 /obj/machinery/computer/monitor,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
@@ -83365,9 +82138,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "uei" = (
-/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/port/greater)
+/area/station/maintenance/department/medical/ghetto/central)
 "uej" = (
 /turf/open/openspace,
 /area/station/security/brig)
@@ -83641,11 +82416,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
-"ugX" = (
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/maintenance/department/medical/ghetto)
 "uhc" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -83711,9 +82481,11 @@
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
 "uhV" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "uhZ" = (
 /turf/closed/wall,
 /area/station/security/checkpoint/supply)
@@ -83792,11 +82564,10 @@
 /turf/open/floor/iron/small,
 /area/station/maintenance/ghetto/central)
 "uiU" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/graffiti,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/iron/grimy,
 /area/station/maintenance/ghetto/fore/starboard)
 "uiY" = (
 /obj/machinery/modular_computer/preset/id{
@@ -83905,14 +82676,12 @@
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "ukw" = (
-/obj/machinery/door/airlock/public,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/commons/locker/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "ukA" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/toy_figure,
@@ -84118,13 +82887,10 @@
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/atmos/project)
 "unJ" = (
-/obj/structure/transport/linear/public,
-/obj/machinery/elevator_control_panel/directional/east{
-	linked_elevator_id = "tram_hall_lift";
-	preset_destination_names = list("2" = "Lower Floor", "3" = "Main Floor")
-	},
-/turf/open/floor/plating/elevatorshaft,
-/area/station/maintenance/ghetto/starboard)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood/tile,
+/area/station/service/library/artgallery)
 "unN" = (
 /turf/open/floor/iron/stairs/right,
 /area/station/hallway/primary/aft)
@@ -84160,11 +82926,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/sorting)
 "uoo" = (
-/obj/structure/fluff/tram_rail/end{
-	dir = 8
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/port/greater)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "uoq" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light/directional/east,
@@ -84190,14 +82956,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "uoQ" = (
-/obj/machinery/door/airlock/medical,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/spawner/random/structure/barricade,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "upd" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/meter,
@@ -84240,14 +83003,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "upA" = (
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/turf/open/floor/wood/parquet,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "upL" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/wood,
@@ -84339,14 +83098,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "urg" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/open/floor/carpet,
-/area/station/service/library)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/sign/departments/med/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "url" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow{
@@ -84372,10 +83129,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "urC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/food_or_drink,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
+/area/station/maintenance/department/security/ghetto/aft)
 "urI" = (
 /obj/effect/spawner/random/engineering/tank,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -84714,18 +83475,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "uxk" = (
-/obj/effect/spawner/random/trash/cigbutt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/structure/table/wood,
+/obj/item/storage/crayons,
+/turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "uxn" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/red/opposingcorners{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "uxo" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -84797,11 +83553,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard/west)
 "uyr" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/obj/structure/chair/stool/directional/south,
+/obj/effect/spawner/random/engineering/flashlight,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "uyt" = (
 /obj/structure/chair/sofa/middle/brown{
 	dir = 8
@@ -85035,10 +83790,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
-"uBq" = (
-/obj/structure/cable,
-/turf/closed/wall,
-/area/station/maintenance/ghetto/fore/starboard)
 "uBw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -85185,10 +83936,12 @@
 /turf/open/floor/iron/edge,
 /area/station/service/hydroponics)
 "uDj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "uDk" = (
 /obj/effect/turf_decal/siding/white,
 /turf/open/water/alternative/muddy/no_fishing,
@@ -85243,9 +83996,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "uEm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/dim/directional/south,
 /obj/item/banner/security/mundane,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/south{
+	name = "maintenance light";
+	nightshift_allowed = 0;
+	nightshift_enabled = 1
+	},
 /turf/open/floor/iron/dark/small,
 /area/station/security/interrogation/ghetto)
 "uEt" = (
@@ -85254,15 +84011,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
-"uEy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/sofa/bench/left{
-	dir = 8
-	},
-/obj/effect/spawner/random/entertainment/plushie,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
 "uEL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -85365,10 +84113,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
 	},
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/carpet,
 /area/station/service/library)
 "uGd" = (
@@ -85415,10 +84162,9 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage)
 "uGE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/indestructible/plating,
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "uGI" = (
 /obj/effect/landmark/start/botanist,
@@ -85577,17 +84323,19 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
 "uIu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/tile/dark_green/anticorner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/north,
+/obj/structure/chair/office{
 	dir = 8
 	},
-/obj/machinery/door/airlock/public/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/turf/open/floor/carpet,
-/area/station/service/library)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "uIx" = (
 /obj/structure/bed/dogbed{
 	desc = "A comfy-looking spider bed. You can even strap your pet in, just in case the gravity turns off.";
@@ -85630,15 +84378,12 @@
 /turf/open/floor/carpet/green,
 /area/station/commons/dorms/apartment1)
 "uIU" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "service_station_shutters";
-	name = "Service Station Shutters"
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "uIZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -85751,13 +84496,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/storage)
 "uKl" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "uKn" = (
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/firealarm/directional/west,
@@ -85886,13 +84631,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
-"uLU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
 "uLV" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -86064,18 +84802,17 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "uNk" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 1
+/obj/structure/rack,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/random/directional/north,
+/obj/structure/railing{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 1
-	},
-/obj/machinery/button/transport/tram/directional/north{
-	id = 1
-	},
-/obj/machinery/transport/destination_sign/indicator/directional/north,
-/turf/open/floor/iron,
+/obj/item/mop,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/ghetto/port/greater)
 "uNF" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
@@ -86416,22 +85153,14 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "uSW" = (
-/obj/machinery/door/airlock/engineering,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "uSZ" = (
 /obj/structure/reagent_dispensers/plumbed{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/turf_decal/delivery/white{
 	color = "#52B4E9"
@@ -86458,11 +85187,9 @@
 /turf/open/floor/iron/checker,
 /area/station/service/bar/atrium/ghetto)
 "uTm" = (
-/obj/effect/spawner/random/vending/colavend,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/dark/opposingcorners,
 /turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/area/station/maintenance/ghetto/port)
 "uTn" = (
 /obj/structure/table/wood,
 /obj/item/folder,
@@ -86548,9 +85275,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
-"uUm" = (
-/turf/open/openspace,
-/area/station/maintenance/port/greater)
 "uUr" = (
 /obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
@@ -86582,20 +85306,21 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "uUQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/fore/starboard)
-"uUU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/railing{
-	dir = 8
-	},
+/obj/machinery/door/airlock,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/port)
+/area/station/maintenance/department/medical/ghetto)
+"uUU" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/fore/starboard)
 "uUV" = (
 /obj/item/assembly/mousetrap/armed,
 /turf/open/floor/plating,
@@ -86724,16 +85449,17 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "uWI" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/graffiti{
+	spawn_loot_chance = 50
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
-"uWP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/random/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/aft)
 "uWT" = (
 /obj/structure/chair/sofa/bench{
 	dir = 4
@@ -87024,14 +85750,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs)
-"vbc" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/chair/stool,
-/obj/machinery/light/small/directional/west,
-/obj/structure/sign/warning/directional/west,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
 "vbj" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/brown{
@@ -87133,14 +85851,9 @@
 /area/station/science/lower)
 "vcU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/east,
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/spawner/random/trash/graffiti,
-/turf/open/floor/iron,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "vcW" = (
 /obj/structure/disposalpipe/segment{
@@ -87152,6 +85865,7 @@
 "vcX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
@@ -87213,7 +85927,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "vej" = (
-/turf/open/indestructible/tram,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "vey" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -87290,11 +86007,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/lockers)
-"vfj" = (
-/obj/effect/spawner/random/trash/graffiti,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
 "vfm" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -87303,11 +86015,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
 "vfq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/structure/ladder,
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/area/station/maintenance/port/greater)
 "vfD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -87682,11 +86393,10 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
 "vkg" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Tram Station - West Control Room"
-	},
+/obj/structure/table,
+/obj/item/lipstick/random,
 /turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/area/station/commons/locker)
 "vkj" = (
 /obj/item/reagent_containers/blood/random,
 /obj/item/reagent_containers/blood/random,
@@ -87947,7 +86657,6 @@
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics/ghetto)
 "vnc" = (
@@ -87955,12 +86664,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
-"vne" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
 "vnk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -88026,10 +86729,10 @@
 /turf/open/water,
 /area/station/maintenance/ghetto/garden)
 "vnP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/vending_refill/cigarette,
+/obj/structure/closet/secure_closet/medical1,
+/obj/effect/spawner/random/maintenance/four,
 /turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/area/station/maintenance/department/medical/ghetto)
 "vnQ" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
 	dir = 4
@@ -88144,12 +86847,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
-"voW" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
 "voZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/xmastree,
@@ -88211,8 +86908,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "vpI" = (
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/indestructible/tram,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/glass_debris,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "vpM" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -88389,10 +87090,12 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hos)
 "vrC" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "vrD" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 8;
@@ -88838,11 +87541,13 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/ghetto)
 "vwy" = (
-/obj/structure/fluff/tram_rail/electric/anchor{
-	dir = 1
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "vwC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -88907,9 +87612,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "vxw" = (
-/obj/effect/spawner/structure/electrified_grille,
-/turf/open/floor/iron/smooth_large,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable,
+/obj/effect/spawner/random/structure/barricade,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "vxy" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -88980,6 +87690,7 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "vyz" = (
+/obj/effect/landmark/start/bartender,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
@@ -89062,12 +87773,13 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/hallway)
 "vzx" = (
-/obj/structure/fence/cut/large{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron/smooth_half,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "vzA" = (
 /obj/structure/table/wood,
 /obj/item/stack/sheet/iron/fifty,
@@ -89524,12 +88236,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "vFq" = (
-/obj/structure/chair/sofa/bench/left{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "vFH" = (
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -89718,16 +88431,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
 "vIw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/button/door/directional/east{
-	id = "service_station_shutters";
-	name = "Service Station Shutter Control"
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/structure/bookcase,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "vIx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -89774,12 +88481,6 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
-"vIY" = (
-/obj/structure/transport/linear/tram/corner/southwest,
-/obj/structure/tram/spoiler,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
 "vIZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -89881,12 +88582,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
-"vKj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/fore/starboard)
 "vKl" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
@@ -89987,8 +88682,10 @@
 /turf/open/floor/iron,
 /area/station/science/lobby)
 "vLc" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/catwalk_floor/iron_dark,
+/obj/structure/disposalpipe/trunk/multiz{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/station/maintenance/department/security/ghetto/aft)
 "vLh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -90040,12 +88737,9 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "vMa" = (
-/obj/structure/transport/linear/tram,
-/obj/structure/tram/split,
-/obj/machinery/transport/destination_sign/split/south,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/item/kirbyplants/random,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/fore/starboard)
 "vMe" = (
 /obj/structure/table/wood,
 /obj/item/toy/crayon/spraycan{
@@ -90167,9 +88861,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "vNR" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/dark,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/ghetto/central/fore)
 "vOa" = (
 /turf/closed/wall,
@@ -90369,11 +89063,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "vRC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 5
-	},
+/obj/structure/cable,
+/obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/central/fore)
+/area/station/maintenance/ghetto/port/greater)
 "vRG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -90395,10 +89088,14 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry/ghetto)
 "vRJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/smooth_large,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/mask/balaclava{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "vRP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -90441,16 +89138,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/lower)
 "vSA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/iron/stairs/right{
-	dir = 1;
-	color = "#9a9a9a"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/station/maintenance/ghetto/starboard)
 "vSF" = (
 /turf/open/floor/iron/white,
@@ -90608,13 +89300,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
-"vUl" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/obj/structure/closet/crate/trashcart/laundry,
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
 "vUs" = (
 /obj/machinery/vending/cola/blue,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -90716,15 +89401,15 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "vVS" = (
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 4
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/obj/effect/turf_decal/siding/white/corner{
-	dir = 4
+/obj/item/kirbyplants/random{
+	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/dark/diagonal_centre,
-/turf/open/floor/iron/white/diagonal,
-/area/station/commons/locker/ghetto)
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/wood/parquet,
+/area/station/service/bar/backroom/ghetto)
 "vVT" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
@@ -90740,7 +89425,6 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
-/obj/machinery/vending/coffee,
 /turf/open/floor/wood,
 /area/station/service/library)
 "vWe" = (
@@ -90807,9 +89491,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/checkpoint/customs)
 "vWK" = (
-/obj/effect/turf_decal/tile/neutral/tram,
-/turf/open/indestructible/tram/plate,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/turf_decal/tile/dark_green/anticorner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "vWQ" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/warden,
@@ -90876,8 +89563,7 @@
 "vXo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/sign/warning/directional/north,
-/turf/open/floor/catwalk_floor,
+/turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "vXq" = (
 /obj/effect/turf_decal/stripes/line{
@@ -91052,13 +89738,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wat" = (
-/obj/structure/railing/platform/reinforced/corner{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/structure/table,
+/obj/item/clothing/head/soft{
+	pixel_x = -2;
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
+/turf/open/floor/iron,
+/area/station/commons/locker)
 "wav" = (
 /obj/machinery/light/directional/west,
 /obj/structure/cable,
@@ -91174,7 +89864,6 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "wcf" = (
@@ -91439,11 +90128,12 @@
 /turf/closed/wall,
 /area/station/service/library)
 "wfW" = (
-/obj/structure/fluff/tram_rail/electric/anchor{
-	dir = 1
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
 "wfY" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -91468,13 +90158,11 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "wgk" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/landmark/firealarm_sanity,
+/turf/open/floor/catwalk_floor,
 /area/station/hallway/secondary/dock)
 "wgr" = (
 /obj/effect/mapping_helpers/airlock/unres{
@@ -91555,14 +90243,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port/aft)
 "whh" = (
-/obj/effect/turf_decal/trimline/tram/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/tram/corner{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/fore/starboard)
 "whm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -91692,18 +90378,19 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/arrivals)
 "wig" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood/parquet,
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/turf/open/floor/carpet,
 /area/station/maintenance/ghetto/fore/starboard)
 "wih" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/dark_green{
+	dir = 1
 	},
-/obj/machinery/medical_kiosk,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "wil" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
 	dir = 8
@@ -91721,9 +90408,14 @@
 	},
 /area/station/security/checkpoint/customs)
 "wiy" = (
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/department/security/ghetto/fore)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/department/security/ghetto/aft)
 "wiz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -91976,9 +90668,10 @@
 /turf/open/floor/iron,
 /area/station/security/prison/ghetto)
 "wmi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/bamboo,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/iron/sepia,
 /area/station/service/library/artgallery)
 "wmq" = (
 /obj/structure/table/wood,
@@ -92108,7 +90801,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/grime,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "woK" = (
@@ -92242,13 +90934,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/white,
 /area/station/science/lower)
-"wrh" = (
-/obj/structure/bed{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/wood,
-/area/station/maintenance/ghetto/fore/starboard)
 "wrk" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -92528,10 +91213,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
-"wuD" = (
-/obj/structure/fluff/tram_rail/electric/anchor,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/port/greater)
 "wuK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -92600,11 +91281,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "wvn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
-/area/station/commons/locker)
+/area/station/hallway/primary/starboard/west)
 "wvz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /obj/structure/sign/directions/engineering{
@@ -92740,6 +91419,7 @@
 "wxj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/fore)
 "wxo" = (
@@ -93142,13 +91822,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wBF" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron/stairs/left{
-	color = "#9a9a9a";
-	dir = 1
-	},
+/obj/effect/spawner/random/trash/hobo_squat,
+/turf/open/floor/iron,
 /area/station/maintenance/ghetto/starboard)
 "wBU" = (
 /obj/structure/cable/layer1,
@@ -93275,11 +91950,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "wDf" = (
-/obj/structure/chair/sofa/bench/left{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/hangover,
+/obj/machinery/bookbinder,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "wDg" = (
@@ -93366,13 +92037,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "wEb" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/directional/south{
-	c_tag = "Tram Station - Central"
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
+/obj/structure/sink/directional/west,
+/turf/open/floor/iron/freezer,
+/area/station/maintenance/ghetto/fore/starboard)
 "wEh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/decal/cleanable/dirt,
@@ -93423,12 +92090,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "wEy" = (
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 1
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port/greater)
 "wEz" = (
@@ -93526,11 +92192,11 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/atmos/storage/gas)
 "wFm" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /obj/structure/closet/secure_closet/personal{
 	anchored = 1
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "wFr" = (
@@ -93633,13 +92299,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
-"wGo" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
 "wGV" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port/fore)
@@ -93690,17 +92349,10 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/station/engineering/gravity_generator)
 "wIj" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/iron/grimy,
 /area/station/maintenance/ghetto/fore/starboard)
 "wIr" = (
 /obj/structure/stairs/east{
@@ -94000,13 +92652,12 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/aft)
 "wLM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office,
+/obj/effect/spawner/random/trash/graffiti{
+	spawn_loot_chance = 50
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/parquet,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "wLY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -94014,10 +92665,10 @@
 /turf/open/floor/iron/dark,
 /area/station/construction)
 "wMc" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/ghetto/fore/starboard)
 "wMd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -94059,10 +92710,10 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "wMN" = (
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/fore/starboard)
 "wMW" = (
 /obj/structure/grille/broken,
@@ -94084,10 +92735,9 @@
 /turf/open/floor/carpet/green,
 /area/station/commons/dorms/apartment1)
 "wNb" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/aft)
+/obj/effect/spawner/random/structure/barricade,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "wNd" = (
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
@@ -94404,17 +93054,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "wRm" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/effect/spawner/random/bureaucracy/pen,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 8
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/glass/reinforced,
 /area/station/hallway/secondary/dock)
 "wRp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -94658,12 +93301,12 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/aft)
 "wTY" = (
-/obj/structure/railing/platform/reinforced/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/open/floor/carpet,
+/area/station/service/library)
 "wUk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -94756,12 +93399,17 @@
 /turf/open/floor/iron/stairs/left,
 /area/station/hallway/primary/central/fore)
 "wVT" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck/cas{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/toy/cards/deck/cas/black{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/carpet,
+/area/station/maintenance/ghetto/fore/starboard)
 "wVV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -94809,10 +93457,22 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage/ghetto/depot)
 "wWG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/south,
+/obj/structure/sign/directions/security/directional/north{
+	pixel_y = 39
+	},
+/obj/structure/sign/directions/arrival/directional/north{
+	pixel_y = 25;
+	dir = 8
+	},
+/obj/structure/sign/directions/medical/directional/north{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/ghetto/aft)
 "wWJ" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron,
@@ -94905,10 +93565,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "wXK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/girder,
 /obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron_dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "wXL" = (
 /obj/structure/closet/emcloset,
@@ -95186,11 +93847,15 @@
 /turf/open/floor/iron/white/corner,
 /area/station/service/kitchen/kitchen_backroom/ghetto)
 "xbG" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/dark_green{
 	dir = 1
 	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "xbH" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/engineering/toolbox,
@@ -95350,12 +94015,14 @@
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
 "xdu" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "xdz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -95465,13 +94132,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/storage)
-"xeG" = (
-/obj/machinery/door/airlock,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet/royalblack,
-/area/station/maintenance/ghetto/fore/starboard)
 "xeI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/light/directional/north,
@@ -95521,10 +94181,12 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/ghetto/storage)
 "xfj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
 /area/station/maintenance/department/medical/ghetto)
 "xfm" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -95568,17 +94230,20 @@
 /area/station/security/prison)
 "xft" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "xfw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/fore)
 "xfy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/departments/restroom/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
+/area/station/maintenance/department/medical/ghetto)
 "xfD" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -95623,8 +94288,8 @@
 /area/station/hallway/primary/central)
 "xfW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "xfY" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -95757,6 +94422,7 @@
 "xgZ" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/item/gun/ballistic/shotgun/doublebarrel,
+/obj/machinery/light/small/directional/south,
 /obj/structure/closet/secure_closet/bar,
 /turf/open/floor/wood,
 /area/station/service/bar/backroom/ghetto)
@@ -95803,10 +94469,8 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "xhT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/catwalk_floor/iron_dark,
+/obj/effect/spawner/random/trash/box,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "xhZ" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
@@ -95873,12 +94537,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
-"xjg" = (
-/obj/structure/chair/sofa/bench/left{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
 "xji" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
@@ -95944,6 +94602,7 @@
 /obj/item/clothing/suit/jacket/straight_jacket,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
 "xjN" = (
@@ -96015,10 +94674,9 @@
 /turf/open/floor/grass,
 /area/station/maintenance/ghetto/garden)
 "xkF" = (
-/obj/structure/chair/sofa/bench/right,
-/obj/effect/spawner/random/entertainment/lighter,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/station/maintenance/ghetto/fore/starboard)
 "xkG" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/grimy,
@@ -96111,7 +94769,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "xmj" = (
 /obj/structure/cable,
@@ -96137,11 +94795,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/greater)
 "xmv" = (
-/obj/structure/chair/sofa/bench/left{
-	dir = 4
-	},
-/obj/machinery/light/warm/directional/west,
-/turf/open/floor/iron,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "xmD" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -96537,11 +95192,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay/ghetto)
 "xsF" = (
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "xsG" = (
 /obj/machinery/requests_console/directional/west{
 	department = "Research Lab";
@@ -96622,13 +95276,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/auxiliary)
 "xtw" = (
-/obj/structure/fluff/tram_rail/electric{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/structure/transport/linear/tram,
-/obj/structure/tram,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "xtx" = (
 /turf/open/floor/iron,
 /area/station/commons/locker)
@@ -96779,13 +95433,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
-"xuJ" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/camera/directional/south{
-	c_tag = "Starboard Primary Hallway 4"
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard/west)
 "xuM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 6
@@ -96812,10 +95459,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chemistry/ghetto)
-"xvE" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/ghetto/aft)
 "xvV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -96906,11 +95549,11 @@
 "xwG" = (
 /obj/machinery/door/airlock/service,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /turf/open/floor/iron/kitchen,
 /area/station/service/bar/atrium/ghetto)
 "xwI" = (
@@ -96956,22 +95599,10 @@
 	},
 /area/station/service/kitchen/kitchen_backroom)
 "xxv" = (
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 1
-	},
-/obj/structure/sign/directions/dorms/directional/north{
-	dir = 4;
-	pixel_y = 37
-	},
-/obj/structure/sign/directions/evac/directional/north{
-	dir = 2;
-	pixel_y = 28
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/fore/starboard)
 "xxx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -97021,9 +95652,10 @@
 /turf/open/floor/iron/half,
 /area/station/commons/dorms)
 "xye" = (
-/obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/obj/effect/mapping_helpers/dead_body_placer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto/morgue)
 "xyi" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
@@ -97033,15 +95665,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
 "xyk" = (
-/obj/machinery/washing_machine,
-/obj/effect/turf_decal/tile/neutral/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/commons/locker/ghetto)
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/wood/large,
+/area/station/maintenance/ghetto/port)
 "xym" = (
 /obj/structure/closet/crate,
 /obj/item/crowbar,
@@ -97210,12 +95836,11 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "xAE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/tile/blue/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/station/commons/locker/ghetto)
+/obj/machinery/light/small/directional/west,
+/obj/structure/broken_flooring/side/directional/south,
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "xAG" = (
 /obj/machinery/door/airlock{
 	id_tag = "AuxToilet1"
@@ -97264,10 +95889,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "xBh" = (
-/obj/machinery/stasis,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/freezer,
+/area/station/maintenance/ghetto/fore/starboard)
 "xBF" = (
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
@@ -97386,11 +96011,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
-"xDq" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral/full,
-/turf/open/floor/iron/textured_large,
-/area/station/hallway/secondary/dock)
 "xDs" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -97402,8 +96022,8 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "xDu" = (
-/obj/structure/sign/departments/tram/directional/east,
-/turf/open/floor/plating,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "xDz" = (
 /obj/machinery/conveyor{
@@ -97423,14 +96043,19 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"xDU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/cigbutt,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
 "xEa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/tram/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/tram/mid_joiner{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/west,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/station/service/bar/backroom/ghetto)
 "xEg" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -97478,7 +96103,7 @@
 /area/station/cargo/office)
 "xEV" = (
 /obj/effect/spawner/random/structure/crate,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "xEW" = (
 /obj/structure/rack,
@@ -97505,8 +96130,30 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "xFn" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/smooth_large,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/tram/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/tram/mid_joiner{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/chair/plastic{
+	pixel_y = 8
+	},
+/obj/item/chair/plastic{
+	pixel_y = 14
+	},
+/obj/item/chair/plastic{
+	pixel_y = 19
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/station/service/bar/backroom/ghetto)
 "xFo" = (
 /obj/structure/cable,
@@ -97557,13 +96204,10 @@
 /area/station/cargo/storage/ghetto/depot)
 "xFG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/mask/balaclava{
-	pixel_x = 2;
-	pixel_y = -3
+/obj/structure/chair/office{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "xFJ" = (
 /obj/machinery/light/broken/directional/west,
@@ -97717,11 +96361,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "xHT" = (
-/obj/structure/fence/post{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth_half,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "xHU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/meter{
@@ -97769,7 +96413,6 @@
 	},
 /obj/item/stack/cable_coil,
 /obj/item/wrench,
-/obj/machinery/light/small/directional/south,
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/backroom/ghetto)
 "xIr" = (
@@ -97797,14 +96440,15 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "xIP" = (
-/obj/effect/turf_decal/trimline/tram/filled/line{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/item/folder,
+/obj/item/pen,
+/turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "xIX" = (
 /obj/structure/table/wood,
@@ -97848,13 +96492,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "xJt" = (
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/turf/open/floor/wood/parquet,
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "xJL" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
@@ -97923,13 +96564,6 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"xKv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/stasis,
-/obj/effect/spawner/random/medical/minor_healing,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
 "xKA" = (
 /obj/machinery/atmospherics/components/binary/valve/digital/on{
 	dir = 1;
@@ -98060,12 +96694,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
 "xLP" = (
-/obj/item/coin/silver{
-	pixel_x = -5;
-	pixel_y = -3
-	},
-/turf/open/floor/plating,
-/area/station/commons/locker/ghetto)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "xLS" = (
 /obj/item/clothing/under/suit/black_really,
 /turf/open/floor/plating,
@@ -98203,11 +96837,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "xNn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/dock)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port)
 "xNp" = (
 /obj/structure/chair/stool{
 	dir = 8
@@ -98232,13 +96867,6 @@
 "xNt" = (
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/magistrate)
-"xNy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/port)
 "xNB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -98367,11 +96995,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "xPh" = (
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic/light,
-/obj/machinery/door/airlock/tram,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/indestructible/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "xPp" = (
 /obj/machinery/modular_computer/preset/civilian{
@@ -98447,11 +97072,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/abandoned)
-"xQn" = (
-/obj/effect/spawner/random/trash/bin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
 "xQu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/structure/cable,
@@ -98795,7 +97415,6 @@
 	},
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/machinery/vending/wallmed/directional/east,
-/obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
 "xUW" = (
@@ -98892,9 +97511,6 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin{
 	pixel_y = 3
-	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Tram Station - East Control Room"
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
@@ -99010,13 +97626,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "xXW" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/grass,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "xYb" = (
 /obj/structure/table/wood,
@@ -99036,13 +97647,11 @@
 /turf/open/misc/sandy_dirt,
 /area/station/service/hydroponics)
 "xYj" = (
-/obj/structure/transport/linear/tram/corner/southeast,
-/obj/structure/tram/spoiler{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/station/maintenance/department/medical/ghetto)
 "xYq" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/structure/cable,
@@ -99059,10 +97668,9 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "xYA" = (
-/obj/structure/fluff/paper/stack{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/l3closet/virology,
+/turf/open/floor/iron,
 /area/station/maintenance/department/medical/ghetto)
 "xYK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -99328,7 +97936,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "ycj" = (
-/turf/open/openspace,
+/obj/structure/sign/plaques/kiddie/library{
+	pixel_x = 32
+	},
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/station/hallway/primary/starboard/west)
 "ycr" = (
 /turf/closed/wall,
@@ -99350,14 +97964,11 @@
 /area/station/service/theater)
 "ycx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/textured,
-/area/station/maintenance/department/medical/ghetto)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/dark_green/fourcorners,
+/obj/structure/frame,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "ycB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -99375,13 +97986,17 @@
 /turf/open/floor/iron/textured_large,
 /area/station/command/teleporter)
 "ycJ" = (
-/obj/machinery/door/airlock/public,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/iron,
+/turf/open/floor/catwalk_floor,
 /area/station/hallway/secondary/dock)
 "ycP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -99399,10 +98014,11 @@
 /turf/open/floor/wood/parquet,
 /area/station/security/courtroom)
 "ycU" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/port/greater)
+/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/ghetto)
 "ycW" = (
 /obj/machinery/status_display/ai/directional/east,
 /obj/item/banner/command/mundane,
@@ -99519,13 +98135,9 @@
 /turf/open/floor/iron,
 /area/station/security/range)
 "yeN" = (
-/obj/structure/transport/linear/tram,
-/obj/structure/tram/split,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto/central)
 "yeP" = (
 /obj/structure/table/wood,
 /obj/item/camera,
@@ -99573,12 +98185,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "yfx" = (
-/obj/structure/fluff/tram_rail/electric/anchor,
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic,
-/obj/structure/chair/sofa/bench/tram,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/medical/ghetto/morgue)
 "yfC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -99674,12 +98286,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "yha" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/obj/structure/sign/calendar/directional/north,
-/turf/open/floor/iron,
+/obj/structure/railing,
+/turf/open/floor/glass/reinforced,
 /area/station/hallway/secondary/dock)
 "yhf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -99776,26 +98384,22 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "yhZ" = (
-/obj/structure/fluff/tram_rail/electric/anchor{
-	dir = 1
-	},
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic,
-/obj/structure/chair/sofa/bench/tram{
-	dir = 1
-	},
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
-"yic" = (
-/obj/effect/turf_decal/trimline/tram/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/tram/filled/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/trash/mess,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_green,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/station/maintenance/department/medical/ghetto)
+"yic" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "yiq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -99891,12 +98495,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/wood/parquet,
 /area/station/hallway/secondary/service)
-"yjr" = (
-/obj/structure/fluff/tram_rail,
-/obj/structure/transport/linear/tram,
-/obj/structure/thermoplastic/light,
-/turf/open/indestructible/plating,
-/area/station/maintenance/ghetto/central/fore)
 "yjy" = (
 /obj/structure/table/optable,
 /turf/open/floor/iron/dark,
@@ -99967,11 +98565,6 @@
 /obj/effect/landmark/navigate_destination/med,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"ykC" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/random/trash/moisture_trap,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/ghetto/central/fore)
 "ykE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -114878,7 +113471,7 @@ hDE
 daZ
 ehS
 cVi
-cgj
+iUu
 oah
 xdE
 xdE
@@ -115130,19 +113723,19 @@ iEV
 iEV
 iEV
 iEV
-iEV
-iEV
-iEV
-iEV
-iEV
-oah
-oah
-oah
-oah
-oah
+tWQ
+tWQ
+tWQ
+tWQ
+tWQ
+tWQ
+tWQ
+tWQ
+tWQ
+tWQ
 yha
 bFY
-suV
+wRm
 klP
 ceC
 doz
@@ -115376,31 +113969,31 @@ doz
 doz
 iEV
 mqU
-fDO
+pCe
 rbi
-uei
-iEV
+rbi
+eRT
 lJB
 xft
 bhg
-qzJ
-qzJ
 dio
-cJf
-dct
+dio
+dio
+dio
+tWQ
 trT
 cTk
 igO
-iEV
-lIH
-jwV
-klP
+mQU
+mQU
+mQU
+xBF
 kMB
-rik
-wAr
-pmP
-bDA
-oah
+tWQ
+tWQ
+gTC
+tWQ
+tWQ
 tWQ
 xWL
 xWL
@@ -115636,29 +114229,29 @@ rbi
 xqb
 xqb
 oqJ
-eRT
+iEV
 qli
 jja
 lwX
 oRG
-iEV
-azn
+fYU
+rbi
 llw
 dGn
-sGQ
+eUy
 cKE
-xqb
+cKE
 bcn
-jAV
-gqH
-rgw
-kMB
-cDt
+eUy
+eUy
+eUy
+eUy
+dvQ
 xNn
-iBB
+cIS
 gkh
 eFw
-pLM
+mQU
 rgO
 rgO
 rgO
@@ -115889,33 +114482,33 @@ doz
 doz
 doz
 iEV
-rbi
-fHp
-cFe
-qhd
 iEV
-eTC
+iEV
+iEV
+iEV
+iEV
+iEV
 hgU
 vcU
 tdq
 iEV
-vIw
-ycU
-dGn
-sGQ
-cKE
-vkg
+xqb
 iEV
+tWQ
+tWQ
 fmY
-nwL
-klP
-xDq
-sSH
-fGv
-cMT
-gqX
-oah
-rgO
+fmY
+tWQ
+fmY
+fmY
+tWQ
+tWQ
+dvQ
+mQU
+mQU
+mQU
+mQU
+xBF
 mLL
 hpS
 qGk
@@ -116145,33 +114738,33 @@ doz
 doz
 doz
 doz
+ceC
+doz
+doz
+doz
+doz
+doz
 iEV
 iEV
 iEV
 iEV
 iEV
+rbi
 iEV
-iEV
-iEV
-iEV
-iEV
-iEV
-iEV
-iEV
-iEV
-iEV
-uSW
-iEV
-iEV
-oah
-oah
-oah
-oah
+nUz
+nUz
+nUz
+nUz
+nUz
+nUz
+nUz
+nUz
+tWQ
 ukw
-oah
-oah
-oah
-oah
+tWQ
+tWQ
+tWQ
+tWQ
 tWQ
 tWQ
 tWQ
@@ -116383,17 +114976,17 @@ doz
 doz
 doz
 doz
+ceC
 doz
 doz
 doz
 doz
 doz
+ceC
 doz
 doz
 doz
-doz
-doz
-doz
+ceC
 doz
 doz
 doz
@@ -116404,30 +114997,30 @@ doz
 doz
 ceC
 doz
-isY
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 iEV
-ipw
-uoo
-hia
-fqD
-oNQ
-keX
-sJU
-fUE
-svx
-cWR
+fDO
+iEV
 nUz
-gJe
-sjP
-iEV
-tsU
-xLP
-tCq
-lrf
+nUz
+tWQ
+fkc
+fkc
+tWQ
+tWQ
+nUz
+tWQ
 gEj
-tfY
-vVS
-tCq
+tWQ
+ceC
+ceC
 doz
 doz
 ceC
@@ -116640,17 +115233,17 @@ doz
 doz
 doz
 doz
+ceC
 doz
 doz
 doz
 doz
 doz
+ceC
 doz
 doz
 doz
-doz
-doz
-doz
+ceC
 doz
 doz
 doz
@@ -116661,30 +115254,30 @@ doz
 doz
 ceC
 doz
-isY
+doz
+doz
+doz
+doz
+doz
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
 iEV
-qpw
-ubd
-paO
-cuf
-pCe
-ucW
+iEV
+iEV
+fDO
+iEV
+nUz
+tWQ
+tWQ
 pVq
-iEV
+lrf
 bJy
-jKq
-tCq
-lLj
-hnY
-cMc
-tvU
-tCq
+tWQ
+tWQ
+tWQ
+fuc
+tWQ
+ceC
+doz
 doz
 doz
 ceC
@@ -116897,17 +115490,17 @@ doz
 doz
 doz
 doz
+ceC
 doz
 doz
 doz
 doz
 doz
+ceC
 doz
 doz
 doz
-doz
-doz
-doz
+ceC
 doz
 doz
 doz
@@ -116918,30 +115511,30 @@ doz
 doz
 ceC
 doz
-isY
+doz
+doz
+doz
+doz
+doz
 iEV
-ipw
-mpa
-idF
 kXD
-oNQ
-iET
-wEy
-xDU
-bkB
-cKv
-fDO
-cKE
-uTm
+xqb
+xqb
+rbi
 iEV
+nUz
+tWQ
 tCq
+uTm
+rgO
+mQU
 tCq
-tCq
-hOR
-hnY
-hPH
-eUc
-tCq
+tWQ
+rCk
+dvQ
+tWQ
+doz
+doz
 doz
 doz
 ceC
@@ -117154,17 +115747,17 @@ doz
 doz
 doz
 doz
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
 doz
 doz
 doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
+ceC
 doz
 doz
 doz
@@ -117175,30 +115768,30 @@ doz
 doz
 ceC
 ceC
-isY
+ceC
+ceC
+ceC
+ceC
+ceC
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
-iET
-wEy
-xqb
-vFq
-mUg
-xkF
+iEV
+iEV
+iEV
+dqr
+iEV
+nUz
+fkc
 qXA
-vrC
-iEV
-pFu
-dhq
-cZT
+mQU
+uTm
+uTm
+uTm
+tWQ
 ivj
-hnY
-hPH
-cTu
-tCq
+dvQ
+tWQ
+ceC
+ceC
 ceC
 ceC
 ceC
@@ -117411,17 +116004,17 @@ doz
 doz
 doz
 doz
+ceC
 doz
 doz
 doz
 doz
 doz
+ceC
 doz
 doz
 doz
-doz
-doz
-doz
+ceC
 doz
 doz
 doz
@@ -117432,30 +116025,30 @@ doz
 ceC
 ceC
 doz
-isY
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
-iET
 tmJ
 xqb
-qJn
-nuf
-rZo
-cKE
-qXA
-nNL
+iEV
+nUz
+fkc
+rti
+rQm
+dnQ
 noM
+rgO
 hnY
-hnY
-hnY
+rlW
 cSQ
-hPH
-nQP
-tCq
+xWL
+doz
+doz
 doz
 doz
 ceC
@@ -117667,18 +116260,18 @@ doz
 doz
 doz
 doz
+isY
+oUZ
+isY
 doz
 doz
 doz
+isY
+oUZ
+isY
 doz
 doz
-doz
-doz
-doz
-doz
-doz
-doz
-doz
+ceC
 doz
 doz
 doz
@@ -117689,30 +116282,30 @@ doz
 ceC
 doz
 doz
-krR
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
-iET
 hQo
 fDO
 sqn
-cKv
-vnP
+nUz
+fkc
+iPz
 twt
-twt
-kKl
-pZB
+rti
+uTm
 ptb
-tSi
+tWQ
 hPH
-hPH
-hPH
-non
-tCq
+cSQ
+xWL
+doz
+doz
 doz
 doz
 ceC
@@ -117933,10 +116526,10 @@ htA
 htA
 htA
 htA
-doz
-doz
-doz
-doz
+isY
+isY
+oUZ
+isY
 doz
 doz
 doz
@@ -117946,32 +116539,32 @@ ceC
 ceC
 doz
 doz
-krR
-iEV
-ipw
-mpa
-gCL
-kXD
-oNQ
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 iEV
 uNk
 xqb
-eWi
-eWi
-kFt
-wGo
+sqn
+nUz
+tWQ
+rgO
 gup
-iEV
+mpa
 dnQ
-gcf
+uTm
 ebI
 gcf
-gcf
-gcf
-biC
-tCq
-tCq
-tCq
+cSQ
+xWL
+doz
+doz
+doz
+doz
 ceC
 had
 rUF
@@ -118203,32 +116796,32 @@ ceC
 doz
 doz
 doz
-isY
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
-iET
 wEy
 fDO
-pCe
-keb
-qhd
-soN
-xQn
 iEV
+nUz
+tWQ
+soN
+mQU
+mQU
 hsa
 rti
-iqc
-hsa
-tCq
-nGh
-pIQ
-osL
-bJM
-tCq
+ebI
+mQU
+eUy
+xWL
+doz
+doz
+doz
+doz
 ceC
 had
 mQU
@@ -118460,32 +117053,32 @@ ceC
 doz
 doz
 doz
-isY
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
-iET
+iEV
+dGe
+iEV
+nUz
+tWQ
+iDA
 pZE
-fDO
-qox
-iEV
-iEV
-iEV
-iEV
-iEV
 kWG
-uyr
-sVm
+kWG
+pZE
+tWQ
 roX
-tCq
-tCq
-tCq
-tCq
-tCq
-tCq
+eUy
+tWQ
+ceC
+ceC
+ceC
+ceC
 had
 had
 mKc
@@ -118717,31 +117310,31 @@ ceC
 ceC
 ceC
 ceC
-isY
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
-iET
 flF
-fDO
-xjg
+rbi
 iEV
-myA
+nUz
+tWQ
 kDI
 xyk
-tCq
+paO
 fbp
+xyk
+tWQ
 uyr
-sVm
-uyr
-vUl
-tCq
-tye
-tye
-tye
+eUy
+tWQ
+ceC
+tWQ
+tWQ
 tWQ
 nCc
 nVX
@@ -118974,32 +117567,32 @@ isY
 doz
 doz
 doz
-isY
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
-iET
-wEy
-fDO
-jnN
 iEV
-sZN
-sCV
-brP
-obg
-bPJ
-cgg
-sVm
-fZJ
-gxJ
-tCq
-eAc
-eAc
-uUU
-avR
+eBD
+iEV
+nUz
+tWQ
+tWQ
+fkc
+fkc
+tWQ
+tWQ
+tWQ
+tWQ
+eUy
+tWQ
+tWQ
+tWQ
+eUy
+eUy
 eUy
 eUy
 eUy
@@ -119231,29 +117824,29 @@ isY
 doz
 doz
 doz
-isY
+doz
+doz
+doz
+doz
+doz
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
+iEV
 iEV
 rVg
-fDO
-kyA
+rbi
 iEV
-rDq
+tWQ
+tWQ
 xAE
 kqT
 cIM
-cIM
+kbJ
 tlu
 nxO
+tWQ
 sVm
-sVm
-sca
-eUy
+tWQ
+avR
 eUy
 dvQ
 tWQ
@@ -119488,29 +118081,29 @@ aPt
 isY
 isY
 doz
-isY
+doz
+doz
+doz
+doz
+doz
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
 mai
-roD
-uhV
+mai
+mai
+mai
 rTY
-iEV
-nfi
+xdu
+wPl
 pfs
 nfi
-tCq
+pfs
 rhY
 pAQ
 kfN
 mIo
-hYO
+eUy
 fWl
-xNy
+eUy
 adv
 sdI
 tWQ
@@ -119745,28 +118338,28 @@ aPt
 aPt
 oUZ
 ceC
-isY
+ceC
+ceC
+ceC
+ceC
+ceC
 iEV
-fgZ
-cOC
-cGn
-sUv
-rjl
-iEV
-iEV
+mai
 iEV
 iEV
 iEV
-tCq
-tCq
-tCq
-tCq
-tCq
-tCq
-tCq
-tCq
-tCq
-fWl
+iEV
+tWQ
+tWQ
+tWQ
+tWQ
+tWQ
+tWQ
+tWQ
+tWQ
+tWQ
+tWQ
+fkc
 tWQ
 tWQ
 tWQ
@@ -120002,13 +118595,13 @@ bcF
 aPt
 isY
 doz
-isY
+doz
+doz
+doz
+doz
+doz
 iEV
-ipw
-wuD
-idF
-eup
-oNQ
+mai
 iEV
 doz
 doz
@@ -120259,13 +118852,13 @@ iaU
 aPt
 isY
 doz
-isY
+doz
+doz
+doz
+doz
+doz
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
+mai
 iEV
 ceC
 ceC
@@ -120516,13 +119109,13 @@ kkN
 aPt
 oUZ
 ceC
-isY
+ceC
+ceC
+ceC
+ceC
+ceC
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
+soo
 iEV
 doz
 doz
@@ -120773,13 +119366,13 @@ vdd
 aPt
 isY
 doz
-isY
+doz
+doz
+doz
+doz
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
+iEV
+mai
 iEV
 doz
 doz
@@ -121030,13 +119623,13 @@ fVY
 aPt
 oUZ
 ceC
-isY
+ceC
+ceC
+ceC
+ceC
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
+gaR
+mai
 iEV
 doz
 doz
@@ -121287,13 +119880,13 @@ aPt
 aPt
 isY
 doz
-isY
+doz
+doz
+doz
+doz
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
+svx
+mai
 iEV
 ceC
 ceC
@@ -121544,13 +120137,13 @@ aPt
 isY
 isY
 doz
-isY
+doz
+doz
+doz
+doz
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
+iEV
+mai
 iEV
 doz
 doz
@@ -121788,7 +120381,7 @@ kft
 mEM
 cYK
 dUz
-dpE
+rbQ
 gsB
 doz
 doz
@@ -121801,12 +120394,12 @@ oUZ
 isY
 doz
 doz
-isY
+doz
+doz
+doz
+doz
+doz
 iEV
-ipw
-mpa
-idF
-kXD
 oNQ
 iEV
 doz
@@ -122058,14 +120651,14 @@ ceC
 doz
 doz
 doz
-krR
+doz
+doz
+doz
+doz
+doz
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
-iEV
+vRC
+tbM
 doz
 doz
 ceC
@@ -122315,15 +120908,15 @@ ceC
 doz
 doz
 doz
-krR
+doz
+doz
+doz
+doz
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
 iEV
-krR
+mai
+iEV
+vbK
 doz
 ceC
 doz
@@ -122572,15 +121165,15 @@ ceC
 doz
 doz
 doz
-krR
+doz
+doz
+doz
+doz
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
+bMs
+mai
 iEV
-sOh
+vbK
 vbK
 ceC
 doz
@@ -122829,15 +121422,15 @@ ceC
 doz
 doz
 doz
-isY
+doz
+doz
+doz
+doz
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
+cDt
+mai
 iEV
-isY
+vbK
 vbK
 ceC
 doz
@@ -123086,15 +121679,15 @@ ceC
 doz
 doz
 doz
-isY
+doz
+doz
+doz
+doz
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
 iEV
-isY
+mai
+iEV
+ceC
 vbK
 ceC
 doz
@@ -123343,15 +121936,15 @@ ceC
 doz
 doz
 doz
-isY
+doz
+doz
+doz
+doz
 iEV
-ipw
-mpa
-idF
 kXD
-oNQ
-iEV
-isY
+mai
+tbM
+ceC
 vbK
 jEk
 doz
@@ -123600,15 +122193,15 @@ ceC
 doz
 doz
 doz
-isY
+doz
+doz
+doz
+doz
 iEV
-ipw
-mpa
-idF
-kXD
+iEV
 oNQ
 iEV
-isY
+ceC
 vbK
 vbK
 ceC
@@ -123846,26 +122439,26 @@ wxj
 hxb
 wxj
 wxj
-sdc
-sdc
-sdc
+jiq
+jiq
+jiq
 wYp
 doz
 doz
 doz
 ceC
+ceC
 aLe
 aLe
 aLe
 aLe
+aLe
+doz
+doz
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
+mai
 iEV
-isY
+ceC
 vbK
 jEk
 vbK
@@ -124105,24 +122698,24 @@ xbp
 uHN
 uHN
 uHN
-sdc
+jiq
 wYp
 doz
 doz
 doz
 ceC
+doz
 aLe
 gnn
 udv
 oBf
+aLe
+doz
+doz
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
+mai
 iEV
-isY
+ceC
 guN
 uVw
 guN
@@ -124368,18 +122961,18 @@ doz
 doz
 doz
 ceC
+doz
 aLe
 mSF
 hsW
 qgL
+aLe
+doz
+doz
 iEV
-ipw
-mpa
-idF
-kXD
-oNQ
+vRC
 iEV
-isY
+doz
 guN
 hLM
 guN
@@ -124619,21 +123212,21 @@ rcb
 bvz
 axt
 xbp
-sdc
+jiq
 wYp
 doz
 doz
 doz
 ceC
+doz
 aLe
 eXx
 kRr
 fHV
+aLe
+doz
+doz
 iEV
-fZI
-nvH
-idF
-aEx
 uGE
 iEV
 guN
@@ -124876,24 +123469,24 @@ gJq
 qlB
 joG
 xbp
-sdc
+jiq
 wYp
 aLe
 adN
 adN
 adN
 aLe
+aLe
 lAL
 kKp
 dhk
-iEV
-lrH
-pNk
-ecD
-taY
-lrH
-iEV
-ccS
+aLe
+aLe
+aLe
+guN
+dwb
+guN
+eDv
 gPU
 hLM
 kJJ
@@ -125133,27 +123726,27 @@ uHN
 ova
 uHN
 uHN
-sdc
-sdc
+jiq
+sRw
 dNb
-sdc
+jiq
 vcX
-sdc
-sdc
-sdc
-sdc
-qzS
-pkM
-lrH
+uDj
+jiq
+jiq
+jiq
+jiq
+jiq
+ecD
 pNk
 ecD
 taY
 lrH
-bTl
-hLM
-hLM
-hLM
-hLM
+kwx
+gyg
+kwx
+kwx
+kwx
 eGx
 kvH
 kGW
@@ -125390,23 +123983,23 @@ nMd
 maf
 uEm
 xbp
-aLe
-aLe
-aLe
-bWl
-qzS
-ssl
+pKB
 aLe
 aLe
 aLe
 aLe
-iEV
-lrH
-pNk
-ecD
-taY
-lrH
-iEV
+aLe
+aLe
+aLe
+aLe
+aLe
+aLe
+aLe
+aLe
+aLe
+guN
+guN
+guN
 guN
 guN
 guN
@@ -125647,27 +124240,27 @@ rwD
 maf
 tWp
 xbp
+jiq
+aLe
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 ceC
-aLe
-aLe
-aQQ
-aLe
-aLe
+doz
+doz
+ceC
 ceC
 doz
-isY
-guN
-hae
-edF
-vWK
-ihB
-aZl
-vzx
-vRJ
-vxw
-guN
-ceC
+doz
+doz
 ceC
 ceC
 ceC
@@ -125904,27 +124497,27 @@ tSu
 maf
 wCJ
 uHN
-doz
-ceC
-ceC
+jiq
 aLe
-qzS
-aLe
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+vbK
+vbK
+vbK
+vbK
+ceC
+doz
 ceC
 ceC
 doz
-isY
-guN
-xbG
-mbC
-vWK
-xsF
-sdN
-mtl
-fjr
-vxw
-guN
 doz
+doz
+ceC
 ceC
 doz
 doz
@@ -126161,26 +124754,26 @@ bzZ
 uxH
 whB
 uHN
+vcX
+aLe
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+doz
 doz
 doz
 ceC
-aLe
-kCC
-aLe
-ceC
-doz
-doz
-isY
-guN
-xbG
-mbC
-vWK
-xsF
-sdN
-dsx
-fjr
-vxw
-guN
 ceC
 vbK
 guN
@@ -126418,27 +125011,27 @@ aLW
 uxH
 uEm
 xbp
-doz
-doz
+jiq
+aLe
 ceC
-vbK
-jEk
-vbK
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
+ceC
 ceC
 doz
 doz
-isY
-guN
-xbG
-mbC
-vWK
-xsF
-sdN
-iqU
-fjr
-vxw
-hBH
-oqy
+vbK
+vbK
+vbK
+vbK
+ceC
 aFm
 sVY
 ixJ
@@ -126675,27 +125268,27 @@ qYD
 nOe
 qYD
 uHN
+jiq
+aLe
+doz
+doz
+doz
+doz
+doz
+doz
 doz
 doz
 doz
 vbK
+vbK
+ceC
+ceC
 ceC
 vbK
-doz
-doz
-doz
-isY
-guN
-xbG
-mbC
-vWK
-xsF
-sdN
-dsx
-iEC
-vxw
-guN
-ceC
+job
+job
+vbK
+vbK
 vbK
 guN
 guN
@@ -126932,6 +125525,8 @@ hHo
 pSG
 tqu
 jxu
+nqa
+aLe
 doz
 doz
 doz
@@ -126941,18 +125536,16 @@ doz
 doz
 doz
 doz
-isY
-guN
-xbG
-mbC
-vWK
-xsF
-sdN
-sJJ
-fjr
-vxw
-guN
 doz
+vbK
+ceC
+doz
+job
+job
+job
+job
+job
+job
 ceC
 doz
 doz
@@ -127189,6 +125782,19 @@ nHl
 nDy
 sUL
 jxu
+jiq
+aLe
+aLe
+aLe
+aLe
+doz
+doz
+job
+doz
+doz
+doz
+doz
+doz
 ceC
 doz
 doz
@@ -127196,26 +125802,13 @@ doz
 doz
 doz
 doz
-doz
 ceC
-isY
+ceC
+doz
+doz
+doz
 guN
-xbG
-mbC
-vWK
-xsF
-sdN
-dsx
-iEC
-vxw
-guN
-ceC
-ceC
-ceC
-ceC
-ceC
-guN
-bsv
+jJN
 guN
 vbK
 doz
@@ -127446,6 +126039,19 @@ xGq
 fJL
 cEP
 jxu
+jiq
+vcX
+jiq
+jiq
+aLe
+ceC
+ceC
+job
+job
+doz
+doz
+doz
+doz
 ceC
 doz
 doz
@@ -127455,24 +126061,11 @@ doz
 doz
 doz
 ceC
-isY
+ceC
+doz
+doz
 guN
-xbG
-mbC
-vWK
-xsF
-sdN
-guN
-guN
-guN
-guN
-guN
-guN
-guN
-guN
-guN
-guN
-xxx
+bsv
 guN
 vbK
 doz
@@ -127706,30 +126299,30 @@ jxu
 jxu
 jxu
 jxu
-cvk
-cvk
-cvk
-cvk
-cvk
-cvk
-cvk
+jiq
+aLe
+doz
+ceC
+job
+job
+doz
+doz
+doz
 guN
-xbG
-mbC
-vWK
-xsF
-sdN
 guN
-wWG
-vRC
-lQX
-ykC
-erm
-nFI
 guN
-fTi
-hLM
-bsv
+guN
+guN
+guN
+guN
+guN
+guN
+guN
+ceC
+guN
+guN
+guN
+xxx
 guN
 vbK
 doz
@@ -127963,29 +126556,29 @@ urI
 upg
 lIV
 jxu
-ugX
-qFZ
-sMr
-bqY
-sMr
-cXa
-ugX
-guN
-xbG
-mbC
-vWK
-xsF
-sdN
-guN
+jiq
+aLe
+doz
+doz
+job
+job
+ceC
+ceC
+ceC
+lVD
+hLM
+kGW
+hLM
+jhh
 nrU
 lek
+hLM
 xhT
-xhT
-pEZ
-pYa
-hvt
-bsv
-bsv
+guN
+guN
+guN
+fTi
+hLM
 bsv
 guN
 vbK
@@ -128220,29 +126813,29 @@ eqe
 iwV
 dqq
 jxu
-tSK
-tSK
-rIX
-cqh
-fZq
-xYA
-tSK
-guN
-xbG
+jiq
+aLe
+ceC
+ceC
+job
+ceC
+ceC
+ceC
+ceC
 lVD
-vWK
-vwy
-sdN
-guN
-wWG
-aIO
-sQw
-guN
-pna
-qyx
-guN
-hFo
 hLM
+bsv
+bsv
+bsv
+bsv
+bsv
+bsv
+bsv
+eDw
+lfS
+faT
+bsv
+bsv
 bsv
 guN
 vbK
@@ -128478,22 +127071,22 @@ pWC
 oAk
 jxu
 dBQ
-hmU
-uWI
-cqh
-lih
-xfj
-rna
+aLe
+aLe
+aLe
+aLe
+aLe
+aLe
+aLe
+aLe
+aLe
+hLM
+bsv
+dhZ
+dhZ
 guN
-xbG
-mbC
-vWK
-xsF
-sdN
 guN
 guN
-guN
-mdX
 guN
 guN
 guN
@@ -128734,26 +127327,26 @@ bML
 bML
 bML
 jxu
-qup
+nqa
+dNb
+jiq
+jiq
+jiq
 eNS
-qup
-cqh
-qup
-eNS
-qup
-guN
-xbG
+jiq
+jiq
+jiq
 mbC
-vWK
-xsF
-sdN
+bsv
+bsv
+dhZ
 dow
 rfJ
 vNR
-bFX
-vbc
-amM
-sUA
+guN
+doz
+doz
+ceC
 guN
 asz
 rHA
@@ -128991,26 +127584,26 @@ tvw
 dib
 dBt
 jxu
-tSK
-urC
-lCL
-qgF
-tSK
-tSK
-sHr
+jiq
+qVj
+qVj
+eDR
+eDR
+qVj
+qVj
+qVj
+qVj
+qVj
 guN
-qQP
-aTK
-jJg
-xtw
-vIY
+iFL
+guN
 guN
 eCW
-oTa
-wat
-dkO
-bFX
-bFX
+guN
+guN
+ceC
+ceC
+doz
 guN
 eSa
 sdw
@@ -129248,26 +127841,26 @@ jsP
 vkZ
 kqa
 jxu
-tSK
+urg
 qVj
-tSK
-nCX
+dFI
+hhW
 cEI
 bMW
-lCL
-guN
+hfN
+rgw
 hbM
 qnq
-lSJ
+guN
 iFL
-bMs
-sTc
-jZk
-guA
-rbr
-dkO
-bqT
-guU
+kGW
+wNb
+xPh
+tbg
+guN
+doz
+doz
+doz
 guN
 haw
 haw
@@ -129505,26 +128098,26 @@ bML
 bML
 bML
 jxu
-hfE
+jiq
 gtv
 nPy
 rST
 iTk
 iqs
-tSK
-guN
+cqh
+jHI
 kdL
 pFX
-roB
-tSU
+guN
+grg
 xPh
-sTc
-iqH
+amM
+tbg
 dJQ
-cJl
-wEb
 guN
-guN
+txs
+doz
+doz
 guN
 guN
 guN
@@ -129762,25 +128355,25 @@ hbF
 gVp
 rbe
 jxu
-bqY
+jiq
 eox
-bqY
-bqY
+pFu
+bWl
+cwC
+nRY
 cqh
-cqh
-cqh
-guN
-kdL
+uei
+oSW
 dZt
-sUP
-tSU
-oEX
-sTc
-iqH
-hTS
-mhz
-rfJ
 guN
+grg
+oEX
+lVD
+tbg
+hTS
+guN
+vbK
+doz
 doz
 ceC
 doz
@@ -130019,28 +128612,28 @@ jhd
 tQL
 xlt
 jxu
-kdc
-rcd
-bqY
+jiq
+qVj
+eWi
 jBp
 nrj
 knh
 hfN
-guN
+pZB
 yeN
 oad
-hRQ
-grg
-vMa
-sTc
-tbg
-rWy
-rbr
-rfJ
 guN
+grg
+fGa
+lVD
+tbg
+tbg
+guN
+vbK
+doz
 doz
 ceC
-doz
+txs
 guN
 bsv
 guN
@@ -130276,30 +128869,30 @@ bGE
 bGE
 bGE
 vXt
-nam
-iwo
-eox
+jiq
+qVj
+qVj
+nzm
 dZS
-dZS
-dZS
-lCL
+qVj
+qVj
+lBG
+hfN
+qVj
 guN
-yeN
-yfx
-cll
-yhZ
+dhZ
 dhZ
 guN
-gwH
-nIg
-rbr
-ciW
+dhZ
 guN
-doz
+guN
+vbK
+ceC
+ceC
 ceC
 doz
 guN
-bsv
+skM
 guN
 vbK
 doz
@@ -130533,33 +129126,33 @@ lza
 qHA
 hFb
 vXt
-gaR
-jkC
-cqh
+vcX
+qVj
+dUG
 qxb
 fIL
-xdu
+fIL
 qPF
-guN
-gEh
-hID
+uSW
+fcz
+qVj
 sUP
 stc
-dhZ
+guN
 sTc
 fei
-rWy
-rbr
-bFX
 guN
-doz
+vbK
+vbK
 ceC
+doz
+doz
 doz
 guN
 bsv
 guN
-vbK
-doz
+guN
+guN
 doz
 doz
 doz
@@ -130789,34 +129382,34 @@ mdT
 hux
 hZl
 qDl
-hhW
-lCL
-dIH
-cqh
+vXt
+jiq
+eDR
+eCX
 iCy
 fcz
-xBh
-xKv
-guN
-kdL
-yjr
-sUP
-tSU
-xPh
-sTc
-fei
-gyB
-cJl
-rfJ
-guN
-ceC
-ceC
-ceC
-guN
-skM
-guN
+fcz
+hfN
+uSW
+lSJ
+cvk
+cvk
+cvk
+cvk
+cvk
+cvk
+cvk
 vbK
 doz
+doz
+doz
+doz
+doz
+guN
+bsv
+tRT
+kwx
+guN
 doz
 doz
 doz
@@ -131046,34 +129639,34 @@ dSw
 iAp
 kHj
 ciz
-aEU
-lCL
-iwo
-bqY
-bqY
-bqY
-bqY
-bqY
-guN
-kdL
-pFX
-roB
-tSU
-oEX
-sTc
+vXt
+nqa
+qVj
+hCs
+fgZ
+ycx
+jAV
+qVj
+pZB
+noF
+cvk
 nAe
-jKp
-mhz
-rfJ
-guN
-doz
-ceC
-doz
-guN
-bsv
-guN
+tSU
+bqY
+tSU
+nAe
+cvk
 vbK
+vbK
+vbK
+doz
 ceC
+ceC
+guN
+hLM
+lni
+kwx
+guN
 ceC
 ceC
 ceC
@@ -131303,34 +129896,34 @@ mdT
 tGw
 rwH
 xjL
-hhW
+vXt
 jiq
-iwo
+eDR
 dEP
 rku
-cqh
+suj
 dvK
-joZ
-guN
+hfN
+uSW
 sxF
-aAu
+cvk
 dif
 bkN
-bMs
-sTc
+bqY
+uIu
 njv
-tXU
-rbr
+cvk
+vbK
 dkO
-guN
-doz
-ceC
-doz
-guN
-jJN
-guN
+vbK
+vbK
 vbK
 doz
+guN
+kJJ
+hLM
+kwx
+guN
 doz
 doz
 ceC
@@ -131561,33 +130154,33 @@ lsU
 xUU
 feT
 vXt
-tdR
-uKl
+jiq
+qVj
 uKl
 hHz
 say
+ipw
 qul
-qul
-guN
-nPf
-aTK
+xLP
+fcz
+cvk
 jJg
 xtw
-xYj
-guN
+bqY
+bsA
 qPh
-aLp
-wTY
+cvk
+bqY
 amK
-guN
-doz
-ceC
-doz
-guN
-bsv
-guN
+bqY
+bqY
 vbK
-doz
+txs
+guN
+guN
+guN
+klx
+guN
 doz
 doz
 ceC
@@ -131818,32 +130411,32 @@ vXt
 vXt
 vXt
 vXt
-bqY
-bqY
-fQm
-bqY
-bqY
-cqh
-cqh
-guN
-xbG
-mbC
-vWK
-xsF
-sdN
+jiq
+qVj
+qVj
+qVj
+qVj
+qVj
+qVj
+vFq
+qVj
+cvk
+qup
 uIU
-rfJ
-dkO
+bqY
+uIU
+qup
+cvk
 qyp
-qyp
-guN
-doz
-ceC
-doz
-guN
-bsv
-guN
-guN
+fZI
+oyA
+bqY
+vbK
+lLj
+obg
+hLM
+teR
+kwx
 guN
 ceC
 ceC
@@ -132075,31 +130668,31 @@ tiq
 gQE
 xEV
 shU
-wMc
-gag
-ycx
+jiq
+jiq
+eDR
 dUG
-gIC
+fcz
 wih
 piL
-guN
+kdc
 xbG
-mbC
-vWK
-xsF
+qup
 sdN
-guN
-guN
-guN
-guN
-guN
-guN
-doz
-ceC
-doz
-guN
-bsv
-wNH
+ceM
+sdN
+ceM
+rWy
+bqY
+bFX
+nCX
+oPU
+bqY
+bqY
+bqY
+bqY
+bqY
+bqY
 kwx
 guN
 doz
@@ -132318,7 +130911,7 @@ oaQ
 wdq
 drT
 drT
-wiy
+drT
 jxu
 jxu
 jxu
@@ -132328,35 +130921,35 @@ jxu
 jxu
 jxu
 jxu
-dTi
-dTi
-bgA
-dKD
-uoQ
-aSl
+qzS
+qzS
+qzS
+qzS
+qzS
+jiq
 dvm
-lCL
+xLP
 bnC
 swu
-lCL
-guN
-xbG
-lVD
-vWK
+bnC
+swu
+rbr
+xfy
+idF
 vwy
-sdN
+xYj
 dsx
-fjr
+dhq
 vxw
-guN
-vbK
-vbK
-vbK
-ceC
-vbK
-guN
-guN
-guN
+wfW
+bir
+jKq
+bqY
+aUb
+tsU
+bkB
+iqc
+bqY
 kwx
 guN
 doz
@@ -132577,43 +131170,43 @@ wdq
 wdq
 wdq
 szM
-trz
-cUx
-eRQ
-cUx
+wxj
+wxj
+hxb
+wxj
 xmh
 xmh
 xmh
-dKD
-dKD
-xmh
-xmh
-dKD
-wMc
-eDv
+jiq
+jiq
+jiq
+vcX
+jiq
+jiq
+jiq
 eDR
 mZy
 eTx
 diB
-lCL
-guN
-xbG
-mbC
-vWK
-xsF
-sdN
+kKl
+fGs
+brP
+qup
+biC
+hZr
+nVs
 xHT
 fjr
-vxw
-guN
-doz
-doz
-doz
-ceC
-doz
-doz
-ceC
-guN
+bqY
+eBh
+cJf
+sUv
+qFZ
+dzN
+jxf
+pna
+lob
+bqY
 kwx
 guN
 guN
@@ -132829,48 +131422,48 @@ oVL
 doz
 doz
 gVh
-iox
-iox
-iox
-iox
+kPZ
 gVh
-cHg
-glK
-glK
+gVh
+gVh
+gVh
+gVh
+gVh
+qdy
 eLo
 dTi
 dTi
 dTi
-bgA
-eBD
-frZ
-oyA
-muS
+dTi
+qzS
+aLe
+aLe
+aLe
+aLe
+wWG
 uXV
 yaz
 yaz
 uXV
 yaz
-jxf
+sJU
 uXV
-guN
-xbG
-mbC
-vWK
-xsF
-sdN
-cwC
-iEC
-vxw
-guN
-ceC
-ceC
-ceC
-ceC
-vbK
-guN
-guN
-guN
+cvk
+cvk
+qup
+cMT
+qup
+cvk
+cvk
+uWI
+lgp
+gqH
+fKu
+xfj
+jwV
+tSK
+jKp
+bqY
 kwx
 kwx
 kwx
@@ -133085,51 +131678,51 @@ doz
 oVL
 doz
 doz
+doz
+ceC
+doz
+doz
+doz
+doz
+doz
 gVh
-gVh
-kPZ
-kPZ
-gVh
-gVh
-gVh
-gVh
-nTL
-glK
+xTx
+qdy
 aLe
 aLe
 aLe
 aLe
 mVb
-grk
-sRw
+aLe
 bgA
+bgA
+aLe
+jiq
 uXV
-bJR
-nYm
 xye
+bTl
+qMz
 nYm
 bup
 gOu
-guN
-xbG
-mbC
-vWK
-xsF
-sdN
+cvk
+cKv
+end
+sca
 iqU
-fjr
-vxw
+bQs
+cvk
 hBH
+lCL
+lCL
+qFZ
 oqy
-oqy
-oqy
-oqy
-aFm
-sVY
-ixJ
-lsH
-lni
-guN
+fZq
+mtl
+yhZ
+bqY
+bqY
+bqY
 mFZ
 wNH
 ccS
@@ -133351,15 +131944,17 @@ doz
 doz
 gVh
 fnE
-glK
+qdy
 aLe
 twJ
 dFL
 aLe
-pKB
+qzS
 xXW
-nVV
 bgA
+bgA
+aLe
+cgj
 yaz
 okD
 okD
@@ -133367,26 +131962,24 @@ rgG
 okD
 lqn
 oUX
-guN
-xbG
-mbC
+cvk
 vWK
 xsF
-sdN
+qaD
 vzx
-fjr
-vxw
-guN
-ceC
-ceC
-ceC
-ceC
-vbK
-guN
-guN
-guN
-wxG
-guN
+fjE
+cvk
+gEh
+hmU
+ycU
+bqY
+cOC
+xYA
+vnP
+qox
+bqY
+tTo
+bqY
 xws
 wNH
 bdK
@@ -133613,37 +132206,37 @@ aLe
 aLe
 aLe
 aLe
-pKB
-xXW
-tSS
-piT
+qzS
+aLe
+bgA
+bgA
+aLe
+jiq
 yaz
 fgw
 pXW
 fgw
-dXW
+yfx
 lqn
 toF
-guN
-xbG
-mbC
-vWK
-xsF
-sdN
-hBs
-fjr
-vxw
-guN
-doz
-doz
-doz
-ceC
-doz
-doz
-ceC
-guN
-guN
-guN
+cvk
+cvk
+cvk
+cvk
+cvk
+cvk
+cvk
+pqG
+lCL
+cTu
+bqY
+bqY
+bqY
+bqY
+bqY
+bqY
+bqY
+bqY
 guN
 snB
 guN
@@ -133869,36 +132462,36 @@ doz
 doz
 aLe
 qYN
-bgA
-eBD
-dGV
-bKA
-bgA
+dTi
+qzS
+aLe
+aLe
+aLe
+aLe
+jiq
 yaz
 qFY
 okD
 bUU
 qkz
-rgG
+bJM
 vgn
-guN
-xbG
-mbC
-vWK
-xsF
-sdN
-dsx
-lBG
-vxw
-guN
-vbK
-vbK
-vbK
-ceC
-vbK
-vbK
-vbK
-raA
+aLe
+dTi
+dTi
+nTL
+chI
+lCL
+lCL
+jEs
+lCL
+lCL
+cxT
+rnJ
+lQX
+azn
+nuf
+bqY
 vuf
 vuf
 cRr
@@ -134126,36 +132719,36 @@ doz
 doz
 aLe
 dtW
-bgA
-eBD
-iSB
-jHI
-bgA
+dTi
+qzS
+aLe
+vbK
+aLe
+muS
+jiq
 uXV
 uXV
 uXV
 uXV
 yaz
-faT
+cGn
 uXV
-guN
-xbG
-mbC
-vWK
-xsF
-sdN
-guN
-otf
-otf
-otf
-otf
-otf
-otf
-otf
-otf
-otf
-otf
-raA
+aLe
+qzS
+aLe
+aLe
+aLe
+dKD
+biC
+upA
+qvJ
+ihB
+uUQ
+fLV
+cca
+pqG
+pqG
+bqY
 aWb
 aWb
 spi
@@ -134383,36 +132976,36 @@ doz
 doz
 aLe
 aLe
-pKB
-eBD
-tEj
-wNb
-bgA
-bgA
-bgA
-chI
+qzS
+qzS
+aLe
+vbK
+aLe
+hVb
+jiq
+fRD
 sRN
 cYY
-cYY
+tvU
 fRD
-guN
-xbG
-mbC
-vWK
-xsF
-sdN
-guN
-gBP
-gTC
-hoU
-rSO
-otf
-cby
-hQg
-aJH
-ciP
-otf
-raA
+sdc
+sdc
+sdc
+sdc
+urC
+sdc
+aLe
+bqY
+bqY
+bqY
+bqY
+bqY
+bqY
+bqY
+bqY
+bqY
+bqY
+bqY
 wOV
 oTV
 gNt
@@ -134640,33 +133233,33 @@ doz
 doz
 ceC
 aLe
-fgH
+aQQ
 aLe
 aLe
-aLe
-aLe
+vbK
 aLe
 ait
 ait
 aLe
-jhh
-bgA
-cYY
-guN
-xbG
-mbC
-vWK
-xsF
-sdN
-guN
-dwb
-stF
+aLe
+aLe
+aLe
+aLe
+aLe
+ssl
+aLe
+aLe
+aLe
+mRC
+hoU
+otf
+gqX
 xEa
-uiH
+tNV
 iWD
 oEZ
 lEK
-hlb
+vVS
 lqt
 otf
 lVT
@@ -134897,28 +133490,28 @@ doz
 doz
 ceC
 aLe
-ato
+qzS
 aLe
 ceC
 vbK
-doz
 aLe
 aLe
 aLe
 aLe
+vbK
+vbK
+vbK
+ceC
 aLe
-oPU
-cYY
-pNZ
-agH
-grQ
+kKp
+xXW
 esN
-tOg
-eSj
-pNZ
-gga
+ciP
+sdc
+gCL
+otf
 xFn
-qMz
+stF
 uiH
 otf
 xgM
@@ -135154,7 +133747,7 @@ doz
 doz
 ceC
 aLe
-kbJ
+kCC
 aLe
 ceC
 vbK
@@ -135163,24 +133756,24 @@ vbK
 vbK
 vbK
 vbK
+doz
+doz
+ceC
 aLe
-xvE
-vLc
-pNZ
-agH
-grQ
-esN
-tOg
-eSj
-pNZ
+kKp
+xXW
+grk
+wiy
+fqD
+cuf
 oCT
+ppD
 uCO
-lgp
 gNa
 fDi
 hwz
 abq
-mVY
+hlb
 xIq
 otf
 bFy
@@ -135411,7 +134004,7 @@ doz
 doz
 ceC
 aLe
-ato
+qzS
 aLe
 ceC
 vbK
@@ -135420,17 +134013,17 @@ ceC
 doz
 doz
 ceC
+ceC
+ceC
+ceC
 aLe
-eKm
-bMl
-pNZ
-agH
-grQ
-esN
-tOg
-eSj
-pNZ
-pDH
+fUE
+xXW
+tTU
+uoo
+aTK
+vLc
+otf
 iYM
 ple
 rgy
@@ -135668,7 +134261,7 @@ doz
 ceC
 ceC
 adN
-ato
+qzS
 aLe
 ceC
 vbK
@@ -135677,20 +134270,20 @@ ceC
 doz
 doz
 doz
+doz
+ceC
+ceC
 aLe
-qTT
-cYY
+aLe
+aLe
 pNZ
-agH
-grQ
-esN
-tOg
-eSj
+ciW
 pNZ
-otf
-eCX
-otf
-otf
+pNZ
+pNZ
+pNZ
+pNZ
+pNZ
 aCd
 dry
 rBw
@@ -135925,8 +134518,8 @@ ceC
 ceC
 ceC
 adN
-ato
-adN
+qzS
+nMs
 jEk
 vbK
 doz
@@ -135934,20 +134527,20 @@ ceC
 doz
 doz
 doz
-aLe
-tlT
-cYY
+doz
+doz
+ceC
+doz
+doz
+doz
 pNZ
-agH
-grQ
-esN
-tOg
-eSj
+nIg
 pNZ
-msN
-yaI
-hZr
-otf
+aPK
+aPK
+aPK
+aPK
+pNZ
 cIu
 fBH
 lQG
@@ -136182,7 +134775,7 @@ doz
 doz
 ceC
 aLe
-ato
+qzS
 aLe
 ceC
 vbK
@@ -136191,21 +134784,21 @@ vbK
 vbK
 vbK
 vbK
-aLe
-jEs
-bMl
+vbK
+vbK
+ceC
+vbK
+vbK
+vbK
 pNZ
-bjm
-iDA
-esN
 jrj
-vKj
 pNZ
-rbQ
-vpn
-dzN
-otf
-otf
+pNZ
+yjO
+rYX
+pNZ
+pNZ
+pNZ
 otf
 otf
 obz
@@ -136439,7 +135032,7 @@ doz
 doz
 ceC
 aLe
-ato
+qzS
 aLe
 ceC
 vbK
@@ -136448,21 +135041,21 @@ doz
 doz
 doz
 ceC
-aLe
-uWP
-cYY
-bgP
-vej
-hVb
-rnJ
+doz
+doz
+ceC
+doz
+doz
+doz
+pNZ
 niz
-vej
-ocb
+jld
+raL
+nFI
+eTK
+uoQ
 yaI
-aCq
-vpn
 yaI
-uDj
 xSN
 ooL
 xbr
@@ -136695,8 +135288,8 @@ doz
 doz
 doz
 ceC
-adN
-ato
+nMs
+qzS
 adN
 ceC
 vbK
@@ -136705,20 +135298,20 @@ doz
 doz
 doz
 doz
-aLe
-nkx
-cYY
-jYi
-vej
-hVb
-rnJ
-niz
+ceC
+doz
+ceC
+doz
+doz
+doz
+pNZ
+tOS
 vej
 vpI
-yaI
-wZR
-vpn
-yaI
+vej
+aar
+tOS
+vej
 hFL
 lVy
 qwC
@@ -136953,7 +135546,7 @@ doz
 doz
 ceC
 adN
-ato
+qzS
 aLe
 ceC
 vbK
@@ -136962,19 +135555,19 @@ vbK
 vbK
 vbK
 ceC
-aLe
-bgA
-cYY
-fAS
-vej
-hVb
-rnJ
-niz
-vej
-gyg
-yaI
-yaI
-aCq
+vbK
+vbK
+ceC
+vbK
+vbK
+vbK
+pNZ
+pNZ
+pNZ
+pNZ
+pNZ
+pNZ
+pNZ
 eRj
 hFL
 xSN
@@ -137210,7 +135803,7 @@ doz
 doz
 ceC
 aLe
-ato
+qzS
 aLe
 ceC
 vbK
@@ -137219,18 +135812,18 @@ doz
 doz
 uXq
 doz
-aLe
-aLe
-aLe
-pNZ
-uUQ
-sAw
-esN
-mGq
-tTo
-pNZ
-pNZ
-pNZ
+doz
+uXq
+ceC
+job
+doz
+uXq
+doz
+job
+ceC
+doz
+uXq
+doz
 pNZ
 vpn
 iYF
@@ -137467,8 +136060,8 @@ doz
 doz
 jEk
 aLe
-ato
-adN
+qzS
+nMs
 ceC
 vbK
 vbK
@@ -137478,16 +136071,16 @@ vbK
 vbK
 vbK
 vbK
-isY
-pNZ
-agH
-grQ
-esN
-tOg
-eSj
-pNZ
-isY
 ceC
+vbK
+vbK
+vbK
+vbK
+vbK
+vbK
+vbK
+sgD
+vbK
 pNZ
 yaI
 aTe
@@ -137723,27 +136316,27 @@ doz
 doz
 doz
 ceC
-pNZ
-vfq
-pNZ
+aLe
+qzS
+aLe
 ceC
 vbK
+doz
 ceC
 ceC
 doz
 doz
 doz
 doz
+ceC
 doz
-isY
-pNZ
-agH
-grQ
-esN
-tOg
-eSj
-pNZ
-isY
+doz
+ceC
+doz
+doz
+doz
+doz
+doz
 doz
 qqz
 uJB
@@ -137980,27 +136573,27 @@ doz
 doz
 doz
 ceC
-qqz
-vfq
-pNZ
+adN
+qzS
+aLe
 ceC
 vbK
 doz
+doz
 ceC
+doz
+doz
+doz
+doz
+ceC
+doz
+doz
+doz
 ceC
 doz
 doz
 doz
 doz
-krR
-pNZ
-agH
-grQ
-esN
-tOg
-eSj
-pNZ
-isY
 doz
 qqz
 foT
@@ -138237,9 +136830,9 @@ doz
 doz
 doz
 ceC
-qqz
-vfq
-qqz
+adN
+qzS
+adN
 ceC
 vbK
 doz
@@ -138249,16 +136842,16 @@ ceC
 doz
 doz
 doz
-krR
-pNZ
-agH
-grQ
-esN
-tOg
-eSj
-pNZ
-isY
 ceC
+doz
+doz
+doz
+doz
+ceC
+doz
+doz
+doz
+vbK
 pNZ
 yaI
 eQX
@@ -138494,30 +137087,30 @@ doz
 doz
 doz
 ceC
-pNZ
-vfq
-pNZ
+aLe
+qzS
+aLe
 ceC
 vbK
 doz
 doz
 doz
+doz
 ceC
+doz
+doz
 ceC
 doz
 doz
-isY
-pNZ
-agH
-grQ
-esN
-tOg
-eSj
-pNZ
-isY
 doz
+doz
+ceC
+doz
+doz
+doz
+vbK
 pNZ
-ceM
+raL
 iYF
 xSN
 tqK
@@ -138751,9 +137344,9 @@ ceC
 doz
 doz
 ceC
-pNZ
-vfq
-pNZ
+aLe
+qzS
+aLe
 ceC
 vbK
 vbK
@@ -138763,18 +137356,18 @@ ceC
 vbK
 vbK
 vbK
-isY
-pNZ
-agH
-grQ
-esN
-tOg
-eSj
-pNZ
-isY
 ceC
+vbK
+vbK
+vbK
+vbK
+ceC
+vbK
+vbK
+vbK
+vbK
 pNZ
-vpn
+loN
 kKA
 pNZ
 iBi
@@ -139008,9 +137601,9 @@ ceC
 ceC
 ceC
 ceC
-qqz
-vfq
-qqz
+adN
+qzS
+nMs
 jEk
 vbK
 uXq
@@ -139020,18 +137613,18 @@ uXq
 doz
 doz
 uXq
-isY
-pNZ
-agH
-grQ
-esN
-tOg
-eSj
-pNZ
-isY
+ceC
+job
 doz
-qqz
-raL
+job
+uXq
+doz
+doz
+uXq
+doz
+vbK
+pNZ
+yaI
 cof
 jfa
 iBi
@@ -139265,9 +137858,9 @@ doz
 doz
 ceC
 ceC
-qqz
-vfq
-pNZ
+adN
+qzS
+aLe
 ceC
 vbK
 vbK
@@ -139277,17 +137870,17 @@ vbK
 vbK
 vbK
 vbK
-isY
+ceC
+vbK
+vbK
+vbK
+vbK
+vbK
+vbK
+vbK
+vbK
+vbK
 pNZ
-agH
-grQ
-esN
-tOg
-eSj
-pNZ
-isY
-doz
-qqz
 yaI
 iYF
 ygA
@@ -139522,28 +138115,28 @@ doz
 doz
 doz
 ceC
-pNZ
-vfq
-pNZ
+aLe
+qzS
+aLe
 ceC
 vbK
-jEk
+doz
+doz
+doz
+ceC
+doz
+doz
+doz
+ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
 vbK
-doz
-ceC
-doz
-doz
-doz
-isY
-pNZ
-agH
-alV
-esN
-wfW
-eSj
-pNZ
-isY
-ceC
 pNZ
 vpn
 eQX
@@ -139783,24 +138376,24 @@ pNZ
 bmk
 pNZ
 ceC
-asK
-hOv
-asK
+vbK
+doz
+doz
 doz
 ceC
 doz
 doz
 doz
-isY
-pNZ
-kQH
-iyj
-nMs
-sgD
-oVO
-pNZ
-pNZ
-pNZ
+ceC
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+doz
+vbK
 pNZ
 evs
 iYF
@@ -140037,12 +138630,12 @@ doz
 doz
 ceC
 pNZ
-vfq
+vpn
 pNZ
 ceC
-asK
-vpn
-asK
+vbK
+doz
+doz
 doz
 ceC
 pNZ
@@ -140050,14 +138643,14 @@ pNZ
 pNZ
 pNZ
 pNZ
-agH
-grQ
-esN
-tOg
-eSj
-qTw
-siU
-iiL
+pNZ
+pNZ
+pNZ
+pNZ
+pNZ
+pNZ
+pNZ
+pNZ
 pNZ
 vpn
 eVl
@@ -140296,28 +138889,28 @@ ceC
 pNZ
 sof
 pNZ
-asK
-asK
-gmH
-asK
 pNZ
 pNZ
+qqz
+pNZ
+pNZ
+ceC
 pNZ
 xJt
 nlp
-upA
-pNZ
-agH
-grQ
-esN
-tOg
-eSj
-pNZ
+aCq
+qQP
+dXW
+jIb
+nQP
+qQP
+fuM
+aTb
 jFO
 rcM
 pNZ
-xDu
-hDQ
+loN
+tfN
 pNZ
 iBi
 iBi
@@ -140551,30 +139144,30 @@ doz
 doz
 ceC
 pNZ
-tbQ
 vpn
-pNZ
-czp
+aCq
 vpn
-eJq
+yaI
+yaI
+yaI
 pNZ
-tTU
-tTU
+doz
+pNZ
 dmZ
 jxY
 kwg
-pNZ
-agH
-grQ
-esN
-tOg
-eSj
+jmc
+jmc
+gxJ
+vIw
+aTb
+nQP
 aTb
 ooM
-vpn
+bll
 pNZ
-pNZ
-wIj
+aCq
+eVl
 pNZ
 koq
 xJQ
@@ -140808,30 +139401,30 @@ doz
 doz
 doz
 pNZ
-tbQ
-tOS
-fGs
-tOS
-ezB
-end
+vpn
+aCq
+yaI
+yaI
+yaI
+yaI
 pNZ
-iPz
-tsu
-dqr
+pNZ
+pNZ
+pNZ
 fHt
 agZ
-pNZ
-agH
+sZN
+ilM
 grQ
-esN
-tOg
-eSj
-rYU
-xIP
-wZR
-hbH
-imh
-lgw
+cUx
+dXW
+lIH
+iyj
+aCq
+roD
+pNZ
+aCq
+tbQ
 pNZ
 eOa
 tCo
@@ -141065,30 +139658,30 @@ doz
 doz
 doz
 pNZ
-tbQ
-aUb
+bMl
 pNZ
-bWM
-vpn
-hCs
+pNZ
+pNZ
+edP
+pNZ
 pNZ
 iDY
-noF
+vpn
 hOk
-jmc
+lyZ
 pfM
-pNZ
-agH
-grQ
-esN
+lyZ
+qpw
+lyZ
 tOg
-eSj
-rYU
+tOg
+pfM
+lyZ
 yic
-yaI
-yaI
-qaD
-vfj
+cZT
+pNZ
+vpn
+pcX
 dGC
 yaI
 yaI
@@ -141322,30 +139915,30 @@ doz
 doz
 doz
 pNZ
-tbQ
-pNZ
-pNZ
-pNZ
-tzu
-tzu
-pNZ
-pNZ
-pNZ
-pNZ
-bll
-agO
-pNZ
-agH
-grQ
-esN
-tOg
-eSj
-rYU
-xIP
-uxk
 yaI
-uLU
-dVQ
+pNZ
+aNW
+qdj
+qdj
+xBh
+pNZ
+kSb
+bop
+nlo
+agO
+agO
+agO
+wIj
+agO
+agO
+agO
+eSj
+eSj
+xIP
+xkF
+pNZ
+tbQ
+tbQ
 pNZ
 ejp
 wcb
@@ -141579,30 +140172,30 @@ doz
 doz
 doz
 pNZ
-tbQ
+yaI
 pNZ
-nHv
+rrP
 qdj
-wrh
+qdj
 kEC
-lob
-llo
-riq
 pNZ
+cWR
+bop
+rYX
 rMx
-wig
-pNZ
+wMc
 agH
-grQ
+agH
+edF
 oKO
-tOg
-eSj
-pNZ
+hia
+tSS
+sCV
 eBA
-yaI
-yaI
-uLU
-hUx
+iwo
+pNZ
+tbQ
+vpn
 pNZ
 eOa
 wZR
@@ -141620,7 +140213,7 @@ ipz
 ipz
 ipz
 sOP
-jrb
+ylv
 mUd
 ipz
 ipz
@@ -141836,30 +140429,30 @@ doz
 doz
 pNZ
 pNZ
-tbQ
+wZR
 pNZ
 rrP
-hOf
-aCq
-cIS
-aCq
+qdj
+wEb
+qdj
+pNZ
 fFu
-eTK
-xeG
+bop
+pNZ
 roH
 wMN
-pNZ
-agH
-grQ
-esN
-tOg
-eSj
+mYD
+jmc
+tdR
+fHp
+vpn
+guA
 rYU
-xIP
+hYO
 gCc
+tzu
+tbQ
 wZR
-uLU
-dLw
 pNZ
 pNZ
 pNZ
@@ -141875,7 +140468,7 @@ ipz
 hxj
 xmv
 qSN
-fYU
+ylv
 qTP
 qTP
 qTP
@@ -142093,45 +140686,45 @@ qqz
 qqz
 qqz
 eJq
-tbQ
+vpn
 pNZ
-kna
-ezB
-pqG
-voW
-keV
-xFG
-dFG
 pNZ
+pNZ
+pNZ
+pNZ
+pNZ
+vpn
+gHC
+tzu
 oxq
-wig
-pNZ
-agH
-grQ
-esN
-tOg
-eSj
-rYU
-xIP
+gIC
+gIC
+vpn
+vrC
+aEU
+aTb
+nzO
+vpn
+hYO
 uxk
-lqd
-kyG
-kSb
+pNZ
+tbQ
+hzG
 qbN
 wXK
 aTF
 kyW
-lMD
-lMD
-lTn
-nzO
+hzG
+hzG
+hzG
+hzG
 lMD
 lTn
 cqr
 vSA
-fyY
-tdI
-fyY
+fQm
+aYG
+vSA
 aYG
 fyY
 tdI
@@ -142350,52 +140943,52 @@ avD
 vpn
 cDZ
 vpn
-tbQ
-pNZ
-pNZ
-pNZ
-pNZ
-pNZ
-pNZ
-pNZ
-pNZ
-pNZ
+vpn
+cGy
+yaI
+hbH
+hUx
+oss
+wZR
+yaI
+ovC
+tzu
 aXp
 wig
-pNZ
-agH
-grQ
-esN
-tOg
-eSj
-rYU
+wVT
+uiU
+xDu
+guA
+cJl
+qhd
+vMa
 biy
-wZR
-vpn
+fZJ
+pNZ
 iUi
-wZR
-fjE
-edP
-oyv
-oyv
-rtR
+vpn
+vpn
+aCq
+yaI
+aCq
+vpn
 xfW
-oyv
+yaI
 rtR
-baO
-oyv
+iDY
+pNZ
 eag
 wBF
-cca
-ylv
 qTP
-ylv
+qTP
+qTP
+woL
 ygR
 qjT
-kUp
 wqP
-jrb
 kUp
+ylv
+jrb
 ucH
 bFg
 rYk
@@ -142607,46 +141200,46 @@ qqz
 qqz
 qqz
 fZE
-tbQ
-vpn
-vpn
-rYX
-aPK
+yaI
+yaI
+aCq
 pNZ
-cxT
-suj
-obZ
-fKu
+pNZ
+pNZ
+yay
+raL
+ovC
+tzu
 wLM
 kAg
-pNZ
-agH
-grQ
-esN
-tOg
-eSj
-lus
-xIP
-ozK
-pNZ
-mYD
+gJe
+rDq
+gBP
 pNZ
 pNZ
 pNZ
 pNZ
-yjO
+cHg
+pNZ
+pNZ
+tbQ
+wCV
+pNZ
+pNZ
+pNZ
 rYX
 pNZ
+pNZ
 gUL
 gUL
 gUL
 gUL
 gUL
 gUL
-soo
-hGt
-hGt
-tNV
+gUL
+gUL
+gUL
+gUL
 ipz
 ipz
 ipz
@@ -142863,31 +141456,31 @@ doz
 doz
 doz
 pNZ
-uBq
-gHs
-tbQ
+pNZ
 vpn
-yjO
+wZR
+tSi
+rYX
 aPK
 pNZ
 loN
-aar
-nlo
-fQQ
+wZR
+ovC
+pNZ
 bfG
 mmk
+xFG
+rIX
+xkF
 pNZ
-agH
-grQ
-esN
-tOg
-eSj
-pNZ
+glK
+ucW
+bDA
 xxv
 wDf
 pNZ
-pcX
-rQm
+tbQ
+wCV
 lKn
 pNZ
 nDT
@@ -142896,14 +141489,14 @@ nDT
 nDT
 gUL
 pjD
-pDZ
+tJE
 pss
-qyA
+pss
+pss
+pss
+tJE
+nGh
 gUL
-tJE
-tJE
-tJE
-ipz
 ipz
 dJv
 rlo
@@ -143121,24 +141714,24 @@ doz
 doz
 doz
 pNZ
-jEA
-tbQ
+jfD
+lqd
 vpn
-yjO
+rYX
 aPK
 pNZ
 yay
-nJa
+yaI
+ovC
 pNZ
 pNZ
 tzu
-tzu
 pNZ
-agH
+pNZ
 dRE
-boU
+pNZ
 kXr
-eSj
+cll
 hll
 whh
 qas
@@ -143153,14 +141746,14 @@ xjE
 xjE
 gUL
 sPc
-cuH
-wmi
+tYc
+hCO
 dfX
+sHr
+ocb
+tYc
+hvt
 gUL
-mFY
-mFY
-mFY
-ipz
 lZL
 wwR
 qhN
@@ -143379,26 +141972,26 @@ doz
 doz
 pNZ
 fSd
-tbQ
-aUb
-pNZ
-pNZ
+yaI
+vpn
+rYX
+aPK
 pNZ
 loN
-tOS
 vpn
-pKF
+ovC
+wZR
 mxD
-fuc
+vpn
+iqH
 pNZ
-qvJ
-jiW
-jiW
-jiW
-jiW
-uiU
-yaI
-aCq
+pNZ
+pNZ
+pNZ
+pNZ
+tzu
+tzu
+pNZ
 pNZ
 nOr
 vpn
@@ -143413,11 +142006,11 @@ roP
 adQ
 wmi
 nRp
-gUL
-mFY
+nRp
+kQH
 rPQ
 mFY
-ipz
+gUL
 qTP
 mkF
 vnl
@@ -143636,26 +142229,26 @@ doz
 doz
 pNZ
 fSd
-tbQ
-iat
-hzG
-nVs
-hzG
-hzG
+yaI
+yaI
+pNZ
+pNZ
+pNZ
+vpn
 dkL
+gHC
+ovC
+ovC
+ovC
+pcX
 pcX
 tbQ
-tbQ
+gHs
 tbQ
 pcX
-pcX
-tbQ
-tbQ
-tbQ
-tfN
 xqL
 tbQ
-pcX
+gmH
 siL
 nOr
 vpn
@@ -143666,15 +142259,15 @@ ueW
 ueW
 nMB
 gUL
-mUv
-tYc
+pjD
 cHG
+cHG
+krR
+rSO
+unJ
+unJ
 hyp
 gUL
-mFY
-unJ
-mFY
-ipz
 nIE
 vKq
 qyV
@@ -143892,28 +142485,28 @@ doz
 doz
 doz
 pNZ
-pNZ
-bBN
-pNZ
-pNZ
-pNZ
-pNZ
+vpn
+vpn
+yaI
+hbH
+uUU
+sAw
 jPb
 wZR
 fxD
 loN
 vpn
 wZR
-ovC
+tbQ
 aCq
-cyA
+aCq
 oss
-uEy
+dkL
 jld
 wZR
 vpn
-vpn
-pNZ
+loN
+bKA
 mTb
 kYX
 jkT
@@ -143926,12 +142519,12 @@ gUL
 gUL
 tnT
 bGg
+tnT
+tnT
+osL
+tnT
 gUL
 gUL
-ipz
-ipz
-ipz
-ipz
 ipz
 kzQ
 cOj
@@ -144149,11 +142742,11 @@ doz
 doz
 doz
 pNZ
-xKk
-yaI
-vpn
-jWg
-kZm
+pNZ
+bBN
+pNZ
+pNZ
+pNZ
 pNZ
 pNZ
 tzu
@@ -144163,12 +142756,12 @@ yaI
 vpn
 ovC
 pNZ
+pNZ
+pNZ
 tzu
 tzu
 tzu
 pNZ
-pNZ
-hUy
 pNZ
 pNZ
 pRX
@@ -144406,12 +142999,12 @@ doz
 doz
 doz
 pNZ
-dbK
-vpn
+xKk
 yaI
 vpn
-ryq
-tzu
+jWg
+kZm
+pNZ
 clj
 cwn
 oVC
@@ -144420,13 +143013,13 @@ mIh
 jqG
 ovC
 pNZ
-dPX
+nHv
 qbI
 lxO
 kMf
 oyv
-suR
-lTM
+llo
+riq
 pNZ
 gGK
 xjE
@@ -144663,11 +143256,11 @@ doz
 doz
 doz
 pNZ
-aKG
+dbK
+vpn
 yaI
-dSo
-wCV
-ebZ
+vpn
+ryq
 tzu
 qcM
 jmD
@@ -144681,10 +143274,10 @@ bbf
 bbf
 ijm
 uxn
-oyv
+ijm
 suR
 mAt
-pNZ
+tzu
 gGK
 xjE
 wFU
@@ -144920,12 +143513,12 @@ doz
 doz
 doz
 pNZ
-pNZ
-pNZ
-pNZ
-pNZ
-pNZ
-pNZ
+aKG
+yaI
+dSo
+wCV
+ebZ
+tzu
 nSr
 cyA
 iJy
@@ -144933,13 +143526,13 @@ pNZ
 wZR
 vpn
 ovC
-tzu
-dPX
-nzm
+pNZ
+kna
+vpn
 dsP
 dPX
-oyv
-jKL
+keb
+vRJ
 cLy
 pNZ
 gGK
@@ -145176,12 +143769,12 @@ doz
 doz
 doz
 doz
-doz
-doz
-doz
-doz
-doz
-doz
+pNZ
+pNZ
+pNZ
+pNZ
+pNZ
+pNZ
 pNZ
 uqY
 aCq
@@ -145190,11 +143783,11 @@ jxo
 yaI
 vvV
 gHC
-tzu
 pNZ
-tzu
-tzu
-tzu
+pNZ
+pNZ
+pNZ
+pNZ
 pNZ
 pNZ
 pNZ
@@ -145447,7 +144040,7 @@ jxo
 wZR
 cgw
 ovC
-tcU
+jld
 pNZ
 lwL
 yaI
@@ -145713,7 +144306,7 @@ iON
 wgO
 pNZ
 pNZ
-oSW
+tOS
 vpn
 wlG
 vpn
@@ -145960,10 +144553,10 @@ pNZ
 pNZ
 pNZ
 pKF
-gHC
-xfy
+pcX
+aCq
 pNZ
-jqG
+gag
 jKL
 woF
 pNZ
@@ -146217,10 +144810,10 @@ bIC
 eSy
 jxo
 vpn
-ovC
+tbQ
 pKF
 pNZ
-axL
+roB
 rrQ
 eME
 veO
@@ -181429,9 +180022,9 @@ oBy
 ccn
 plF
 oBy
-wNd
-wNd
-wNd
+job
+job
+job
 oBy
 qHQ
 oBy
@@ -181686,9 +180279,9 @@ tMr
 xPH
 plF
 oBy
-wNd
+job
 aIa
-wNd
+job
 oBy
 qHQ
 oBy
@@ -181943,9 +180536,9 @@ oBy
 lOr
 plF
 oBy
-uUm
-uUm
-uUm
+kJd
+kJd
+kJd
 oBy
 eJr
 oBy
@@ -182460,7 +181053,7 @@ jVA
 jVA
 wNd
 oBy
-qgy
+vfq
 oCL
 oBy
 hEU
@@ -182477,8 +181070,8 @@ nQA
 rAW
 jTv
 xtx
-bir
-ppD
+djS
+djS
 cRf
 jal
 xAG
@@ -182734,8 +181327,8 @@ nQA
 rAW
 pDI
 xtx
-djS
-djS
+xtx
+xtx
 dyb
 jal
 ekQ
@@ -183248,9 +181841,9 @@ iTq
 rAW
 sGD
 xtx
-xtx
-xtx
-fuM
+oZH
+oZH
+yaM
 jal
 jal
 jal
@@ -183503,14 +182096,14 @@ nQA
 daW
 qRR
 hrS
-wvn
-eBh
+xtx
+xtx
 bzM
-bzM
-nfN
-quE
+vkg
+yaM
+gwH
 baW
-baW
+gaS
 xPx
 ppx
 anM
@@ -183761,10 +182354,10 @@ krI
 xYK
 ske
 kvr
-nDY
+kvr
 fzZ
-fzZ
-cWP
+wat
+kvr
 quE
 hrl
 kBo
@@ -184017,13 +182610,13 @@ jBv
 cTW
 jXy
 hrS
-kNT
-jIb
+xtx
+xtx
+bzM
 idE
-idE
-ocx
-quE
-gaS
+yaM
+iat
+nVV
 gaS
 xPx
 pNR
@@ -184276,9 +182869,9 @@ kar
 rAW
 azb
 xtx
-xtx
-xtx
-kNT
+djS
+djS
+yaM
 mvv
 xPx
 xPx
@@ -185050,7 +183643,7 @@ xtx
 xtx
 xtx
 mMs
-gib
+xtx
 xPx
 vRs
 xQZ
@@ -185284,8 +183877,8 @@ oBy
 oBy
 sIG
 lVo
-qsJ
-qsJ
+oBy
+oBy
 qsJ
 xxo
 wGV
@@ -185541,10 +184134,10 @@ oBy
 fbS
 llS
 eyH
-qsJ
-sFc
-qCq
-jdT
+oBy
+gJs
+tDb
+xxo
 jwG
 tYD
 tYD
@@ -185799,9 +184392,9 @@ qsJ
 omS
 qsJ
 qsJ
-sFc
-qCq
-dFI
+gJs
+tDb
+vXo
 jwG
 kJd
 kcZ
@@ -186058,7 +184651,7 @@ wea
 qsJ
 qsJ
 qsJ
-vXo
+uhV
 jwG
 tYD
 kcZ
@@ -186315,7 +184908,7 @@ ydj
 ads
 tOZ
 avf
-dFI
+vXo
 jwG
 kJd
 kcZ
@@ -186572,7 +185165,7 @@ egJ
 sFx
 tOZ
 xQe
-dFI
+vXo
 jwG
 tYD
 kcZ
@@ -186829,7 +185422,7 @@ fcS
 pRF
 qsJ
 jMv
-dFI
+vXo
 jwG
 kJd
 kcZ
@@ -187341,9 +185934,9 @@ dtX
 cos
 tuG
 qsJ
-sFc
-qCq
-dFI
+gJs
+tDb
+vXo
 jwG
 kJd
 kcZ
@@ -187598,9 +186191,9 @@ qsJ
 okl
 tOZ
 qsJ
-sFc
-qCq
-jdT
+gJs
+tDb
+xxo
 jwG
 tYD
 tYD
@@ -207921,12 +206514,12 @@ mtZ
 mtZ
 nBv
 nBv
-bsA
-iPQ
-tFk
-gnf
-fLV
-sKd
+jxy
+kkl
+qTw
+kkl
+kkl
+kkl
 kkl
 sKd
 nnU
@@ -208177,13 +206770,13 @@ gnf
 tAH
 xOH
 hoB
-wVT
-dGe
-dGe
-vne
-jxy
-hCO
-hCO
+hoB
+gnf
+naE
+sKd
+sKd
+sKd
+sKd
 kkl
 avQ
 rFp
@@ -208436,13 +207029,13 @@ tiS
 sKq
 jyv
 gnf
-gnf
-gnf
-gnf
-klx
-nRY
+bjm
+sKd
+sKd
+sKd
+sKd
 kkl
-qkC
+bMM
 nnU
 nnU
 kYb
@@ -208693,11 +207286,11 @@ gnf
 gnf
 gnf
 gnf
-ycj
-ycj
-ycj
-nGW
-teR
+naE
+sKd
+sKd
+sKd
+sKd
 kkl
 sKd
 hWd
@@ -208950,11 +207543,11 @@ qhn
 pjS
 qhn
 wfV
-ycj
-ycj
-ycj
-nGW
-teR
+naE
+sKd
+sKd
+sKd
+ocr
 kkl
 naE
 soG
@@ -209207,11 +207800,11 @@ fMi
 sdm
 hBi
 wfV
-ycj
-ycj
+naE
+sKd
 ycj
 nGW
-teR
+sKd
 kkl
 sKd
 rYC
@@ -209464,11 +208057,11 @@ kxw
 gnc
 hBi
 wfV
+tfY
+wTY
 wfV
 wfV
-wfV
-wfV
-oPg
+sKd
 kkl
 sKd
 nPk
@@ -209724,10 +208317,10 @@ tgE
 uFW
 peu
 kWv
-uIu
-naE
+wfV
+eUY
 kkl
-xuJ
+cpL
 vlt
 vlt
 eDS
@@ -209979,10 +208572,10 @@ tnv
 amc
 amc
 tmF
-aNW
-amc
-urg
-sKd
+iXT
+hBs
+wfV
+wvn
 kkl
 niF
 mrI
@@ -210236,10 +208829,10 @@ heS
 wrS
 xhC
 fWn
-jPj
+mVY
 kHB
 wfV
-mRC
+qEI
 kkl
 niF
 mrI
@@ -210494,11 +209087,11 @@ wYe
 uMw
 fWn
 iXT
-bQs
+uMw
 wfV
-eUY
+sKd
 kkl
-cpL
+niF
 vlt
 xOv
 aAz
@@ -210744,7 +209337,7 @@ gnf
 gnf
 gnf
 dFK
-dFK
+sOh
 bMb
 wYe
 sAo

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -11431,6 +11431,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/curtain/bounty,
 /obj/item/bedsheet/brown,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "cLH" = (
@@ -14335,6 +14336,7 @@
 "dsP" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "dsQ" = (
@@ -14564,7 +14566,7 @@
 "dvA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock,
+/obj/machinery/door/airlock/bathroom,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
@@ -16056,6 +16058,7 @@
 "dPX" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "dQe" = (
@@ -19560,6 +19563,7 @@
 "eME" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "eMH" = (
@@ -24344,14 +24348,10 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
 "fUE" = (
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
-	color = "#ff0000";
-	name = "Scrubbers multi deck pipe adapter";
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
-	color = "#0000ff";
-	name = "Supply multi deck pipe adapter";
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -24791,14 +24791,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/hallway/secondary/service)
-"gag" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/graffiti{
-	spawn_loot_chance = 50
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
 "gaj" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/open/floor/plating,
@@ -25717,6 +25709,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/barricade,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "gmK" = (
@@ -33767,11 +33760,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/atmos)
-"ijm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
 "ijq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41368,6 +41356,8 @@
 /obj/item/clothing/under/syndicate/tacticool{
 	pixel_x = -1
 	},
+/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "kej" = (
@@ -42028,6 +42018,8 @@
 /obj/structure/bed,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bedsheet/orange,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "knd" = (
@@ -44246,9 +44238,6 @@
 "kMf" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "kMh" = (
@@ -46752,9 +46741,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "lrM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable,
 /obj/machinery/duct,
@@ -47225,7 +47211,6 @@
 /turf/open/floor/wood/parquet/amaranth,
 /area/station/maintenance/ghetto/fore/starboard)
 "lxO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/bed{
 	dir = 1
 	},
@@ -55825,7 +55810,12 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
 "nFn" = (
-/obj/effect/spawner/random/structure/closet_maintenance,
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "nFH" = (
@@ -57438,7 +57428,7 @@
 /area/station/maintenance/department/engine)
 "nZH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock,
+/obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
@@ -59506,9 +59496,6 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/item/bedsheet/black{
 	dir = 1
 	},
@@ -65180,6 +65167,7 @@
 	dir = 4
 	},
 /obj/machinery/light/small/directional/south,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "pSd" = (
@@ -65971,7 +65959,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/storage/primary)
 "qbI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/showcase/machinery/tv/broken,
 /turf/open/floor/plating,
@@ -66776,6 +66763,7 @@
 	},
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light/small/directional/west,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics/ghetto)
 "qnH" = (
@@ -70766,13 +70754,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port/greater)
 "roB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/urinal{
-	pixel_y = 32
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/carpet/royalblack,
 /area/station/maintenance/ghetto/fore/starboard)
 "roD" = (
 /obj/machinery/light/small/directional/south,
@@ -71049,10 +71034,8 @@
 /area/station/maintenance/ghetto/fore/starboard)
 "rrQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "rrW" = (
 /turf/open/floor/engine/n2,
@@ -75430,7 +75413,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "suR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/carpet/royalblack,
 /area/station/maintenance/ghetto/fore/starboard)
 "svg" = (
@@ -78508,9 +78493,9 @@
 "tmy" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/mirror/directional/west,
 /obj/structure/sink/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/mirror/broken/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "tmz" = (
@@ -83480,7 +83465,6 @@
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "uxn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "uxo" = (
@@ -86657,6 +86641,7 @@
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics/ghetto)
 "vnc" = (
@@ -89094,6 +89079,7 @@
 	pixel_x = 2;
 	pixel_y = -3
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/maintenance/ghetto/fore/starboard)
 "vRP" = (
@@ -90801,6 +90787,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/grime,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "woK" = (
@@ -142497,7 +142484,7 @@ fxD
 loN
 vpn
 wZR
-tbQ
+ovC
 aCq
 aCq
 oss
@@ -143271,10 +143258,10 @@ nJa
 gHC
 sEw
 bbf
-bbf
-ijm
+roB
+aCq
 uxn
-ijm
+aCq
 suR
 mAt
 tzu
@@ -143528,7 +143515,7 @@ vpn
 ovC
 pNZ
 kna
-vpn
+tOS
 dsP
 dPX
 keb
@@ -143785,9 +143772,9 @@ vvV
 gHC
 pNZ
 pNZ
-pNZ
-pNZ
-pNZ
+tzu
+tzu
+tzu
 pNZ
 pNZ
 pNZ
@@ -144553,10 +144540,10 @@ pNZ
 pNZ
 pNZ
 pKF
-pcX
+gHC
 aCq
 pNZ
-gag
+jqG
 jKL
 woF
 pNZ
@@ -144810,10 +144797,10 @@ bIC
 eSy
 jxo
 vpn
-tbQ
+ovC
 pKF
 pNZ
-roB
+axL
 rrQ
 eME
 veO

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -113,7 +113,6 @@
 /area/station/maintenance/ghetto/storage)
 "abV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/aft)
@@ -2486,10 +2485,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
 "aFm" = (
-/obj/structure/marker_beacon/indigo,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/open/floor/carpet,
+/area/station/service/library/ghetto)
 "aFr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -5051,7 +5050,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto)
 "bkP" = (
@@ -5638,9 +5636,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
 "brP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 4
@@ -5894,7 +5889,6 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "bvz" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/security/interrogation/ghetto)
@@ -6306,7 +6300,6 @@
 "bAf" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
@@ -7301,7 +7294,6 @@
 /area/station/security/brig)
 "bMW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 8
@@ -7448,8 +7440,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bOB" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
@@ -7801,11 +7791,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"bTl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/medical/ghetto/morgue)
 "bTH" = (
 /turf/closed/wall,
 /area/station/maintenance/starboard/aft)
@@ -7965,7 +7950,6 @@
 /area/station/engineering/gravity_generator)
 "bWl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/dark_green/fourcorners,
 /turf/open/floor/iron/white,
@@ -8018,7 +8002,7 @@
 	pixel_y = 5
 	},
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/service/bar/backroom/ghetto)
 "bWR" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -9294,7 +9278,6 @@
 /area/station/maintenance/ghetto/fore/starboard)
 "cll" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
@@ -9929,6 +9912,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
+"ctr" = (
+/obj/structure/cable,
+/turf/open/floor/asphalt,
+/area/station/maintenance/ghetto/garden)
 "ctu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10210,9 +10197,6 @@
 /area/station/tcommsat/server)
 "cwC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -10486,9 +10470,10 @@
 /turf/open/floor/iron/dark/small,
 /area/station/commons/vacant_room/commissary)
 "cAm" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/tcommsat/server)
+/obj/structure/table,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/station/maintenance/ghetto/sorting)
 "cAv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow,
@@ -13646,11 +13631,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
-"dkL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
 "dkM" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -14577,9 +14557,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "dvK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
@@ -16402,6 +16379,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"dVC" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plating/airless,
+/area/station/science/ordnance/bomb)
 "dVO" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -18037,7 +18019,6 @@
 /area/station/service/library)
 "erd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/xenobio,
 /area/station/science/xenobiology)
 "erk" = (
@@ -19038,6 +19019,9 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "eGy" = (
@@ -20232,7 +20216,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "eWi" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -22400,7 +22383,6 @@
 /area/station/engineering/hallway)
 "fxD" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
@@ -23286,7 +23268,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "fHp" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bookcase,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -24417,6 +24398,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/auxiliary)
 "fVJ" = (
@@ -24449,6 +24431,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/grass,
 /area/station/maintenance/ghetto/garden)
 "fVY" = (
@@ -24586,7 +24569,6 @@
 /area/station/service/theater)
 "fXy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -26585,7 +26567,6 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "gyV" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /obj/effect/spawner/random/engineering/canister,
@@ -28852,6 +28833,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
+"gZK" = (
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/central/fore)
 "gZN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
@@ -31903,7 +31891,6 @@
 /area/station/science/xenobiology)
 "hKO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
 /obj/effect/spawner/random/clothing/bowler_or_that,
 /obj/effect/spawner/random/clothing/costume,
@@ -34276,7 +34263,6 @@
 /area/station/security/holding_cell)
 "iqs" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/firealarm_sanity,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto/central)
@@ -34752,7 +34738,6 @@
 /area/station/science/research)
 "iwo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/random,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
@@ -34842,9 +34827,10 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "ixJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central/fore)
+/turf/open/floor/wood,
+/area/station/service/library/ghetto)
 "iyj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood{
@@ -34878,7 +34864,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "iyG" = (
@@ -35128,7 +35113,6 @@
 /area/station/medical/virology)
 "iCy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/dark_green/fourcorners,
 /turf/open/floor/iron/white,
@@ -35381,6 +35365,7 @@
 /area/station/cargo/sorting)
 "iFS" = (
 /obj/structure/chair/stool/directional/east,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "iFU" = (
@@ -36014,7 +35999,6 @@
 /area/station/medical/surgery/aft)
 "iNq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
@@ -36483,7 +36467,6 @@
 "iTk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -36548,15 +36531,6 @@
 /obj/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"iTU" = (
-/obj/machinery/plate_press,
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/ghetto)
 "iTX" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
@@ -36576,7 +36550,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "iUi" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37620,7 +37593,6 @@
 /obj/item/trash/raisins,
 /obj/item/trash/pistachios,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "jgF" = (
@@ -37846,6 +37818,11 @@
 /obj/effect/landmark/navigate_destination/dockaux,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/dock)
+"jjt" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "jjz" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal{
@@ -38010,8 +37987,6 @@
 /area/station/maintenance/ghetto/fore/starboard)
 "jmq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/library/ghetto)
 "jmB" = (
@@ -38024,12 +37999,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
-"jmD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
 "jmE" = (
 /obj/machinery/computer/monitor,
 /obj/structure/cable,
@@ -39083,7 +39052,6 @@
 /area/station/command/heads_quarters/cmo)
 "jBp" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/dark_green,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39592,7 +39560,6 @@
 /area/station/hallway/secondary/dock)
 "jHI" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/office{
 	dir = 1
 	},
@@ -39900,11 +39867,6 @@
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
-"jKL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/fore/starboard)
 "jKQ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line,
@@ -42425,7 +42387,6 @@
 /area/station/engineering/lobby)
 "ksl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/half{
 	color = "#800080";
 	dir = 4
@@ -42737,6 +42698,9 @@
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "kvH" = (
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central/fore)
 "kvK" = (
@@ -42791,7 +42755,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/prison)
 "kwg" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -44679,7 +44642,6 @@
 /area/station/security/prison/visit)
 "kSb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
@@ -45059,7 +45021,6 @@
 "kXr" = (
 /obj/structure/bookcase/random/adult,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/fore/starboard)
 "kXt" = (
@@ -45330,6 +45291,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
+"laK" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "laU" = (
 /obj/machinery/light/floor,
 /obj/effect/turf_decal/siding/wood/amaranth{
@@ -46284,6 +46249,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "lnw" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "lnB" = (
@@ -47237,6 +47203,11 @@
 "lyf" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/starboard/fore)
+"lyx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/fore)
 "lyE" = (
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
@@ -48227,7 +48198,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/aft)
 "lLq" = (
@@ -48816,7 +48786,6 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/electrical/ghetto)
 "lSJ" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/machinery/light/small/directional/south,
@@ -49984,14 +49953,6 @@
 "mgM" = (
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/trash)
-"mgS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/aft)
 "mgZ" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "engsm";
@@ -51148,7 +51109,6 @@
 /area/station/engineering/dronefabricator)
 "mxD" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
@@ -51346,7 +51306,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage/ghetto/depot)
 "mAt" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/knife,
 /turf/open/floor/carpet/royalblack,
@@ -52009,7 +51968,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "mIh" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
 /obj/effect/spawner/random/trash/garbage,
@@ -53279,6 +53237,7 @@
 /turf/open/floor/wood/large,
 /area/station/maintenance/ghetto/fore/starboard)
 "mYF" = (
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/starboard)
 "mYH" = (
@@ -54232,7 +54191,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/public,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/barricade/wooden/crude,
@@ -54545,7 +54503,6 @@
 /turf/open/floor/iron/smooth,
 /area/station/commons/toilet/restrooms)
 "noF" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/machinery/airalarm/directional/south,
@@ -55589,10 +55546,6 @@
 /obj/effect/spawner/random/structure/tank_holder,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
-"nCd" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/station/maintenance/aft)
 "nCg" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/stairs/right{
@@ -56797,9 +56750,6 @@
 /turf/open/floor/iron/airless,
 /area/station/science/ordnance/bomb)
 "nRY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/dark_green/half,
 /turf/open/floor/iron/white,
@@ -59950,6 +59900,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/visible{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "oEI" = (
@@ -59968,7 +59919,6 @@
 	},
 /obj/structure/flora/bush/jungle/b/style_random,
 /obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/floor,
 /turf/open/floor/grass,
@@ -61554,8 +61504,6 @@
 "oZA" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
@@ -62022,8 +61970,6 @@
 /area/station/engineering/hallway/west)
 "pfA" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/maintenance/two,
 /obj/structure/rack,
 /turf/open/floor/plating,
@@ -62047,11 +61993,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
-"pfM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/grimy,
-/area/station/maintenance/ghetto/fore/starboard)
 "pgc" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/door/window/brigdoor/right/directional/north{
@@ -62339,8 +62280,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway/west)
 "pjD" = (
-/obj/structure/table/wood/fancy,
-/obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/spawner/random/decoration/statue{
 	spawn_loot_chance = 35
 	},
@@ -63041,7 +62980,6 @@
 /area/station/maintenance/aft)
 "psf" = (
 /obj/item/clothing/suit/syndicatefake,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /obj/effect/turf_decal/siding/wood/amaranth{
@@ -64472,6 +64410,10 @@
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"pIQ" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plating,
+/area/station/maintenance/ghetto/port/aft)
 "pJa" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -64497,6 +64439,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/central/aft)
 "pJp" = (
@@ -64894,6 +64837,10 @@
 /area/station/maintenance/ghetto/fore/starboard)
 "pNZ" = (
 /turf/closed/wall,
+/area/station/maintenance/ghetto/fore/starboard)
+"pOe" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "pOi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -65785,7 +65732,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
 "pZC" = (
@@ -65942,7 +65888,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "qbg" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/plating,
@@ -68476,7 +68421,6 @@
 "qMz" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical/ghetto/morgue)
 "qMA" = (
@@ -68977,7 +68921,6 @@
 	},
 /area/station/commons/dorms)
 "qTg" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/maintenance/two,
 /obj/structure/rack,
@@ -69592,10 +69535,10 @@
 /turf/open/floor/iron/telecomms,
 /area/station/tcommsat/server)
 "raL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
+/obj/structure/ladder,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "raM" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -69702,7 +69645,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/prison)
 "rcb" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/washing_machine,
 /turf/open/floor/plating,
@@ -70790,6 +70732,7 @@
 	dir = 1;
 	pixel_x = -32
 	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
 "roQ" = (
@@ -72179,7 +72122,6 @@
 /area/station/maintenance/starboard/upper)
 "rIw" = (
 /obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/mirror/directional/west,
 /obj/structure/sink/directional/east,
@@ -73889,12 +73831,6 @@
 	},
 /turf/open/space/openspace,
 /area/space)
-"scS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "scV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -74363,7 +74299,6 @@
 /area/station/maintenance/department/security/ghetto)
 "siI" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
@@ -75372,9 +75307,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "suj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
@@ -76855,6 +76787,7 @@
 "sPc" = (
 /obj/structure/table/wood/fancy,
 /obj/machinery/door/window/right/directional/south,
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
 "sPh" = (
@@ -77404,13 +77337,11 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/station/maintenance/port)
 "sVY" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/floodlight_frame/completed,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/ghetto/central/fore)
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/grass,
+/area/station/maintenance/ghetto/garden)
 "sWx" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/food/cheese/wheel,
@@ -77990,13 +77921,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
-"tfN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/ghetto/fore/starboard)
 "tfQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -78608,7 +78532,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "tnt" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -80836,6 +80759,7 @@
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/aft)
 "tOb" = (
@@ -81189,6 +81113,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto)
+"tSR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plating,
+/area/station/maintenance/port/greater)
 "tSS" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
@@ -82550,7 +82479,6 @@
 /area/station/maintenance/ghetto/central)
 "uiU" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron/grimy,
 /area/station/maintenance/ghetto/fore/starboard)
@@ -83131,6 +83059,7 @@
 /obj/machinery/door/airlock/wood,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/ghetto/garden)
 "urR" = (
@@ -83793,11 +83722,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/engineering/atmos)
-"uBN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/cafeteria,
-/area/station/maintenance/ghetto/fore/starboard)
 "uBQ" = (
 /obj/machinery/computer/cargo{
 	dir = 1
@@ -85136,12 +85060,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
-"uSW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/station/maintenance/department/medical/ghetto/central)
 "uSZ" = (
 /obj/structure/reagent_dispensers/plumbed{
 	dir = 1
@@ -85152,7 +85070,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "uTk" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/instrument/guitar,
 /obj/structure/rack,
@@ -88154,7 +88071,6 @@
 "vEy" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /obj/effect/spawner/random/clothing/costume,
 /obj/effect/spawner/random/clothing/costume,
@@ -88901,7 +88817,6 @@
 "vPf" = (
 /obj/machinery/chem_heater,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/station/maintenance/aft)
 "vPg" = (
@@ -89073,7 +88988,6 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry/ghetto)
 "vRJ" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/mask/balaclava{
 	pixel_x = 2;
@@ -90369,7 +90283,6 @@
 /turf/open/floor/carpet,
 /area/station/maintenance/ghetto/fore/starboard)
 "wih" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/dark_green{
@@ -92698,7 +92611,6 @@
 /area/station/service/library)
 "wMN" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/ghetto/fore/starboard)
@@ -94171,7 +94083,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/ghetto)
@@ -94411,7 +94322,7 @@
 /obj/item/gun/ballistic/shotgun/doublebarrel,
 /obj/machinery/light/small/directional/south,
 /obj/structure/closet/secure_closet/bar,
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/station/service/bar/backroom/ghetto)
 "xhf" = (
 /obj/structure/disposalpipe/segment,
@@ -95083,7 +94994,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
@@ -96304,7 +96214,6 @@
 /area/station/engineering/hallway)
 "xHf" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/station/maintenance/aft)
 "xHl" = (
@@ -97114,7 +97023,6 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "xQJ" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/cafeteria,
@@ -97951,7 +97859,6 @@
 /area/station/service/theater)
 "ycx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/dark_green/fourcorners,
 /obj/structure/frame,
 /turf/open/floor/iron/white,
@@ -98173,7 +98080,6 @@
 /area/station/maintenance/ghetto/port)
 "yfx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -98473,8 +98379,8 @@
 "yjk" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/engineering/toolbox,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "yjq" = (
@@ -116580,7 +116486,7 @@ doz
 doz
 rmU
 oLG
-aec
+pIQ
 rxh
 aec
 xeU
@@ -117282,7 +117188,7 @@ iVr
 wVe
 bPK
 cYD
-iTU
+mfG
 aNy
 ttR
 fvp
@@ -123736,9 +123642,9 @@ kwx
 kwx
 eGx
 kvH
-kGW
-hLM
-hLM
+gZK
+bsv
+bsv
 qwV
 bsv
 bsv
@@ -125019,11 +124925,11 @@ vbK
 vbK
 vbK
 ceC
-aFm
-sVY
-ixJ
+jEk
+obg
+hLM
 iyE
-ixJ
+hLM
 bsv
 guN
 vbK
@@ -127357,8 +127263,8 @@ oQk
 bcx
 cwv
 phd
-cAm
-cAm
+phd
+phd
 eRz
 phd
 ycr
@@ -127871,8 +127777,8 @@ mnw
 pSO
 dpR
 phd
-cAm
-cAm
+phd
+phd
 eUx
 phd
 ycr
@@ -129120,7 +129026,7 @@ qxb
 fIL
 fIL
 qPF
-uSW
+pZB
 fcz
 qVj
 sUP
@@ -129377,7 +129283,7 @@ iCy
 fcz
 fcz
 hfN
-uSW
+pZB
 lSJ
 cvk
 cvk
@@ -129891,7 +129797,7 @@ rku
 suj
 dvK
 hfN
-uSW
+pZB
 sxF
 cvk
 dif
@@ -131687,7 +131593,7 @@ aLe
 jiq
 uXV
 xye
-bTl
+nYm
 qMz
 nYm
 bup
@@ -133305,7 +133211,7 @@ doz
 ceC
 ceC
 rmv
-bOl
+cAm
 owg
 cYe
 aMD
@@ -135037,7 +134943,7 @@ doz
 pNZ
 niz
 jld
-raL
+fxD
 nFI
 eTK
 uoQ
@@ -137097,7 +137003,7 @@ doz
 doz
 vbK
 pNZ
-raL
+fxD
 iYF
 xSN
 tqK
@@ -138897,7 +138803,7 @@ jFO
 rcM
 pNZ
 loN
-tfN
+xqL
 pNZ
 iBi
 iBi
@@ -139656,13 +139562,13 @@ iDY
 vpn
 hOk
 lyZ
-pfM
+lyZ
 lyZ
 qpw
 lyZ
 tOg
 tOg
-pfM
+lyZ
 lyZ
 yic
 cZT
@@ -141194,7 +141100,7 @@ pNZ
 pNZ
 pNZ
 yay
-raL
+fxD
 ovC
 tzu
 wLM
@@ -141969,7 +141875,7 @@ vpn
 ovC
 wZR
 mxD
-vpn
+pOe
 iqH
 pNZ
 pNZ
@@ -142222,7 +142128,7 @@ pNZ
 pNZ
 pNZ
 vpn
-dkL
+yaI
 gHC
 ovC
 ovC
@@ -142488,7 +142394,7 @@ ovC
 aCq
 aCq
 oss
-dkL
+yaI
 jld
 wZR
 vpn
@@ -142765,7 +142671,7 @@ nMR
 jmq
 vwP
 vwP
-ueW
+ixJ
 ueW
 qRm
 xjE
@@ -143020,9 +142926,9 @@ qKB
 qKB
 qKB
 qKB
-kDD
-kDD
-kDD
+aFm
+aFm
+aFm
 hVO
 vwP
 xjE
@@ -143250,7 +143156,7 @@ vpn
 ryq
 tzu
 qcM
-jmD
+rrQ
 pVh
 kXf
 nJa
@@ -144544,7 +144450,7 @@ gHC
 aCq
 pNZ
 jqG
-jKL
+aCq
 woF
 pNZ
 pNZ
@@ -144791,7 +144697,7 @@ doz
 doz
 pNZ
 vEy
-uBN
+gZN
 vfG
 bIC
 eSy
@@ -145564,7 +145470,7 @@ pNZ
 gpE
 iip
 gZN
-jKL
+aCq
 aCq
 ppT
 yaI
@@ -146119,7 +146025,7 @@ iCg
 dgR
 cys
 kql
-cIc
+sVY
 hpB
 vGX
 whJ
@@ -146376,7 +146282,7 @@ pLp
 iHY
 mYF
 urL
-mnZ
+ctr
 mnZ
 hBq
 mnZ
@@ -181032,8 +180938,8 @@ bWR
 mrK
 rQH
 oBy
+tSR
 jVA
-wNd
 wNd
 plF
 jVA
@@ -187464,7 +187370,7 @@ wBe
 aGv
 iIx
 tOZ
-fvw
+raL
 fmX
 tjE
 hif
@@ -187518,7 +187424,7 @@ oXc
 oXc
 gwX
 mjS
-mGR
+jjt
 oXc
 hjt
 pHF
@@ -187721,7 +187627,7 @@ jGH
 aGv
 iIx
 qsJ
-hsU
+fvw
 iRc
 qsJ
 kfL
@@ -189619,7 +189525,7 @@ awU
 rgH
 rgH
 wTo
-aWy
+laK
 cZJ
 cZJ
 cZJ
@@ -197735,7 +197641,7 @@ fgy
 fgy
 fqI
 vFc
-vFc
+lyx
 ntW
 hiu
 cqO
@@ -198067,7 +197973,7 @@ yfM
 dEB
 hXT
 hXT
-mgS
+lLm
 hXT
 dSL
 hpN
@@ -198324,7 +198230,7 @@ dRA
 dRA
 fbB
 vTH
-mgS
+lLm
 dEB
 hpN
 hpN
@@ -198833,7 +198739,7 @@ dRA
 bkn
 tiz
 mdI
-nCd
+xHf
 wyy
 dRA
 usk
@@ -199604,7 +199510,7 @@ dRA
 pTY
 wpy
 rJA
-nCd
+xHf
 hXT
 myz
 hZw
@@ -201665,7 +201571,7 @@ ksy
 qOo
 dmG
 hpN
-mgS
+lLm
 hXT
 alC
 ceC
@@ -202950,7 +202856,7 @@ rRN
 hzQ
 iUw
 sEn
-mgS
+lLm
 jVT
 hpN
 ceC
@@ -204759,7 +204665,7 @@ qoY
 oAC
 eve
 wLH
-nCd
+xHf
 vTH
 hXT
 hXT
@@ -205525,7 +205431,7 @@ bsf
 aSI
 xjF
 kot
-nCd
+xHf
 vsK
 iFJ
 jtk
@@ -206047,7 +205953,7 @@ dRA
 dRA
 dRA
 dRA
-nCd
+xHf
 hFK
 lnM
 dRA
@@ -209144,7 +209050,7 @@ gph
 aOV
 dRA
 qfL
-nCd
+xHf
 bxT
 kot
 eUj
@@ -209401,7 +209307,7 @@ qnk
 aOV
 dsZ
 dWl
-nCd
+xHf
 ulb
 kot
 gxY
@@ -209916,7 +209822,7 @@ cvE
 dRA
 dRA
 qHD
-nCd
+xHf
 kot
 vlJ
 eXj
@@ -215539,7 +215445,7 @@ jUC
 jUC
 jUC
 vXX
-scS
+jUC
 jUC
 aYy
 fki
@@ -222731,7 +222637,7 @@ fyN
 dHm
 xqi
 eCg
-dhK
+dVC
 bKD
 kJd
 tYD

--- a/modular_bandastation/mapping/code/areas/station.dm
+++ b/modular_bandastation/mapping/code/areas/station.dm
@@ -87,6 +87,10 @@
 	name = "Ghetto Abandoned Medbay Morgue"
 	icon_state = "morgue_maint"
 
+/area/station/maintenance/department/medical/ghetto/central
+	name = "Ghetto Abandoned Medbay Entrance"
+	icon_state = "medbay_maint_central"
+
 // Non-Department
 /area/station/maintenance/ghetto/port
 	name = "Ghetto Port Maintenance"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Частичный реверт реворка Гетто Коробки по стримерскому запросу, увы.

## Changelog

:cl:
map: Кибериада: Сделан частичный откат реворка Гетто, в частности северной её части, включая трамвай.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
