### PR TITLE
Balance: Remove corazargh from the inverse chemical of ephedrine

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -576,7 +576,7 @@
 	purity = REAGENT_STANDARD_PURITY
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	addiction_types = list(/datum/addiction/stimulants = 4) //1.6 per 2 seconds
-	inverse_chem = /datum/reagent/inverse/corazargh
+	inverse_chem = /datum/reagent/inverse // BANDASTATION EDIT - Original: /inverse/corazargh
 	inverse_chem_val = 0.4
 	metabolized_traits = list(TRAIT_BATON_RESISTANCE, TRAIT_STIMULATED)
 


### PR DESCRIPTION
## Что этот PR делает

Убирает реагент /inverse/corazargh при передозе эфедрином

## Почему это хорошо для игры

Инверсивный эффект накладывает на жертву "Проклятое сердце" (один в один, как с шахты). При этом, если его не кликать, кукла умирает ваншотом. Учитывая, что в бою ты не сможешь кликать его постоянно — можешь не заметить, растеряться, не увидеть или по другой причине, то ты просто умираешь примерно через 10 секунд.

Пример из реальной ситуации: https://discord.com/channels/1097181193939730453/1097182855613907004/1406383859494555658

Теперь при передозе ты будешь умирать дольше и более очевидно, при этом будет больше шансов сделать что-то чтобы спастись и подумать.

## Тестирование

Локалка

## Changelog

:cl:
balance: Реагент передоза для эфедрина заменен на более адекватный
/:cl:
