### PR TITLE
Remove custodial key from uplink

### DIFF
--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -925,7 +925,6 @@
 		you need before he gets back. And remember: DON'T TELL ANYONE! -M.T"
 	item = /obj/item/keycard/syndicate_fridge
 	purchasable_from = UPLINK_CLOWN_OPS | UPLINK_NUKE_OPS
-*/
 
 /datum/uplink_item/base_keys/custodial_key
 	name = "Syndicate Custodial Access Card"
@@ -933,6 +932,7 @@
 	with some janitorial supplies and an canister of water vapour."
 	item = /obj/item/keycard/syndicate_custodial
 	purchasable_from = UPLINK_CLOWN_OPS | UPLINK_NUKE_OPS
+*/
 
 // Hats
 // It is fundamental for the game's health for there to be a hat crate for nuclear operatives.


### PR DESCRIPTION
## Что этот PR делает
Удаляет из аплинка ключ от уборочных помещенией, т.к на нашей базе их нет.

## Почему это хорошо для игры
Забыли удалить

## Changelog

:cl:
fix: Из аплинка нюки удален ключ от уборочных помещенией
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
