### PR TITLE
Balance: Aim distance increase and damage multiplier reduce

### DIFF
--- a/code/__DEFINES/projectiles.dm
+++ b/code/__DEFINES/projectiles.dm
@@ -66,7 +66,7 @@
 #define CALIBER_PEA "pea"
 
 /// For gunpoints, how many tiles around the target the shooter can roam without losing their shot
-#define GUNPOINT_SHOOTER_STRAY_RANGE 2
+#define GUNPOINT_SHOOTER_STRAY_RANGE 4 // BANDASTATION EDIT - Increase aiming distance from 2 to 4
 
 /// A spark will be generated for each THIS amount of damage dealt to a robotic limb by a projectile.
 #define PROJECTILE_DAMAGE_PER_ROBOTIC_SPARK 20

--- a/code/datums/components/gunpoint.dm
+++ b/code/datums/components/gunpoint.dm
@@ -7,9 +7,9 @@
 /// How much the damage and wound bonus mod is multiplied when you're on stage 1
 #define GUNPOINT_MULT_STAGE_1 1.25
 /// As above, for stage 2
-#define GUNPOINT_MULT_STAGE_2 2
+#define GUNPOINT_MULT_STAGE_2 1.75 // BANDASTATION EDIT - reduce damage multiplier from 2 to 1.75 due to increased aim distance
 /// As above, for stage 3
-#define GUNPOINT_MULT_STAGE_3 2.5
+#define GUNPOINT_MULT_STAGE_3 2.25 // BANDASTATION EDIT - reduce damage multiplier from 2.5 to 2.25 due to increased aim distance
 
 
 /datum/component/gunpoint


### PR DESCRIPTION
## Что этот PR делает

Увеличивает дистанцию взятия на прицел с 2-х тайлов до 4-х.
Уменьшает множитель урона во 2 и 3 стадии на 0.25

## Почему это хорошо для игры

Механика взятия на прицел никем не используется, потому что она работает на слишком короткое расстояние, в связи с чем ею невозможно воспользоваться адекватно, и она одновременно бесполезна, так как нет смысла прицеливаться в бою и на 2 тайла вперёд.

У нас периодически возникают ситуации со взятием в заложники. Благодаря увеличению дистанции игрок на антаге (или тот, кто возьмет в заложники) сможет более явно угрожать тем, кто к нему приближается, при этом нарушение этого требования всё ещё нанесёт больше урона, чем обычно. 

Как по мне такое измение должно повысить ролеплау составляющее, при этом немного улучшит позицию того, кто берет кого-то в заложники или на прицел.

Микроанализ на примере трёх пресетов множителей показывает, что 1,75/2,25 выглядит как самый оптимальный вариант. 1,5/2 я посчитал слишком сильным нерфом, а стандартные значения 2/2,5 слишком сильными. Для расчёта количества попаданий брался базовый урон - 25, кукла без защиты.

<img width="1060" height="293" alt="image" src="https://github.com/user-attachments/assets/d0454f01-d891-4a7e-a27f-42524693ef77" />

## Изображения изменений

<details>
<summary>Было</summary> <img width="668" height="528" alt="image" src="https://github.com/user-attachments/assets/73c3ca90-a06a-4715-b709-ccfbd77f390d" /></details>
<details>
<summary>Стало</summary> <img width="929" height="699" alt="image" src="https://github.com/user-attachments/assets/6fb66fe3-7c3f-4cfb-86fe-e972a080b393" /></details>

## Тестирование

Локалка

## Changelog

:cl:
balance: Дальность взятия на прицел увеличена с 2-х до 4-х тайлов
balance: Множители урона во второй и третьей фазе прицеливания снижены на 0,25
/:cl:

