### PR TITLE
Remove holiday tile recoloring

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -97,19 +97,22 @@ GLOBAL_LIST_INIT(holiday_mail, list())
 			return holiday_colors[(thing_to_color.x % holiday_colors.len) + 1]
 
 /proc/request_holiday_colors(atom/thing_to_color, pattern)
-	switch(pattern)
-		if(PATTERN_RANDOM)
-			return "#[random_short_color()]"
-		if(PATTERN_RAINBOW)
-			var/datum/holiday/pride_week/rainbow_datum = new()
-			return rainbow_datum.get_holiday_colors(thing_to_color, PATTERN_DEFAULT)
-	if(!length(GLOB.holidays))
-		return
-	for(var/holiday_key in GLOB.holidays)
-		var/datum/holiday/holiday_real = GLOB.holidays[holiday_key]
-		if(!holiday_real.holiday_colors)
-			continue
-		return holiday_real.get_holiday_colors(thing_to_color, pattern || holiday_real.holiday_pattern)
+	// // BANDASTATION REMOVAL START - Remove tile holidays tile recoloring
+	// switch(pattern)
+	// 	if(PATTERN_RANDOM)
+	// 		return "#[random_short_color()]"
+	// 	if(PATTERN_RAINBOW)
+	// 		var/datum/holiday/pride_week/rainbow_datum = new()
+	// 		return rainbow_datum.get_holiday_colors(thing_to_color, PATTERN_DEFAULT)
+	// if(!length(GLOB.holidays))
+	// 	return
+	// for(var/holiday_key in GLOB.holidays)
+	// 	var/datum/holiday/holiday_real = GLOB.holidays[holiday_key]
+	// 	if(!holiday_real.holiday_colors)
+	// 		continue
+	// 	return holiday_real.get_holiday_colors(thing_to_color, pattern || holiday_real.holiday_pattern)
+	// // BANDASTATION REMOVAL END - Remove tile holidays tile recoloring
+	return // BANDASTATION ADDITION - Remove tile holidays tile recoloring
 
 // The actual holidays
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Удаляет перекраску декалей пола при праздниках.

## Почему это хорошо для игры
Когда все отделы превращаются в мешанину из разноцветных плиток мне становится плохо. Особенно когда оно перекрашивает то, что не было задумано для перекраски.

## Тестирование
Проверил на локалке.

## Changelog

:cl:
del: Вырезана перекраска декалей пола при праздниках.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
