### PR TITLE
Two hand requirement to carry flatpack

### DIFF
--- a/code/game/objects/items/flatpacks.dm
+++ b/code/game/objects/items/flatpacks.dm
@@ -26,6 +26,7 @@
 			),
 		)
 	AddElement(/datum/element/contextual_screentip_tools, tool_behaviors)
+	AddComponent(/datum/component/two_handed, require_twohands = TRUE)
 
 	board = !isnull(new_board) ? new_board : new board(src) // i got board
 	if(board.loc != src)

--- a/code/game/objects/items/flatpacks.dm
+++ b/code/game/objects/items/flatpacks.dm
@@ -26,7 +26,7 @@
 			),
 		)
 	AddElement(/datum/element/contextual_screentip_tools, tool_behaviors)
-	AddComponent(/datum/component/two_handed, require_twohands = TRUE)
+	AddComponent(/datum/component/two_handed, require_twohands = TRUE) // BANDASTATION Addition
 
 	board = !isnull(new_board) ? new_board : new board(src) // i got board
 	if(board.loc != src)


### PR DESCRIPTION
## Что этот PR делает

Теперь нужно носить флатпак в двух руках
Взял строчку с кода цветочка
closes #1836 

## Почему это хорошо для игры

Выглядит логично с учётом размера 

## Изображения изменений

<img width="124" height="85" alt="image" src="https://github.com/user-attachments/assets/ffa55c3a-eb39-40a8-b0d7-b7b8a887e1ff" />
<img width="125" height="86" alt="image" src="https://github.com/user-attachments/assets/45ff7304-9001-44f3-a970-93a92d8f5eb4" />
Фича с обёрткой осталась. Никому не говорите

## Тестирование

Скопировал строчку с кода цветочка, вставил в код флатпака.
Взял в руку флатпак, а оно требует вторую. Дела...

## Changelog

:cl:
balance: Теперь флатпак требует две руки для переноски
/:cl: