### PR TITLE
RLD into engi-vend

### DIFF
--- a/code/modules/vending/engivend.dm
+++ b/code/modules/vending/engivend.dm
@@ -24,7 +24,7 @@
 	)
 	premium = list(
 		/obj/item/storage/belt/utility = 3,
-		/obj/item/construction/rld = 3,	//BANDASTATION ADD - engivend expansion
+		/obj/item/construction/rld = 2,	//BANDASTATION ADD - engivend expansion
 		/obj/item/storage/bag/material_pouch = 3, //BANDASTATION ADD - engivend expansion
 		/obj/item/construction/rcd/loaded = 2,
 		/obj/item/storage/box/smart_metal_foam = 1,

--- a/code/modules/vending/engivend.dm
+++ b/code/modules/vending/engivend.dm
@@ -24,8 +24,8 @@
 	)
 	premium = list(
 		/obj/item/storage/belt/utility = 3,
-		/obj/item/construction/rld = 2,	//BANDASTATION ADD - engivend expansion
 		/obj/item/storage/bag/material_pouch = 3, //BANDASTATION ADD - engivend expansion
+		/obj/item/construction/rld = 2,	//BANDASTATION ADD - engivend expansion
 		/obj/item/construction/rcd/loaded = 2,
 		/obj/item/storage/box/smart_metal_foam = 1,
 	)

--- a/code/modules/vending/engivend.dm
+++ b/code/modules/vending/engivend.dm
@@ -24,6 +24,8 @@
 	)
 	premium = list(
 		/obj/item/storage/belt/utility = 3,
+		/obj/item/construction/rld = 3,	//BANDASTATION ADD - RLD into engi-vend
+		/obj/item/storage/bag/material_pouch = 3, //BANDASTATION ADD - RLD into engi-vend
 		/obj/item/construction/rcd/loaded = 2,
 		/obj/item/storage/box/smart_metal_foam = 1,
 	)

--- a/code/modules/vending/engivend.dm
+++ b/code/modules/vending/engivend.dm
@@ -24,8 +24,8 @@
 	)
 	premium = list(
 		/obj/item/storage/belt/utility = 3,
-		/obj/item/construction/rld = 3,	//BANDASTATION ADD - RLD into engi-vend
-		/obj/item/storage/bag/material_pouch = 3, //BANDASTATION ADD - RLD into engi-vend
+		/obj/item/construction/rld = 3,	//BANDASTATION ADD - engivend expansion
+		/obj/item/storage/bag/material_pouch = 3, //BANDASTATION ADD - engivend expansion
 		/obj/item/construction/rcd/loaded = 2,
 		/obj/item/storage/box/smart_metal_foam = 1,
 	)

--- a/modular_bandastation/balance/_balance.dme
+++ b/modular_bandastation/balance/_balance.dme
@@ -30,6 +30,5 @@
 #include "code/wounds/cranial_fissure.dm"
 #include "code/mod_types.dm"
 #include "code/tools.dm"
-#include "code/vendings.dm"
 
 #include "code/~undefs.dm"

--- a/modular_bandastation/balance/_balance.dme
+++ b/modular_bandastation/balance/_balance.dme
@@ -29,5 +29,7 @@
 #include "code/weapons/rifle.dm"
 #include "code/wounds/cranial_fissure.dm"
 #include "code/mod_types.dm"
+#include "code/tools.dm"
+#include "code/vendings.dm"
 
 #include "code/~undefs.dm"

--- a/modular_bandastation/balance/code/cargo/packs/goodies.dm
+++ b/modular_bandastation/balance/code/cargo/packs/goodies.dm
@@ -32,4 +32,4 @@
 
 // MARK: TOOLS
 /datum/supply_pack/goody/rapid_lighting_device
-	cost = PAYCHECK_CREW * 7 // Original price: 500 New price: 350
+	cost = PAYCHECK_CREW * 4 // Original price: 500 New price: 200

--- a/modular_bandastation/balance/code/cargo/packs/goodies.dm
+++ b/modular_bandastation/balance/code/cargo/packs/goodies.dm
@@ -29,3 +29,7 @@
 
 /datum/supply_pack/goody/match38br
 	cost = PAYCHECK_CREW * 4 // Original price: 100 New price: 200
+
+// MARK: TOOLS
+/datum/supply_pack/goody/rapid_lighting_device
+	cost = PAYCHECK_CREW * 7 // Original price: 500 New price: 350

--- a/modular_bandastation/balance/code/tools.dm
+++ b/modular_bandastation/balance/code/tools.dm
@@ -1,0 +1,3 @@
+// MARK: ENGINEERING
+/obj/item/construction/rld
+	custom_premium_price = PAYCHECK_COMMAND * 5 // Premium price for vendings: 500

--- a/modular_bandastation/balance/code/tools.dm
+++ b/modular_bandastation/balance/code/tools.dm
@@ -1,3 +1,3 @@
 // MARK: ENGINEERING
 /obj/item/construction/rld
-	custom_premium_price = PAYCHECK_COMMAND * 5 // Premium price for vendings: 500
+	custom_premium_price = PAYCHECK_COMMAND * 3 // Premium price for vendings: 300

--- a/modular_bandastation/balance/code/vendings.dm
+++ b/modular_bandastation/balance/code/vendings.dm
@@ -1,5 +1,0 @@
-/obj/machinery/vending/engivend/build_inventories(start_empty)
-	contraband += list(
-		/obj/item/construction/rld = 2
-	)
-	. = ..()

--- a/modular_bandastation/balance/code/vendings.dm
+++ b/modular_bandastation/balance/code/vendings.dm
@@ -1,0 +1,5 @@
+/obj/machinery/vending/engivend/build_inventories(start_empty)
+	contraband += list(
+		/obj/item/construction/rld = 2
+	)
+	. = ..()

--- a/modular_bandastation/objects/code/items/material_pouch.dm
+++ b/modular_bandastation/objects/code/items/material_pouch.dm
@@ -36,9 +36,3 @@
 	atom_storage.max_slots = 2
 	atom_storage.numerical_stacking = TRUE
 	atom_storage.set_holdable(matpouch_holdables)
-
-/obj/machinery/vending/engivend/build_inventories(start_empty)
-	premium += list(
-		/obj/item/storage/bag/material_pouch = 3
-	)
-	. = ..()


### PR DESCRIPTION
## Что этот PR делает

Добавляет rapid light device(RLD) в инженерный вендор, в раздел контрабанды за 500 кредитов в количестве двух штук.
Цена заказа в карго снижена до 350 кредитов, чтобы был смысл его там заказывать.
## Почему это хорошо для игры

RLD - редкоиспользуемый, но полезный инструмент. Все что он делает - позволяет быстро строить свет или кидать химсвет. Возможность покупки в вендоре позволяет избежать продолжительной возни с карго, если он срочно нужен или инженер не хочет ждать доставки. Изменение цены поставки сохранит валидность заказа инструмента именно через карго.

## Тестирование

Локальные тесты
## Changelog

:cl:
add: RLD теперь доступен в качестве контрабанды в инженерном вендоре за 300 кредитов. Ресток - 2 штуки.
balance: Цена покупки RLD в карго снижена до 200 кредитов
/:cl:
