### PR TITLE
Randomize TTS on mob randomize

### DIFF
--- a/code/modules/admin/create_mob.dm
+++ b/code/modules/admin/create_mob.dm
@@ -30,6 +30,9 @@
 	// Snowflake for Ethereals
 	human.updatehealth()
 	human.updateappearance(mutcolor_update = TRUE)
+	// BANDASTATION ADD Start - TTS
+	human.AddComponent(/datum/component/tts_component)
+	// BANDASTATION ADD End - TTS
 
 /**
  * Randomizes a human, but produces someone who looks exceedingly average (by most standards).

--- a/code/modules/admin/create_mob.dm
+++ b/code/modules/admin/create_mob.dm
@@ -62,3 +62,6 @@
 	human.updatehealth()
 	if(update_body)
 		human.updateappearance(mutcolor_update = TRUE)
+	// BANDASTATION ADD Start - TTS
+	human.AddComponent(/datum/component/tts_component)
+	// BANDASTATION ADD End - TTS


### PR DESCRIPTION
## Что этот PR делает
Добавляет рандомизацию ТТС при рандомизации моба

## Почему это хорошо для игры
Ну.. логично

## Тестирование
Локальные тесты

## Changelog

:cl:
add: ТТС рандомизируется при рандомизации моба
/:cl: