### PR TITLE
Changing the recipe of the tajaran and vulp mut toxin

### DIFF
--- a/modular_bandastation/species/code/reagents/mutation.dm
+++ b/modular_bandastation/species/code/reagents/mutation.dm
@@ -8,7 +8,7 @@
 
 /datum/chemical_reaction/slime/slimevulpkanin
 	results = list(/datum/reagent/mutationtoxin/vulpkanin = 1)
-	required_reagents = list(/datum/reagent/love = 5)
+	required_reagents = list(/datum/reagent/consumable/nutriment/protein = 1)
 	required_container = /obj/item/slime_extract/green
 
 /datum/reagent/mutationtoxin/tajaran
@@ -21,7 +21,7 @@
 
 /datum/chemical_reaction/slime/slimetajaran
 	results = list(/datum/reagent/mutationtoxin/tajaran = 1)
-	required_reagents = list(/datum/reagent/consumable/milk = 5)
+	required_reagents = list(/datum/reagent/consumable/milk = 1)
 	required_container = /obj/item/slime_extract/green
 
 /datum/chemical_reaction/slime/slimemoth


### PR DESCRIPTION
## Что этот PR делает

Меняет рецепты токсины мутации для таяр и вульп, а именно любовь в вульп-токсине поменяна на протеин (что достается из мяса и не только), и заменено количество требуемых реагентов для каждого рецепта, потому что все остальные рецепты токсинов мутаций требуют всего 1 юнит на 1 юнит токсина.

## Почему это хорошо для игры

Вульп-токсин и таяр-токсин теперь как и все остальные создаваемые токсины мутаций требуют всего 1 юнит (1:1, что логично). Любовь для создания вульпы? Серьезно?

## Изображения изменений

<img width="516" height="117" alt="Screenshot_392" src="https://github.com/user-attachments/assets/2eb35a47-135c-4a35-8b02-64ef9438bec2" />
<img width="149" height="168" alt="Screenshot_391" src="https://github.com/user-attachments/assets/13333b17-503a-466c-b214-64175af3c659" />

## Тестирование

Локалка

## Changelog

:cl:
qol: Изменены ксенобиологические рецепты мутации в таяр и вульп. Для токсина превращения в вульп теперь требуется протеин вместо любви. Оба токсина теперь создаются 1:1, за 1 юнит вещества - 1 юнит токсина.
/:cl:
