### PR TITLE
Self examine translate fix

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -124,7 +124,7 @@
 	var/bleed_overlay_icon
 
 	//Damage messages used by help_shake_act()
-	var/light_brute_msg = "ушибленной и болит"
+	var/light_brute_msg = "ушибленной"
 	var/medium_brute_msg = "потрёпанной"
 	var/heavy_brute_msg = "искалеченной"
 

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -125,12 +125,12 @@
 
 	//Damage messages used by help_shake_act()
 	var/light_brute_msg = "ушибленной и болит"
-	var/medium_brute_msg = "побитой"
-	var/heavy_brute_msg = "словно отслаивается"
+	var/medium_brute_msg = "потрёпанной"
+	var/heavy_brute_msg = "искалеченной"
 
 	var/light_burn_msg = "покрасневшей и онемевшей"
 	var/medium_burn_msg = "покрытой волдырями"
-	var/heavy_burn_msg = "отслаивает кожу"
+	var/heavy_burn_msg = "отслаивающей кожу"
 
 	//Damage messages used by examine(). the desc that is most common accross all bodyparts gets shown
 	var/list/damage_examines = list(
@@ -326,7 +326,7 @@
 
 	if(self_aware)
 		if(!shown_brute && !shown_burn)
-			status = "нет повреждений"
+			status = "ноль повреждений"
 		else
 			status = "[shown_brute] урона от ушибов и [shown_burn] урона от ожогов"
 
@@ -352,7 +352,7 @@
 			status = "невредимой"
 
 	var/no_damage
-	if(status == "невредимой" || status == "нет повреждений")
+	if(status == "невредимой" || status == "ноль повреждений")
 		no_damage = TRUE
 
 	var/is_disabled = ""

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -124,12 +124,12 @@
 	var/bleed_overlay_icon
 
 	//Damage messages used by help_shake_act()
-	var/light_brute_msg = "ушиблена и болит"
-	var/medium_brute_msg = "избита"
+	var/light_brute_msg = "ушибленной и болит"
+	var/medium_brute_msg = "побитой"
 	var/heavy_brute_msg = "словно отслаивается"
 
-	var/light_burn_msg = "покраснела и онемела"
-	var/medium_burn_msg = "покрыта волдырями"
+	var/light_burn_msg = "покрасневшей и онемевшей"
+	var/medium_burn_msg = "покрытой волдырями"
 	var/heavy_burn_msg = "отслаивает кожу"
 
 	//Damage messages used by examine(). the desc that is most common accross all bodyparts gets shown
@@ -326,7 +326,7 @@
 
 	if(self_aware)
 		if(!shown_brute && !shown_burn)
-			status = "никаких повреждений"
+			status = "нет повреждений"
 		else
 			status = "[shown_brute] урона от ушибов и [shown_burn] урона от ожогов"
 
@@ -349,10 +349,10 @@
 			status += light_burn_msg
 
 		if(status == "")
-			status = "в порядке"
+			status = "невредимой"
 
 	var/no_damage
-	if(status == "в порядке" || status == "нет повреждений")
+	if(status == "невредимой" || status == "нет повреждений")
 		no_damage = TRUE
 
 	var/is_disabled = ""


### PR DESCRIPTION
## Что этот PR делает
Фиксит перевод самоосмотра.

## Почему это хорошо для игры
Текстик получше в окошечке.

## Изображения изменений
<img width="637" height="146" alt="image" src="https://github.com/user-attachments/assets/27667bfc-f257-48d7-913c-ad5465809ab3" />

## Тестирование
Локалочка

## Changelog

:cl:
translation: Больше не будет никаких "Ваша левая нога выглядит в порядке" при осмотре самого себя
/:cl: