### PR TITLE
HOP quarters remote access

### DIFF
--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -43,7 +43,7 @@
 	if(!isnull(owner_trim))
 		var/datum/id_trim/job/trim_singlet = SSid_access.trim_singletons_by_path[owner_trim]
 		access_list |= trim_singlet.access
-		access_list |= trim_singlet.wildcard_access
+		access_list |= trim_singlet.wildcard_access // BANDASTATION ADDITION - Door remote access fix
 
 /obj/item/door_remote/proc/is_my_domain(area/restricted_area)
 	for(var/area/dominion as anything in our_domain)


### PR DESCRIPTION

## Что этот PR делает

Добавляет Главе Персонала утерянный доступ к кабинету на ремоутер
## Почему это хорошо для игры
Глава Персонала может теперь открывать свой кабинет пультиком. Удобно.
## Изображения изменений
А их нет. Уви.
## Тестирование
На локалке проверил, дверки открывает. Ура-ура.
## Changelog

:cl:
fix: Добавлен доступ к кабинету ГП в массив доступов ремоутера ГП
/:cl:
