### PR TITLE
Fix cleanbot achievement

### DIFF
--- a/code/modules/mob/living/basic/bots/cleanbot/cleanbot.dm
+++ b/code/modules/mob/living/basic/bots/cleanbot/cleanbot.dm
@@ -287,7 +287,7 @@
 	return TRUE
 
 /mob/living/basic/bot/cleanbot/proc/update_title(new_job_title)
-	new_job_title = job_title_ru_to_en(new_job_title) ///check for ru job title
+	new_job_title = job_title_ru_to_en(new_job_title) // BANDASTATION ADDITION - Check for ru job title
 	if(isnull(job_titles[new_job_title]) || (new_job_title in stolen_valor))
 		return
 

--- a/code/modules/mob/living/basic/bots/cleanbot/cleanbot.dm
+++ b/code/modules/mob/living/basic/bots/cleanbot/cleanbot.dm
@@ -287,6 +287,7 @@
 	return TRUE
 
 /mob/living/basic/bot/cleanbot/proc/update_title(new_job_title)
+    new_job_title = job_title_ru_to_en(new_job_title) ///check for ru job title
 	if(isnull(job_titles[new_job_title]) || (new_job_title in stolen_valor))
 		return
 

--- a/code/modules/mob/living/basic/bots/cleanbot/cleanbot.dm
+++ b/code/modules/mob/living/basic/bots/cleanbot/cleanbot.dm
@@ -287,7 +287,7 @@
 	return TRUE
 
 /mob/living/basic/bot/cleanbot/proc/update_title(new_job_title)
-    new_job_title = job_title_ru_to_en(new_job_title) ///check for ru job title
+	new_job_title = job_title_ru_to_en(new_job_title) ///check for ru job title
 	if(isnull(job_titles[new_job_title]) || (new_job_title in stolen_valor))
 		return
 


### PR DESCRIPTION

## Что этот PR делает
Делает возможным получение ачивки CLEANBOSS aka One Lean, Mean, Cleaning Machine

Самая банальная реализация с фиксом в 1 строку.

В коде пытаюсь обновить `new_job_title` с русской версии на англ, с помощью функции `job_title_ru_to_en`, в случае если это русская, то мы получим англ версию, если это и так англ то ничего не изменится и нам вернут туже англ версию.
## Почему это хорошо для игры
Люблю ачивки и все что с этим связано! Каждый день бы получал ачивку!

## Изображения изменений
## Тестирование
Trust me bro

## Changelog

:cl:
fix: Теперь возможно получить ачивку One Lean, Mean, Cleaning Machine
/:cl:
