### PR TITLE
Translate: ID cards, job honorifics, money and PDA systems

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -31,19 +31,19 @@
 #define VENDING_CREDITS_COLLECTION_AMOUNT 0.2
 
 #define ACCOUNT_CIV "CIV"
-#define ACCOUNT_CIV_NAME "Civil Budget"
+#define ACCOUNT_CIV_NAME "Гражданский бюджет"
 #define ACCOUNT_ENG "ENG"
-#define ACCOUNT_ENG_NAME "Engineering Budget"
+#define ACCOUNT_ENG_NAME "Инженерный бюджет"
 #define ACCOUNT_SCI "SCI"
-#define ACCOUNT_SCI_NAME "Scientific Budget"
+#define ACCOUNT_SCI_NAME "Научный бюджет"
 #define ACCOUNT_MED "MED"
-#define ACCOUNT_MED_NAME "Medical Budget"
+#define ACCOUNT_MED_NAME "Медицинский бюджет"
 #define ACCOUNT_SRV "SRV"
-#define ACCOUNT_SRV_NAME "Service Budget"
+#define ACCOUNT_SRV_NAME "Бюджет обслуживания"
 #define ACCOUNT_CAR "CAR"
-#define ACCOUNT_CAR_NAME "Cargo Budget"
+#define ACCOUNT_CAR_NAME "Бюджет снабжения"
 #define ACCOUNT_SEC "SEC"
-#define ACCOUNT_SEC_NAME "Defense Budget"
+#define ACCOUNT_SEC_NAME "Оборонный бюджет"
 
 #define IS_DEPARTMENTAL_CARD(card) (card in SSeconomy.dep_cards)
 #define IS_DEPARTMENTAL_ACCOUNT(account) (account in SSeconomy.departmental_accounts)

--- a/code/datums/components/payment.dm
+++ b/code/datums/components/payment.dm
@@ -110,7 +110,7 @@
 
 	if(physical_cash_total > 0)
 		var/obj/item/holochip/holochange = new /obj/item/holochip(user.loc, physical_cash_total) //Change is made in holocredits exclusively.
-		holochange.name = "[holochange.credits] credit holochip"
+		holochange.name = "голочип с [holochange.credits] кр."
 		if(ishuman(user))
 			var/mob/living/carbon/human/paying_customer = user
 			var/successfully_put_in_hands

--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -132,7 +132,7 @@
 		return
 
 	if(!attached_circuit)
-		examine_text += span_notice("There is no integrated circuit attached.")
+		examine_text += span_notice("Нет прикреплённой интегральной платы.")
 		return
 
 	examine_text += span_notice("There is an integrated circuit attached. Use a multitool to access the wiring. Use a screwdriver to remove it from [source].")

--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -134,7 +134,7 @@
 		ACCESS_CE,
 		)
 	job = /datum/job/atmospheric_technician
-	honorifics = list("Technician")
+	honorifics = list("Техник")
 	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/bartender
@@ -183,7 +183,7 @@
 		ACCESS_HOP,
 		)
 	job = /datum/job/pun_pun
-	honorifics = list(", Almighty Scourge")
+	honorifics = list(", Всемогущий бич")
 	honorific_positions = HONORIFIC_POSITION_LAST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/bitrunner
@@ -254,7 +254,7 @@
 		ACCESS_CHANGE_IDS,
 	)
 	job = /datum/job/bridge_assistant
-	honorifics = list("Underling", "Assistant", "Mate")
+	honorifics = list("Подчинённый", "Ассистент", "Помощник")
 	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/captain
@@ -272,7 +272,7 @@
 	job = /datum/job/captain
 	big_pointer = TRUE
 	pointer_color = COLOR_COMMAND_BLUE
-	honorifics = list("Captain", "Cpt.")
+	honorifics = list("Капитан", "Кэп")
 	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /// Captain gets all station accesses hardcoded in because it's the Captain.
@@ -308,7 +308,7 @@
 		ACCESS_QM,
 		)
 	job = /datum/job/cargo_technician
-	honorifics = list("Courier")
+	honorifics = list("Курьер")
 	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 
@@ -333,7 +333,7 @@
 		ACCESS_HOP,
 		)
 	job = /datum/job/chaplain
-	honorifics = list("Chaplain", "Reverend")
+	honorifics = list("Священник", "Преподобный")
 	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/chemist
@@ -403,7 +403,7 @@
 	job = /datum/job/chief_engineer
 	big_pointer = TRUE
 	pointer_color = COLOR_ENGINEERING_ORANGE
-	honorifics = list("Chief")
+	honorifics = list("Начальник")
 	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/chief_medical_officer
@@ -446,7 +446,7 @@
 	job = /datum/job/chief_medical_officer
 	big_pointer = TRUE
 	pointer_color = COLOR_MEDICAL_BLUE
-	honorifics = list(", PhD.", ", MD.")
+	honorifics = list(", доктор наук", ", доктор медицин")
 	honorific_positions = HONORIFIC_POSITION_LAST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/clown
@@ -490,13 +490,13 @@
 		ACCESS_HOP,
 		)
 	job = /datum/job/cook
-	honorifics = list("Cook")
+	honorifics = list("Повар")
 	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/cook/chef
 	assignment = JOB_CHEF
 	sechud_icon_state = SECHUD_CHEF
-	honorifics = list("Chef")
+	honorifics = list("Шеф")
 	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/coroner
@@ -574,7 +574,7 @@
 		ACCESS_HOS,
 	)
 	job = /datum/job/detective
-	honorifics = list("Detective", "Investigator")
+	honorifics = list("Детектив", "Следователь")
 	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/detective/refresh_trim_access()
@@ -720,7 +720,7 @@
 	job = /datum/job/head_of_security
 	big_pointer = TRUE
 	pointer_color = COLOR_SECURITY_RED
-	honorifics = list("Chief Officer", "Chief", "Officer")
+	honorifics = list("Старший офицер", "Начальник", "Офицер")
 	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/head_of_security/refresh_trim_access()
@@ -752,7 +752,7 @@
 		ACCESS_CHANGE_IDS,
 		)
 	job = /datum/job/janitor
-	honorifics = list("Custodian")
+	honorifics = list("Тех.персонал")
 	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/lawyer
@@ -775,7 +775,7 @@
 		ACCESS_HOP,
 		)
 	job = /datum/job/lawyer
-	honorifics = list(", Esq.")
+	honorifics = list(", Юрист")
 	honorific_positions = HONORIFIC_POSITION_LAST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/medical_doctor
@@ -802,7 +802,7 @@
 		ACCESS_CMO,
 		)
 	job = /datum/job/doctor
-	honorifics = list("Doctor", "Dr.")
+	honorifics = list("Доктор", "Док.")
 	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/mime
@@ -856,7 +856,7 @@
 		ACCESS_CMO,
 		)
 	job = /datum/job/paramedic
-	honorifics = list("EMT")
+	honorifics = list("СМП")
 	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/prisoner
@@ -873,7 +873,7 @@
 		)
 	job = /datum/job/prisoner
 	threat_modifier = 1 // I'm watching you
-	honorifics = list("Convict")
+	honorifics = list("Осуждённый")
 	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/prisoner/one
@@ -927,7 +927,7 @@
 		ACCESS_HOP,
 	)
 	job = /datum/job/psychologist
-	honorifics = list(", PhD.")
+	honorifics = list(", доктор наук")
 	honorific_positions = HONORIFIC_POSITION_LAST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/quartermaster
@@ -969,7 +969,7 @@
 	job = /datum/job/quartermaster
 	big_pointer = TRUE
 	pointer_color = COLOR_CARGO_BROWN
-	honorifics = list("Manager")
+	honorifics = list("Менеджер")
 	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/research_director
@@ -1021,7 +1021,7 @@
 	job = /datum/job/research_director
 	big_pointer = TRUE
 	pointer_color = COLOR_SCIENCE_PINK
-	honorifics = list("Director", "Dir.")
+	honorifics = list("Директор", "Дир.")
 	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/roboticist
@@ -1080,7 +1080,7 @@
 		ACCESS_RD,
 		)
 	job = /datum/job/scientist
-	honorifics = list("Researcher")
+	honorifics = list("Исследователь")
 	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /// Sec officers have departmental variants. They each have their own trims with bonus departmental accesses.
@@ -1110,7 +1110,7 @@
 		ACCESS_HOS,
 		)
 	job = /datum/job/security_officer
-	honorifics = list("Officer")
+	honorifics = list("Офицер")
 	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 	/// List of bonus departmental accesses that departmental sec officers get by default.
 	var/department_access = list()
@@ -1190,7 +1190,7 @@
 		ACCESS_SURGERY,
 		ACCESS_VIROLOGY,
 	)
-	honorifics = list("Orderly", "Officer")
+	honorifics = list("Охранник", "Офицер")
 
 /datum/id_trim/job/security_officer/science
 	assignment = JOB_SECURITY_OFFICER_SCIENCE
@@ -1273,7 +1273,7 @@
 		ACCESS_CE,
 		)
 	job = /datum/job/station_engineer
-	honorifics = list("Engineer")
+	honorifics = list("Инженер")
 	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/veteran_advisor
@@ -1296,7 +1296,7 @@
 	template_access = list()
 	job = /datum/job/veteran_advisor
 	big_pointer = TRUE
-	honorifics = list("General", "Gen.")
+	honorifics = list("Генерал", "Ген.")
 	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/veteran_advisor/refresh_trim_access()
@@ -1336,7 +1336,7 @@
 		ACCESS_HOS,
 		)
 	job = /datum/job/warden
-	honorifics = list("Officer", "Watchman", "Lieutenant", "Lt.")
+	honorifics = list("Офицер", "Сторож", "Лейтенант", "Л-т.")
 	honorific_positions = HONORIFIC_POSITION_FIRST | HONORIFIC_POSITION_LAST | HONORIFIC_POSITION_FIRST_FULL | HONORIFIC_POSITION_NONE
 
 /datum/id_trim/job/warden/refresh_trim_access()

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -354,7 +354,7 @@
 
 	var/holochip_amount = id_card.registered_account.account_balance
 	new /obj/item/holochip(wallet, holochip_amount)
-	id_card.registered_account.adjust_money(-holochip_amount, "System: Withdrawal")
+	id_card.registered_account.adjust_money(-holochip_amount, "Система: Вывод средств")
 
 	new /obj/effect/spawner/random/entertainment/wallet_storage(wallet)
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -11,7 +11,7 @@
  * FINGERPRINT CARD HOLDER
  * FINGERPRINT CARD
  */
-
+//
 
 
 /*
@@ -505,8 +505,8 @@
 	if(Adjacent(user))
 		var/minor
 		if(registered_name && registered_age && registered_age < AGE_MINOR)
-			minor = " <b>(MINOR)</b>"
-		user.visible_message(span_notice("[user] shows you: [icon2html(src, viewers(user))] [src.name][minor]."), span_notice("You show \the [src.name][minor]."))
+			minor = " <b>(НЕСОВЕРШЕННОЛЕТНИЙ)</b>"
+		user.visible_message(span_notice("[user] показывает вам: [icon2html(src, viewers(user))] [src.name][minor]."), span_notice("Вы показываете [src.name][minor]."))
 	add_fingerprint(user)
 
 /obj/item/card/id/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
@@ -525,36 +525,36 @@
 /obj/item/card/id/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
 
-	context[SCREENTIP_CONTEXT_RMB] = "Project pay stand"
+	context[SCREENTIP_CONTEXT_RMB] = "Проекция стойки оплаты"
 
 	if(isnull(held_item) || (held_item == src))
-		context[SCREENTIP_CONTEXT_LMB] = "Show ID"
+		context[SCREENTIP_CONTEXT_LMB] = "Показать ID"
 	else if(iscash(held_item) || istype(held_item, /obj/item/storage/bag/money))
-		context[SCREENTIP_CONTEXT_LMB] = "Insert"
+		context[SCREENTIP_CONTEXT_LMB] = "Вставить"
 	else if(istype(held_item, /obj/item/rupee))
-		context[SCREENTIP_CONTEXT_LMB] = "Insert?"
+		context[SCREENTIP_CONTEXT_LMB] = "Вставить?"
 
 	if(isnull(registered_account) || registered_account.replaceable) //Same check we use when we check if we can assign an account
-		context[SCREENTIP_CONTEXT_ALT_RMB] = "Assign account"
+		context[SCREENTIP_CONTEXT_ALT_RMB] = "Привязать аккаунт"
 	else if(registered_account.account_balance > 0)
-		context[SCREENTIP_CONTEXT_ALT_LMB] = "Withdraw credits"
+		context[SCREENTIP_CONTEXT_ALT_LMB] = "Вывести кредиты"
 	if(trim && length(trim.honorifics))
-		context[SCREENTIP_CONTEXT_CTRL_LMB] = "Toggle honorific"
+		context[SCREENTIP_CONTEXT_CTRL_LMB] = "Переключить звание"
 	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/card/id/add_item_context(obj/item/source, list/context, atom/target, mob/living/user)
 	. = ..()
 	if(iscash(target))
-		context[SCREENTIP_CONTEXT_LMB] = "Insert into card"
+		context[SCREENTIP_CONTEXT_LMB] = "Вставить в карту"
 		return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/card/id/proc/try_project_paystand(mob/user, turf/target)
 	if(!COOLDOWN_FINISHED(src, last_holopay_projection))
-		balloon_alert(user, "still recharging")
+		balloon_alert(user, "перезаряжается")
 		return
 	if(!can_be_used_in_payment(user))
-		balloon_alert(user, "no account!")
-		to_chat(user, span_warning("You need a valid bank account to do this."))
+		balloon_alert(user, "нет аккаунта!")
+		to_chat(user, span_warning("Для этого вам нужен действительный банковский счёт."))
 		return
 	/// Determines where the holopay will be placed based on tile contents
 	var/turf/projection
@@ -567,8 +567,8 @@
 	else if(can_proj_holopay(user_loc))
 		projection = user_loc
 	if(!projection)
-		balloon_alert(user, "no space")
-		to_chat(user, span_warning("You need to be standing on or near an open tile to do this."))
+		balloon_alert(user, "нет места!")
+		to_chat(user, span_warning("Для этого вам нужно стоять на открытой плитке или рядом с ней."))
 		return
 	/// Success: Valid tile for holopay placement
 	if(my_store)
@@ -635,7 +635,7 @@
  */
 /obj/item/card/id/proc/set_holopay_name(name)
 	if(length(name) < 3 || length(name) > MAX_NAME_LEN)
-		to_chat(usr, span_warning("Must be between 3 - 42 characters."))
+		to_chat(usr, span_warning("Должно быть от 3 до 42 символов."))
 	else
 		holopay_name = html_encode(trim(name, MAX_NAME_LEN))
 
@@ -653,7 +653,7 @@
 
 /obj/item/card/id/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	if(istype(tool, /obj/item/rupee))
-		to_chat(user, span_warning("Your ID smartly rejects the strange shard of glass. Who knew, apparently it's not ACTUALLY valuable!"))
+		to_chat(user, span_warning("Ваша ID-карта ловко отклоняет странный осколок стекла. Кто бы мог подумать, что на самом деле он не представляет ценности!"))
 		return ITEM_INTERACT_BLOCKING
 	else if(iscash(tool))
 		return insert_money(tool, user) ? ITEM_INTERACT_SUCCESS : ITEM_INTERACT_BLOCKING
@@ -663,7 +663,7 @@
 		var/money_added = mass_insert_money(money_contained, user)
 		if(!money_added)
 			return ITEM_INTERACT_BLOCKING
-		to_chat(user, span_notice("You stuff the contents into the card! They disappear in a puff of bluespace smoke, adding [money_added] worth of credits to the linked account."))
+		to_chat(user, span_notice("Вы вставляете содержимое на карту! Они исчезают в клубах блюспейс-дыма, пополняя счёт на [money_added] кр. к привязанному аккаунту."))
 		return ITEM_INTERACT_SUCCESS
 	return NONE
 
@@ -682,21 +682,21 @@
 		physical_currency = TRUE
 
 	if(!registered_account)
-		to_chat(user, span_warning("[src] doesn't have a linked account to deposit [money] into!"))
+		to_chat(user, span_warning("У [declent_ru(ACCUSATIVE)] нет привязанного аккаунта, на который можно было бы внести [money.declent_ru(ACCUSATIVE)]!"))
 		return FALSE
 	var/cash_money = money.get_item_credit_value()
 	if(!cash_money)
-		to_chat(user, span_warning("[money] doesn't seem to be worth anything!"))
+		to_chat(user, span_warning("[money.declent_ru(ACCUSATIVE)] кажется, ничего не стоит!"))
 		return FALSE
-	registered_account.adjust_money(cash_money, "System: Deposit")
+	registered_account.adjust_money(cash_money, "Система: Вложение")
 	SSblackbox.record_feedback("amount", "credits_inserted", cash_money)
-	log_econ("[cash_money] credits were inserted into [src] owned by [src.registered_name]")
+	log_econ("[cash_money] кредитов вставлено в [declent_ru(ACCUSATIVE)] принадлежащий [src.registered_name]")
 	if(physical_currency)
-		to_chat(user, span_notice("You stuff [money] into [src]. It disappears in a small puff of bluespace smoke, adding [cash_money] credits to the linked account."))
+		to_chat(user, span_notice("Вы запихиваете [money.declent_ru(ACCUSATIVE)] в [declent_ru(ACCUSATIVE)]. Деньги исчезают в клубе блюспейс-дыма, пополняя счёт на [cash_money] кр."))
 	else
-		to_chat(user, span_notice("You insert [money] into [src], adding [cash_money] credits to the linked account."))
+		to_chat(user, span_notice("Вы вставляете [money.declent_ru(ACCUSATIVE)] в [declent_ru(ACCUSATIVE)], пополняя счёт на [cash_money] кр."))
 
-	to_chat(user, span_notice("The linked account now reports a balance of [registered_account.account_balance] cr."))
+	to_chat(user, span_notice("Текущий баланс счёта: [registered_account.account_balance] кр."))
 	qdel(money)
 	return TRUE
 
@@ -709,7 +709,7 @@
  */
 /obj/item/card/id/proc/mass_insert_money(list/money, mob/user)
 	if(!registered_account)
-		to_chat(user, span_warning("[src] doesn't have a linked account to deposit into!"))
+		to_chat(user, span_warning("[declent_ru(ACCUSATIVE)] нет привязанного аккаунта для пополнения!"))
 		return FALSE
 
 	if (!money || !length(money))
@@ -721,7 +721,7 @@
 		total += physical_money.get_item_credit_value()
 		CHECK_TICK
 
-	registered_account.adjust_money(total, "System: Deposit")
+	registered_account.adjust_money(total, "Система: Пополнение")
 	SSblackbox.record_feedback("amount", "credits_inserted", total)
 	log_econ("[total] credits were inserted into [src] owned by [src.registered_name]")
 	QDEL_LIST(money)
@@ -739,34 +739,34 @@
 	. = FALSE
 	var/datum/bank_account/old_account = registered_account
 	if(loc != user)
-		to_chat(user, span_warning("You must be holding the ID to continue!"))
+		to_chat(user, span_warning("Вы должны держать ID-карту, чтобы продолжить!"))
 		return FALSE
 	var/list/user_memories = user.mind.memories
 	var/datum/memory/key/account/user_key = user_memories[/datum/memory/key/account]
 	var/default_account = (istype(user_key) && user_key.remembered_id) || 11111
-	var/new_bank_id = tgui_input_number(user, "Enter the account ID to associate with this card.", "Link Bank Account", default_account, 999999, 111111)
+	var/new_bank_id = tgui_input_number(user, "Введите номер аккаунта для привязки к этой карте.", "Привязать банковский аккаунт", default_account, 999999, 111111)
 	if(!new_bank_id || QDELETED(user) || QDELETED(src) || issilicon(user) || !alt_click_can_use_id(user) || loc != user)
 		return FALSE
 	if(registered_account?.account_id == new_bank_id)
-		to_chat(user, span_warning("The account ID was already assigned to this card."))
+		to_chat(user, span_warning("Аккаунт уже был присвоен этой карте."))
 		return FALSE
 	var/datum/bank_account/account = SSeconomy.bank_accounts_by_id["[new_bank_id]"]
 	if(isnull(account))
-		to_chat(user, span_warning("The account ID number provided is invalid."))
+		to_chat(user, span_warning("Номер счёта является недействительным."))
 		return FALSE
 	if(old_account)
 		old_account.bank_cards -= src
 		account.account_balance += old_account.account_balance
 	account.bank_cards += src
 	registered_account = account
-	to_chat(user, span_notice("The provided account has been linked to this ID card. It contains [account.account_balance] credits."))
+	to_chat(user, span_notice("Указанный аккаунт был привязан к этой ID-карте. Он содержит [account.account_balance] кр."))
 	return TRUE
 
 /obj/item/card/id/click_alt(mob/living/user)
 	if(!alt_click_can_use_id(user))
 		return NONE
 	if(registered_account.account_debt)
-		var/choice = tgui_alert(user, "Choose An Action", "Bank Account", list("Withdraw", "Pay Debt"))
+		var/choice = tgui_alert(user, "Выберите действие", "Аккаунт банка", list("Вывести", "Погасить долг"))
 		if(!choice || QDELETED(user) || QDELETED(src) || !alt_click_can_use_id(user) || loc != user)
 			return CLICK_ACTION_BLOCKING
 		if(choice == "Pay Debt")
@@ -776,30 +776,30 @@
 		registered_account.bank_card_talk(span_warning("内部服务器错误"), TRUE)
 		return CLICK_ACTION_SUCCESS
 	if(loc != user)
-		to_chat(user, span_warning("You must be holding the ID to continue!"))
+		to_chat(user, span_warning("Вы должны держать ID-карту, чтобы продолжить!"))
 		return CLICK_ACTION_BLOCKING
 	if(registered_account.replaceable && !registered_account.account_balance)
-		var/choice = tgui_alert(user, "This card's account is unassigned. Would you like to link a bank account?", "Bank Account", list("Link Account", "Leave Unassigned"))
+		var/choice = tgui_alert(user, "Счёт к этой карте не привязан. Хотите привязать банковский счёт?", "Аккаунт банка", list("Привязать аккаунт", "Оставить незаполненным"))
 		if(!choice || QDELETED(user) || QDELETED(src) || !alt_click_can_use_id(user) || loc != user)
 			return CLICK_ACTION_BLOCKING
 		if(choice == "Link Account")
 			set_new_account(user)
 			return CLICK_ACTION_SUCCESS
-	var/amount_to_remove = tgui_input_number(user, "How much do you want to withdraw? (Max: [registered_account.account_balance] cr)", "Withdraw Funds", max_value = registered_account.account_balance)
+	var/amount_to_remove = tgui_input_number(user, "Сколько вы хотите вывести? (Макс: [registered_account.account_balance] кр.)", "Вывести средства", max_value = registered_account.account_balance)
 	if(!amount_to_remove || QDELETED(user) || QDELETED(src) || issilicon(user) || loc != user)
 		return CLICK_ACTION_BLOCKING
 	if(!alt_click_can_use_id(user))
 		return CLICK_ACTION_BLOCKING
-	if(registered_account.adjust_money(-amount_to_remove, "System: Withdrawal"))
+	if(registered_account.adjust_money(-amount_to_remove, "Система: Вывод средств"))
 		var/obj/item/holochip/holochip = new (user.drop_location(), amount_to_remove)
 		user.put_in_hands(holochip)
-		to_chat(user, span_notice("You withdraw [amount_to_remove] credits into a holochip."))
+		to_chat(user, span_notice("Вы вывели [amount_to_remove] кр. в голочип."))
 		SSblackbox.record_feedback("amount", "credits_removed", amount_to_remove)
 		log_econ("[amount_to_remove] credits were removed from [src] owned by [src.registered_name]")
 		return CLICK_ACTION_SUCCESS
 	else
 		var/difference = amount_to_remove - registered_account.account_balance
-		registered_account.bank_card_talk(span_warning("ERROR: The linked account requires [difference] more credit\s to perform that withdrawal."), TRUE)
+		registered_account.bank_card_talk(span_warning("ОШИБКА: Для вывода средств с привязанного аккаунта требуется на [difference] больше кр."), TRUE)
 		return CLICK_ACTION_BLOCKING
 
 /obj/item/card/id/click_alt_secondary(mob/user)
@@ -809,15 +809,15 @@
 		set_new_account(user)
 
 /obj/item/card/id/proc/pay_debt(user)
-	var/amount_to_pay = tgui_input_number(user, "How much do you want to pay? (Max: [registered_account.account_balance] cr)", "Debt Payment", max_value = min(registered_account.account_balance, registered_account.account_debt))
+	var/amount_to_pay = tgui_input_number(user, "Сколько вы хотите заплатить? (Макс: [registered_account.account_balance] кр.)", "Выплата долга", max_value = min(registered_account.account_balance, registered_account.account_debt))
 	if(!amount_to_pay || QDELETED(src) || loc != user || !alt_click_can_use_id(user))
 		return
 	var/prev_debt = registered_account.account_debt
 	var/amount_paid = registered_account.pay_debt(amount_to_pay)
 	if(amount_paid)
-		var/message = span_notice("You pay [amount_to_pay] credits of a [prev_debt] cr debt. [registered_account.account_debt] cr to go.")
+		var/message = span_notice("Вы заплатили [amount_to_pay] кредитов из [prev_debt] вашего долга. Осталось выплатить [registered_account.account_debt] кр.")
 		if(!registered_account.account_debt)
-			message = span_nicegreen("You pay the last [amount_to_pay] credits of your debt, extinguishing it. Congratulations!")
+			message = span_nicegreen("Вы заплатили последние [amount_to_pay] кр. из вашего долга, погасив его. Поздравляю!")
 		to_chat(user, message)
 
 /obj/item/card/id/examine(mob/user)
@@ -826,25 +826,25 @@
 		return
 
 	if(registered_account && !isnull(registered_account.account_id))
-		. += "The account linked to the ID belongs to '[registered_account.account_holder]' and reports a balance of [registered_account.account_balance] cr."
+		. += "Аккаунт привязанный к ID принадлежит '[registered_account.account_holder]' и отображает баланс в размере [registered_account.account_balance] кр."
 		if(ACCESS_COMMAND in access)
 			var/datum/bank_account/linked_dept = SSeconomy.get_dep_account(registered_account.account_job.paycheck_department)
-			. += "The [linked_dept.account_holder] linked to the ID reports a balance of [linked_dept.account_balance] cr."
+			. += "[linked_dept.account_holder] привязанный к ID отображает баланс [linked_dept.account_balance] кр."
 	else
-		. += span_notice("Alt-Right-Click the ID to set the linked bank account.")
+		. += span_notice("Alt-ПКМ, чтобы привязать ID-карту к банковскому счёту.")
 
 	if(HAS_TRAIT(user, TRAIT_ID_APPRAISER))
-		. += HAS_TRAIT(src, TRAIT_JOB_FIRST_ID_CARD) ? span_boldnotice("Hmm... yes, this ID was issued from Central Command!") : span_boldnotice("This ID was created in this sector, not by Central Command.")
+		. += HAS_TRAIT(src, TRAIT_JOB_FIRST_ID_CARD) ? span_boldnotice("Хмм... да, этот ID был выдан Центральным Командованием!") : span_boldnotice("Этот ID был сделан в этом секторе, не Центральным Командованием.")
 		if(HAS_TRAIT(src, TRAIT_TASTEFULLY_THICK_ID_CARD) && (user.is_holding(src) || (user.CanReach(src) && user.put_in_hands(src, ignore_animation = FALSE))))
 			ADD_TRAIT(src, TRAIT_NODROP, "psycho")
-			. += span_hypnophrase("Look at that subtle coloring... The tasteful thickness of it. Oh my God, it even has a watermark...")
+			. += span_hypnophrase("Посмотрите, какой нежный оттенок... На изысканную толщину. Боже мой, на нём даже есть водяной знак...")
 			var/sound/slowbeat = sound('sound/effects/health/slowbeat.ogg', repeat = TRUE)
 			user.playsound_local(get_turf(src), slowbeat, 40, 0, channel = CHANNEL_HEARTBEAT, use_reverb = FALSE)
 			if(isliving(user))
 				var/mob/living/living_user = user
 				living_user.adjust_jitter(10 SECONDS)
 			addtimer(CALLBACK(src, PROC_REF(drop_card), user), 10 SECONDS)
-	. += span_notice("<i>There's more information below, you can look again to take a closer look...</i>")
+	. += span_notice("<i>Ниже приведена более подробная информация, вы можете просмотреть её еще раз, чтобы рассмотреть поближе...</i>")
 
 /obj/item/card/id/proc/drop_card(mob/user)
 	user.stop_sound_channel(CHANNEL_HEARTBEAT)
@@ -854,7 +854,7 @@
 	for(var/mob/living/carbon/human/viewing_mob in viewers(user, 2))
 		if(viewing_mob.stat || viewing_mob == user)
 			continue
-		viewing_mob.say("Is something wrong? [first_name(user.name)]... you're sweating.", forced = "psycho")
+		viewing_mob.say("Что-то не так? [first_name(user.name)]... ты потеешь.", forced = "psycho")
 		break
 
 /obj/item/card/id/examine_more(mob/user)
@@ -862,33 +862,33 @@
 	if(!user.can_read(src))
 		return
 
-	. += span_notice("<i>You examine [src] closer, and note the following...</i>")
+	. += span_notice("<i>Вы рассматриваете [declent_ru(ACCUSATIVE)] ближе, и подмечаете...</i>")
 
 	if(registered_age)
-		. += "The card indicates that the holder is [registered_age] years old. [(registered_age < AGE_MINOR) ? "There's a holographic stripe that reads <b>[span_danger("'MINOR: DO NOT SERVE ALCOHOL OR TOBACCO'")]</b> along the bottom of the card." : ""]"
+		. += "На карточке указан возраст [registered_age]. [(registered_age < AGE_MINOR) ? "Внизу карточки есть голографическая полоска с надписью <b>[span_danger("НЕСОВЕРШЕННОЛЕТНИЙ: НЕ ПОДАВАТЬ АЛКОГОЛЬ ИЛИ ТАБАК")]</b>." : ""]"
 	if(registered_account)
 		if(registered_account.mining_points)
-			. += "There's [registered_account.mining_points] mining point\s loaded onto the card's bank account."
-		. += "The account linked to the ID belongs to '[registered_account.account_holder]' and reports a balance of [registered_account.account_balance] cr."
+			. += "На карточке показывается шахтёрские очки в количестве [registered_account.mining_points]."
+		. += "Привязанный аккаунт к ID принадлежит '[registered_account.account_holder]' и отображает баланс в размере [registered_account.account_balance] кр."
 		if(registered_account.account_debt)
-			. += span_warning("The account is currently indebted for [registered_account.account_debt] cr. [100*DEBT_COLLECTION_COEFF]% of all earnings will go towards extinguishing it.")
+			. += span_warning("На данный момент на счёте имеется задолженность в размере [registered_account.account_debt] кр. [100*DEBT_COLLECTION_COEFF]% заработанных средств пойдет на его погашение.")
 		if(registered_account.account_job)
 			var/datum/bank_account/D = SSeconomy.get_dep_account(registered_account.account_job.paycheck_department)
 			if(D)
-				. += "The [D.account_holder] reports a balance of [D.account_balance] cr."
-		. += span_info("Alt-Click the ID to pull money from the linked account in the form of holochips.")
-		. += span_info("You can insert credits into the linked account by pressing holochips, cash, or coins against the ID.")
+				. += "[D.account_holder] имеет баланс [D.account_balance] кр."
+		. += span_info("Alt-ЛКМ, чтобы снять деньги с ID-карты в виде голочипов.")
+		. += span_info("Вы можете вставлять кредиты на привязанный аккаунт, прикладывая голочипы, наличку или монеты на ID-карту.")
 		if(registered_account.replaceable)
-			. += span_info("Alt-Right-Click the ID to change the linked bank account.")
+			. += span_info("Alt-ПКМ, чтобы поменять привязанный банковский аккаунт.")
 		if(registered_account.civilian_bounty)
-			. += span_info("<b>There is an active civilian bounty.</b>")
+			. += span_info("<b>Активные гражданские заказы.</b>")
 			. += span_info("<i>[registered_account.bounty_text()]</i>")
-			. += span_info("Quantity: [registered_account.bounty_num()]")
-			. += span_info("Reward: [registered_account.bounty_value()]")
+			. += span_info("Количество: [registered_account.bounty_num()]")
+			. += span_info("Награда: [registered_account.bounty_value()]")
 		if(registered_account.account_holder == user.real_name)
-			. += span_boldnotice("If you lose this ID card, you can reclaim your account by Alt-Clicking a blank ID card while holding it and entering your account ID number.")
+			. += span_boldnotice("Если вы потеряете ID-карту, то можете восстановить аккаунт нажав Alt+ЛКМ на пустой ID-карте, когда держите его или введя номер аккаунта.")
 	else
-		. += span_info("There is no registered account linked to this card. Alt-Click to add one.")
+		. += span_info("Нет привязанного аккаунта к этой ID-карте. Alt-ЛКМ, чтобы добавить аккаунт.")
 
 	return .
 
@@ -916,9 +916,9 @@
 	var/name_string
 	if(registered_name)
 		if(trim && (honorific_position & ~HONORIFIC_POSITION_NONE))
-			name_string = "[update_honorific()]'s ID Card"
+			name_string = "ID-карта \"[update_honorific()]\""
 		else
-			name_string = "[registered_name]'s ID Card"
+			name_string = "ID-карта \"[registered_name]\""
 	else
 		name_string = initial(name)
 
@@ -926,9 +926,9 @@
 
 	if(is_intern)
 		if(assignment)
-			assignment_string = trim?.intern_alt_name || "Intern [assignment]"
+			assignment_string = trim?.intern_alt_name || "Стажёр [assignment]"
 		else
-			assignment_string = "Intern"
+			assignment_string = "Стажёр"
 	else
 		assignment_string = assignment
 
@@ -969,7 +969,7 @@
 		return
 
 	if(!length(trim.honorifics))
-		balloon_alert(user, "card has no honorific to use!")
+		balloon_alert(user, "карта не имеет почётного звания!")
 		return
 
 	var/list/choices = list()
@@ -978,7 +978,7 @@
 		if(trim.honorific_positions & readable_names[i]) //If the positions list has the same bit value as the readable list.
 			choices += i
 
-	var/chosen_position = tgui_input_list(user, "What position do you want your honorific in?", "Flair!", choices)
+	var/chosen_position = tgui_input_list(user, "На какой должности вы хотите получить звание?", "Специализация!", choices)
 	if(user.incapacitated || !in_contents_of(user))
 		return
 	var/honorific_position_to_use = readable_names[chosen_position]
@@ -987,25 +987,25 @@
 	honorific_title = null //We reset this regardless so that we don't stack titles on accident.
 
 	if(honorific_position_to_use & HONORIFIC_POSITION_NONE)
-		balloon_alert(user, "honorific disabled")
+		balloon_alert(user, "звание отключено")
 	else
-		var/new_honorific = tgui_input_list(user, "What honorific do you want to use?", "Flair!!!", trim.honorifics)
+		var/new_honorific = tgui_input_list(user, "Какое звание хотите использовать?", "Специализация!!!", trim.honorifics)
 		if(!new_honorific || user.incapacitated || !in_contents_of(user))
 			return
 		chosen_honorific = new_honorific
 		switch(honorific_position_to_use)
 			if(HONORIFIC_POSITION_FIRST)
 				honorific_position = HONORIFIC_POSITION_FIRST
-				balloon_alert(user, "honorific set: display first name")
+				balloon_alert(user, "звание установлено: показывать имя")
 			if(HONORIFIC_POSITION_LAST)
 				honorific_position = HONORIFIC_POSITION_LAST
-				balloon_alert(user, "honorific set: display last name")
+				balloon_alert(user, "звание установлено: показать фамилию")
 			if(HONORIFIC_POSITION_FIRST_FULL)
 				honorific_position = HONORIFIC_POSITION_FIRST_FULL
-				balloon_alert(user, "honorific set: start of full name")
+				balloon_alert(user, "звание установлено: начало полного имени")
 			if(HONORIFIC_POSITION_LAST_FULL)
 				honorific_position = HONORIFIC_POSITION_LAST_FULL
-				balloon_alert(user, "honorific set: end of full name")
+				balloon_alert(user, "звание установлено: конец полного имени")
 
 	update_label()
 
@@ -1018,7 +1018,7 @@
 
 /obj/item/card/id/away/hotel
 	name = "Staff ID"
-	desc = "A staff ID used to access the hotel's doors."
+	desc = "ID-карта сотрудника, используемый для допуска к шлюзам отеля."
 	trim = /datum/id_trim/away/hotel
 
 /obj/item/card/id/away/hotel/security
@@ -1031,27 +1031,27 @@
 
 /obj/item/card/id/away/old/sec
 	name = "Charlie Station Security Officer's ID card"
-	desc = "A faded Charlie Station ID card. You can make out the rank \"Security Officer\"."
+	desc = "Выцветшее ID сотрудника станции 'Чарли'. Вы можете разглядеть должность \"Офицер\"."
 	trim = /datum/id_trim/away/old/sec
 
 /obj/item/card/id/away/old/sci
 	name = "Charlie Station Scientist's ID card"
-	desc = "A faded Charlie Station ID card. You can make out the rank \"Scientist\"."
+	desc = "Выцветшее ID сотрудника станции 'Чарли'. Вы можете разглядеть должность \"Учёный\"."
 	trim = /datum/id_trim/away/old/sci
 
 /obj/item/card/id/away/old/eng
 	name = "Charlie Station Engineer's ID card"
-	desc = "A faded Charlie Station ID card. You can make out the rank \"Station Engineer\"."
+	desc = "Выцветшее ID сотрудника станции 'Чарли'. Вы можете разглядеть должность \"Станционный инженер\"."
 	trim = /datum/id_trim/away/old/eng
 
 /obj/item/card/id/away/old/equipment
 	name = "Engineering Equipment Access"
-	desc = "A special ID card that allows access to engineering equipment."
+	desc = "Специальная ID-карта, дающая доступ к инженерному оборудованию."
 	trim = /datum/id_trim/away/old/equipment
 
 /obj/item/card/id/away/old/robo
 	name = "Delta Station Roboticist's ID card"
-	desc = "An ID card that allows access to bots maintenance protocols."
+	desc = "ID-карта, позволяющая получить доступ к протоколам обслуживания ботов."
 	trim = /datum/id_trim/away/old/robo
 
 /obj/item/card/id/away/deep_storage //deepstorage.dmm space ruin
@@ -1059,11 +1059,11 @@
 
 /obj/item/card/id/away/filmstudio
 	name = "Film Studio ID"
-	desc = "An ID card that allows access to the variety of airlocks present in the film studio"
+	desc = "ID-карта, позволяющая получить доступ ко множеству шлюзов, имеющихся на киностудии."
 
 /obj/item/card/id/departmental_budget
 	name = "departmental card (ERROR)"
-	desc = "Provides access to the departmental budget."
+	desc = "Обеспечивает доступ к бюджету отдела."
 	icon_state = "budgetcard"
 	var/department_ID = ACCOUNT_CIV
 	var/department_name = ACCOUNT_CIV_NAME
@@ -1077,7 +1077,7 @@
 		if(!B.bank_cards.Find(src))
 			B.bank_cards += src
 		name = "departmental card ([department_name])"
-		desc = "Provides access to the [department_name]."
+		desc = "Обеспечивает доступ к бюджету [department_name]."
 	SSeconomy.dep_cards += src
 
 /obj/item/card/id/departmental_budget/Destroy()
@@ -1093,12 +1093,12 @@
 	icon_state = "car_budget" //saving up for a new tesla
 
 /obj/item/card/id/departmental_budget/click_alt(mob/living/user)
-	registered_account.bank_card_talk(span_warning("Withdrawing is not compatible with this card design."), TRUE) //prevents the vault bank machine being useless and putting money from the budget to your card to go over personal crates
+	registered_account.bank_card_talk(span_warning("Снятие средств не совместимо с данным дизайном карты."), TRUE) //prevents the vault bank machine being useless and putting money from the budget to your card to go over personal crates
 	return CLICK_ACTION_BLOCKING
 
 /obj/item/card/id/advanced
 	name = "identification card"
-	desc = "A card used to provide ID and determine access across the station. Has an integrated digital display and advanced microchips."
+	desc = "Карта, используемая для идентификации личности и определения доступа на станцию. Имеет встроенный цифровой дисплей и усовершенствованные микрочипы."
 	icon_state = "card_grey"
 
 	wildcard_slots = WILDCARD_LIMIT_GREY
@@ -1136,7 +1136,7 @@
 /obj/item/card/id/advanced/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
 	if(istype(held_item, /obj/item/toy/crayon))
-		context[SCREENTIP_CONTEXT_LMB] = "Recolor ID"
+		context[SCREENTIP_CONTEXT_LMB] = "Перекрасить ID"
 		return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/card/id/advanced/proc/after_input_check(mob/user)
@@ -1154,9 +1154,9 @@
 
 /obj/item/card/id/advanced/proc/recolor_id(mob/living/user, obj/item/toy/crayon/our_crayon)
 	if(our_crayon.is_capped)
-		balloon_alert(user, "take the cap off first!")
+		balloon_alert(user, "сначала снимите колпачок!")
 		return ITEM_INTERACT_BLOCKING
-	var/choice = tgui_alert(usr, "Recolor Department or Subdepartment?", "Recoloring ID...", list("Department", "Subdepartment"))
+	var/choice = tgui_alert(usr, "Перекрасить отдел или подотдел?", "Перекрашиваем ID...", list("Отдел", "Подотдел"))
 	if(isnull(choice) \
 		|| QDELETED(user) \
 		|| QDELETED(src) \
@@ -1171,12 +1171,12 @@
 			if(!do_after(user, 2 SECONDS))
 				return ITEM_INTERACT_BLOCKING
 			department_color_override = our_crayon.paint_color
-			balloon_alert(user, "recolored")
+			balloon_alert(user, "перекрашен")
 		if("Subdepartment")
 			if(!do_after(user, 1 SECONDS))
 				return ITEM_INTERACT_BLOCKING
 			subdepartment_color_override = our_crayon.paint_color
-			balloon_alert(user, "recolored")
+			balloon_alert(user, "перекрашен")
 	update_icon()
 	return ITEM_INTERACT_SUCCESS
 
@@ -1273,7 +1273,7 @@
 
 /obj/item/card/id/advanced/silver
 	name = "silver identification card"
-	desc = "A silver card which shows honour and dedication."
+	desc = "Серебряная карточка, свидетельствующая о чести и преданности делу."
 	icon_state = "card_silver"
 	inhand_icon_state = "silver_id"
 	assigned_icon_state = "assigned_silver"
@@ -1281,7 +1281,7 @@
 
 /obj/item/card/id/advanced/robotic
 	name = "magnetic identification card"
-	desc = "An integrated card which shows the work poured into opening doors."
+	desc = "Встроенная карта, показывающая работу, вложенную в открытие дверей."
 	icon_state = "card_carp" //im not a spriter
 	inhand_icon_state = "silver_id"
 	assigned_icon_state = "assigned_silver"
@@ -1299,7 +1299,7 @@
 
 /obj/item/card/id/advanced/platinum
 	name = "platinum identification card"
-	desc = "A platinum card which shows the highest level of dedication."
+	desc = "Платиновая карта, демонстрирующая высший уровень преданности."
 	icon_state = "card_platinum"
 	inhand_icon_state = "platinum_id"
 	assigned_icon_state = "assigned_silver"
@@ -1311,7 +1311,7 @@
 
 /obj/item/card/id/advanced/gold
 	name = "gold identification card"
-	desc = "A golden card which shows power and might."
+	desc = "Золотая карта, которая показывает власть и могущество."
 	icon_state = "card_gold"
 	inhand_icon_state = "gold_id"
 	assigned_icon_state = "assigned_silver"
@@ -1323,7 +1323,7 @@
 
 /obj/item/card/id/advanced/gold/captains_spare
 	name = "captain's spare ID"
-	desc = "The spare ID of the High Lord himself."
+	desc = "Запасная ID-карта капитана, дающая мощь и власть на станции."
 	registered_name = JOB_CAPTAIN_RU
 	trim = /datum/id_trim/job/captain
 	registered_age = null
@@ -1337,7 +1337,7 @@
 
 /obj/item/card/id/advanced/centcom
 	name = "\improper CentCom ID"
-	desc = "An ID straight from Central Command."
+	desc = "ID-карта, полученная непосредственно из Центрального Командования."
 	icon_state = "card_centcom"
 	assigned_icon_state = "assigned_centcom"
 	registered_name = JOB_CENTCOM
@@ -1347,7 +1347,7 @@
 
 /obj/item/card/id/advanced/centcom/ert
 	name = "\improper CentCom ID"
-	desc = "An ERT ID card."
+	desc = "ID-карта бойца ОБР."
 	registered_age = null
 	registered_name = "Emergency Response Intern"
 	trim = /datum/id_trim/centcom/ert
@@ -1390,7 +1390,7 @@
 
 /obj/item/card/id/advanced/black
 	name = "black identification card"
-	desc = "This card is telling you one thing and one thing alone. The person holding this card is an utter badass."
+	desc = "Эта карта говорит вам лишь одно. Человек, держащий эту карту - настоящий крутой."
 	icon_state = "card_black"
 	assigned_icon_state = "assigned_syndicate"
 	wildcard_slots = WILDCARD_LIMIT_GOLD
@@ -1404,7 +1404,7 @@
 
 /obj/item/card/id/advanced/black/syndicate_command
 	name = "syndicate ID card"
-	desc = "An ID straight from the Syndicate."
+	desc = "ID-карта прямо из Синдиката."
 	registered_name = "Syndicate"
 	registered_age = null
 	trim = /datum/id_trim/syndicom
@@ -1412,20 +1412,20 @@
 
 /obj/item/card/id/advanced/black/syndicate_command/crew_id
 	name = "syndicate ID card"
-	desc = "An ID straight from the Syndicate."
+	desc = "ID-карта прямо из Синдиката."
 	registered_name = "Syndicate"
 	trim = /datum/id_trim/syndicom/crew
 
 /obj/item/card/id/advanced/black/syndicate_command/captain_id
 	name = "syndicate captain ID card"
-	desc = "An ID straight from the Syndicate."
+	desc = "ID-карта прямо из Синдиката."
 	registered_name = "Syndicate"
 	trim = /datum/id_trim/syndicom/captain
 
 
 /obj/item/card/id/advanced/black/syndicate_command/captain_id/syndie_spare
 	name = "syndicate captain's spare ID"
-	desc = "The spare ID of the Dark Lord himself."
+	desc = "Запасная ID-карта самого Тёмного Лорда."
 	registered_name = "Captain"
 	registered_age = null
 
@@ -1455,7 +1455,7 @@
 /obj/item/card/id/advanced/debug/alt_click_can_use_id(mob/living/user)
 	. = ..()
 	if(!. || isnull(user.client?.holder)) // admins only as a safety so people don't steal all the dollars. spawn in a holochip if you want them to get some dosh
-		registered_account.bank_card_talk(span_warning("Only authorized representatives of Nanotrasen may use this card."), force = TRUE)
+		registered_account.bank_card_talk(span_warning("Только уполномоченные представители Нанотрейзен могут пользоваться этой картой."), force = TRUE)
 		return FALSE
 
 	return TRUE
@@ -1463,14 +1463,14 @@
 /obj/item/card/id/advanced/debug/can_be_used_in_payment(mob/living/user)
 	. = ..()
 	if(!. || isnull(user.client?.holder))
-		registered_account.bank_card_talk(span_warning("Only authorized representatives of Nanotrasen may use this card."), force = TRUE)
+		registered_account.bank_card_talk(span_warning("Только уполномоченные представители Нанотрейзен могут пользоваться этой картой."), force = TRUE)
 		return FALSE
 
 	return TRUE
 
 /obj/item/card/id/advanced/prisoner
 	name = "prisoner ID card"
-	desc = "You are a number, you are not a free man."
+	desc = "Ты - число, ты не свободный человек."
 	icon_state = "card_prisoner"
 	inhand_icon_state = "orange-id"
 	registered_name = "Scum"
@@ -1493,7 +1493,7 @@
 /obj/item/card/id/advanced/prisoner/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
 	if(isidcard(held_item))
-		context[SCREENTIP_CONTEXT_LMB] = "Set sentence time"
+		context[SCREENTIP_CONTEXT_LMB] = "Установить время приговора"
 		return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/card/id/advanced/prisoner/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
@@ -1510,7 +1510,7 @@
 		balloon_alert(user, "в доступе отказано!")
 		return ITEM_INTERACT_BLOCKING
 	if(!user.is_holding(src))
-		to_chat(user, span_warning("You must be holding the ID to continue!"))
+		to_chat(user, span_warning("Вы должны держать ID-карту, чтобы продолжить!"))
 		return ITEM_INTERACT_BLOCKING
 
 	if(timed) // If we already have a time set, reset the card
@@ -1518,19 +1518,19 @@
 		time_to_assign = initial(time_to_assign)
 		registered_name = initial(registered_name)
 		STOP_PROCESSING(SSobj, src)
-		to_chat(user, "Resetting prisoner ID to default parameters.")
+		to_chat(user, "Сброс параметров ID-карты заключённого.")
 		return ITEM_INTERACT_SUCCESS
 
-	var/choice = tgui_input_number(user, "Sentence time in seconds", "Sentencing")
+	var/choice = tgui_input_number(user, "Время приговора в секундах", "Приговор")
 	if(isnull(choice) || QDELETED(user) || QDELETED(src) || !user.can_perform_action(src, FORBID_TELEKINESIS_REACH) || !user.is_holding(src))
 		return ITEM_INTERACT_BLOCKING
 	time_to_assign = choice
-	to_chat(user, "You set the sentence time to [DisplayTimeText(time_to_assign * 10)].")
+	to_chat(user, "Вы установили время приговора на [DisplayTimeText(time_to_assign * 10)].")
 	timed = TRUE
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/card/id/advanced/prisoner/proc/start_timer()
-	say("Sentence started, welcome to the corporate rehabilitation center!")
+	say("Приговор вступил в силу. Добро пожаловать в корпоративный реабилитационный центр!")
 	START_PROCESSING(SSobj, src)
 
 /obj/item/card/id/advanced/prisoner/examine(mob/user)
@@ -1540,25 +1540,25 @@
 
 	if(timed)
 		if(time_to_assign > 0)
-			. += span_notice("The digital timer on the card is set to [DisplayTimeText(time_to_assign * 10)]. The timer will start once the prisoner passes through the prison gate scanners.")
+			. += span_notice("Цифровой таймер на карте установлен на [DisplayTimeText(time_to_assign * 10)]. Таймер запустится, когда заключённый пройдёт через сканеры тюремных ворот.")
 		else if(time_left <= 0)
-			. += span_notice("The digital timer on the card has zero seconds remaining. You leave a changed man, but a free man nonetheless.")
+			. += span_notice("На цифровом таймере карты осталось ноль секунд. Вы выходите изменённым человеком, но свободным человеком.")
 		else
-			. += span_notice("The digital timer on the card has [DisplayTimeText(time_left * 10)] remaining. Don't do the crime if you can't do the time.")
+			. += span_notice("На цифровом таймере карты осталось [DisplayTimeText(time_left * 10)]. Не совершай преступление, если не можешь отбыть срок.")
 
-	. += span_notice("[EXAMINE_HINT("Swipe")] a security ID on the card to [timed ? "re" : ""]set the genpop sentence time.")
-	. += span_notice("Remember to [EXAMINE_HINT("swipe")] the card on a genpop locker to link it.")
+	. += span_notice("[EXAMINE_HINT("Проведите")] ID-картой СБ по карте, чтобы назначить/сбросить время приговора.")
+	. += span_notice("Не забудьте [EXAMINE_HINT("провести")] картой по шкафчику, чтобы привязать его.")
 
 /obj/item/card/id/advanced/prisoner/process(seconds_per_tick)
 	if(!timed)
 		return
 	time_left -= seconds_per_tick
 	if(time_left <= 0)
-		say("Sentence time has been served. Thank you for your cooperation in our corporate rehabilitation program!")
+		say("Срок наказания отбыт. Благодарим вас за сотрудничество в рамках нашей корпоративной программы реабилитации!")
 		STOP_PROCESSING(SSobj, src)
 
 /obj/item/card/id/advanced/prisoner/attack_self(mob/user)
-	to_chat(usr, span_notice("You have accumulated [points] out of the [goal] points you need for freedom."))
+	to_chat(usr, span_notice("Вы набрали [points] из числа [goal] очков, необходимых вам для обретения свободы."))
 
 /obj/item/card/id/advanced/prisoner/one
 	name = "Prisoner #13-001"
@@ -1617,7 +1617,7 @@
 /obj/item/card/id/advanced/plainclothes/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
 	if(isnull(held_item) || (held_item == src))
-		context[SCREENTIP_CONTEXT_LMB] = "Show/Flip ID"
+		context[SCREENTIP_CONTEXT_LMB] = "Показать/Перевернуть ID"
 		return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/card/id/advanced/plainclothes/examine(mob/user)
@@ -1628,12 +1628,12 @@
 		. += span_smallnotice("flip it to switch to the plainclothes identity.")
 
 /obj/item/card/id/advanced/plainclothes/attack_self(mob/user)
-	var/popup_input = tgui_input_list(user, "Choose Action", "Two-Sided ID", list("Show", "Flip"))
+	var/popup_input = tgui_input_list(user, "Выберите действия", "Двухсторонняя ID", list("Показать", "Перевернуть"))
 	if(!popup_input || !after_input_check(user))
 		return TRUE
 	if(popup_input == "Show")
 		return ..()
-	balloon_alert(user, "flipped")
+	balloon_alert(user, "перевёрнуто")
 	if(trim_assignment_override)
 		SSid_access.remove_trim_override(src)
 	else
@@ -1644,14 +1644,14 @@
 /obj/item/card/id/advanced/plainclothes/update_label()
 	if(!trim_assignment_override)
 		return ..()
-	var/name_string = registered_name ? "[registered_name]'s ID Card" : initial(name)
+	var/name_string = registered_name ? "ID-карта \"[registered_name]\"" : initial(name)
 	var/datum/id_trim/fake = SSid_access.trim_singletons_by_path[alt_trim]
 	name = "[name_string] ([fake.assignment])"
 
 /obj/item/card/id/advanced/chameleon
 	name = "agent card"
-	desc = "An advanced chameleon ID card. Swipe this card on another ID card, or a person wearing one, to copy access. \
-		Has special magnetic properties which force it to the front of wallets."
+	desc = "Усовершенствованная ID-карта хамелеон. Проведите этой картой по другой ID-карте или по человеку, который ее носит, чтобы скопировать доступ. \
+		Обладает особыми магнитными свойствами, которые позволяют прикреплять ее к передней части кошелька."
 	trim = /datum/id_trim/chameleon
 	trim_changeable = FALSE
 	actions_types = list(/datum/action/item_action/chameleon/change/id, /datum/action/item_action/chameleon/change/id_trim)
@@ -1694,21 +1694,21 @@
 	// to sneakily steal their accesses by swiping our agent ID card near them. As a result, we
 	// return ITEM_INTERACT_BLOCKING to cancel any part of the following the attack chain.
 	if(ishuman(interacting_with))
-		interacting_with.balloon_alert(user, "scanning ID card...")
+		interacting_with.balloon_alert(user, "сканируем ID-карту...")
 
 		if(!do_after(user, 2 SECONDS, interacting_with, hidden = TRUE))
-			interacting_with.balloon_alert(user, "interrupted!")
+			interacting_with.balloon_alert(user, "прервано!")
 			return ITEM_INTERACT_BLOCKING
 
 		var/mob/living/carbon/human/human_target = interacting_with
 		var/list/target_id_cards = human_target.get_all_contents_type(/obj/item/card/id)
 
 		if(!length(target_id_cards))
-			interacting_with.balloon_alert(user, "no IDs!")
+			interacting_with.balloon_alert(user, "нет ID!")
 			return ITEM_INTERACT_BLOCKING
 
 		var/selected_id = pick(target_id_cards)
-		interacting_with.balloon_alert(user, UNLINT("IDs synced"))
+		interacting_with.balloon_alert(user, UNLINT("ID синхронизированы"))
 		theft_target = WEAKREF(selected_id)
 		ui_interact(user)
 		return ITEM_INTERACT_SUCCESS
@@ -1716,7 +1716,7 @@
 	if(isitem(interacting_with))
 		var/obj/item/target_item = interacting_with
 
-		interacting_with.balloon_alert(user, "scanning ID card...")
+		interacting_with.balloon_alert(user, "сканируем ID-карту...")
 
 		var/list/target_id_cards = target_item.get_all_contents_type(/obj/item/card/id)
 		var/target_item_id = target_item.GetID()
@@ -1725,11 +1725,11 @@
 			target_id_cards |= target_item_id
 
 		if(!length(target_id_cards))
-			interacting_with.balloon_alert(user, "no IDs!")
+			interacting_with.balloon_alert(user, "нет ID!")
 			return ITEM_INTERACT_BLOCKING
 
 		var/selected_id = pick(target_id_cards)
-		interacting_with.balloon_alert(user, UNLINT("IDs synced"))
+		interacting_with.balloon_alert(user, UNLINT("ID синхронизированы"))
 		theft_target = WEAKREF(selected_id)
 		ui_interact(user)
 		return ITEM_INTERACT_SUCCESS
@@ -1806,7 +1806,7 @@
 
 	var/obj/item/card/id/target_card = theft_target?.resolve()
 	if(QDELETED(target_card))
-		to_chat(usr, span_notice("The ID card you were attempting to scan is no longer in range."))
+		to_chat(usr, span_notice("ID-карта, которую вы сканировали - вне досягаемости."))
 		target_card = null
 		return TRUE
 
@@ -1814,7 +1814,7 @@
 	var/turf/our_turf = get_turf(src)
 	var/turf/target_turf = get_turf(target_card)
 	if(!our_turf.Adjacent(target_turf))
-		to_chat(usr, span_notice("The ID card you were attempting to scan is no longer in range."))
+		to_chat(usr, span_notice("ID-карта, которую вы сканировали - вне досягаемости."))
 		target_card = null
 		return TRUE
 
@@ -1828,17 +1828,17 @@
 				return TRUE
 
 			if(!(access_type in target_card.access))
-				to_chat(usr, span_notice("ID error: ID card rejected your attempted access modification."))
+				to_chat(usr, span_notice("ошибка ID: ID-карта отклонила вашу попытку изменить доступ."))
 				LOG_ID_ACCESS_CHANGE(usr, src, "failed to add [SSid_access.get_access_desc(access_type)][try_wildcard ? " with wildcard [try_wildcard]" : ""]")
 				return TRUE
 
 			if(!can_add_wildcards(list(access_type), try_wildcard))
-				to_chat(usr, span_notice("ID error: ID card rejected your attempted access modification."))
+				to_chat(usr, span_notice("ошибка ID: ID-карта отклонила вашу попытку изменить доступ."))
 				LOG_ID_ACCESS_CHANGE(usr, src, "failed to add [SSid_access.get_access_desc(access_type)][try_wildcard ? " with wildcard [try_wildcard]" : ""]")
 				return TRUE
 
 			if(!add_access(list(access_type), try_wildcard))
-				to_chat(usr, span_notice("ID error: ID card rejected your attempted access modification."))
+				to_chat(usr, span_notice("ошибка ID: ID-карта отклонила вашу попытку изменить доступ."))
 				LOG_ID_ACCESS_CHANGE(usr, src, "failed to add [SSid_access.get_access_desc(access_type)][try_wildcard ? " with wildcard [try_wildcard]" : ""]")
 				return TRUE
 
@@ -1850,14 +1850,14 @@
 /obj/item/card/id/advanced/chameleon/attack_self(mob/user)
 	if(!user.can_perform_action(user, NEED_DEXTERITY| FORBID_TELEKINESIS_REACH))
 		return ..()
-	var/popup_input = tgui_input_list(user, "Choose Action", "Agent ID", list("Show", "Forge/Reset", "Change Account ID"))
+	var/popup_input = tgui_input_list(user, "Выберите действие", "ID агента", list("Показать", "Подделать/Сброс", "Поменять ID аккаунта"))
 	if(!popup_input || !after_input_check(user))
 		return TRUE
 	switch(popup_input)
-		if ("Change Account ID")
+		if ("Поменять ID аккаунта")
 			set_new_account(user)
 			return
-		if("Show")
+		if("Показать")
 			return ..()
 
 	///"Forge/Reset", kept outside the switch() statement to reduce indentation.
@@ -1870,11 +1870,11 @@
 		update_label()
 		update_icon()
 		forged = FALSE
-		to_chat(user, span_notice("You successfully reset the ID card."))
+		to_chat(user, span_notice("Вы успешно сбросили настройки ID-карты."))
 		return
 
 	///forge the ID if not forged.s
-	var/input_name = tgui_input_text(user, "What name would you like to put on this card? Leave blank to randomise.", "Agent card name", registered_name ? registered_name : (ishuman(user) ? user.real_name : user.name), max_length = MAX_NAME_LEN, encode = FALSE)
+	var/input_name = tgui_input_text(user, "Какое имя вы хотите указать на этой карте? Оставьте пустым для случайного имени.", "Имя агентской карты", registered_name ? registered_name : (ishuman(user) ? user.real_name : user.name), max_length = MAX_NAME_LEN, encode = FALSE)
 
 	if(!after_input_check(user))
 		return TRUE
@@ -1889,7 +1889,7 @@
 		else
 			input_name = "[pick(GLOB.first_names)] [pick(GLOB.last_names)]"
 
-	var/change_trim = tgui_alert(user, "Adjust the appearance of your card's trim?", "Modify Trim", list("Yes", "No"))
+	var/change_trim = tgui_alert(user, "Настроить внешний вид оформления вашей карты?", "Изменить оформление", list("Да", "Нет"))
 	if(!after_input_check(user))
 		return TRUE
 	var/selected_trim_path
@@ -1901,19 +1901,19 @@
 			if(trim && trim.trim_state && trim.assignment)
 				var/fake_trim_name = "[trim.assignment] ([trim.trim_state])"
 				trim_list[fake_trim_name] = trim_path
-		selected_trim_path = tgui_input_list(user, "Select trim to apply to your card.\nNote: This will not grant any trim accesses.", "Forge Trim", sort_list(trim_list, GLOBAL_PROC_REF(cmp_typepaths_asc)))
+		selected_trim_path = tgui_input_list(user, "Выберите оформление для применения к вашей карте.\nПримечание: Это не предоставит никаких доступов оформления.", "Подделка оформления", sort_list(trim_list, GLOBAL_PROC_REF(cmp_typepaths_asc)))
 		if(!after_input_check(user))
 			return TRUE
 
-	var/target_occupation = tgui_input_text(user, "What occupation would you like to put on this card?\nNote: This will not grant any access levels.", "Agent card job assignment", assignment ? assignment : "Assistant", max_length = MAX_NAME_LEN)
+	var/target_occupation = tgui_input_text(user, "Какую должность вы хотите указать на этой карте?\nПримечание: Это не предоставит никаких уровней доступа.", "Должность агентской карты", assignment ? assignment : "Ассистент", max_length = MAX_NAME_LEN)
 	if(!after_input_check(user))
 		return TRUE
 
-	var/new_age = tgui_input_number(user, "Choose the ID's age", "Agent card age", AGE_MIN, AGE_MAX, AGE_MIN)
+	var/new_age = tgui_input_number(user, "Выберите возраст на ID", "Возраст на агентской карте", AGE_MIN, AGE_MAX, AGE_MIN)
 	if(!after_input_check(user))
 		return TRUE
 
-	var/wallet_spoofing = tgui_alert(user, "Activate wallet ID spoofing, allowing this card to force itself to occupy the visible ID slot in wallets?", "Wallet ID Spoofing", list("Yes", "No"))
+	var/wallet_spoofing = tgui_alert(user, "Активировать подмену ID в кошельках, позволяя этой карте принудительно занимать видимый слот ID в кошельках?", "Подмена ID в кошельках", list("Да", "Нет"))
 	if(!after_input_check(user))
 		return
 
@@ -1930,7 +1930,7 @@
 	update_label()
 	update_icon()
 	forged = TRUE
-	to_chat(user, span_notice("You successfully forge the ID card."))
+	to_chat(user, span_notice("Вы успешно подделали ID-карту."))
 	user.log_message("forged \the [initial(name)] with name \"[registered_name]\", occupation \"[assignment]\" and trim \"[trim?.assignment]\".", LOG_GAME)
 
 	if(!ishuman(user))
@@ -1947,7 +1947,7 @@
 	if(account)
 		account.bank_cards += src
 		registered_account = account
-		to_chat(user, span_notice("Your account number has been automatically assigned."))
+		to_chat(user, span_notice("Ваш номер счёта был автоматически назначен."))
 
 /obj/item/card/id/advanced/chameleon/add_item_context(obj/item/source, list/context, atom/target, mob/living/user,)
 	. = ..()
@@ -1955,13 +1955,13 @@
 	if(!in_range(user, target))
 		return .
 	if(isidcard(target))
-		context[SCREENTIP_CONTEXT_LMB] = "Copy access"
+		context[SCREENTIP_CONTEXT_LMB] = "Скопировать доступ"
 		return CONTEXTUAL_SCREENTIP_SET
 	if(ishuman(target))
-		context[SCREENTIP_CONTEXT_RMB] = "Copy access"
+		context[SCREENTIP_CONTEXT_RMB] = "Скопировать доступ"
 		return CONTEXTUAL_SCREENTIP_SET
 	if(isitem(target))
-		context[SCREENTIP_CONTEXT_RMB] = "Scan for access"
+		context[SCREENTIP_CONTEXT_RMB] = "Сканировать на доступ"
 		return CONTEXTUAL_SCREENTIP_SET
 	return .
 
@@ -1971,8 +1971,8 @@
 
 /// Upgraded variant of agent id, can hold unlimited amount of accesses.
 /obj/item/card/id/advanced/chameleon/elite
-	desc = "A highly advanced chameleon ID card. Swipe this card on another ID card, or a person wearing one, to copy access. \
-		Has special magnetic properties which force it to the front of wallets, and an embedded high-end microchip to hold unlimited access codes."
+	desc = "Высокотехнологичная хамелеон ID-карта. Проведите этой картой по другой ID-карте или человеку, носящему её, чтобы скопировать доступ. \
+		Имеет специальные магнитные свойства, которые заставляют её занимать передний слот в кошельках, и встроенный высококлассный микрочип для хранения неограниченных кодов доступа."
 	wildcard_slots = WILDCARD_LIMIT_GOLD
 
 /obj/item/card/id/advanced/chameleon/elite/black
@@ -2025,7 +2025,7 @@
  */
 /obj/item/card/cardboard
 	name = "cardboard identification card"
-	desc = "A card used to provide ID and det- Heeeey, wait a second, this is just a piece of cut cardboard!"
+	desc = "Карточка, используемая для удостоверения личности и... Эй, подождите секунду, это всего лишь кусок картона!"
 	icon_state = "cardboard_id"
 	inhand_icon_state = "cardboard-id"
 	worn_icon_state = "nothing"
@@ -2085,12 +2085,12 @@
 /obj/item/card/cardboard/proc/modify_card(mob/living/user, obj/item/item)
 	if(!user.mind)
 		return
-	var/popup_input = tgui_input_list(user, "What To Change", "Cardboard ID", list("Name", "Assignment", "Trim", "Reset"))
+	var/popup_input = tgui_input_list(user, "Что изменить", "Картонный ID", list("Имя", "Должность", "Оформление", "Сброс"))
 	if(!after_input_check(user, item, popup_input))
 		return
 	switch(popup_input)
 		if("Name")
-			var/raw_input = tgui_input_text(user, "What name would you like to put on this card?", "Cardboard card name", scribbled_name || (ishuman(user) ? user.real_name : user.name), max_length = MAX_NAME_LEN)
+			var/raw_input = tgui_input_text(user, "Какое имя вы хотели бы написать на этой карте?", "Имя на картонной карте", scribbled_name || (ishuman(user) ? user.real_name : user.name), max_length = MAX_NAME_LEN)
 			var/input_name = sanitize_name(raw_input, allow_numbers = TRUE)
 			if(!after_input_check(user, item, input_name, scribbled_name))
 				return
@@ -2099,7 +2099,7 @@
 			var/list/details = item.get_writing_implement_details()
 			details_colors[INDEX_NAME_COLOR] = details["color"] || COLOR_BLACK
 		if("Assignment")
-			var/input_assignment = tgui_input_text(user, "What assignment would you like to put on this card?", "Cardboard card job ssignment", scribbled_assignment || "Assistant", max_length = MAX_NAME_LEN)
+			var/input_assignment = tgui_input_text(user, "Какую должность вы хотели бы написать на этой карте?", "Должность на картонной карте", scribbled_assignment || "Ассистент", max_length = MAX_NAME_LEN)
 			if(!after_input_check(user, item, input_assignment, scribbled_assignment))
 				return
 			playsound(src, SFX_WRITING_PEN, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE, SOUND_FALLOFF_EXPONENT + 3, ignore_walls = FALSE)
@@ -2115,7 +2115,7 @@
 					if(trim?.trim_state && trim.assignment)
 						possible_trims |= replacetext(trim.trim_state, "trim_", "")
 				sortTim(possible_trims, GLOBAL_PROC_REF(cmp_typepaths_asc))
-			var/input_trim = tgui_input_list(user, "Select trim to apply to your card.\nNote: This will not grant any trim accesses.", "Forge Trim", possible_trims)
+			var/input_trim = tgui_input_list(user, "Выберите оформление для применения к вашей карте.\nПримечание: Это не предоставит никаких доступов оформления.", "Сброс оформления", possible_trims)
 			if(!input_trim || !after_input_check(user, item, input_trim, scribbled_trim))
 				return
 			playsound(src, SFX_WRITING_PEN, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE, SOUND_FALLOFF_EXPONENT + 3, ignore_walls = FALSE)
@@ -2141,7 +2141,7 @@
 /obj/item/card/cardboard/attack_self(mob/user)
 	if(!Adjacent(user))
 		return
-	user.visible_message(span_notice("[user] shows you: [icon2html(src, viewers(user))] [name]."), span_notice("You show \the [name]."))
+	user.visible_message(span_notice("[user] показывает: [icon2html(src, viewers(user))] [name]."), span_notice("Вы показываете [name]."))
 	add_fingerprint(user)
 
 /obj/item/card/cardboard/update_name()
@@ -2149,7 +2149,7 @@
 	if(!scribbled_name)
 		name = initial(name)
 		return
-	name = "[scribbled_name]'s ID Card ([scribbled_assignment])"
+	name = "ID-карта \"[scribbled_name]\" ([scribbled_assignment])"
 
 /obj/item/card/cardboard/update_overlays()
 	. = ..()
@@ -2178,15 +2178,15 @@
 
 /obj/item/card/cardboard/examine(mob/user)
 	. = ..()
-	. += span_notice("You could use a pen or crayon to forge a name, assignment or trim.")
+	. += span_notice("Вы можете использовать ручку или карандаш, чтобы подделать имя, должность и оформление.")
 
 /obj/item/card/cardboard/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
 	if(isnull(held_item) || (held_item == src))
-		context[SCREENTIP_CONTEXT_LMB] = "Show ID"
+		context[SCREENTIP_CONTEXT_LMB] = "Показать ID"
 		return CONTEXTUAL_SCREENTIP_SET
 	else if(IS_WRITING_UTENSIL(held_item))
-		context[SCREENTIP_CONTEXT_LMB] = "Modify"
+		context[SCREENTIP_CONTEXT_LMB] = "Изменить"
 		return CONTEXTUAL_SCREENTIP_SET
 
 #undef INDEX_NAME_COLOR

--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -1,6 +1,6 @@
 /obj/item/suspiciousphone
 	name = "suspicious phone"
-	desc = "This device raises pink levels to unknown highs."
+	desc = "Это устройство повышает уровень розового цвета до неизвестных максимумов."
 	icon = 'icons/obj/antags/syndicate_tools.dmi'
 	icon_state = "suspiciousphone"
 	w_class = WEIGHT_CLASS_SMALL
@@ -11,12 +11,12 @@
 
 /obj/item/suspiciousphone/attack_self(mob/living/user)
 	if(!ISADVANCEDTOOLUSER(user))
-		to_chat(user, span_warning("This device is too advanced for you!"))
+		to_chat(user, span_warning("Это устройство слишком продвинуто для вас!"))
 		return
 	if(dumped)
-		to_chat(user, span_warning("You already activated Protocol CRAB-17."))
+		to_chat(user, span_warning("Вы уже активировали протокол CRAB-17."))
 		return FALSE
-	if(tgui_alert(user, "Are you sure you want to crash this market with no survivors?", "Protocol CRAB-17", list("Yes", "No")) == "Yes")
+	if(tgui_alert(user, "Вы уверены, что хотите обрушить этот рынок без выживших?", "Протокол CRAB-17", list("Да", "Нет")) == "Yes")
 		if(dumped || QDELETED(src)) //Prevents fuckers from cheesing alert
 			return FALSE
 		var/turf/targetturf = get_safe_random_station_turf_equal_weight()
@@ -32,7 +32,7 @@
 			B.being_dumped = TRUE
 		new /obj/effect/dumpeet_target(targetturf, L)
 
-		to_chat(user, span_notice("You have activated Protocol CRAB-17."))
+		to_chat(user, span_notice("Вы активировали протокол CRAB-17."))
 		user.log_message("activated Protocol CRAB-17.", LOG_GAME)
 
 		dumped = TRUE
@@ -40,7 +40,7 @@
 
 /obj/structure/checkoutmachine
 	name = "\improper Nanotrasen Space-Coin Market"
-	desc = "This is good for spacecoin because"
+	desc = "Это хорошо для Спейскоин, потому что."
 	icon = 'icons/obj/machines/money_machine.dmi'
 	icon_state = "bogdanoff"
 	layer = ABOVE_ALL_MOB_LAYER
@@ -60,7 +60,7 @@
 
 /obj/structure/checkoutmachine/examine(mob/living/user)
 	. = ..()
-	. += span_info("It has a flashing <b>ID card reader</b> for convenient cashing out.")
+	. += span_info("У него есть мигающее <b>устройство считывания ID</b> для удобного обналичивания.")
 
 /**
  * Check whether any accounts in the accounts_to_rob list are still being drained.
@@ -75,7 +75,7 @@
 
 /obj/structure/checkoutmachine/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
 	if(!canwalk)
-		balloon_alert(user, "not ready to accept transactions!")
+		balloon_alert(user, "не готов принимать переводы!")
 		return
 
 	if(check_if_finished())
@@ -84,7 +84,7 @@
 
 	var/obj/item/card/id/card = attacking_item.GetID()
 	if(!card)
-		balloon_alert(user, "your [attacking_item.name] gets repelled by the id card reader")
+		balloon_alert(user, "устройство считывания ID отталкивает [attacking_item.name]")
 
 		var/throwtarget = get_step(user, get_dir(src, user))
 		user.safe_throw_at(throwtarget, 1, 1, force = MOVE_FORCE_EXTREMELY_STRONG)
@@ -93,14 +93,14 @@
 		return
 
 	if(!card.registered_account)
-		balloon_alert(user, "card has no registered account!")
+		balloon_alert(user, "у карты нет зарегистрированного счета!")
 		return
 
 	if(!card.registered_account.being_dumped)
-		balloon_alert(user, "funds are already safe!")
+		balloon_alert(user, "средства уже находятся в безопасности!")
 		return
 
-	to_chat(user, span_warning("You quickly cash out your funds to a more secure banking location. Funds are safu.")) // This is a reference and not a typo
+	to_chat(user, span_warning("Вы быстро обналичиваете свои средства в более надёждной банковской среде. Средства в безопасности.")) // This is a reference and not a typo
 	card.registered_account.being_dumped = FALSE
 
 	if(check_if_finished())
@@ -223,7 +223,7 @@
 		var/amount = round(B.account_balance * percentage_lost) // We don't want fractions of a credit stolen. That's just agony for everyone.
 		var/datum/bank_account/account = bogdanoff?.get_bank_account() || internal_account
 		account.transfer_money(B, amount, "?VIVA¿: !LA CRABBE¡")
-		B.bank_card_talk("You have lost [percentage_lost * 100]% of your funds! A spacecoin credit deposit machine is located at: [get_area(src)].")
+		B.bank_card_talk("Вы потеряли [percentage_lost * 100]% из ваших средств! Машина для депозитов Спейскоин находится в: [get_area(src)].")
 	addtimer(CALLBACK(src, PROC_REF(dump)), 15 SECONDS) //Drain every 15 seconds
 
 /obj/structure/checkoutmachine/process()
@@ -260,7 +260,7 @@
 	name = ""
 	icon = 'icons/obj/machines/money_machine_64.dmi'
 	pixel_z = 300
-	desc = "Get out of the way!"
+	desc = "Уйди с дороги!"
 	layer = FLY_LAYER//that wasn't flying, that was falling with style!
 	plane = ABOVE_GAME_PLANE
 	icon_state = "missile_blur"
@@ -268,7 +268,7 @@
 
 /obj/effect/dumpeet_target
 	name = "Landing Zone Indicator"
-	desc = "A holographic projection designating the landing zone of something. It's probably best to stand back."
+	desc = "Голографическая проекция, обозначающая зону приземления чего-либо. Наверное, лучше отойти в сторону."
 	icon = 'icons/mob/telegraphing/telegraph_holographic.dmi'
 	icon_state = "target_circle"
 	layer = PROJECTILE_HIT_THRESHHOLD_LAYER
@@ -282,7 +282,7 @@
 	bogdanoff = user
 	addtimer(CALLBACK(src, PROC_REF(startLaunch)), 10 SECONDS)
 	sound_to_playing_players('sound/items/dump_it.ogg', 20)
-	deadchat_broadcast("Protocol CRAB-17 has been activated. A space-coin market has been launched at the station!", turf_target = get_turf(src), message_type=DEADCHAT_ANNOUNCEMENT)
+	deadchat_broadcast("Протокол CRAB-17 был активирован. Машина для депозитов Спейскоин была запущена на станцию!", turf_target = get_turf(src), message_type=DEADCHAT_ANNOUNCEMENT)
 
 /**
  * Sets up the falling animation for the checkout machine.

--- a/code/game/objects/items/credit_holochip.dm
+++ b/code/game/objects/items/credit_holochip.dm
@@ -1,6 +1,6 @@
 /obj/item/holochip
 	name = "credit holochip"
-	desc = "A hard-light chip encoded with an amount of credits. It is a modern replacement for physical money that can be directly converted to virtual currency and vice-versa. Keep away from magnets."
+	desc = "Чип, в котором закодировано количество кредитов. Это современная замена физическим деньгам, которые можно напрямую конвертировать в виртуальную валюту и наоборот. Держите подальше от магнитов."
 	icon = 'icons/obj/economy.dmi'
 	icon_state = "holochip"
 	base_icon_state = "holochip"
@@ -24,20 +24,20 @@
 
 /obj/item/holochip/examine(mob/user)
 	. = ..()
-	. += "[span_notice("It's loaded with [credits] credit[( credits > 1 ) ? "s" : ""]")]\n"+\
-	span_notice("Alt-Click to split.")
+	. += "[span_notice("В нём [credits] кр.")]"+\
+	span_notice("Alt-ЛКМ, чтобы разделить.")
 
 /obj/item/holochip/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	if(istype(held_item, /obj/item/holochip))
-		context[SCREENTIP_CONTEXT_LMB] = "Merge Into"
-	context[SCREENTIP_CONTEXT_ALT_LMB] = "Extract Credits"
+		context[SCREENTIP_CONTEXT_LMB] = "Слить в"
+	context[SCREENTIP_CONTEXT_ALT_LMB] = "Разделить кредиты"
 	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/holochip/get_item_credit_value()
 	return credits
 
 /obj/item/holochip/update_name()
-	name = "\improper [credits] credit holochip"
+	name = "голочип номиналом [credits] кр."
 	return ..()
 
 /obj/item/holochip/update_icon_state()
@@ -108,16 +108,16 @@
 
 	var/obj/item/holochip/merged_holochip = tool
 	credits += merged_holochip.credits
-	balloon_alert(user, "merged!")
+	balloon_alert(user, "слиты!")
 	update_appearance()
 	qdel(merged_holochip)
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/holochip/click_alt(mob/user)
 	if(loc != user)
-		to_chat(user, span_warning("You must be holding the holochip to continue!"))
+		to_chat(user, span_warning("Вы должны держать голочип, чтобы продолжить!"))
 		return CLICK_ACTION_BLOCKING
-	var/split_amount = tgui_input_number(user, "How many credits do you want to extract from the holochip? (Max: [credits] cr)", "Holochip", max_value = credits)
+	var/split_amount = tgui_input_number(user, "Сколько кредитов вы хотите разделить с голочипа? (Макс: [credits] кр.)", "Голочип", max_value = credits)
 	if(!split_amount || QDELETED(user) || QDELETED(src) || issilicon(user) || !usr.can_perform_action(src, NEED_DEXTERITY|FORBID_TELEKINESIS_REACH) || loc != user)
 		return CLICK_ACTION_BLOCKING
 	var/new_credits = spend(split_amount, TRUE)
@@ -126,7 +126,7 @@
 		if(!user.put_in_hands(chip))
 			chip.forceMove(user.drop_location())
 		add_fingerprint(user)
-	to_chat(user, span_notice("You extract [split_amount] credits into a new holochip."))
+	to_chat(user, span_notice("Вы разделили [split_amount] кр. в новый голочип."))
 	return CLICK_ACTION_SUCCESS
 
 /obj/item/holochip/emp_act(severity)
@@ -135,7 +135,7 @@
 		return
 	var/wipe_chance = 60 / severity
 	if(prob(wipe_chance))
-		visible_message(span_warning("[src] fizzles and disappears!"))
+		visible_message(span_warning("[declent_ru(ACCUSATIVE)] шипит и исчезает!"))
 		qdel(src) //rip cash
 
 /obj/item/holochip/thousand

--- a/code/game/objects/items/stacks/cash.dm
+++ b/code/game/objects/items/stacks/cash.dm
@@ -23,7 +23,7 @@
 /obj/item/stack/spacecash/update_desc()
 	. = ..()
 	var/total_worth = get_item_credit_value()
-	desc = "It's worth [total_worth] credit[(total_worth > 1) ? "s" : null] in total."
+	desc = "Стоит [total_worth] кр. в общей сумме."
 
 /obj/item/stack/spacecash/get_item_credit_value()
 	return (amount*value)

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -146,10 +146,10 @@
 /datum/bank_account/proc/pay_debt(amount, is_payment = TRUE)
 	var/amount_to_pay = min(amount, account_debt)
 	if(is_payment)
-		if(!adjust_money(-amount, "Other: Debt Payment"))
+		if(!adjust_money(-amount, "Прочее: Оплата долга"))
 			return 0
 	else
-		add_log_to_history(-amount, "Other: Debt Collection")
+		add_log_to_history(-amount, "Прочее: Взыскание долгов")
 	log_econ("[amount_to_pay] credits were removed from [account_holder]'s bank account to pay a debt of [account_debt]")
 	account_debt -= amount_to_pay
 	SEND_SIGNAL(src, COMSIG_BANK_ACCOUNT_DEBT_PAID)
@@ -164,11 +164,11 @@
  */
 /datum/bank_account/proc/transfer_money(datum/bank_account/from, amount, transfer_reason)
 	if(from.has_money(amount))
-		var/reason_to = "Transfer: From [from.account_holder]"
-		var/reason_from = "Transfer: To [account_holder]"
+		var/reason_to = "Перевод: От [from.account_holder]"
+		var/reason_from = "Перевод: [account_holder]"
 
 		if(IS_DEPARTMENTAL_ACCOUNT(from))
-			reason_to = "Nanotrasen: Salary"
+			reason_to = "Нанотрейзен: Зарплата"
 			reason_from = ""
 
 		if(transfer_reason)
@@ -196,7 +196,7 @@
 	if(amount_of_paychecks == 1)
 		money_to_transfer = clamp(money_to_transfer, 0, PAYCHECK_CREW) //We want to limit single, passive paychecks to regular crew income.
 	if(free)
-		adjust_money(money_to_transfer, "Nanotrasen: Shift Payment")
+		adjust_money(money_to_transfer, "Нанотрейзен: Оплата смены")
 		SSblackbox.record_feedback("amount", "free_income", money_to_transfer)
 		SSeconomy.station_target += money_to_transfer
 		log_econ("[money_to_transfer] credits were given to [src.account_holder]'s account from income.")
@@ -205,12 +205,12 @@
 		var/datum/bank_account/department_account = SSeconomy.get_dep_account(account_job.paycheck_department)
 		if(department_account)
 			if(!transfer_money(department_account, money_to_transfer))
-				bank_card_talk("ERROR: Payday aborted, departmental funds insufficient.")
+				bank_card_talk("ОШИБКА: Зарплата не выдана. Средств отдела недостаточно.")
 				return FALSE
 			else
-				bank_card_talk("Payday processed, account now holds [account_balance] cr.")
+				bank_card_talk("Поступила зарплата. На аккаунте теперь [account_balance] кр.")
 				return TRUE
-	bank_card_talk("ERROR: Payday aborted, unable to contact departmental account.")
+	bank_card_talk("ОШИБКА: Зарплата не выдана. Не удалось связаться со счётом отдела.")
 	return FALSE
 
 /**

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -3,7 +3,7 @@
 // consoles use "procssor" item that is held inside it.
 /obj/item/modular_computer
 	name = "modular microcomputer"
-	desc = "A small portable microcomputer."
+	desc = "Небольшой портативный микрокомпьютер."
 	icon = 'icons/obj/machines/computer.dmi'
 	icon_state = "laptop"
 	light_on = FALSE
@@ -265,7 +265,7 @@
 /obj/item/modular_computer/get_id_examine_strings(mob/user)
 	. = ..()
 	if(stored_id)
-		. += "[src] is displaying [stored_id]:"
+		. += "[declent_ru()] отображает [stored_id]:"
 		. += stored_id.get_id_examine_strings(user)
 
 /obj/item/modular_computer/proc/print_text(text_to_print, paper_title = "")
@@ -300,8 +300,8 @@
 	stored_id = inserting_id
 
 	if(!isnull(user))
-		to_chat(user, span_notice("You insert \the [inserting_id] into the card slot."))
-		balloon_alert(user, "inserted ID")
+		to_chat(user, span_notice("Вы вставляете [inserting_id] в слот карты."))
+		balloon_alert(user, "вставлен ID")
 
 	playsound(src, 'sound/machines/terminal/terminal_insert_disc.ogg', 50, FALSE)
 
@@ -331,8 +331,8 @@
 
 	alt_stored_id = secondary_id
 	if(!isnull(user))
-		to_chat(user, span_notice("You insert \the [secondary_id] into the secondary card slot."))
-		balloon_alert(user, "inserted secondary ID")
+		to_chat(user, span_notice("Вы вставляете [secondary_id] в слот дополнительной карты."))
+		balloon_alert(user, "вставлен дополнительный ID")
 	playsound(src, 'sound/machines/terminal/terminal_insert_disc.ogg', 50, FALSE)
 
 	return TRUE
@@ -357,8 +357,8 @@
 	alt_stored_id = null
 
 	if(!silent && !isnull(user))
-		to_chat(user, span_notice("You remove \the [lost_id] from the secondary card slot."))
-		balloon_alert(user, "removed secondary ID")
+		to_chat(user, span_notice("Вы вытаскиваете [lost_id] из слота дополнительной карты."))
+		balloon_alert(user, "дополнительный ID извлечён")
 	playsound(src, 'sound/machines/terminal/terminal_insert_disc.ogg', 50, FALSE)
 
 	return TRUE
@@ -385,8 +385,8 @@
 	stored_id = null
 
 	if(!silent && !isnull(user))
-		to_chat(user, span_notice("You remove \the [lost_id] from the card slot."))
-		balloon_alert(user, "removed ID")
+		to_chat(user, span_notice("Вы вытаскиваете [lost_id] со слота карты."))
+		balloon_alert(user, "ID извлечён")
 	playsound(src, 'sound/machines/terminal/terminal_insert_disc.ogg', 50, FALSE)
 
 	if(ishuman(loc))
@@ -418,12 +418,12 @@
 
 /obj/item/modular_computer/emag_act(mob/user, obj/item/card/emag/emag_card, forced)
 	if(!enabled && !forced)
-		balloon_alert(user, "turn it on first!")
+		balloon_alert(user, "сначала включите!")
 		return FALSE
 	if(obj_flags & EMAGGED)
-		balloon_alert(user, "already emagged!")
+		balloon_alert(user, "уже емагнут!")
 		if (emag_card)
-			to_chat(user, span_notice("You swipe \the [src] with [emag_card]. A console window fills the screen, but it quickly closes itself after only a few lines are written to it."))
+			to_chat(user, span_notice("Вы проводите по [declent_ru(DATIVE)] [emag_card.declent_ru(INSTRUMENTAL)]. Окно консоли включается, но оно быстро закрывается после того, как в него записывается всего несколько строк."))
 		return FALSE
 
 	. = ..()
@@ -432,9 +432,9 @@
 	obj_flags |= EMAGGED
 	device_theme = PDA_THEME_SYNDICATE
 	if(user)
-		balloon_alert(user, "syndieOS loaded")
+		balloon_alert(user, "syndieOS загружен")
 		if (emag_card)
-			to_chat(user, span_notice("You swipe \the [src] with [emag_card]. A console window momentarily fills the screen, with white text rapidly scrolling past."))
+			to_chat(user, span_notice("Вы проводите по [declent_ru(DATIVE)] [emag_card.declent_ru(INSTRUMENTAL)]. Окно консоли на мгновение заполняет белый текст, быстро прокручиваемый по экрану."))
 	return TRUE
 
 /obj/item/modular_computer/examine(mob/user)
@@ -449,63 +449,63 @@
 			. += span_warning("Разваливается на части!")
 
 	if(long_ranged)
-		. += "It is upgraded with an experimental long-ranged network capabilities, picking up NTNet frequencies while further away."
-	. += span_notice("It has [max_capacity] GQ of storage capacity.")
+		. += "Он оснащён экспериментальными сетевыми возможностями дальнего действия, позволяющими работать на частотах NTNet на удалении."
+	. += span_notice("Ёмкость жёсткого диска [max_capacity] GQ.")
 
 	if(stored_id)
 		if(Adjacent(user))
-			. += "It has \the [stored_id] card inserted in its card slot.[alt_stored_id ? "" : " [span_info("Alt-click to eject it.")]"]"
+			. += "Внутри имеется [stored_id] в слоте карты.[alt_stored_id ? "" : " [span_info("Alt+ЛКМ чтобы вытащить.")]"]"
 		else
-			. += "Its identification card slot is currently occupied."
+			. += "Слот ID-карты занят."
 
 	if(alt_stored_id)
 		if(Adjacent(user))
-			. += "It has \the [alt_stored_id] card stored in its secondary card slot. [span_info("Alt-click to eject it.")]"
+			. += "Внутри имеется [alt_stored_id] в дополнительном слоте карты. [span_info("Alt+ЛКМ чтобы вытащить.")]"
 		else
-			. += "Its secondary identification card slot is currently occupied."
+			. += "Дополнительный слот ID-карты занят."
 
 	if(internal_cell)
-		. += span_info("Right-click it with a screwdriver to eject the [internal_cell].")
+		. += span_info("ПКМ с отвёрткой, чтобы вытащить [internal_cell.declent_ru(ACCUSATIVE)].")
 
 /obj/item/modular_computer/examine_more(mob/user)
 	. = ..()
-	. += "Storage capacity: [used_capacity]/[max_capacity]GQ"
+	. += "Жёсткий диск: [used_capacity]/[max_capacity]GQ"
 
 	for(var/datum/computer_file/app_examine as anything in stored_files)
 		if(app_examine.on_examine(src, user))
 			. += app_examine.on_examine(src, user)
 
 	if(Adjacent(user))
-		. += span_notice("Paper level: [stored_paper] / [max_paper].")
+		. += span_notice("Количество бумаги: [stored_paper] / [max_paper].")
 
 /obj/item/modular_computer/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	. = ..()
 
 	if(isidcard(held_item))
-		context[SCREENTIP_CONTEXT_LMB] = stored_id ? "Swap ID" : "Insert ID"
+		context[SCREENTIP_CONTEXT_LMB] = stored_id ? "Поменять ID" : "Вставить ID"
 		if(HAS_TRAIT(src, TRAIT_MODPC_TWO_ID_SLOTS))
-			context[SCREENTIP_CONTEXT_RMB] = alt_stored_id ? "Swap Secondary ID" : "Insert Secondary ID"
+			context[SCREENTIP_CONTEXT_RMB] = alt_stored_id ? "Поменять дополнительный ID" : "Вставить дополнительный ID"
 		. = CONTEXTUAL_SCREENTIP_SET
 
 	if(held_item?.tool_behaviour == TOOL_SCREWDRIVER && internal_cell)
-		context[SCREENTIP_CONTEXT_RMB] = "Remove Cell"
+		context[SCREENTIP_CONTEXT_RMB] = "Вытащить батарею"
 		. = CONTEXTUAL_SCREENTIP_SET
 	if(held_item?.tool_behaviour == TOOL_WRENCH)
-		context[SCREENTIP_CONTEXT_RMB] = "Deconstruct"
+		context[SCREENTIP_CONTEXT_RMB] = "Разрушить"
 		. = CONTEXTUAL_SCREENTIP_SET
 
 	if(alt_stored_id)
-		context[SCREENTIP_CONTEXT_ALT_RMB] = "Remove Secondary ID"
+		context[SCREENTIP_CONTEXT_ALT_RMB] = "Вытащить дополнительный ID"
 		. = CONTEXTUAL_SCREENTIP_SET
 	if(stored_id) // ID get removed first before pAIs
-		context[SCREENTIP_CONTEXT_ALT_LMB] = "Remove ID"
+		context[SCREENTIP_CONTEXT_ALT_LMB] = "Вытащить ID"
 		. = CONTEXTUAL_SCREENTIP_SET
 	else if(inserted_pai)
-		context[SCREENTIP_CONTEXT_ALT_LMB] = "Remove pAI"
+		context[SCREENTIP_CONTEXT_ALT_LMB] = "Вытащить пИИ"
 		. = CONTEXTUAL_SCREENTIP_SET
 
 	if(inserted_disk)
-		context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB] = "Remove Disk"
+		context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB] = "Вытащить диск"
 		. = CONTEXTUAL_SCREENTIP_SET
 	return . || NONE
 
@@ -558,9 +558,9 @@
 	if(atom_integrity <= integrity_failure * max_integrity)
 		if(user)
 			if(issynth)
-				to_chat(user, span_warning("You send an activation signal to \the [src], but it responds with an error code. It must be damaged."))
+				to_chat(user, span_warning("Вы отправляете сигнал активации на [declent_ru(ACCUSATIVE)], но он выдаёт код ошибки. Должно быть, он повреждён."))
 			else
-				to_chat(user, span_warning("You press the power button, but the computer fails to boot up, displaying variety of errors before shutting down again."))
+				to_chat(user, span_warning("Вы нажимаете кнопку питания, но компьютер не загружается, отображая различные ошибки, прежде чем снова выключиться."))
 		return FALSE
 
 	if(use_energy(base_active_power_usage)) // checks if the PC is powered
@@ -570,9 +570,9 @@
 		update_appearance()
 		if(user)
 			if(issynth)
-				to_chat(user, span_notice("You send an activation signal to \the [src], turning it on."))
+				to_chat(user, span_notice("Вы отправляете сигнал активации на [declent_ru(ACCUSATIVE)], включая его."))
 			else
-				to_chat(user, span_notice("You press the power button and start up \the [src]."))
+				to_chat(user, span_notice("Вы нажимаете кнопку питания, включая [declent_ru(ACCUSATIVE)]."))
 			if(open_ui)
 				update_tablet_open_uis(user)
 		SEND_SIGNAL(src, COMSIG_MODULAR_COMPUTER_TURNED_ON, user)
@@ -580,9 +580,9 @@
 	else // Unpowered
 		if(user)
 			if(issynth)
-				to_chat(user, span_warning("You send an activation signal to \the [src] but it does not respond."))
+				to_chat(user, span_warning("Вы отправляете сигнал активации на [declent_ru(ACCUSATIVE)], но он не отвечает."))
 			else
-				to_chat(user, span_warning("You press the power button but \the [src] does not respond."))
+				to_chat(user, span_warning("Вы нажимаете кнопку питания [declent_ru(ACCUSATIVE)], но он не отвечает."))
 		return FALSE
 
 // Process currently calls handle_power(), may be expanded in future if more things are added.
@@ -625,7 +625,7 @@
 	if(!call_source || !call_source.alert_able || call_source.alert_silenced || !alerttext) //Yeah, we're checking alert_able. No, you don't get to make alerts that the user can't silence.
 		return FALSE
 	playsound(src, sound, 50, TRUE)
-	physical.loc.visible_message(span_notice("[icon2html(physical, viewers(physical.loc))] \The [src] displays a [call_source.filedesc] notification: [alerttext]"))
+	physical.loc.visible_message(span_notice("[icon2html(physical, viewers(physical.loc))] Монитор [declent_ru(GENITIVE)] показывает уведомление [call_source.filedesc]: [alerttext]"))
 
 /obj/item/modular_computer/proc/ring(ringtone, list/balloon_alertees) // bring bring
 	if(!use_energy())
@@ -702,7 +702,7 @@
 
 	if(isnull(program) || !istype(program)) // Program not found or it's not executable program.
 		if(user)
-			to_chat(user, span_danger("\The [src]'s screen shows \"I/O ERROR - Unable to run program\" warning."))
+			to_chat(user, span_danger("Монитор [declent_ru(GENITIVE)] показывает предупреждение \"ОШИБКА ВВОДА/ВЫВОДА - Невозможно запустить программу\"."))
 		return FALSE
 
 	if(active_program == program)
@@ -724,12 +724,12 @@
 
 	if(idle_threads.len > max_idle_programs)
 		if(user)
-			to_chat(user, span_danger("\The [src] displays a \"Maximal CPU load reached. Unable to run another program.\" error."))
+			to_chat(user, span_danger("[declent_ru(NOMINATIVE)] показывает ошибку \"Максимальная нагрузка на ЦП. Не удаётся запустить другую программу.\"."))
 		return FALSE
 
 	if(program.program_flags & PROGRAM_REQUIRES_NTNET && !get_ntnet_status()) // The program requires NTNet connection, but we are not connected to NTNet.
 		if(user)
-			to_chat(user, span_danger("\The [src]'s screen shows \"Unable to connect to NTNet. Please retry. If problem persists contact your system administrator.\" warning."))
+			to_chat(user, span_danger("[declent_ru(NOMINATIVE)] показывает предупреждение \"Не удаётся подключиться к NTNet. Пожалуйста, повторите попытку. Если проблема не устраняется, обратитесь к своему системному администратору.\"."))
 		return FALSE
 
 	if(!program.on_start(user))
@@ -771,7 +771,7 @@
 	if(!get_ntnet_status())
 		return FALSE
 
-	return SSmodular_computers.add_log("[src]: [text]")
+	return SSmodular_computers.add_log("[declent_ru(NOMINATIVE)]: [text]")
 
 /obj/item/modular_computer/proc/close_all_programs()
 	active_program?.kill_program()
@@ -783,7 +783,7 @@
 	if(looping_sound)
 		soundloop.stop()
 	if(physical && loud)
-		physical.visible_message(span_notice("\The [src] shuts down."))
+		physical.visible_message(span_notice("[declent_ru(NOMINATIVE)] выключается."))
 	enabled = FALSE
 	update_appearance()
 	SEND_SIGNAL(src, COMSIG_MODULAR_COMPUTER_SHUT_DOWN, loud)
@@ -823,7 +823,7 @@
 		return FALSE
 	if(!COOLDOWN_FINISHED(src, disabled_time))
 		if(user)
-			balloon_alert(user, "disrupted!")
+			balloon_alert(user, "сбой!")
 		return FALSE
 	set_light_on(!light_on)
 	update_appearance()
@@ -860,39 +860,39 @@
 	if(!saved_identification && !saved_job)
 		name = initial(name)
 		return
-	name = "[saved_identification] ([saved_job])"
+	name = "КПК \"[saved_identification]\" ([saved_job])"
 
 /obj/item/modular_computer/screwdriver_act_secondary(mob/living/user, obj/item/tool)
 	. = ..()
 	if(internal_cell)
-		user.balloon_alert(user, "cell removed")
+		user.balloon_alert(user, "батарея извлечена")
 		internal_cell.forceMove(drop_location())
 		internal_cell = null
 		return ITEM_INTERACT_SUCCESS
 	else
-		user.balloon_alert(user, "no cell!")
+		user.balloon_alert(user, "нет батареи!")
 
 /obj/item/modular_computer/wrench_act_secondary(mob/living/user, obj/item/tool)
 	. = ..()
 	tool.play_tool_sound(src, user, 20, volume=20)
 	deconstruct(TRUE)
-	user.balloon_alert(user, "disassembled")
+	user.balloon_alert(user, "разобрано")
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/modular_computer/welder_act(mob/living/user, obj/item/tool)
 	. = ..()
 	if(atom_integrity == max_integrity)
-		to_chat(user, span_warning("\The [src] does not require repairs."))
+		to_chat(user, span_warning("[declent_ru(NOMINATIVE)] не требует починки."))
 		return ITEM_INTERACT_SUCCESS
 
 	if(!tool.tool_start_check(user, amount=1))
 		return ITEM_INTERACT_SUCCESS
 
-	to_chat(user, span_notice("You begin repairing damage to \the [src]..."))
+	to_chat(user, span_notice("Вы начинаете чинить повреждения [declent_ru(ACCUSATIVE)]..."))
 	if(!tool.use_tool(src, user, 20, volume=50))
 		return ITEM_INTERACT_SUCCESS
 	atom_integrity = max_integrity
-	to_chat(user, span_notice("You repair \the [src]."))
+	to_chat(user, span_notice("Вы чините [declent_ru(ACCUSATIVE)]."))
 	update_appearance()
 	return ITEM_INTERACT_SUCCESS
 
@@ -938,7 +938,7 @@
 /obj/item/modular_computer/proc/money_act(mob/user, obj/item/money)
 	var/obj/item/card/id/inserted_id = stored_id?.GetID()
 	if(!inserted_id)
-		balloon_alert(user, "no ID!")
+		balloon_alert(user, "нет ID!")
 		return ITEM_INTERACT_BLOCKING
 	return inserted_id.insert_money(money, user) ? ITEM_INTERACT_SUCCESS : ITEM_INTERACT_BLOCKING
 
@@ -948,7 +948,7 @@
 	if(!user.transferItemToLoc(card, src))
 		return ITEM_INTERACT_BLOCKING
 	inserted_pai = card
-	balloon_alert(user, "inserted pai")
+	balloon_alert(user, "пИИ установлен")
 	if(inserted_pai.pai)
 		inserted_pai.pai.give_messenger_ability()
 	update_appearance(UPDATE_ICON)
@@ -958,28 +958,28 @@
 	if(ismachinery(physical))
 		return ITEM_INTERACT_BLOCKING
 	if(internal_cell)
-		to_chat(user, span_warning("You try to connect \the [new_cell] to \the [src], but its connectors are occupied."))
+		to_chat(user, span_warning("Вы пытаетесь установить [new_cell.declent_ru(ACCUSATIVE)] к [declent_ru(DATIVE)], но разъём уже занят."))
 		return ITEM_INTERACT_BLOCKING
 	if(!user.transferItemToLoc(new_cell, src))
 		return ITEM_INTERACT_BLOCKING
 	internal_cell = new_cell
-	to_chat(user, span_notice("You plug \the [new_cell] to \the [src]."))
+	to_chat(user, span_notice("Вы вставляете [new_cell.declent_ru(ACCUSATIVE)] в [declent_ru(DATIVE)]."))
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/modular_computer/proc/photo_act(mob/user, obj/item/photo/scanned_photo)
 	if(!store_file(new /datum/computer_file/picture(scanned_photo.picture)))
-		balloon_alert(user, "no space!")
+		balloon_alert(user, "нет места!")
 		return ITEM_INTERACT_BLOCKING
-	balloon_alert(user, "photo scanned")
+	balloon_alert(user, "фото отсканировано")
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/modular_computer/proc/paper_act(mob/user, obj/item/paper/new_paper)
 	if(stored_paper >= max_paper)
-		balloon_alert(user, "no more room!")
+		balloon_alert(user, "нет больше места!")
 		return ITEM_INTERACT_BLOCKING
 	if(!user.temporarilyRemoveItemFromInventory(new_paper))
 		return ITEM_INTERACT_BLOCKING
-	balloon_alert(user, "inserted paper")
+	balloon_alert(user, "бумага вставлена")
 	qdel(new_paper)
 	playsound(src, 'sound/machines/computer/paper_insert.ogg', 40, vary = TRUE)
 	stored_paper++
@@ -987,7 +987,7 @@
 
 /obj/item/modular_computer/proc/paper_bin_act(mob/user, obj/item/paper_bin/bin)
 	if(bin.total_paper <= 0)
-		balloon_alert(user, "empty bin!")
+		balloon_alert(user, "корзина пуста!")
 		return ITEM_INTERACT_BLOCKING
 	var/papers_added //just to keep track
 	while((bin.total_paper > 0) && (stored_paper < max_paper))
@@ -996,8 +996,8 @@
 		bin.remove_paper()
 	if(!papers_added)
 		return ITEM_INTERACT_BLOCKING
-	balloon_alert(user, "inserted paper")
-	to_chat(user, span_notice("Added in [papers_added] new sheets. You now have [stored_paper] / [max_paper] printing paper stored."))
+	balloon_alert(user, "бумага вставлена")
+	to_chat(user, span_notice("Добавлено [papers_added] новых листов. У вас теперь [stored_paper] / [max_paper] сохранённой бумага для печати."))
 	playsound(src, 'sound/machines/computer/paper_insert.ogg', 40, vary = TRUE)
 	bin.update_appearance()
 	return ITEM_INTERACT_SUCCESS
@@ -1007,9 +1007,9 @@
 		return ITEM_INTERACT_BLOCKING
 	if(inserted_disk)
 		user.put_in_hands(inserted_disk)
-		balloon_alert(user, "disks swapped")
+		balloon_alert(user, "диски поменяны местами")
 	else
-		balloon_alert(user, "disk inserted")
+		balloon_alert(user, "диск вставлен")
 	inserted_disk = disk
 	playsound(src, 'sound/machines/card_slide.ogg', 50)
 	return ITEM_INTERACT_SUCCESS
@@ -1023,7 +1023,7 @@
 	alt_stored_id?.forceMove(droploc)
 	inserted_disk?.forceMove(droploc)
 	if (!disassembled)
-		physical.visible_message(span_notice("\The [src] breaks apart!"))
+		physical.visible_message(span_notice("[declent_ru(NOMINATIVE)] распадается на части!"))
 	new /obj/item/stack/sheet/iron(droploc, steel_sheet_cost * (disassembled ? 1 : 0.5))
 	relay_qdel()
 
@@ -1055,7 +1055,7 @@
 		inserted_pai.pai.remove_messenger_ability()
 	if(user)
 		user.put_in_hands(inserted_pai)
-		balloon_alert(user, "removed pAI")
+		balloon_alert(user, "пИИ извлечён")
 	else
 		inserted_pai.forceMove(drop_location())
 	inserted_pai = null

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -113,10 +113,10 @@
 		return ..()
 	var/obj/item/computer_disk/virus/clown/installed_cartridge = inserted_disk
 	if(!installed_cartridge.charges)
-		to_chat(user, span_notice("Out of virus charges."))
+		to_chat(user, span_notice("Закончились заряды вируса."))
 		return ..()
 
-	to_chat(user, span_notice("You upload the virus to [target]!"))
+	to_chat(user, span_notice("Вы загрузили вирус в [target.declent_ru(ACCUSATIVE)]!"))
 	var/sig_list = list(COMSIG_ATOM_ATTACK_HAND)
 	if(istype(target,/obj/machinery/door/airlock))
 		sig_list = list(COMSIG_AIRLOCK_OPEN, COMSIG_AIRLOCK_CLOSE)
@@ -133,10 +133,10 @@
 	. = ..()
 
 	if(inserted_item)
-		context[SCREENTIP_CONTEXT_CTRL_LMB] = "Remove [inserted_item]"
+		context[SCREENTIP_CONTEXT_CTRL_LMB] = "Достать [inserted_item.declent_ru(ACCUSATIVE)]"
 		. = CONTEXTUAL_SCREENTIP_SET
 	else if(istype(held_item) && is_type_in_list(held_item, contained_item))
-		context[SCREENTIP_CONTEXT_LMB] = "Insert [held_item]"
+		context[SCREENTIP_CONTEXT_LMB] = "Вставить [held_item.declent_ru(ACCUSATIVE)]"
 		. = CONTEXTUAL_SCREENTIP_SET
 
 	return . || NONE
@@ -153,14 +153,14 @@
 	if(!is_type_in_list(tool, contained_item))
 		return NONE
 	if(tool.w_class >= WEIGHT_CLASS_SMALL) // Anything equal to or larger than small won't work
-		user.balloon_alert(user, "too big!")
+		user.balloon_alert(user, "слишком большой!")
 		return ITEM_INTERACT_BLOCKING
 	if(!user.transferItemToLoc(tool, src))
 		return ITEM_INTERACT_BLOCKING
 	if(inserted_item)
 		swap_pen(user, tool)
 	else
-		balloon_alert(user, "inserted [tool]")
+		balloon_alert(user, "вставлен [tool.declent_ru(ACCUSATIVE)]")
 		inserted_item = tool
 		playsound(src, 'sound/machines/pda_button/pda_button1.ogg', 50, TRUE)
 	return ITEM_INTERACT_SUCCESS
@@ -185,7 +185,7 @@
 		return
 
 	if(inserted_item)
-		balloon_alert(user, "removed [inserted_item]")
+		balloon_alert(user, "извлечён [inserted_item.declent_ru(ACCUSATIVE)]")
 		user.put_in_hands(inserted_item)
 		inserted_item = null
 		update_appearance()
@@ -193,7 +193,7 @@
 
 /obj/item/modular_computer/pda/proc/swap_pen(mob/user, obj/item/tool)
 	if(inserted_item)
-		balloon_alert(user, "swapped pens")
+		balloon_alert(user, "ручки поменяны местами")
 		user.put_in_hands(inserted_item)
 		inserted_item = tool
 		update_appearance()
@@ -210,13 +210,13 @@
 	if (ismob(loc))
 		var/mob/loc_mob = loc
 		loc_mob.show_message(
-			msg = span_userdanger("Your [src] explodes!"),
+			msg = span_userdanger("Ваш [declent_ru(ACCUSATIVE)] взрывается!"),
 			type = MSG_VISUAL,
-			alt_msg = span_warning("You hear a loud *pop*!"),
+			alt_msg = span_warning("Вы слышите громкий хлопок!"),
 			alt_type = MSG_AUDIBLE,
 		)
 	else
-		visible_message(span_danger("[src] explodes!"), span_warning("You hear a loud *pop*!"))
+		visible_message(span_danger("[declent_ru(ACCUSATIVE)] взрывается!"), span_warning("Вы слышите громкий хлопок!"))
 
 	target.client?.give_award(/datum/award/achievement/misc/clickbait, target)
 

--- a/modular_bandastation/translations/code/translation_data/ru_names.toml
+++ b/modular_bandastation/translations/code/translation_data/ru_names.toml
@@ -25292,3 +25292,48 @@ accusative = "знамя синтетиков"
 instrumental = "знаменем синтетиков"
 prepositional = "знамени синтетиков"
 gender = "neuter"
+
+["captain's spare ID"]
+nominative = "запасная ID-карта капитана"
+genitive = "запасной ID-карты капитана"
+dative = "запасной ID-карте капитана"
+accusative = "запасную ID-карту капитана"
+instrumental = "запасной ID-картой капитана"
+prepositional = "запасной ID-карте капитана"
+gender = "female"
+
+["silver identification card"]
+nominative = "серебряная ID-карта"
+genitive = "серебряной ID-карты"
+dative = "серебряной ID-карте"
+accusative = "серебряную ID-карту"
+instrumental = "серебряной ID-картой"
+prepositional = "серебряной ID-карте"
+gender = "female"
+
+["space cash"]
+nominative = "космоналичка"
+genitive = "космоналички"
+dative = "космоналичке"
+accusative = "космоналичку"
+instrumental = "космоналичкой"
+prepositional = "космоналичке"
+gender = "female"
+
+["Nanotrasen Space-Coin Market"]
+nominative = "Рынок Космокоин Нанотрейзен"
+genitive = "Рынка Космокоин Нанотрейзен"
+dative = "Рынку Космокоин Нанотрейзен"
+accusative = "Рынок Космокоин Нанотрейзен"
+instrumental = "Рынком Космокоин Нанотрейзен"
+prepositional = "Рынке Космокоин Нанотрейзен"
+gender = "male"
+
+["suspicious phone"]
+nominative = "подозрительный телефон"
+genitive = "подозрительного телефона"
+dative = "подозрительному телефону"
+accusative = "подозрительный телефон"
+instrumental = "подозрительным телефоном"
+prepositional = "подозрительном телефоне"
+gender = "male"


### PR DESCRIPTION
## Что этот PR делает

Переводит всё (почти всё), что связано с деньгами, ID и КПК. Действия, тгуи окошки и прочее тоже переведены. 

## Почему это хорошо для игры

ID-карты и КПК теперь на русском языке. Так же почти всё что связано с деньгами и сами деньги. 
Так же теперь вы не вставляете батарею в себя, а в КПК "*ваше имя*" (должность)

## Изображения изменений

<img width="634" height="518" alt="Снимок экрана 2025-08-22 021636" src="https://github.com/user-attachments/assets/3f0b9eea-76ef-4456-9ff8-4701209d2d7c" />
<img width="473" height="110" alt="Снимок экрана 2025-08-22 021702" src="https://github.com/user-attachments/assets/c7f40e7b-6e51-4022-9432-4b29f36196fe" />


## Тестирование

Запустил локалку и проверил, переведено ли. Вроде переведено....
Ну хорошо, что билдится...

## Changelog

:cl:
translation: Переведены ID-карты. Описания и прочее, что отображается при осмотре. Так же взаимодействия с ними.
translation: Переведены КПК. Взаимодействия и описания. Так же исправлено, что отображалось только имя и должность. Теперь "КПК" будет отображаться в начале, а затем имя с должностью. 
translation: Переведены звания. Теперь звания имеют русский перевод (honorifics).
translation: Переведены деньги. 
translation: Переведён CRAB-17. Обрушить рынок можно и на русском языке.
/:cl:
