### PR TITLE
Add: Additional sound admin verbs

### DIFF
--- a/modular_bandastation/admin/code/admin_helpers.dm
+++ b/modular_bandastation/admin/code/admin_helpers.dm
@@ -5,3 +5,15 @@
 			valid_holders += holder
 
 	return valid_holders
+
+/proc/prepare_admin_sound(vol, sound/sound_file)
+	var/sound/admin_sound = new
+	admin_sound.file = sound_file
+	admin_sound.priority = 250
+	admin_sound.channel = CHANNEL_ADMIN
+	admin_sound.frequency = 1
+	admin_sound.wait = 1
+	admin_sound.repeat = FALSE
+	admin_sound.status = SOUND_STREAM
+	admin_sound.volume = vol
+	return admin_sound

--- a/modular_bandastation/admin/code/admin_helpers.dm
+++ b/modular_bandastation/admin/code/admin_helpers.dm
@@ -6,14 +6,14 @@
 
 	return valid_holders
 
-/proc/prepare_admin_sound(vol, sound/sound_file)
-	var/sound/admin_sound = new
-	admin_sound.file = sound_file
-	admin_sound.priority = 250
-	admin_sound.channel = CHANNEL_ADMIN
-	admin_sound.frequency = 1
-	admin_sound.wait = 1
-	admin_sound.repeat = FALSE
+/proc/prepare_admin_sound(new_volume, sound/sound_file)
+	var/sound/admin_sound = new (
+		file = sound_file,
+		channel = CHANNEL_ADMIN,
+		wait = TRUE,
+		volume = new_volume
+	)
 	admin_sound.status = SOUND_STREAM
-	admin_sound.volume = vol
+	admin_sound.priority = 250
 	return admin_sound
+

--- a/modular_bandastation/admin/code/admin_verbs.dm
+++ b/modular_bandastation/admin/code/admin_verbs.dm
@@ -63,15 +63,7 @@ ADMIN_VERB(play_zlevel_sound, R_SOUND, "Play Z-level Sound", "Plays a sound only
 		return
 	vol = clamp(vol, 1, 100)
 
-	var/sound/admin_sound = new
-	admin_sound.file = sound
-	admin_sound.priority = 250
-	admin_sound.channel = CHANNEL_ADMIN
-	admin_sound.frequency = 1
-	admin_sound.wait = 1
-	admin_sound.repeat = FALSE
-	admin_sound.status = SOUND_STREAM
-	admin_sound.volume = vol
+	var/sound/admin_sound = prepare_admin_sound(vol, sound)
 
 	var/zlevel = user.mob.z
 	log_admin("[key_name(user)] played a z-level sound [sound] on level [zlevel]")
@@ -94,15 +86,7 @@ ADMIN_VERB(play_sound_in_view, R_SOUND, "Play Sound in View", "Plays a sound to 
 		return
 	vol = clamp(vol, 1, 100)
 
-	var/sound/admin_sound = new
-	admin_sound.file = sound
-	admin_sound.priority = 250
-	admin_sound.channel = CHANNEL_ADMIN
-	admin_sound.frequency = 1
-	admin_sound.wait = 1
-	admin_sound.repeat = FALSE
-	admin_sound.status = SOUND_STREAM
-	admin_sound.volume = vol
+	var/sound/admin_sound = prepare_admin_sound(vol, sound)
 
 	var/list/mob/hearers = list()
 	// If non-default we need additional calculations

--- a/modular_bandastation/admin/code/admin_verbs.dm
+++ b/modular_bandastation/admin/code/admin_verbs.dm
@@ -62,7 +62,8 @@ ADMIN_VERB(play_zlevel_sound, R_SOUND, "Play Z-level Sound", "Plays a sound only
 
 	var/sound/admin_sound = prepare_admin_sound(volume, sound)
 
-	var/zlevel = user.mob.z
+	var/turf/mob_turf = get_turf(user.mob)
+	var/zlevel = mob_turf.z
 	log_admin("[key_name(user)] played a z-level sound [sound] on level [zlevel]")
 	message_admins("[key_name_admin(user)] played a z-level sound [sound] on level [zlevel]")
 

--- a/modular_bandastation/admin/code/admin_verbs.dm
+++ b/modular_bandastation/admin/code/admin_verbs.dm
@@ -67,8 +67,9 @@ ADMIN_VERB(play_zlevel_sound, R_SOUND, "Play Z-level Sound", "Plays a sound only
 	log_admin("[key_name(user)] played a z-level sound [sound] on level [zlevel]")
 	message_admins("[key_name_admin(user)] played a z-level sound [sound] on level [zlevel]")
 
-	for(var/mob/hearer in GLOB.player_list)
-		if(hearer.z != zlevel)
+	for(var/mob/hearer as anything in GLOB.player_list)
+		var/turf/hearer_turf = get_turf(hearer)
+		if(hearer_turf.z != zlevel)
 			continue
 		var/volume_modifier = hearer.client.prefs.read_preference(/datum/preference/numeric/volume/sound_midi)
 		if(volume_modifier > 0)

--- a/modular_bandastation/admin/code/admin_verbs.dm
+++ b/modular_bandastation/admin/code/admin_verbs.dm
@@ -1,8 +1,12 @@
+//MARK: Debug Outfit
+
 ADMIN_VERB_ONLY_CONTEXT_MENU(spawn_debug_outfit, R_SPAWN, "(Debug) Debug Outfit", mob/admin in world)
 	if(tgui_alert(admin,"Это заспавнит вас в специальном Debug прикиде, удаляя при этом ваше старое тело если оно было. Вы уверены?", "Debug Outfit", list("Да", "Нет")) != "Да")
 		return
 	var/mob/living/carbon/human/admin_body = admin.change_mob_type(/mob/living/carbon/human, delete_old_mob = TRUE)
 	admin_body.equipOutfit(/datum/outfit/debug)
+
+//MARK: Download Icon
 
 ADMIN_VERB_ONLY_CONTEXT_MENU(download_flaticon, R_ADMIN, "(Special) Download Icon", atom/thing in world)
 	var/icon/image = getFlatIcon(thing, no_anim = TRUE)
@@ -29,6 +33,8 @@ ADMIN_VERB_ONLY_CONTEXT_MENU(download_flaticon, R_ADMIN, "(Special) Download Ico
 
 	usr << ftp(image, "[thing.name]_[image_width]x[image_height].png")
 
+//MARK: Man Up
+
 ADMIN_VERB_AND_CONTEXT_MENU(man_up, R_ADMIN, "Man Up", "Tells mob to man up and deal with it.", ADMIN_CATEGORY_FUN, mob/living/target in world)
 	if(QDELETED(target))
 		return
@@ -38,6 +44,8 @@ ADMIN_VERB_AND_CONTEXT_MENU(man_up, R_ADMIN, "Man Up", "Tells mob to man up and 
 	log_admin("[key_name(user)] told [key_name(target)] to man up and deal with it.")
 	message_admins("[key_name_admin(user)] told [key_name(target)] to man up and deal with it.")
 
+//MARK: Global Man Up
+
 ADMIN_VERB(global_man_up, R_ADMIN, "Global Man Up", "Tells everyone to man up and deal with it.", ADMIN_CATEGORY_FUN)
 	if(tgui_alert(user, "Вы уверены что хотите отправить глобальное сообщение?", "Подтверждение глобального Man Up", list("Да", "Нет")) == "Да")
 		for(var/sissy in GLOB.player_list)
@@ -46,3 +54,75 @@ ADMIN_VERB(global_man_up, R_ADMIN, "Global Man Up", "Tells everyone to man up an
 
 		log_admin("[key_name(user)] told everyone to man up and deal with it.")
 		message_admins("[key_name_admin(user)] told everyone to man up and deal with it.")
+
+//MARK: Play Z-level Sound
+
+ADMIN_VERB(play_zlevel_sound, R_SOUND, "Play Z-level Sound", "Plays a sound only on your z-level.", ADMIN_CATEGORY_FUN, sound as sound)
+	var/vol = tgui_input_number(user, "На какой громкости воспроизвести звук (1-100)?", default = 100, max_value = 100)
+	if(!vol)
+		return
+	vol = clamp(vol, 1, 100)
+
+	var/sound/admin_sound = new
+	admin_sound.file = sound
+	admin_sound.priority = 250
+	admin_sound.channel = CHANNEL_ADMIN
+	admin_sound.frequency = 1
+	admin_sound.wait = 1
+	admin_sound.repeat = FALSE
+	admin_sound.status = SOUND_STREAM
+	admin_sound.volume = vol
+
+	var/zlevel = user.mob.z
+	log_admin("[key_name(user)] played a z-level sound [sound] on level [zlevel]")
+	message_admins("[key_name_admin(user)] played a z-level sound [sound] on level [zlevel]")
+
+	for(var/mob/M in GLOB.player_list)
+		if(M.z != zlevel)
+			continue
+		var/volume_modifier = M.client.prefs.read_preference(/datum/preference/numeric/volume/sound_midi)
+		if(volume_modifier > 0)
+			admin_sound.volume = vol * M.client.admin_music_volume * (volume_modifier/100)
+			SEND_SOUND(M, admin_sound)
+			admin_sound.volume = vol
+
+//MARK: Play Sound in View
+
+ADMIN_VERB(play_sound_in_view, R_SOUND, "Play Sound in View", "Plays a sound to all player in view.", ADMIN_CATEGORY_FUN, sound as sound)
+	var/vol = tgui_input_number(user, "На какой громкости воспроизвести звук (1-100)?", default = 100, max_value = 100)
+	if(!vol)
+		return
+	vol = clamp(vol, 1, 100)
+
+	var/sound/admin_sound = new
+	admin_sound.file = sound
+	admin_sound.priority = 250
+	admin_sound.channel = CHANNEL_ADMIN
+	admin_sound.frequency = 1
+	admin_sound.wait = 1
+	admin_sound.repeat = FALSE
+	admin_sound.status = SOUND_STREAM
+	admin_sound.volume = vol
+
+	var/list/mob/hearers = list()
+	// If non-default we need additional calculations
+	if(user.view_size.width)
+		// Info about user field of view is presented by two vars Width and Height. They can be 0, 3, 5, 7...
+		// They always have the same value.
+		// So I made this kind of calculation to present them as single number.
+		// I think it's better to put it in different proc, but now I will leave it be like this.
+		hearers = get_hearers_in_view(8 + (user.view_size.width - 1) / 2, user.mob)
+	else
+		hearers = get_hearers_in_view(8, user.mob)
+
+	log_admin("[key_name(user)] played a view-sound [sound]")
+	message_admins("[key_name_admin(user)] played a view-sound [sound]")
+
+	for(var/mob/M in hearers)
+		if(isnull(M.client))
+			continue
+		var/volume_modifier = M.client.prefs.read_preference(/datum/preference/numeric/volume/sound_midi)
+		if(volume_modifier > 0)
+			admin_sound.volume = vol * M.client.admin_music_volume * (volume_modifier/100)
+			SEND_SOUND(M, admin_sound)
+			admin_sound.volume = vol

--- a/modular_bandastation/admin/code/admin_verbs.dm
+++ b/modular_bandastation/admin/code/admin_verbs.dm
@@ -102,7 +102,7 @@ ADMIN_VERB(play_sound_in_view, R_SOUND, "Play Sound in View", "Plays a sound to 
 	log_admin("[key_name(user)] played a view-sound [sound]")
 	message_admins("[key_name_admin(user)] played a view-sound [sound]")
 
-	for(var/mob/M in hearers)
+	for(var/mob/hearer as anything in hearers)
 		if(isnull(M.client))
 			continue
 		var/volume_modifier = M.client.prefs.read_preference(/datum/preference/numeric/volume/sound_midi)

--- a/modular_bandastation/admin/code/admin_verbs.dm
+++ b/modular_bandastation/admin/code/admin_verbs.dm
@@ -111,9 +111,9 @@ ADMIN_VERB(play_sound_in_view, R_SOUND, "Play Sound in View", "Plays a sound to 
 		// They always have the same value.
 		// So I made this kind of calculation to present them as single number.
 		// I think it's better to put it in different proc, but now I will leave it be like this.
-		hearers = get_hearers_in_view(8 + (user.view_size.width - 1) / 2, user.mob)
+		hearers = get_hearers_in_view(DEFAULT_SIGHT_DISTANCE + (user.view_size.width - 1) / 2, user.mob)
 	else
-		hearers = get_hearers_in_view(8, user.mob)
+		hearers = get_hearers_in_view(DEFAULT_SIGHT_DISTANCE, user.mob)
 
 	log_admin("[key_name(user)] played a view-sound [sound]")
 	message_admins("[key_name_admin(user)] played a view-sound [sound]")


### PR DESCRIPTION

## Что этот PR делает
ПР добавляет два новых верба для воспроизведения кастомных звуков через админку.

Play Z-level Sound воспроизводит звук только на том уровне, где находится юзер.
Play Sound in View воспроизводит звук для всех мобов с клиентов в области поля зрения юзера.

Зачем нужен Play Sound in View когда есть Play Local Sound? Локальный звук имеет зависимость громкости от источника. А также он затихает за пределами 8 клеток от источника. Мой же работает на произвольное расстояние и не затихает. Полезно для массовых божественных галлюцинаций и подобного.
## Почему это хорошо для игры

Админам удобно. Меня Кону и Громбила попросили. Заодно метки добавил в файл.

## Изображения изменений

<img width="627" height="180" alt="image" src="https://github.com/user-attachments/assets/084cd813-50c3-4819-ae5f-b0911d25adb6" />
<img width="267" height="154" alt="image" src="https://github.com/user-attachments/assets/ad07dfb8-045b-4377-ae95-1fa4366514f3" />
## Тестирование

На локалочке проверил на двух клиентах.

## Changelog

:cl:
admin: Добавлено 2 новые кнопки: Play Z-level Sound и Play Sound in View
/:cl:
