### PR TITLE
Fix: No more galactic map next to the stairs in library

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -26375,7 +26375,6 @@
 	c_tag = "Library - South";
 	dir = 2
 	},
-/obj/structure/statue/gold/galactic_map,
 /turf/open/floor/wood,
 /area/station/service/library)
 "gwp" = (

--- a/modular_bandastation/galactic_map/code/galactic_map.dm
+++ b/modular_bandastation/galactic_map/code/galactic_map.dm
@@ -11,3 +11,8 @@
 		ui = new(user, src, "GalacticMap")
 		ui.set_autoupdate(FALSE)
 		ui.open()
+
+/datum/area_spawn/galactic_map
+	target_areas = list(/area/station/service/library)
+	desired_atom = /obj/structure/statue/gold/galactic_map
+	mode = AREA_SPAWN_MODE_HUG_WALL

--- a/modular_bandastation/galactic_map/code/galactic_map.dm
+++ b/modular_bandastation/galactic_map/code/galactic_map.dm
@@ -11,8 +11,3 @@
 		ui = new(user, src, "GalacticMap")
 		ui.set_autoupdate(FALSE)
 		ui.open()
-
-/datum/area_spawn/galactic_map
-	target_areas = list(/area/station/service/library)
-	desired_atom = /obj/structure/statue/gold/galactic_map
-	mode = AREA_SPAWN_MODE_HUG_WALL


### PR DESCRIPTION

## Что этот PR делает
Убирает лишний объект, на его место идёт уже существующий автомаппер.
## Почему это хорошо для игры
Лестница is free again
## Изображения изменений
### До:
<img width="728" height="905" alt="image" src="https://github.com/user-attachments/assets/d6f4b4f1-afa1-4758-8762-9a6a6b36a526" />

### После:
<img width="1206" height="984" alt="image" src="https://github.com/user-attachments/assets/b2f634f8-c7f6-436a-8348-4450bd85ecae" />
## Тестирование
Загрузил, прогрузил, выгрузил, потом сбилдил, повторил, короче ворк
## Changelog

:cl:
map: Убрана галактическая карта в библиотеке кибериады, на место которой теперь идёт автомапер. Лестница в библиотеке кибериады больше не заблокирована.
/:cl:
