### PR TITLE
Fix broken lobby online when too much players

### DIFF
--- a/modular_bandastation/title_screen/html/title_screen_default.css
+++ b/modular_bandastation/title_screen/html/title_screen_default.css
@@ -329,7 +329,7 @@ html.loading {
   top: 0.5rem;
   right: 0.5rem;
   gap: 0.5rem;
-  width: 15rem;
+  width: 230px;
   transition: transform var(--transition-time);
   z-index: 2;
 
@@ -359,6 +359,7 @@ html.loading {
     width: 100%;
 
     td {
+      white-space: nowrap;
       padding: 0;
 
       &:last-child {


### PR DESCRIPTION
## Что этот PR делает
Количество игроков в лобби больше не будет ломаться, если игроков слишком много

## Изображения изменений
<img width="254" height="147" alt="image" src="https://github.com/user-attachments/assets/39e53b90-a9cf-4cac-abfa-d69b195c3f74" />

## Changelog

:cl:
fix: Количество игроков в лобби больше не должно съезжать, если цифры уходят в трёхначные значение (мы такое не предусмотрели)
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
