### PR TITLE
remove: remove stupid fishing sources

### DIFF
--- a/code/game/objects/structures/maintenance.dm
+++ b/code/game/objects/structures/maintenance.dm
@@ -39,12 +39,15 @@ at the cost of risking a vicious bite.**/
 		var/picked_item = pick_weight(loot_table)
 		hidden_item = new picked_item(src)
 
+	/* BANDASTATION REMOVAL START - Stupid TG Shit
 	var/datum/fish_source/moisture_trap/fish_source = new
 	if(prob(50)) // 50% chance there's another item to fish out of there
 		var/picked_item = pick_weight(loot_table)
 		fish_source.fish_table[picked_item] = 5
 		fish_source.fish_counts[picked_item] = 1;
+
 	AddComponent(/datum/component/fishing_spot, fish_source)
+	BANDASTATION REMOVAL END */
 
 
 /obj/structure/moisture_trap/Destroy()

--- a/code/game/objects/structures/water_structures/toilet.dm
+++ b/code/game/objects/structures/water_structures/toilet.dm
@@ -42,8 +42,10 @@
 	if(!isnull(has_water_reclaimer))
 		src.has_water_reclaimer = has_water_reclaimer
 	update_appearance(UPDATE_ICON)
+	/* BANDASTATION REMOVAL START - Stupid TG Shit
 	if(mapload && SSmapping.level_trait(z, ZTRAIT_STATION))
 		AddComponent(/datum/component/fishing_spot, GLOB.preset_fish_sources[/datum/fish_source/toilet])
+	BANDASTATION REMOVAL START - Stupid TG Shit */
 	AddElement(/datum/element/fish_safe_storage)
 	register_context()
 	create_reagents(reagent_capacity)

--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -181,7 +181,9 @@
 
 	AddElement(/datum/element/block_turf_fingerprints)
 	AddComponent(/datum/component/redirect_attack_hand_from_turf, interact_check = CALLBACK(src, PROC_REF(verify_user_can_see)))
+	/* BANDASTATION REMOVAL START - Stupid TG Shit
 	AddComponent(/datum/component/fishing_spot, GLOB.preset_fish_sources[/datum/fish_source/dimensional_rift])
+	BANDASTATION REMOVAL END */
 
 /obj/effect/heretic_influence/proc/verify_user_can_see(mob/user)
 	return (user.mind in GLOB.reality_smash_track.tracked_heretics)

--- a/code/modules/antagonists/space_dragon/carp_rift.dm
+++ b/code/modules/antagonists/space_dragon/carp_rift.dm
@@ -111,7 +111,9 @@
 		healing_color = COLOR_BLUE, \
 	)
 
+	/* BANDASTATION REMOVAL START - Stupid TG Shit
 	AddComponent(/datum/component/fishing_spot, /datum/fish_source/carp_rift)
+	BANDASTATION REMOVAL END */
 
 	gravity_aura = new(
 		/* host = */src,

--- a/code/modules/vending/vendor/_vending.dm
+++ b/code/modules/vending/vendor/_vending.dm
@@ -241,8 +241,10 @@
 		AddComponent(/datum/component/payment, 0, SSeconomy.get_dep_account(payment_department), PAYMENT_VENDING)
 	register_context()
 
+	/* BANDASTATION REMOVAL START - Stupid TG Shit
 	if(fish_source_path)
 		AddComponent(/datum/component/fishing_spot, fish_source_path)
+	BANDASTATION REMOVAL END */
 
 /obj/machinery/vending/atom_break(damage_flag)
 	. = ..()


### PR DESCRIPTION
## Что этот PR делает

Удаляет рыбалку из:
- унитазов
- влагосборников
- карповых разломов
- скрытого портала еретика
- вендоматов

## Почему это хорошо для игры

Засуньте свою рыбалку в анусах себе в анус

## Changelog

:cl:
del: Удаляет рыбалку из: унитазов, влагосборников, карповых разломов, скрытого портала еретика, вендоматов
/:cl:
