### PR TITLE
Bring back formaldehyde in medipen

### DIFF
--- a/modular_bandastation/balance/code/_brain.dm
+++ b/modular_bandastation/balance/code/_brain.dm
@@ -98,4 +98,4 @@
 	list_reagents = list( /datum/reagent/medicine/epinephrine = 7, /datum/reagent/medicine/c2/aiuri = 7, /datum/reagent/medicine/c2/libital = 7, /datum/reagent/medicine/leporazine = 6, /datum/reagent/toxin/formaldehyde = 3)
 
 /obj/item/reagent_containers/hypospray/medipen/survival/luxury
-	list_reagents = list(/datum/reagent/medicine/salbutamol = 9, /datum/reagent/medicine/c2/penthrite = 9, /datum/reagent/medicine/oxandrolone = 9, /datum/reagent/medicine/sal_acid = 10 ,/datum/reagent/medicine/omnizine = 10 ,/datum/reagent/medicine/leporazine = 10, , /datum/reagent/toxin/formaldehyde = 3)
+	list_reagents = list(/datum/reagent/medicine/salbutamol = 9, /datum/reagent/medicine/c2/penthrite = 9, /datum/reagent/medicine/oxandrolone = 9, /datum/reagent/medicine/sal_acid = 10 ,/datum/reagent/medicine/omnizine = 10 ,/datum/reagent/medicine/leporazine = 10, /datum/reagent/toxin/formaldehyde = 3)

--- a/modular_bandastation/balance/code/_brain.dm
+++ b/modular_bandastation/balance/code/_brain.dm
@@ -94,11 +94,8 @@
 		leaver.remove_status_effect(/datum/status_effect/grouped/stasis, STASIS_MACHINE_EFFECT)
 		REMOVE_TRAIT(leaver, TRAIT_TUMOR_SUPPRESSED, TRAIT_GENERIC)
 
-/obj/item/reagent_containers/hypospray/medipen
-	list_reagents = list(/datum/reagent/medicine/epinephrine = 10, /datum/reagent/medicine/coagulant = 2)
-
 /obj/item/reagent_containers/hypospray/medipen/survival
 	list_reagents = list( /datum/reagent/medicine/epinephrine = 7, /datum/reagent/medicine/c2/aiuri = 7, /datum/reagent/medicine/c2/libital = 7, /datum/reagent/medicine/leporazine = 6, /datum/reagent/toxin/formaldehyde = 3)
 
 /obj/item/reagent_containers/hypospray/medipen/survival/luxury
-	list_reagents = list(/datum/reagent/medicine/salbutamol = 10, /datum/reagent/medicine/c2/penthrite = 10, /datum/reagent/medicine/oxandrolone = 10, /datum/reagent/medicine/sal_acid = 10 ,/datum/reagent/medicine/omnizine = 10 ,/datum/reagent/medicine/leporazine = 5, /datum/reagent/toxin/formaldehyde = 5)
+	list_reagents = list(/datum/reagent/medicine/salbutamol = 9, /datum/reagent/medicine/c2/penthrite = 9, /datum/reagent/medicine/oxandrolone = 9, /datum/reagent/medicine/sal_acid = 10 ,/datum/reagent/medicine/omnizine = 10 ,/datum/reagent/medicine/leporazine = 10, , /datum/reagent/toxin/formaldehyde = 3)

--- a/modular_bandastation/balance/code/_brain.dm
+++ b/modular_bandastation/balance/code/_brain.dm
@@ -98,4 +98,4 @@
 	list_reagents = list( /datum/reagent/medicine/epinephrine = 7, /datum/reagent/medicine/c2/aiuri = 7, /datum/reagent/medicine/c2/libital = 7, /datum/reagent/medicine/leporazine = 6, /datum/reagent/toxin/formaldehyde = 3)
 
 /obj/item/reagent_containers/hypospray/medipen/survival/luxury
-	list_reagents = list(/datum/reagent/medicine/salbutamol = 9, /datum/reagent/medicine/c2/penthrite = 9, /datum/reagent/medicine/oxandrolone = 9, /datum/reagent/medicine/sal_acid = 10 ,/datum/reagent/medicine/omnizine = 10 ,/datum/reagent/medicine/leporazine = 10, /datum/reagent/toxin/formaldehyde = 3)
+	list_reagents = list(/datum/reagent/medicine/salbutamol = 9, /datum/reagent/medicine/c2/penthrite = 9, /datum/reagent/medicine/oxandrolone = 9, /datum/reagent/medicine/sal_acid = 10, /datum/reagent/medicine/omnizine = 10, /datum/reagent/medicine/leporazine = 10, /datum/reagent/toxin/formaldehyde = 3)


### PR DESCRIPTION
## Что этот PR делает
Возвращает формальдегид в медипен

## Почему это хорошо для игры
Меньше непреднамеренных выводов из раунда

## Тестирование
Локальные тесты

## Changelog

:cl:
add: Формальдегид возвращен в медипен
/:cl: