### PR TITLE
BALANCE: buffs the spess vines

### DIFF
--- a/code/modules/events/space_vines/vine_controller.dm
+++ b/code/modules/events/space_vines/vine_controller.dm
@@ -124,9 +124,9 @@ GLOBAL_LIST_INIT(vine_mutations_list, init_vine_mutation_list())
 		return
 
 	/// Bonus spread for kudzu that has just started out (ie. with low vine count)
-	var/start_spread_bonus = max(5 - spread_multiplier * (vine_count ** 2) / 400, 0)
+	var/start_spread_bonus = max(20 - spread_multiplier * (vine_count ** 2) / 800, 0) //  BANDASTATION EDIT. ORIGINAL: max(5 - spread_multiplier * (vine_count ** 2) / 400, 0) (BALANCE: buffs the spess vines)
 	/// Base spread rate, depends solely on spread multiplier and vine count
-	var/spread_base = 0.5 * vine_count / spread_multiplier
+	var/spread_base = 1 * vine_count / spread_multiplier //  BANDASTATION EDIT. ORIGINAL: 0.5 * vine_count / spread_multiplier (BALANCE: buffs the spess vines)
 	/// Actual maximum spread rate for this process tick
 	var/spread_max = round(clamp(seconds_per_tick * (spread_base + start_spread_bonus), max(seconds_per_tick * minimum_spread_rate, 1), spread_cap))
 	var/amount_processed = 0


### PR DESCRIPTION
## Что этот PR делает

Меняет циферки в двух строчках чтобы космо лоза росла шустрей.
Циферки смотрите в коде.
Видео не будет, ибо у меня чёт не работает жифорс экспирианс.

Скорость роста лозы выросла в 2 раза
Начальное количество лозы выросло в 4 раза

## Почему это хорошо для игры

Лоза КРАЙНЕ медленно растёт, её в начале может уничтожить любой ассистент со сваркой(про косу я молчу).
Мой ПР делает лозу более живучей при старте.

## Тестирование

Локалочка, лоза растёт быстрей чем раньше.

## Changelog

:cl:
balance: Лоза теперь быстрей растёт, особенно при её появлении
/:cl:

