### PR TITLE
BALANCE: nerfing status_effect/mayhem for safer using

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -407,7 +407,7 @@
 
 /datum/status_effect/mayhem
 	id = "Mayhem"
-	duration = 2 MINUTES
+	duration = 15 SECONDS// BANDASTATION EDIT
 	alert_type = null
 	/// The chainsaw spawned by the status effect
 	var/obj/item/chainsaw/doomslayer/chainsaw
@@ -433,7 +433,7 @@
 		ADD_TRAIT(chainsaw, TRAIT_NODROP, TRAIT_STATUS_EFFECT(id))
 		owner.put_in_hands(chainsaw, forced = TRUE)
 		chainsaw.attack_self(owner)
-		owner.reagents.add_reagent(/datum/reagent/medicine/adminordrazine, 25)
+		owner.reagents.add_reagent(/datum/reagent/medicine/adminordrazine, 5)// BANDASTATION EDIT
 
 	owner.log_message("entered a blood frenzy", LOG_ATTACK)
 	to_chat(owner, span_narsiesmall("KILL, KILL, KILL! YOU HAVE NO ALLIES ANYMORE, NO TEAM MATES OR ALLEGIANCES! KILL THEM ALL!"))

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -407,7 +407,7 @@
 
 /datum/status_effect/mayhem
 	id = "Mayhem"
-	duration = 15 SECONDS// BANDASTATION EDIT - Original: 2 MINUTES
+	duration = 15 SECONDS // BANDASTATION EDIT - Original: 2 MINUTES (BALANCE: nerfing status_effect/mayhem for safer using)
 	alert_type = null
 	/// The chainsaw spawned by the status effect
 	var/obj/item/chainsaw/doomslayer/chainsaw
@@ -433,7 +433,7 @@
 		ADD_TRAIT(chainsaw, TRAIT_NODROP, TRAIT_STATUS_EFFECT(id))
 		owner.put_in_hands(chainsaw, forced = TRUE)
 		chainsaw.attack_self(owner)
-		owner.reagents.add_reagent(/datum/reagent/medicine/adminordrazine, 5)// BANDASTATION EDIT - Original: 25
+		owner.reagents.add_reagent(/datum/reagent/medicine/adminordrazine, 5)// BANDASTATION EDIT - Original: 25 (BALANCE: nerfing status_effect/mayhem for safer using)
 
 	owner.log_message("entered a blood frenzy", LOG_ATTACK)
 	to_chat(owner, span_narsiesmall("KILL, KILL, KILL! YOU HAVE NO ALLIES ANYMORE, NO TEAM MATES OR ALLEGIANCES! KILL THEM ALL!"))

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -407,7 +407,7 @@
 
 /datum/status_effect/mayhem
 	id = "Mayhem"
-	duration = 15 SECONDS// BANDASTATION EDIT
+	duration = 15 SECONDS// BANDASTATION EDIT - Original: 2 MINUTES
 	alert_type = null
 	/// The chainsaw spawned by the status effect
 	var/obj/item/chainsaw/doomslayer/chainsaw
@@ -433,7 +433,7 @@
 		ADD_TRAIT(chainsaw, TRAIT_NODROP, TRAIT_STATUS_EFFECT(id))
 		owner.put_in_hands(chainsaw, forced = TRUE)
 		chainsaw.attack_self(owner)
-		owner.reagents.add_reagent(/datum/reagent/medicine/adminordrazine, 5)// BANDASTATION EDIT
+		owner.reagents.add_reagent(/datum/reagent/medicine/adminordrazine, 5)// BANDASTATION EDIT - Original: 25
 
 	owner.log_message("entered a blood frenzy", LOG_ATTACK)
 	to_chat(owner, span_narsiesmall("KILL, KILL, KILL! YOU HAVE NO ALLIES ANYMORE, NO TEAM MATES OR ALLEGIANCES! KILL THEM ALL!"))

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -433,7 +433,7 @@
 		ADD_TRAIT(chainsaw, TRAIT_NODROP, TRAIT_STATUS_EFFECT(id))
 		owner.put_in_hands(chainsaw, forced = TRUE)
 		chainsaw.attack_self(owner)
-		owner.reagents.add_reagent(/datum/reagent/medicine/adminordrazine, 5)// BANDASTATION EDIT - Original: 25 (BALANCE: nerfing status_effect/mayhem for safer using)
+		owner.reagents.add_reagent(/datum/reagent/medicine/adminordrazine, 5) // BANDASTATION EDIT - Original: 25 (BALANCE: nerfing status_effect/mayhem for safer using)
 
 	owner.log_message("entered a blood frenzy", LOG_ATTACK)
 	to_chat(owner, span_narsiesmall("KILL, KILL, KILL! YOU HAVE NO ALLIES ANYMORE, NO TEAM MATES OR ALLEGIANCES! KILL THEM ALL!"))


### PR DESCRIPTION
## Что этот PR делает

Меняет 2 циферки эффекта безумия от хаоса в бутылке:
Время действия безумия было понижено до 15 секунд вместо 2 минут(2 минуты это реально много)
Количество adminordrazine вводимого при получении эффекты было понижено с 25 до 5(ибо 25 юнитов слишком много для 15 секунд)

## Почему это хорошо для игры

Хаос в бутылке — это очень опасный предмет для антагов и экипажа, однако данный пр делает его значительно безопаснее.  
Пример: раньше, если антаг бежал от аравы СБ и он активировал бутылку с хаосом в надежде натравить сбух друг на друга, это скорее всего приводило к убийству лишнего количества экипажа (космонавтик, находящийся под воздействием безумия, возможно, захочет убить ещё больше людей чем нужно антагу за эти 1-2 минуты, которые у него есть). 
А после этого ПРа антаг уже точно будет знать, что живые сбухи под безумием после боя друг с другом не пойдут резать экипаж по всей станции, потому что за 15 секунд они максимум успеют убить друг друга.  
Короче: этот ПР делает хаос в бутылке намного безопаснее для использования антагами. Меньшее время действия шизы — крайне низкий шанс убить лишних космонавтиков.

## Тестирование

На локалке

## Changelog

:cl:
balance: Эффект безумия от хаоса в бутылке получил НЁРФ на время действия (15 секунд вместо 2 минут).
/:cl:
