### PR TITLE
Ru job titles in code phrases

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -257,7 +257,7 @@ GLOBAL_DATUM(syndicate_code_response_regex, /regex)
 					if(2)
 						var/datum/job/job = pick(SSjob.joinable_occupations)
 						if(job)
-							. += job_title_ru(job.title) //Returns a job.
+							. += LOWER_TEXT(job_title_ru(job.title)) //Returns a job.
 						else
 							stack_trace("Failed to pick(SSjob.joinable_occupations) on generate_code_phrase()")
 							. += "Bug"

--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -257,7 +257,7 @@ GLOBAL_DATUM(syndicate_code_response_regex, /regex)
 					if(2)
 						var/datum/job/job = pick(SSjob.joinable_occupations)
 						if(job)
-							. += job.title //Returns a job.
+							. += job_title_ru(job.title) //Returns a job.
 						else
 							stack_trace("Failed to pick(SSjob.joinable_occupations) on generate_code_phrase()")
 							. += "Bug"


### PR DESCRIPTION

## Что этот PR делает
Делает русскоязычные профки в кодовых фразах.

## Изображения изменений
<img width="310" height="155" alt="image" src="https://github.com/user-attachments/assets/e3fdbc61-bb58-4608-b986-d24b4c85314d" />

## Тестирование
Локалка.

## Changelog

:cl:
translation: Название профок в кодовых фразах теперь выдаются на русском.
/:cl:
