### PR TITLE
Add new OOC chat glowing

### DIFF
--- a/modular_bandastation/chat/code/badges.dm
+++ b/modular_bandastation/chat/code/badges.dm
@@ -21,8 +21,8 @@ GLOBAL_LIST(badge_icons_cache)
 	if(donor_tier && prefs.read_preference(/datum/preference/toggle/donor_public) || prefs.is_byond_member && (prefs.toggles & MEMBER_PUBLIC))
 		var/selected_pref = GLOB.donor_shines[prefs.read_preference(/datum/preference/choiced/donor_chat_effect)]
 		var/donor_color = prefs.read_preference(/datum/preference/color/ooc_color) || GLOB.normal_ooc_colour
-		var/donor_shine = donor_tier >= 3 && selected_pref ? "class='tier-[donor_tier] [selected_pref]'" : FALSE
-		parts += "<span [donor_shine || ""] style='[donor_shine ? "--shine-color: [donor_color];" : "color: [donor_color];"]'>[key]</span>"
+		var/donor_shine = donor_tier >= 3 && selected_pref ? "class='tier-[donor_tier] [selected_pref]'" : ""
+		parts += "<span [donor_shine] style='[donor_shine ? "--shine-color: [donor_color];" : "color: [donor_color];"]'>[key]</span>"
 	else
 		parts += "[key]"
 

--- a/modular_bandastation/chat/code/badges.dm
+++ b/modular_bandastation/chat/code/badges.dm
@@ -20,7 +20,7 @@ GLOBAL_LIST(badge_icons_cache)
 
 	if(donor_tier && prefs.read_preference(/datum/preference/toggle/donor_public) || prefs.is_byond_member && (prefs.toggles & MEMBER_PUBLIC))
 		var/donor_color = prefs.read_preference(/datum/preference/color/ooc_color) || GLOB.normal_ooc_colour
-		var/donor_shine = "class='tier-[donor_tier] [GLOB.donor_shines[prefs.read_preference(/datum/preference/choiced/donor_chat_shine)]]'"
+		var/donor_shine = "class='tier-[donor_tier] [GLOB.donor_shines[prefs.read_preference(/datum/preference/choiced/donor_chat_effect)]]'"
 		parts += "<span [donor_shine] style='[donor_shine ? "--shine-color: [donor_color];" : "color: [donor_color];"]'>[key]</span>"
 	else
 		parts += "[key]"

--- a/modular_bandastation/chat/code/badges.dm
+++ b/modular_bandastation/chat/code/badges.dm
@@ -19,7 +19,7 @@ GLOBAL_LIST(badge_icons_cache)
 		parts += badge_parts
 
 	if(donor_tier && prefs.read_preference(/datum/preference/toggle/donor_public) || prefs.is_byond_member && (prefs.toggles & MEMBER_PUBLIC))
-		var/selected_pref = GLOB.donor_shines[prefs.read_preference(/datum/preference/choiced/donor_chat_effect)]
+		var/selected_pref = GLOB.donor_chat_effects[prefs.read_preference(/datum/preference/choiced/donor_chat_effect)]
 		var/donor_color = prefs.read_preference(/datum/preference/color/ooc_color) || GLOB.normal_ooc_colour
 		var/donor_shine = donor_tier >= 3 && selected_pref ? "class='tier-[donor_tier] [selected_pref]'" : ""
 		parts += "<span [donor_shine] style='[donor_shine ? "--shine-color: [donor_color];" : "color: [donor_color];"]'>[key]</span>"

--- a/modular_bandastation/chat/code/badges.dm
+++ b/modular_bandastation/chat/code/badges.dm
@@ -19,9 +19,10 @@ GLOBAL_LIST(badge_icons_cache)
 		parts += badge_parts
 
 	if(donor_tier && prefs.read_preference(/datum/preference/toggle/donor_public) || prefs.is_byond_member && (prefs.toggles & MEMBER_PUBLIC))
+		var/selected_pref = GLOB.donor_shines[prefs.read_preference(/datum/preference/choiced/donor_chat_effect)]
 		var/donor_color = prefs.read_preference(/datum/preference/color/ooc_color) || GLOB.normal_ooc_colour
-		var/donor_shine = "class='tier-[donor_tier] [GLOB.donor_shines[prefs.read_preference(/datum/preference/choiced/donor_chat_effect)]]'"
-		parts += "<span [donor_shine] style='[donor_shine ? "--shine-color: [donor_color];" : "color: [donor_color];"]'>[key]</span>"
+		var/donor_shine = donor_tier >= 3 && selected_pref ? "class='tier-[donor_tier] [selected_pref]'" : FALSE
+		parts += "<span [donor_shine || ""] style='[donor_shine ? "--shine-color: [donor_color];" : "color: [donor_color];"]'>[key]</span>"
 	else
 		parts += "[key]"
 

--- a/modular_bandastation/chat/code/badges.dm
+++ b/modular_bandastation/chat/code/badges.dm
@@ -20,7 +20,7 @@ GLOBAL_LIST(badge_icons_cache)
 
 	if(donor_tier && prefs.read_preference(/datum/preference/toggle/donor_public) || prefs.is_byond_member && (prefs.toggles & MEMBER_PUBLIC))
 		var/donor_color = prefs.read_preference(/datum/preference/color/ooc_color) || GLOB.normal_ooc_colour
-		var/donor_shine = donor_tier >= 3 && prefs.read_preference(/datum/preference/toggle/donor_chat_shine) ? "class='shine'" : ""
+		var/donor_shine = "class='tier-[donor_tier] [GLOB.donor_shines[prefs.read_preference(/datum/preference/choiced/donor_chat_shine)]]'"
 		parts += "<span [donor_shine] style='[donor_shine ? "--shine-color: [donor_color];" : "color: [donor_color];"]'>[key]</span>"
 	else
 		parts += "[key]"

--- a/modular_bandastation/chat/code/chat_preferences.dm
+++ b/modular_bandastation/chat/code/chat_preferences.dm
@@ -1,11 +1,22 @@
+GLOBAL_LIST_INIT(donor_shines, list(
+	"Автоматически" = "auto",
+	"Металлик" = "metal",
+	"Светящийся" = "glowing",
+))
+
+/datum/preference/choiced/donor_chat_shine
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "donor_chat_shine"
+	savefile_identifier = PREFERENCE_PLAYER
+
+/datum/preference/choiced/donor_chat_shine/init_possible_values()
+	return assoc_to_keys(GLOB.donor_shines)
+
+/datum/preference/choiced/donor_chat_shine/create_default_value()
+	return GLOB.donor_shines[1]
+
 /datum/preference/toggle/donor_public
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 	default_value = TRUE
 	savefile_key = "donor_public"
-	savefile_identifier = PREFERENCE_PLAYER
-
-/datum/preference/toggle/donor_chat_shine
-	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
-	default_value = TRUE
-	savefile_key = "donor_chat_shine"
 	savefile_identifier = PREFERENCE_PLAYER

--- a/modular_bandastation/chat/code/chat_preferences.dm
+++ b/modular_bandastation/chat/code/chat_preferences.dm
@@ -2,17 +2,18 @@ GLOBAL_LIST_INIT(donor_shines, list(
 	"Автоматически" = "auto",
 	"Металлик" = "metal",
 	"Светящийся" = "glowing",
+	"Выключить" = "off",
 ))
 
-/datum/preference/choiced/donor_chat_shine
+/datum/preference/choiced/donor_chat_effect
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
-	savefile_key = "donor_chat_shine"
+	savefile_key = "donor_chat_effect"
 	savefile_identifier = PREFERENCE_PLAYER
 
-/datum/preference/choiced/donor_chat_shine/init_possible_values()
+/datum/preference/choiced/donor_chat_effect/init_possible_values()
 	return assoc_to_keys(GLOB.donor_shines)
 
-/datum/preference/choiced/donor_chat_shine/create_default_value()
+/datum/preference/choiced/donor_chat_effect/create_default_value()
 	return GLOB.donor_shines[1]
 
 /datum/preference/toggle/donor_public

--- a/modular_bandastation/chat/code/chat_preferences.dm
+++ b/modular_bandastation/chat/code/chat_preferences.dm
@@ -1,4 +1,4 @@
-GLOBAL_LIST_INIT(donor_shines, list(
+GLOBAL_LIST_INIT(donor_chat_effects, list(
 	"Автоматически" = "auto",
 	"Металлик" = "metal",
 	"Светящийся" = "glowing",
@@ -11,10 +11,10 @@ GLOBAL_LIST_INIT(donor_shines, list(
 	savefile_identifier = PREFERENCE_PLAYER
 
 /datum/preference/choiced/donor_chat_effect/init_possible_values()
-	return assoc_to_keys(GLOB.donor_shines)
+	return assoc_to_keys(GLOB.donor_chat_effects)
 
 /datum/preference/choiced/donor_chat_effect/create_default_value()
-	return GLOB.donor_shines[1]
+	return GLOB.donor_chat_effects[1]
 
 /datum/preference/toggle/donor_public
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES

--- a/modular_bandastation/chat/code/chat_preferences.dm
+++ b/modular_bandastation/chat/code/chat_preferences.dm
@@ -2,7 +2,7 @@ GLOBAL_LIST_INIT(donor_shines, list(
 	"Автоматически" = "auto",
 	"Металлик" = "metal",
 	"Светящийся" = "glowing",
-	"Выключить" = "off",
+	"Выключить" = null,
 ))
 
 /datum/preference/choiced/donor_chat_effect

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1363,20 +1363,27 @@ $border-width-px: $border-width * 1px;
   }
 }
 
-.tier-3,
-.tier-4,
-.tier-5 {
-  &.metal {
+.metal {
+  .tier-3,
+  .tier-4,
+  .tier-5 {
     @include metalic();
-  }
-
-  &.glowing {
-    @include glowing();
   }
 }
 
-.tier-5.glowing {
-  @include shine();
+.glowing {
+  .tier-3 {
+    @include metalic();
+  }
+
+  .tier-4,
+  .tier-5 {
+    @include glowing();
+  }
+
+  .tier-5 {
+    @include shine();
+  }
 }
 
 .auto {

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1363,21 +1363,6 @@ $border-width-px: $border-width * 1px;
   }
 }
 
-.auto {
-  &.tier-3 {
-    @include metalic();
-  }
-
-  &.tier-4,
-  &.tier-5 {
-    @include glowing();
-  }
-
-  &.tier-5 {
-    @include shine();
-  }
-}
-
 .tier-3,
 .tier-4,
 .tier-5 {
@@ -1390,8 +1375,21 @@ $border-width-px: $border-width * 1px;
   }
 }
 
-.tier-5 {
-  &.glowing {
+.tier-5.glowing {
+  @include shine();
+}
+
+.auto {
+  &.tier-3 {
+    @include metalic();
+  }
+
+  &.tier-4,
+  &.tier-5 {
+    @include glowing();
+  }
+
+  &.tier-5 {
     @include shine();
   }
 }

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1364,24 +1364,24 @@ $border-width-px: $border-width * 1px;
 }
 
 .metal {
-  .tier-3,
-  .tier-4,
-  .tier-5 {
+  &.tier-3,
+  &.tier-4,
+  &.tier-5 {
     @include metalic();
   }
 }
 
 .glowing {
-  .tier-3 {
+  &.tier-3 {
     @include metalic();
   }
 
-  .tier-4,
-  .tier-5 {
+  &.tier-4,
+  &.tier-5 {
     @include glowing();
   }
 
-  .tier-5 {
+  &.tier-5 {
     @include shine();
   }
 }

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1291,7 +1291,7 @@ $border-width-px: $border-width * 1px;
   vertical-align: unset;
 }
 
-@keyframes donor_shine {
+@keyframes metalic-anim {
   0%,
   33% {
     background-position-x: var(--shine-start);
@@ -1302,7 +1302,7 @@ $border-width-px: $border-width * 1px;
   }
 }
 
-.shine {
+@mixin metalic() {
   --shine-start: 100%;
   --shine-end: -100%;
   color: transparent !important;
@@ -1314,5 +1314,84 @@ $border-width-px: $border-width * 1px;
   );
   background-clip: text;
   background-size: 220% 220%;
-  animation: donor_shine 5s infinite linear;
+  animation: metalic-anim 5s infinite linear;
+}
+
+@keyframes glowing-anim {
+  0% {
+    background-position: 0;
+  }
+
+  100% {
+    background-position-x: var(--size);
+  }
+}
+
+@mixin glowing() {
+  --size: 75px;
+  position: relative;
+  color: transparent !important;
+  background: linear-gradient(
+    to right,
+    var(--shine-color),
+    hsl(from var(--shine-color) calc(h + 15) s calc(l + 20)),
+    var(--shine-color)
+  );
+  background-clip: text;
+  background-size: var(--size) auto;
+  animation: glowing-anim 3s infinite linear;
+}
+
+@mixin shine() {
+  &:before {
+    --tranclucent-shine: hsl(from var(--shine-color) h s l / 0.5);
+    content: '';
+    filter: blur(6px);
+    pointer-events: none;
+    position: absolute;
+    width: 100%;
+    height: 0.5lh;
+    align-self: center;
+    background: linear-gradient(
+      to right,
+      var(--tranclucent-shine),
+      hsl(from var(--tranclucent-shine) calc(h + 15) s calc(l + 20)),
+      var(--tranclucent-shine)
+    );
+    background-size: inherit;
+    animation: glowing-anim 3s infinite linear;
+  }
+}
+
+.auto {
+  &.tier-3 {
+    @include metalic();
+  }
+
+  &.tier-4,
+  &.tier-5 {
+    @include glowing();
+  }
+
+  &.tier-5 {
+    @include shine();
+  }
+}
+
+.tier-3,
+.tier-4,
+.tier-5 {
+  &.metal {
+    @include metalic();
+  }
+
+  &.glowing {
+    @include glowing();
+  }
+}
+
+.tier-5 {
+  &.glowing {
+    @include shine();
+  }
 }

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1377,22 +1377,8 @@ $border-width-px: $border-width * 1px;
   }
 }
 
+.auto,
 .glowing {
-  &.tier-3 {
-    @include metalic();
-  }
-
-  &.tier-4,
-  &.tier-5 {
-    @include glowing();
-  }
-
-  &.tier-5 {
-    @include shine();
-  }
-}
-
-.auto {
   &.tier-3 {
     @include metalic();
   }

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1308,9 +1308,9 @@ $border-width-px: $border-width * 1px;
   color: transparent !important;
   background: linear-gradient(
     130deg,
-    var(--shine-color) 1em,
-    hsl(from var(--shine-color) h s calc(l + 20)) 2em,
-    var(--shine-color) 3em
+    var(--stabilized-color) 1em,
+    hsl(from var(--stabilized-color) h s calc(l + 20)) 2em,
+    var(--stabilized-color) 3em
   );
   background-clip: text;
   background-size: 220% 220%;
@@ -1333,9 +1333,9 @@ $border-width-px: $border-width * 1px;
   color: transparent !important;
   background: linear-gradient(
     to right,
-    var(--shine-color),
-    hsl(from var(--shine-color) calc(h + 15) s calc(l + 20)),
-    var(--shine-color)
+    var(--stabilized-color),
+    hsl(from var(--stabilized-color) calc(h + 15) s calc(l + 20)),
+    var(--stabilized-color)
   );
   background-clip: text;
   background-size: var(--size) auto;
@@ -1344,7 +1344,7 @@ $border-width-px: $border-width * 1px;
 
 @mixin shine() {
   &:before {
-    --tranclucent-shine: hsl(from var(--shine-color) h s l / 0.5);
+    --tranclucent-shine: hsl(from var(--stabilized-color) h s l / 0.5);
     content: '';
     filter: blur(6px);
     pointer-events: none;
@@ -1361,6 +1361,12 @@ $border-width-px: $border-width * 1px;
     background-size: inherit;
     animation: glowing-anim 3s infinite linear;
   }
+}
+
+.tier-3,
+.tier-4,
+.tier-5 {
+  --stabilized-color: oklch(from var(--shine-color) min(max(l, 0.33), 0.8) c h);
 }
 
 .metal {

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/bandastation/donor_chat_shine.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/bandastation/donor_chat_shine.tsx
@@ -1,9 +1,10 @@
-import { CheckboxInput, type FeatureToggle } from '../../base';
+import type { Feature } from '../../base';
+import { FeatureDropdownInput } from '../../dropdowns';
 
-export const donor_chat_shine: FeatureToggle = {
+export const donor_chat_shine: Feature<string> = {
   name: 'Блеск ника в чате',
   category: 'Чат',
   description:
     'Если включено, ваш никнейм в OOC чате будет "блестеть". Требует включённого статуса бустера.',
-  component: CheckboxInput,
+  component: FeatureDropdownInput,
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/bandastation/donor_chat_shine.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/bandastation/donor_chat_shine.tsx
@@ -5,6 +5,6 @@ export const donor_chat_effect: Feature<string> = {
   name: 'Блеск ника в чате',
   category: 'Чат',
   description:
-    'Выбор эффекта переливания ckey в OOC чате. Требует включённого статуса бустера.',
+    'Выбор эффекта переливания никнейма в OOC чате. Требует включённого статуса бустера.',
   component: FeatureDropdownInput,
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/bandastation/donor_chat_shine.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/bandastation/donor_chat_shine.tsx
@@ -1,10 +1,10 @@
 import type { Feature } from '../../base';
 import { FeatureDropdownInput } from '../../dropdowns';
 
-export const donor_chat_shine: Feature<string> = {
+export const donor_chat_effect: Feature<string> = {
   name: 'Блеск ника в чате',
   category: 'Чат',
   description:
-    'Если включено, ваш никнейм в OOC чате будет "блестеть". Требует включённого статуса бустера.',
+    'Выбор эффекта переливания ckey в OOC чате. Требует включённого статуса бустера.',
   component: FeatureDropdownInput,
 };


### PR DESCRIPTION
## Что этот PR делает
Добавлен новый Discord-like эффект для скея в ООС чате
Доступен с тира 4, светится с тира 5

## Почему это хорошо для игры
Почему бы и нет, мне делать больше нехуй

## Изображения изменений

![dreamseeker_X2y2rSb2GL](https://github.com/user-attachments/assets/5c9e5fc2-456d-4b0f-af3f-405c84482f65)

## Тестирование
Ну типа

## Changelog

:cl:
add: Добавлен новый эффект в ООС чат для бустеров, вдохновлённый дискордом - переливающийся ник от 4 тира и вдобавок светящийся при тире 5. Можно выбрать в префах.
/:cl:
