### PR TITLE
Change permanent death mode - switch to permanent brain traumas

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -606,10 +606,6 @@
 						fail_reason = "Tissue damage too severe, repair and try again."
 					if (DEFIB_FAIL_HUSK)
 						fail_reason = "Patient's body is a mere husk, repair and try again."
-					// BANDASTATION EDIT START - PERMA-DEATH
-					if (DEFIB_FAIL_PERMANENTLY_DEAD)
-						fail_reason = "Patient's brain electomagnetic activity gone. It's too late for them..."
-					// BANDASTATION EDIT END - PERMA-DEATH
 					if (DEFIB_FAIL_FAILING_BRAIN)
 						fail_reason = "Patient's brain is too damaged, repair and try again."
 					if (DEFIB_FAIL_NO_INTELLIGENCE)

--- a/code/modules/lost_crew/damages/decay.dm
+++ b/code/modules/lost_crew/damages/decay.dm
@@ -12,10 +12,7 @@
 	var/decay_ticks = max_decay_time * severity * 0.5
 
 	for(var/obj/item/organ/internal in body.organs)
-		// BANDASTATION ADDITION START - PERMA-DEATH ORGAN DAMAGE
-		if(!(ispath(internal, /obj/item/organ/brain) && CONFIG_GET(flag/brain_permanent_death)))
-			internal.apply_organ_damage(decay_ticks * internal.decay_factor)
-		// BANDASTATION ADDITION END - PERMA-DEATH ORGAN DAMAGE
+		internal.apply_organ_damage(decay_ticks * internal.decay_factor)
 
 	return TRUE
 

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -208,7 +208,7 @@
 
 /obj/item/organ/brain/proc/check_for_repair(obj/item/item, mob/user)
 	if(damage && item.is_drainable() && item.reagents.has_reagent(/datum/reagent/medicine/mannitol) && (organ_flags & ORGAN_ORGANIC)) //attempt to heal the brain
-		if(brainmob?.health <= HEALTH_THRESHOLD_DEAD || (CONFIG_GET(flag/brain_permanent_death) && (organ_flags & ORGAN_FAILING))) //if the brain is fucked anyway, do nothing // BANDASTATION EDIT - PERMA-DEATH ORGAN DAMAGE
+		if(brainmob?.health <= HEALTH_THRESHOLD_DEAD) //if the brain is fucked anyway, do nothing
 			to_chat(user, span_warning("[src] is far too damaged, there's nothing else we can do for it!"))
 			return TRUE
 
@@ -653,10 +653,13 @@
 
 /obj/item/organ/brain/apply_organ_damage(damage_amount, maximum = maxHealth, required_organ_flag = NONE)
 	. = ..()
-	// BANDASTATION ADDITION START - PERMA-DEATH ORGAN DAMAGE
-	if(CONFIG_GET(flag/brain_permanent_death) && (organ_flags & ORGAN_FAILING))
-		return -(maxHealth)
-	// BANDASTATION ADDITION END - PERMA-DEATH ORGAN DAMAGE
+	// BANDASTATION EDIT - PERMA-DEATH-TRAUMAS
+	if(CONFIG_GET(flag/brain_permanent_death) && (organ_flags & ORGAN_FAILING) && !apply_death_trauma)
+		apply_death_trauma = TRUE
+		gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_ABSOLUTE)
+	if(CONFIG_GET(flag/brain_permanent_death) && !(organ_flags & ORGAN_FAILING) && apply_death_trauma)
+		apply_death_trauma = FALSE
+	// BANDASTATION EDIT - PERMA-DEATH-TRAUMAS
 	if(!owner)
 		return FALSE
 	if(damage >= 60)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -847,30 +847,13 @@
 	return ..()
 
 /mob/living/carbon/can_be_revived()
-	// BANDASTATION EDIT START - PERMA-DEATH
-	var/obj/item/organ/brain/brain = get_organ_by_type(/obj/item/organ/brain)
-	var/brain_non_functional = isnull(brain) || (CONFIG_GET(flag/brain_permanent_death) && brain.organ_flags & ORGAN_FAILING)
-	if(brain_non_functional && !IS_CHANGELING(src) || HAS_TRAIT(src, TRAIT_HUSK))
+	if(!get_organ_by_type(/obj/item/organ/brain) && (!IS_CHANGELING(src)) || HAS_TRAIT(src, TRAIT_HUSK))
 		return FALSE
-	// BANDASTATION EDIT END - PERMA-DEATH
 	return ..()
 
 /mob/living/carbon/proc/can_defib()
 	if (HAS_TRAIT(src, TRAIT_SUICIDED))
 		return DEFIB_FAIL_SUICIDE
-
-	// BANDASTATION EDIT START - PERMA-DEATH
-	var/obj/item/organ/brain/current_brain = get_organ_by_type(/obj/item/organ/brain)
-
-	if (QDELETED(current_brain))
-		return DEFIB_FAIL_NO_BRAIN
-
-	if (current_brain.suicided || (current_brain.brainmob && HAS_TRAIT(current_brain.brainmob, TRAIT_SUICIDED)))
-		return DEFIB_FAIL_NO_INTELLIGENCE
-
-	if (current_brain.organ_flags & ORGAN_FAILING)
-		return CONFIG_GET(flag/brain_permanent_death) ? DEFIB_FAIL_PERMANENTLY_DEAD : DEFIB_FAIL_FAILING_BRAIN
-	// BANDASTATION EDIT END - PERMA-DEATH
 
 	if (HAS_TRAIT(src, TRAIT_HUSK))
 		return DEFIB_FAIL_HUSK
@@ -891,7 +874,6 @@
 		if (heart.organ_flags & ORGAN_FAILING)
 			return DEFIB_FAIL_FAILING_HEART
 
-	/* // BANDASTATION EDIT START - PERMA-DEATH
 	var/obj/item/organ/brain/current_brain = get_organ_by_type(/obj/item/organ/brain)
 
 	if (QDELETED(current_brain))
@@ -902,7 +884,6 @@
 
 	if (current_brain.suicided || (current_brain.brainmob && HAS_TRAIT(current_brain.brainmob, TRAIT_SUICIDED)))
 		return DEFIB_FAIL_NO_INTELLIGENCE
-		*/ // BANDASTATION EDIT END - PERMA-DEATH
 
 	if(IS_FAKE_KEY(key))
 		return DEFIB_NOGRAB_AGHOST

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -242,16 +242,10 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	var/message = check_damage_thresholds(owner)
 	prev_damage = damage
 
-	var/old_organ_flags = organ_flags // BANDASTATION ADD - PERMA-DEATH
 	if(damage >= maxHealth)
 		organ_flags |= ORGAN_FAILING
 	else
 		organ_flags &= ~ORGAN_FAILING
-
-	// BANDASTATION ADDITION START - PERMA-DEATH
-	if(old_organ_flags != organ_flags)
-		owner?.med_hud_set_status()
-	// BANDASTATION ADDITION END - PERMA-DEATH
 
 	if(message && owner && owner.stat <= SOFT_CRIT)
 		to_chat(owner, message)

--- a/modular_bandastation/balance/code/_brain.dm
+++ b/modular_bandastation/balance/code/_brain.dm
@@ -1,15 +1,10 @@
+/obj/item/organ/brain
+	var/apply_death_trauma = FALSE
+
 /obj/item/organ/brain/Initialize(mapload)
 	. = ..()
 	if(CONFIG_GET(flag/brain_permanent_death))
 		decay_factor = STANDARD_ORGAN_DECAY * 2 //7 минут до полной смерти (в 4 раза быстрее чем по умолчанию (30 минут))
-
-/datum/surgery/brain_surgery/can_start(mob/user, mob/living/carbon/target)
-	. = ..()
-	if(!.)
-		return
-
-	var/obj/item/organ/brain/brain = target.get_organ_slot(ORGAN_SLOT_BRAIN)
-	return !(brain.organ_flags & ORGAN_FAILING) || !CONFIG_GET(flag/brain_permanent_death)
 
 /datum/config_entry/flag/brain_permanent_death
 	default = FALSE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Изменяет старую имплементацию постоянной смерти - с невозможности восстановить мозг на получение постоянной тяжелой травмы мозга.
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Меньше конфузов, когда лунный еретик буквально выводит все куклы из раунда убивая им мозг.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений
<img width="639" height="301" alt="image" src="https://github.com/user-attachments/assets/0eed4656-cde2-4b24-8cfd-f244c9fc9afc" />

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
Локальный сервер
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
balance: В режиме постоянной смерти теперь вместо смерти проставляются постоянные травмы.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
