### PR TITLE
Move map vote to round end

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -257,6 +257,7 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 
 	handle_hearts()
 	set_observer_default_invisibility(0, span_warning("Раунд закончился! Вы теперь видны для живых."))
+	INVOKE_ASYNC(SSvote, TYPE_PROC_REF(/datum/controller/subsystem/vote, initiate_vote), /datum/vote/map_vote, vote_initiator_name = "Map Rotation", forced = TRUE) // BANDASTATION ADD - move to roundend
 
 	CHECK_TICK
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -815,6 +815,10 @@ SUBSYSTEM_DEF(ticker)
 
 	if(!delay)
 		delay = CONFIG_GET(number/round_end_countdown) * 10
+		// BANDASTATION ADD Start - roundend vote
+		var/vote_time = CONFIG_GET(number/vote_period)
+		delay = vote_time > delay ? vote_time * 1.5 : delay
+		// BANDASTATION ADD End - roundend vote
 
 	var/skip_delay = check_rights()
 	if(delay_end && !skip_delay)

--- a/code/modules/shuttle/mobile_port/variants/emergency/emergency.dm
+++ b/code/modules/shuttle/mobile_port/variants/emergency/emergency.dm
@@ -233,7 +233,7 @@
 					color_override = "orange",
 				)
 				INVOKE_ASYNC(SSticker, TYPE_PROC_REF(/datum/controller/subsystem/ticker, poll_hearts))
-				INVOKE_ASYNC(SSvote, TYPE_PROC_REF(/datum/controller/subsystem/vote, initiate_vote), /datum/vote/map_vote, vote_initiator_name = "Map Rotation", forced = TRUE)
+				// INVOKE_ASYNC(SSvote, TYPE_PROC_REF(/datum/controller/subsystem/vote, initiate_vote), /datum/vote/map_vote, vote_initiator_name = "Map Rotation", forced = TRUE) // BANDASTATION REMOVE - move to roundend
 
 				if(!is_reserved_level(z))
 					CRASH("Emergency shuttle did not move to transit z-level!")


### PR DESCRIPTION
## Что этот PR делает
Перемещает голосование за карту в конец раунда, чтобы если раунд закончился без отлета шаттла голосование все равно было.

## Почему это хорошо для игры
Можно голосовать за карту при уничтожении станции

## Changelog

:cl:
add: Голосование за карту теперь после конца раунда
/:cl: