### PR TITLE
Balance: Plasmaman brute damage modifier

### DIFF
--- a/modular_bandastation/balance/_balance.dme
+++ b/modular_bandastation/balance/_balance.dme
@@ -28,6 +28,7 @@
 #include "code/weapons/baton.dm"
 #include "code/weapons/rifle.dm"
 #include "code/wounds/cranial_fissure.dm"
+#include "code/bodyparts/plasmaman_limbs.dm"
 #include "code/mod_types.dm"
 #include "code/tools.dm"
 

--- a/modular_bandastation/balance/code/bodyparts/plasmaman_limbs.dm
+++ b/modular_bandastation/balance/code/bodyparts/plasmaman_limbs.dm
@@ -1,0 +1,17 @@
+/obj/item/bodypart/arm/left/plasmaman
+    brute_modifier = 0.9
+
+/obj/item/bodypart/arm/right/plasmaman
+    brute_modifier = 0.9
+
+/obj/item/bodypart/head/plasmaman
+    brute_modifier = 0.9
+
+/obj/item/bodypart/leg/left/plasmaman
+    brute_modifier = 0.9
+
+/obj/item/bodypart/leg/right/plasmaman
+    brute_modifier = 0.9
+
+/obj/item/bodypart/chest/plasmaman
+    brute_modifier = 0.9


### PR DESCRIPTION
## Что этот PR делает

Модульно заменяет модификатор брут урона у плазмаменом с 1.5 до 0.9, как написано в особенностях расы

## Почему это хорошо для игры

Плазмамены теперь не будут умирать от двух выстрелов ансема

## Изображения изменений
Странно видеть особенность меньше урона от брута, но у все конечности плазмача получают в 1.5 раза больше урона 
<img width="285" height="189" alt="plasmastas" src="https://github.com/user-attachments/assets/e6cf30d0-c6d3-4d2e-84f7-bc9989e5ffdd" />


## Тестирование

Локалка

## Changelog

:cl:

balance: Раса плазмаменов больше не получает в 1.5 раза больше урона от брута. Теперь значение модификатора - 0.9

/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
