### PR TITLE
Metal Hydrogen Axe buff

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -358,6 +358,7 @@ GLOBAL_LIST_INIT(tool_items, list(
 	/obj/item/wirecutters,
 	/obj/item/wrench,
 	/obj/item/spess_knife,
+	/obj/item/fireaxe/metal_h2_axe,
 ))
 
 // Keys for equip_in_one_of_slots, if you add new ones update the assoc lists in equip_in_one_of_slots

--- a/modular_bandastation/atmos_tweaks/_atmos_tweaks.dm
+++ b/modular_bandastation/atmos_tweaks/_atmos_tweaks.dm
@@ -1,0 +1,16 @@
+/datum/modpack/atmos_tweaks
+	/// A string name for the modpack. Used for looking up other modpacks in init.
+	name = "atmos_tweaks"
+	/// A string desc for the modpack. Can be used for modpack verb list as description.
+	desc = "Atmos tweaks"
+	/// A string with authors of this modpack.
+	author = "nasend_"
+
+/datum/modpack/atmos_tweaks/pre_initialize()
+	. = ..()
+
+/datum/modpack/atmos_tweaks/initialize()
+	. = ..()
+
+/datum/modpack/atmos_tweaks/post_initialize()
+	. = ..()

--- a/modular_bandastation/atmos_tweaks/_atmos_tweaks.dme
+++ b/modular_bandastation/atmos_tweaks/_atmos_tweaks.dme
@@ -1,0 +1,3 @@
+#include "_atmos_tweaks.dm"
+
+#include "code/atmos_tweaks.dm"

--- a/modular_bandastation/atmos_tweaks/code/atmos_tweaks.dm
+++ b/modular_bandastation/atmos_tweaks/code/atmos_tweaks.dm
@@ -1,0 +1,5 @@
+/obj/item/fireaxe/metal_h2_axe
+	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
+	force = 24
+	force_unwielded = 24
+	force_wielded = 24

--- a/modular_bandastation/modular_bandastation.dme
+++ b/modular_bandastation/modular_bandastation.dme
@@ -13,6 +13,7 @@
 #include "ai_laws/_ai_laws.dme"
 #include "announcers/_announcers.dme"
 #include "antagonists/_antagonists.dme"
+#include "atmos_tweaks/_atmos_tweaks.dme"
 #include "augmentation_preferences/_augmentation_preferences.dme"
 #include "autohiss/_autohiss.dme"
 #include "automapper/_automapper.dme"


### PR DESCRIPTION
## Что этот PR делает

Топор из metalhydrogen'а вмещается в сумку, тулбелт, лезет на пояс. Урон топора поднят до урона стандартного фаеракса. Урон при одноручном и двуручном хвате равен, но вещи ломаются лучше при двуручном хвате, как было раньше. 

## Почему это хорошо для игры

Топор из метал гидрогена довольно тяжек в получении, а атмостех, занявшийся его получением, получит ослабленную версию стандартного топора по дамагу, но зато с механикой лома, что как по мне не то чтобы балансно, учитывая как он получается. Атмостеху тритору будет выгоднее не варить броню и топор, а залутать стандартный топор и коморку секов в инже.

## Изображения изменений


## Тестирование

Все работает как задумывалось.

## Changelog

:cl:nasend_
balance: Топор из металического водорода баффнут: теперь он лезет в сумку и тулбелт, можно носить на поясе. Урон поднят до уровня стандартного топора. Урон в двуручном и одноручном хвате равен.
/:cl: