### PR TITLE
Some improvements to assault pods

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2624,6 +2624,8 @@
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/tile/neutral/full,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/supplypod/loading/ert)
 "amf" = (
@@ -12699,6 +12701,11 @@
 "bVR" = (
 /turf/open/floor/carpet/black,
 /area/centcom/central_command_areas/courtroom)
+"bWh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/supplypod/loading/ert)
 "bWN" = (
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -13815,6 +13822,9 @@
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supplypod/loading/ert)
 "dMI" = (
@@ -14466,6 +14476,12 @@
 	},
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/planetary_port/plaza)
+"fgf" = (
+/obj/structure/fluff/fake_vent{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/supplypod/loading/ert)
 "fgA" = (
 /obj/structure/flora/tree/jungle/small/style_random,
 /obj/effect/light_emitter/podbay,
@@ -15823,6 +15839,8 @@
 	req_access = list("cent_general");
 	pixel_x = 24
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/supplypod/loading/ert)
 "hUU" = (
@@ -16390,6 +16408,8 @@
 	req_access = list("cent_general");
 	pixel_x = -24
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/supplypod/loading/ert)
 "jlb" = (
@@ -16585,6 +16605,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral/full,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/supplypod/loading/ert)
 "jCW" = (
@@ -16958,7 +16980,7 @@
 	dir = 2;
 	dwidth = 3;
 	height = 7;
-	name = "escape pod loader";
+	name = "CentCom Assault Pod Dock";
 	roundstart_template = /datum/map_template/shuttle/assault_pod/nanotrasen;
 	width = 7
 	},
@@ -17312,6 +17334,8 @@
 "lul" = (
 /obj/effect/turf_decal/tile/neutral/full,
 /obj/structure/sign/warning/docking/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/supplypod/loading/ert)
 "lum" = (
@@ -17703,6 +17727,8 @@
 /area/centcom/central_command_areas/planetary_port/library)
 "mgQ" = (
 /obj/structure/light_fake/spot/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/centcom/central_command_areas/supplypod/loading/ert)
 "mhS" = (
@@ -18291,6 +18317,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/full,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/supplypod/loading/ert)
 "nGu" = (
@@ -18345,6 +18373,8 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/planetary_port)
 "nNP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/centcom/central_command_areas/supplypod/loading/ert)
 "nOh" = (
@@ -19310,6 +19340,12 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/central_command_areas/admin)
+"pKG" = (
+/obj/structure/fluff/fake_vent{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/supplypod/loading/ert)
 "pNI" = (
 /obj/effect/decal/nt_logo{
 	dir = 1;
@@ -19357,6 +19393,8 @@
 	req_access = list("cent_general");
 	pixel_y = -24
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/supplypod/loading/ert)
 "pSy" = (
@@ -19451,6 +19489,8 @@
 /area/centcom/central_command_areas/planetary_port/plaza)
 "qjj" = (
 /obj/structure/light_fake/spot/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/centcom/central_command_areas/supplypod/loading/ert)
 "qkR" = (
@@ -19732,6 +19772,12 @@
 /obj/structure/sign/poster/official/moth_delam/directional/west,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/planetary_port)
+"qRG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/supplypod/loading/ert)
 "qRR" = (
 /obj/structure/chair/sofa/left/brown{
 	dir = 1
@@ -19786,6 +19832,8 @@
 /area/centcom/central_command_areas/planetary_port/hotel)
 "rfL" = (
 /obj/structure/light_fake/spot/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/centcom/central_command_areas/supplypod/loading/ert)
 "rkF" = (
@@ -20423,6 +20471,8 @@
 "sLF" = (
 /obj/effect/turf_decal/tile/neutral/full,
 /obj/structure/sign/warning/docking/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/supplypod/loading/ert)
 "sLM" = (
@@ -21112,6 +21162,8 @@
 "uow" = (
 /obj/effect/turf_decal/tile/neutral/full,
 /obj/structure/sign/warning/docking/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/supplypod/loading/ert)
 "upl" = (
@@ -21426,6 +21478,8 @@
 "vae" = (
 /obj/effect/turf_decal/caution/stand_clear/red,
 /obj/effect/turf_decal/tile/neutral/full,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/supplypod/loading/ert)
 "vaP" = (
@@ -21487,6 +21541,8 @@
 "vfJ" = (
 /obj/effect/turf_decal/tile/neutral/full,
 /obj/structure/sign/warning/docking/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/supplypod/loading/ert)
 "viC" = (
@@ -21752,6 +21808,8 @@
 /area/centcom/central_command_areas/conference_room)
 "vEX" = (
 /obj/structure/light_fake/spot/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/centcom/central_command_areas/supplypod/loading/ert)
 "vFo" = (
@@ -54125,7 +54183,7 @@ aYd
 aYd
 aYd
 ivd
-apv
+pKG
 uXy
 aYd
 aYd
@@ -55660,7 +55718,7 @@ aaa
 aaa
 aaa
 oga
-apv
+qRG
 apv
 pQP
 oga
@@ -55917,7 +55975,7 @@ aaa
 aaa
 aaa
 fDD
-apv
+qRG
 apv
 jBB
 gyM
@@ -55930,9 +55988,9 @@ aWT
 aWT
 gyM
 vae
-apv
-apv
-apv
+bWh
+bWh
+bWh
 nNP
 xyB
 oga
@@ -57723,7 +57781,7 @@ xTk
 xTk
 xTk
 trU
-apv
+fgf
 bJp
 xTk
 xTk

--- a/_maps/templates/lazy_templates/ss220/syndie_cc.dmm
+++ b/_maps/templates/lazy_templates/ss220/syndie_cc.dmm
@@ -2008,7 +2008,7 @@
 /obj/docking_port/stationary{
 	area_type = /area/centcom/syndicate_base/elite_squad;
 	height = 5;
-	name = "syndicate recon outpost";
+	name = "Syndicate Strike Team Dock";
 	roundstart_template = /datum/map_template/shuttle/sst/basic;
 	shuttle_id = "syndicate_sst";
 	width = 11;
@@ -2524,7 +2524,7 @@
 /obj/docking_port/stationary{
 	area_type = /area/centcom/syndicate_base/infteam;
 	height = 5;
-	name = "syndicate recon outpost";
+	name = "Syndicate Infiltrators Dock";
 	roundstart_template = /datum/map_template/shuttle/sit/basic;
 	shuttle_id = "syndicate_sit";
 	width = 11;
@@ -4645,7 +4645,7 @@
 /obj/docking_port/stationary{
 	area_type = /area/centcom/syndicate_base;
 	height = 22;
-	name = "syndicate recon outpost";
+	name = "Syndicate Mothership Dock";
 	roundstart_template = /datum/map_template/shuttle/infiltrator/basic;
 	shuttle_id = "syndicate_away";
 	width = 18;
@@ -8826,7 +8826,7 @@
 	dir = 2;
 	dwidth = 3;
 	height = 7;
-	name = "escape pod loader";
+	name = "Syndicate Assault Pod Dock";
 	roundstart_template = /datum/map_template/shuttle/assault_pod/default;
 	width = 7
 	},

--- a/code/modules/shuttle/mobile_port/variants/assault_pod.dm
+++ b/code/modules/shuttle/mobile_port/variants/assault_pod.dm
@@ -59,7 +59,12 @@
 		if(S.shuttleId == shuttle_id)
 			S.possible_destinations = "[landing_zone.shuttle_id]"
 
-	to_chat(user, span_notice("Landing zone set."))
+	to_chat(user, span_notice("Зона высадки установлена."))
+	// BANDASTATION ADDITION START - Assault Pod Improvements
+	say("Установлена зона высадки: [picked_area]")
+	log_game("[key_name(user)] set the landing zone for the [lzname]([REF(src)]) to [AREACOORD(T)].")
+	message_admins(span_adminnotice("[ADMIN_LOOKUPFLW(user)] set the landing zone for the [lzname]([REF(src)]) to [ADMIN_VERBOSEJMP(T)]."))
+	// BANDASTATION ADDITION END - Assault Pod Improvements
 
 	qdel(src)
 

--- a/modular_bandastation/objects/code/shuttles.dm
+++ b/modular_bandastation/objects/code/shuttles.dm
@@ -120,7 +120,7 @@
 
 /// Initiate the landing zone effect
 /obj/docking_port/mobile/proc/initiate_drop_landing(obj/docking_port/stationary/S1, animate_time)
-	if(!S1 || drop_landing_in_progress || (!drop_landing_sound && !drop_landing_effect))
+	if(!S1 || S1.roundstart_template || drop_landing_in_progress || (!drop_landing_sound && !drop_landing_effect))
 		return
 
 	drop_landing_in_progress = TRUE
@@ -146,6 +146,9 @@
 
 	if(drop_landing_effect)
 		create_drop_landing_effect(S1, effect_turf, animate_time)
+
+	var/mutable_appearance/alert_overlay = mutable_appearance('icons/mob/telegraphing/telegraph_holographic.dmi', "target_box")
+	notify_ghosts("Зона посадки десантной капсулы!", source = effect_turf, header = "Десант", alert_overlay = alert_overlay)
 
 /// Create the landing zone effect in center of landing area
 /obj/docking_port/mobile/proc/create_drop_landing_effect(obj/docking_port/stationary/S1, turf/effect_turf, animate_time)
@@ -226,6 +229,9 @@
 /obj/docking_port/mobile/gamma/register()
 	. = ..()
 	SSshuttle.gamma = src
+
+/obj/docking_port/mobile/assault_pod
+	drop_landing_sound = 'sound/effects/alert.ogg'
 
 /obj/docking_port/mobile/assault_pod/nanotrasen
 	name = "Nanotrasen assault pod"


### PR DESCRIPTION

## Что этот PR делает
Чейнджлог.

## Изображения изменений
<img width="864" height="481" alt="Снимок экрана 2025-08-17 023202" src="https://github.com/user-attachments/assets/7db4f0cf-b4d9-4020-8d20-efa2ed0dfcb7" />

## Changelog

:cl:
qol: Десантные штурмовые поды теперь оповещают гостов о месте высадки.
qol: Стандартизирован нейминг доков на Синди-ЦК.
fix: Эффект зоны высадки более не проигрывается, если шаттл отправляется на свою раундстарт позицию.
admin: Добавлено логгирование десантных штурмовых подов.
/:cl:
