### PR TITLE
Auto gamma level on war

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -90,6 +90,8 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 		to_chat(user, "You've attracted the attention of powerful forces within the syndicate. \
 			A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission.")
 
+	SSsecurity_level.set_level(SEC_LEVEL_GAMMA) // BANDASTATION ADD
+
 	distribute_tc()
 	CONFIG_SET(number/shuttle_refuel_delay, max(CONFIG_GET(number/shuttle_refuel_delay), CHALLENGE_SHUTTLE_DELAY))
 	SSblackbox.record_feedback("amount", "nuclear_challenge_mode", 1)


### PR DESCRIPTION
## Что этот PR делает
При объявлении войны ставится гамма код

## Почему это хорошо для игры
Админам не нужно ставить ручками

## Changelog

:cl:
add: При объявлении войны автоматически ставится гамма код
/:cl: