### PR TITLE
Dont check skillchip on admin RCD

### DIFF
--- a/modular_bandastation/skillchip_rcd/code/skillchip_rcd.dm
+++ b/modular_bandastation/skillchip_rcd/code/skillchip_rcd.dm
@@ -23,6 +23,12 @@
 /obj/item/construction/rcd/exosuit/check_engineer_skillchip(mob/user, alert = TRUE)
 	return TRUE
 
+/obj/item/construction/rcd/combat/admin/check_engineer_skillchip(mob/user, alert = TRUE)
+	return TRUE
+
+/obj/item/construction/rcd/arcd/check_engineer_skillchip(mob/user, alert = TRUE)
+	return TRUE
+
 /obj/item/construction/rcd/examine(mob/user)
 	. = ..()
 	. += "Для полноценного использования требуется скиллчип инженера."


### PR DESCRIPTION
## Что этот PR делает
Убирает проверку скиллчипа у админ РЦД

## Почему это хорошо для игры
Щитспавн вещи

## Тестирование
Локальные тесты

## Changelog

:cl:
fix: Убрано требование скиллчипа у админ РЦД
/:cl: