### PR TITLE
nuclear disk not teleported when skrell headpocket is removed from the head, headpocket contents is dropped on removal from the head

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -471,9 +471,7 @@
 		if(owner)
 			bodypart_organ.Remove(bodypart_organ.owner)
 		else
-			if(bodypart_organ.bodypart_remove(src))
-				if(drop_loc) //can be null if being deleted
-					bodypart_organ.forceMove(get_turf(drop_loc))
+			bodypart_organ.bodypart_remove(src, drop_location = get_turf(drop_loc)) // BANDASTATION ADDITION - Don't move organs to nullspace to move later
 
 	if(drop_loc) //can be null during deletion
 		for(var/atom/movable/movable as anything in src)

--- a/code/modules/surgery/organs/organ_movement.dm
+++ b/code/modules/surgery/organs/organ_movement.dm
@@ -217,7 +217,7 @@
 
 /// Called to remove an organ from a limb. Do not put any mob operations here (except the bodypart_getter at the start)
 /// Give EITHER a limb OR a limb_owner
-/obj/item/organ/proc/bodypart_remove(obj/item/bodypart/limb, mob/living/carbon/limb_owner, movement_flags)
+/obj/item/organ/proc/bodypart_remove(obj/item/bodypart/limb, mob/living/carbon/limb_owner, movement_flags, atom/drop_location) // BANDASTATION ADDITION - Don't move organs to nullspace to move later: (atom/drop_location)
 	SHOULD_CALL_PARENT(TRUE)
 
 	if(!isnull(limb_owner))
@@ -225,9 +225,14 @@
 
 	UnregisterSignal(src, COMSIG_MOVABLE_MOVED) //DONT MOVE THIS!!!! we moves the organ right after, so we unregister before we move them physically
 
+	// BANDASTATION ADDITION START - Don't move organs to nullspace to move later
 	// The true movement is here
-	moveToNullspace()
+	if(drop_location)
+		forceMove(drop_location)
+	else
+		moveToNullspace()
 	bodypart_owner = null
+	// BANDASTATION ADDITION END - Don't move organs to nullspace to move later
 
 	on_bodypart_remove(limb)
 

--- a/modular_bandastation/species/code/surgery/organs/external/skrell_external.dm
+++ b/modular_bandastation/species/code/surgery/organs/external/skrell_external.dm
@@ -27,6 +27,10 @@
 	. = ..()
 	atom_storage.open_storage(user)
 
+/obj/item/organ/head_tentacle/on_bodypart_remove(obj/item/bodypart/limb, movement_flags)
+	. = ..()
+	atom_storage.remove_all()
+
 // MARK: Action
 
 /datum/action/item_action/organ_action/headpocket


### PR DESCRIPTION
## Что этот PR делает

closes https://github.com/ss220club/BandaStation/issues/1918

Ядерный диск не убегают из кармашка в тентаклях скрелла при вскрытии головы
Содержимое кармашка скрелла выпадает при вскрытии головы

## Почему это хорошо для игры

Баги плохо

## Тестирование
Локально протестировал. Всё работает как надо

:cl:
add: Содержимое кармашка скрелла выпадает при вскрытии головы
fix: Ядерный диск не убегают из кармашка в тентаклях скрелла при вскрытии головы
/:cl:
