### PR TITLE
Fix blackout 2

### DIFF
--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -92,6 +92,7 @@
 	// qdel the mob with the temporary component will ensure the original mind will go back into the body and vice versa for the stranger mind
 	if(!temp_component)
 		stranger_backseat?.ghostize()
+	switch_personalities(reset_to_owner = TRUE) // BANDASTATION ADD
 	QDEL_NULL(stranger_backseat)
 	QDEL_NULL(owner_backseat)
 	..()

--- a/modular_bandastation/ssd_indicator/code/ssd_indicator.dm
+++ b/modular_bandastation/ssd_indicator/code/ssd_indicator.dm
@@ -95,7 +95,8 @@ GLOBAL_VAR_INIT(ssd_indicator_overlay, mutable_appearance('modular_bandastation/
 	handle_detach(source)
 
 /mob/living/Logout()
-	AddElement(/datum/element/ssd)
+	if(!QDELETED(src))
+		AddElement(/datum/element/ssd)
 	. = ..()
 
 /mob/living


### PR DESCRIPTION
## Что этот PR делает
Второй фикс алкогольного развоения личности, теперь оригинальный владелец не должен оставаться в гостах

## Тестирование
Локальные тесты

## Changelog

:cl:
fix: Алкогольное развоения личности больше не оставляет оригинального владельца тела в гостах
/:cl: