### PR TITLE
Fix: Duplicating hepler changes

### DIFF
--- a/code/__HELPERS/duplicating.dm
+++ b/code/__HELPERS/duplicating.dm
@@ -81,8 +81,8 @@ GLOBAL_PROTECT(duplicate_forbidden_vars)
 			var/mob/living/carbon/copied_carbon = made_copy
 			//transfer DNA over (also body features), then update skin color.
 			original_carbon.dna.copy_dna(copied_carbon.dna)
-			copied_carbon.appearance = new /mutable_appearance(original_carbon.appearance) // BANDASTATION FIX: appearance copying
 			copied_carbon.updateappearance(mutcolor_update = TRUE)
+			copied_carbon.regenerate_icons() // BANDASTATION FIX: appearance copying
 
 		var/mob/living/original_living = original
 		var/mob/living/copied_living = made_copy

--- a/code/__HELPERS/duplicating.dm
+++ b/code/__HELPERS/duplicating.dm
@@ -65,6 +65,7 @@ GLOBAL_PROTECT(duplicate_forbidden_vars)
 		return
 
 	var/atom/made_copy = new original.type(spawning_location)
+
 	for(var/atom_vars in original.vars - GLOB.duplicate_forbidden_vars)
 		if(islist(original.vars[atom_vars]))
 			var/list/var_list = original.vars[atom_vars]
@@ -82,6 +83,7 @@ GLOBAL_PROTECT(duplicate_forbidden_vars)
 			original_carbon.dna.copy_dna(copied_carbon.dna)
 			copied_carbon.appearance = new /mutable_appearance(original_carbon.appearance) // BANDASTATION FIX: appearance copying
 			copied_carbon.updateappearance(mutcolor_update = TRUE)
+
 		var/mob/living/original_living = original
 		var/mob/living/copied_living = made_copy
 		//transfer implants, we do this so the original's implants being removed won't destroy ours.

--- a/code/__HELPERS/duplicating.dm
+++ b/code/__HELPERS/duplicating.dm
@@ -63,7 +63,7 @@ GLOBAL_PROTECT(duplicate_forbidden_vars)
 	if(!original)
 		return
 
-	var/atom/made_copy = new original.type(spawning_location)
+	var/atom/movable/made_copy = new original.type(spawning_location) // BANDASTATION FIX: copying move to new loc
 
 	for(var/atom_vars in original.vars - GLOB.duplicate_forbidden_vars)
 		if(islist(original.vars[atom_vars]))
@@ -80,8 +80,8 @@ GLOBAL_PROTECT(duplicate_forbidden_vars)
 			var/mob/living/carbon/copied_carbon = made_copy
 			//transfer DNA over (also body features), then update skin color.
 			original_carbon.dna.copy_dna(copied_carbon.dna)
+			copied_carbon.appearance = new /mutable_appearance(original_carbon.appearance) // BANDASTATION FIX: appearance copying fix
 			copied_carbon.updateappearance(mutcolor_update = TRUE)
-
 		var/mob/living/original_living = original
 		var/mob/living/copied_living = made_copy
 		//transfer implants, we do this so the original's implants being removed won't destroy ours.
@@ -91,5 +91,5 @@ GLOBAL_PROTECT(duplicate_forbidden_vars)
 		//transfer quirks, we do this because transfering the original's quirks keeps the 'owner' as the original.
 		for(var/datum/quirk/original_quirks as anything in original_living.quirks)
 			copied_living.add_quirk(original_quirks.type, announce = FALSE)
-
+	made_copy.forceMove(spawning_location) // BANDASTATION FIX: copying move to new loc
 	return made_copy

--- a/code/__HELPERS/duplicating.dm
+++ b/code/__HELPERS/duplicating.dm
@@ -9,6 +9,7 @@ GLOBAL_LIST_INIT(duplicate_forbidden_vars, list(
 	"atmos_adjacent_turfs",
 	"bodyparts",
 	"ckey",
+	"pixloc", // BANDASTATION FIX: copied atom move to correct loc
 	"client_mobs_in_contents",
 	"_listen_lookup",
 	"computer_id",
@@ -63,8 +64,7 @@ GLOBAL_PROTECT(duplicate_forbidden_vars)
 	if(!original)
 		return
 
-	var/atom/movable/made_copy = new original.type(spawning_location) // BANDASTATION FIX: copied atom move to correct loc
-
+	var/atom/made_copy = new original.type(spawning_location)
 	for(var/atom_vars in original.vars - GLOB.duplicate_forbidden_vars)
 		if(islist(original.vars[atom_vars]))
 			var/list/var_list = original.vars[atom_vars]
@@ -91,5 +91,5 @@ GLOBAL_PROTECT(duplicate_forbidden_vars)
 		//transfer quirks, we do this because transfering the original's quirks keeps the 'owner' as the original.
 		for(var/datum/quirk/original_quirks as anything in original_living.quirks)
 			copied_living.add_quirk(original_quirks.type, announce = FALSE)
-	made_copy.forceMove(spawning_location) // BANDASTATION FIX: copied atom move to correct loc
+
 	return made_copy

--- a/code/__HELPERS/duplicating.dm
+++ b/code/__HELPERS/duplicating.dm
@@ -63,7 +63,7 @@ GLOBAL_PROTECT(duplicate_forbidden_vars)
 	if(!original)
 		return
 
-	var/atom/movable/made_copy = new original.type(spawning_location) // BANDASTATION FIX: copying move to new loc
+	var/atom/movable/made_copy = new original.type(spawning_location) // BANDASTATION FIX: copied atom move to correct loc
 
 	for(var/atom_vars in original.vars - GLOB.duplicate_forbidden_vars)
 		if(islist(original.vars[atom_vars]))
@@ -80,7 +80,7 @@ GLOBAL_PROTECT(duplicate_forbidden_vars)
 			var/mob/living/carbon/copied_carbon = made_copy
 			//transfer DNA over (also body features), then update skin color.
 			original_carbon.dna.copy_dna(copied_carbon.dna)
-			copied_carbon.appearance = new /mutable_appearance(original_carbon.appearance) // BANDASTATION FIX: appearance copying fix
+			copied_carbon.appearance = new /mutable_appearance(original_carbon.appearance) // BANDASTATION FIX: appearance copying
 			copied_carbon.updateappearance(mutcolor_update = TRUE)
 		var/mob/living/original_living = original
 		var/mob/living/copied_living = made_copy
@@ -91,5 +91,5 @@ GLOBAL_PROTECT(duplicate_forbidden_vars)
 		//transfer quirks, we do this because transfering the original's quirks keeps the 'owner' as the original.
 		for(var/datum/quirk/original_quirks as anything in original_living.quirks)
 			copied_living.add_quirk(original_quirks.type, announce = FALSE)
-	made_copy.forceMove(spawning_location) // BANDASTATION FIX: copying move to new loc
+	made_copy.forceMove(spawning_location) // BANDASTATION FIX: copied atom move to correct loc
 	return made_copy


### PR DESCRIPTION
## Что этот PR делает
Фиксит местоположение скопированного объекта а так же позволяет копировать ВНЕШНИЙ ВИД карбонов используя дропподы и билдмод-копирование.
## Почему это хорошо для игры
Копирование работает корректно
## Тестирование
Создание дубликатов мобов с одинаковой внешкой, дублирование объектов.
## Changelog

:cl: Ez-Briz
fix: Модуль копирования в билдмоде теперь корректно копирует мобов и ставит новые объекты в корректное место.
/:cl:
