### PR TITLE
Balance: rpld now uses plastic

### DIFF
--- a/modular_bandastation/balance/_balance.dme
+++ b/modular_bandastation/balance/_balance.dme
@@ -20,6 +20,7 @@
 #include "code/materials_market.dm"
 #include "code/mobs/shade.dm"
 #include "code/religion.dm"
+#include "code/rpld.dm"
 #include "code/speed/base_speed.dm"
 #include "code/speed/movespeed_modifier.dm"
 #include "code/station_traits.dm"

--- a/modular_bandastation/balance/code/rpld.dm
+++ b/modular_bandastation/balance/code/rpld.dm
@@ -1,15 +1,15 @@
 /obj/item/construction/plumbing
 	desc = "Устройство для быстрой постройки и разбора. Перезаряжается пластиком."
 	matter = 0
+	var/list/recharge_materials = list(
+    	/obj/item/stack/sheet/plastic = 4,
+	)
 
 /obj/item/construction/plumbing/loaded
 	matter = 200
 
 /obj/item/construction/plumbing/service/loaded
 	matter = 200
-
-/obj/item/stack/sheet/plastic
-	var/plastic_matter_amount = 4
 
 /obj/item/construction/plumbing/insert_matter(obj/item, mob/user)
 	if(iscyborg(user))
@@ -24,16 +24,18 @@
 	return loaded
 
 /obj/item/construction/plumbing/loadwithsheets(obj/item/stack/the_stack, mob/user)
-	if(!istype(the_stack, /obj/item/stack/sheet/plastic))
+	var/matter_value = recharge_materials[the_stack.type] || recharge_materials[the_stack.parent_type]
+	if(!matter_value)
 		balloon_alert(user, "неверный материал!")
 		return FALSE
-	var/obj/item/stack/sheet/plastic/plastic_stack = the_stack
-	var/maxsheets = round((max_matter-matter) / plastic_stack.plastic_matter_amount)
+
+	var/maxsheets = floor((max_matter - matter) / matter_value)
 	if(maxsheets > 0)
-		var/amount_to_use = min(plastic_stack.amount, maxsheets)
-		plastic_stack.use(amount_to_use)
-		matter += plastic_stack.plastic_matter_amount * amount_to_use
+		var/amount_to_use = min(the_stack.amount, maxsheets)
+		the_stack.use(amount_to_use)
+		matter += matter_value * amount_to_use
 		playsound(loc, 'sound/machines/click.ogg', 50, TRUE)
 		return TRUE
+
 	balloon_alert(user, "хранилище заполнено!")
 	return FALSE

--- a/modular_bandastation/balance/code/rpld.dm
+++ b/modular_bandastation/balance/code/rpld.dm
@@ -1,0 +1,56 @@
+/obj/item/rcd_ammo/plumbing/large
+	ammoamt = 160
+
+/obj/item/construction/plumbing
+	matter = 0
+
+/obj/item/construction/plumbing/loaded
+	matter = 200
+
+/obj/item/construction/plumbing/service/loaded
+	matter = 200
+
+/obj/item/stack/sheet/plastic
+	var/plastic_matter_amount = 4
+
+/obj/item/rcd_ammo/plumbing
+	name = "RPLD matter cartridge"
+	desc = "Highly compressed matter for the RPLD."
+
+/obj/item/construction/plumbing/insert_matter(obj/item, mob/user)
+	if(iscyborg(user))
+		return FALSE
+
+	var/loaded = FALSE
+	if(istype(item, /obj/item/rcd_ammo/plumbing))
+		var/obj/item/rcd_ammo/plumbing/ammo = item
+		var/load = min(ammo.ammoamt, max_matter - matter)
+		if(load <= 0)
+			balloon_alert(user, "storage full!")
+			return FALSE
+		ammo.ammoamt -= load
+		if(ammo.ammoamt <= 0)
+			qdel(ammo)
+		matter += load
+		playsound(loc, 'sound/machines/click.ogg', 50, TRUE)
+		loaded = TRUE
+	else if(isstack(item))
+		loaded = loadwithsheets(item, user)
+	if(loaded)
+		update_appearance() //ensures that ammo counters (if present) get updated
+	return loaded
+
+/obj/item/construction/plumbing/loadwithsheets(obj/item/stack/the_stack, mob/user)
+	if(!istype(the_stack, /obj/item/stack/sheet/plastic))
+		balloon_alert(user, "invalid sheets!")
+		return FALSE
+	var/obj/item/stack/sheet/plastic/plastic_stack = the_stack
+	var/maxsheets = round((max_matter-matter) / plastic_stack.plastic_matter_amount) //calculate the max number of sheets that will fit in RCD
+	if(maxsheets > 0)
+		var/amount_to_use = min(plastic_stack.amount, maxsheets)
+		plastic_stack.use(amount_to_use)
+		matter += plastic_stack.plastic_matter_amount * amount_to_use
+		playsound(loc, 'sound/machines/click.ogg', 50, TRUE)
+		return TRUE
+	balloon_alert(user, "storage full!")
+	return FALSE

--- a/modular_bandastation/balance/code/rpld.dm
+++ b/modular_bandastation/balance/code/rpld.dm
@@ -1,7 +1,5 @@
-/obj/item/rcd_ammo/plumbing/large
-	ammoamt = 160
-
 /obj/item/construction/plumbing
+	desc = "Устройство для быстрой постройки и разбора. Перезаряжается пластиком."
 	matter = 0
 
 /obj/item/construction/plumbing/loaded
@@ -13,28 +11,13 @@
 /obj/item/stack/sheet/plastic
 	var/plastic_matter_amount = 4
 
-/obj/item/rcd_ammo/plumbing
-	name = "RPLD matter cartridge"
-	desc = "Highly compressed matter for the RPLD."
-
 /obj/item/construction/plumbing/insert_matter(obj/item, mob/user)
 	if(iscyborg(user))
 		return FALSE
 
 	var/loaded = FALSE
-	if(istype(item, /obj/item/rcd_ammo/plumbing))
-		var/obj/item/rcd_ammo/plumbing/ammo = item
-		var/load = min(ammo.ammoamt, max_matter - matter)
-		if(load <= 0)
-			balloon_alert(user, "storage full!")
-			return FALSE
-		ammo.ammoamt -= load
-		if(ammo.ammoamt <= 0)
-			qdel(ammo)
-		matter += load
-		playsound(loc, 'sound/machines/click.ogg', 50, TRUE)
-		loaded = TRUE
-	else if(isstack(item))
+
+	if(isstack(item))
 		loaded = loadwithsheets(item, user)
 	if(loaded)
 		update_appearance() //ensures that ammo counters (if present) get updated
@@ -42,15 +25,15 @@
 
 /obj/item/construction/plumbing/loadwithsheets(obj/item/stack/the_stack, mob/user)
 	if(!istype(the_stack, /obj/item/stack/sheet/plastic))
-		balloon_alert(user, "invalid sheets!")
+		balloon_alert(user, "неверный материал!")
 		return FALSE
 	var/obj/item/stack/sheet/plastic/plastic_stack = the_stack
-	var/maxsheets = round((max_matter-matter) / plastic_stack.plastic_matter_amount) //calculate the max number of sheets that will fit in RCD
+	var/maxsheets = round((max_matter-matter) / plastic_stack.plastic_matter_amount)
 	if(maxsheets > 0)
 		var/amount_to_use = min(plastic_stack.amount, maxsheets)
 		plastic_stack.use(amount_to_use)
 		matter += plastic_stack.plastic_matter_amount * amount_to_use
 		playsound(loc, 'sound/machines/click.ogg', 50, TRUE)
 		return TRUE
-	balloon_alert(user, "storage full!")
+	balloon_alert(user, "хранилище заполнено!")
 	return FALSE


### PR DESCRIPTION

## Что этот PR делает
Переводит конструктор водопровода (RPLD) на использование пластика. Раундстартом он пустой, что не позволит сделать с нулевой автоматизированный завод всех реагентов.
## Почему это хорошо для игры
Теперь станция не будет иметь ВСЕ базовые медикаменты меньше чем за пол часа, усложняет бесконечное производство патчей от всего урона и эфедрина. Возвращает смысл существования больших бикеров в химию.
## Тестирование
Построил, зарядил пластиком, металлом не зарядил.
## Changelog
:cl:
balance: Инструмент для пламбинга (хим.заводный РЦД) теперь заряжается ТОЛЬКО пластиком, раундстартом появляется пустым.
/:cl:
