### PR TITLE
Cyberiad: Deforest First Aid Station

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -73623,6 +73623,7 @@
 /area/station/maintenance/department/medical/ghetto/central)
 "saE" = (
 /obj/effect/spawner/random/vending/snackvend,
+/obj/machinery/wall_healer/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "saM" = (
@@ -81794,6 +81795,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Arrivals Hallway"
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "uaM" = (
@@ -92918,7 +92920,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
-/obj/machinery/vending/wallmed/directional/north,
+/obj/machinery/wall_healer/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "wQN" = (
@@ -97081,9 +97083,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "xRD" = (
-/obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/wall_healer/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "xRI" = (


### PR DESCRIPTION
## Что этот PR делает

Добавляет 3 настенных Deforest First Aid Station в прибытие, мед, отбытие для лечения и остановки кровотечений за день.

## Почему это хорошо для игры

Удобный прибор, который не особо быстро, взымая плату, может помочь залечить небольшие повреждения. Для ситуаций: когда есть небольшие повреждения и лень идти в мед; когда срочно нужно хоть немного полечиться, чтобы не упасть в крит. Не заменит врачей, т.к. платно, не быстро, да и не все лечит

## Изображения изменений

<img width="221" height="237" alt="image" src="https://github.com/user-attachments/assets/5f01d600-b5e2-45a6-99c3-8bf2e2e8dc94" />
<img width="332" height="236" alt="image" src="https://github.com/user-attachments/assets/281d1f02-c76a-4b60-8829-834343861ca8" />
<img width="213" height="154" alt="image" src="https://github.com/user-attachments/assets/3f19db05-9fa5-41c0-845f-64135fff08ce" />

## Тестирование

Локалка

## Changelog

:cl:
map: Кибериада: добавлены 3 настенные станции для покупки бинтов и лечения за кредиты. Расположены в прибытие, отбытие и меде (вместо настенного NanoMed)
/:cl:
