### PR TITLE
Save map state every second

### DIFF
--- a/tgui/packages/tgui/interfaces/common/NanoMap.tsx
+++ b/tgui/packages/tgui/interfaces/common/NanoMap.tsx
@@ -19,6 +19,7 @@ import {
 import { Button, Image, Stack } from 'tgui-core/components';
 import { clamp01 } from 'tgui-core/math';
 import { type BooleanLike, classes } from 'tgui-core/react';
+import { throttle } from 'tgui-core/timer';
 import { resolveAsset } from '../../assets';
 import { Direction } from '../../constants';
 
@@ -170,8 +171,9 @@ export function NanoMap(props: Props) {
         wheel={{ step: defaultScale }}
         doubleClick={{ disabled: true }}
         panning={{ velocityDisabled: true }}
-        onWheel={handleTransformed}
-        onPanningStop={handleTransformed}
+        onTransformed={throttle((state) => {
+          handleTransformed(state);
+        }, 1000)} // Saving 1 time at a second, let's not fuck localState
       >
         <Stack
           fill


### PR DESCRIPTION
## Что этот PR делает
Состояние наномапы теперь сохраняется раз в секунду, при любом взаимодействии с ней (зум, перетаскивание, любая анимация)

## Почему это хорошо для игры
Состояние всегда сохраняется и обновляется
Грустно что нет встроенного пропса в react zoom pan pinch, но думаю throttle тоже сойдёт, не должно ебать локал сторыгу
