### PR TITLE
[MOB PORT] Добавляем свиней в ботанику на карты

### DIFF
--- a/_maps/bandastation/automapper/automapper_config.toml
+++ b/_maps/bandastation/automapper/automapper_config.toml
@@ -88,6 +88,13 @@ required_map = "DeltaStation2.dmm"
 coordinates = [208, 128, 1]
 trait_name = "Station"
 
+[templates.deltastation_hydro_pig]
+map_files = ["deltastation_hydro_pig.dmm"]
+directory = "_maps/bandastation/automapper/templates/deltastation/"
+required_map = "DeltaStation2.dmm"
+coordinates = [122, 170, 1]
+trait_name = "Station"
+
 # MetaStation
 [templates.metastation_lawyer_office]
 map_files = ["metastation_lawyer_office.dmm"]
@@ -166,6 +173,12 @@ required_map = "MetaStation.dmm"
 coordinates = [108, 171, 1]
 trait_name = "Station"
 
+[templates.metastation_hydro_pig]
+map_files = ["metastation_hydro_pig.dmm"]
+directory = "_maps/bandastation/automapper/templates/metastation/"
+required_map = "MetaStation.dmm"
+coordinates = [133, 113, 1]
+trait_name = "Station"
 
 # IceBoxStation
 [templates.iceboxstation_blueshield_office]
@@ -250,6 +263,13 @@ map_files = ["iceboxstation_armory_hammer.dmm"]
 directory = "_maps/bandastation/automapper/templates/iceboxstation/"
 required_map = "IceBoxStation.dmm"
 coordinates = [105, 182, 2]
+trait_name = "Station"
+
+[templates.iceboxstation_hydro_pig]
+map_files = ["iceboxstation_hydro_pig.dmm"]
+directory = "_maps/bandastation/automapper/templates/iceboxstation/"
+required_map = "IceBoxStation.dmm"
+coordinates = [140, 135, 2]
 trait_name = "Station"
 
 # TramStation
@@ -365,4 +385,11 @@ map_files = ["tramstation_specops_port.dmm"]
 directory = "_maps/bandastation/automapper/templates/tramstation/"
 required_map = "tramstation.dmm"
 coordinates = [9, 114, 2]
+trait_name = "Station"
+
+[templates.tramstation_hydro_pig]
+map_files = ["tramstation_hydro_pig.dmm"]
+directory = "_maps/bandastation/automapper/templates/tramstation/"
+required_map = "tramstation.dmm"
+coordinates = [124, 159, 1]
 trait_name = "Station"

--- a/_maps/bandastation/automapper/templates/deltastation/deltastation_hydro_pig.dmm
+++ b/_maps/bandastation/automapper/templates/deltastation/deltastation_hydro_pig.dmm
@@ -1,0 +1,55 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/mob/living/basic/cow/black/pipa,
+/turf/open/floor/iron/half,
+/area/station/service/hydroponics)
+"l" = (
+/mob/living/basic/pig/named/Yanas,
+/turf/open/floor/iron/half,
+/area/station/service/hydroponics)
+"n" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/status_display/ai/directional/south,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/mob/living/basic/chicken/cock/clucky,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
+"q" = (
+/obj/machinery/hydroponics/constructable,
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/mob/living/basic/chicken/wife,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
+"w" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/mob/living/basic/pig/named/Sanya,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
+"N" = (
+/mob/living/basic/pig/named/Marina,
+/turf/open/floor/iron/half,
+/area/station/service/hydroponics)
+
+(1,1,1) = {"
+N
+w
+"}
+(2,1,1) = {"
+l
+n
+"}
+(3,1,1) = {"
+a
+q
+"}

--- a/_maps/bandastation/automapper/templates/iceboxstation/iceboxstation_hydro_pig.dmm
+++ b/_maps/bandastation/automapper/templates/iceboxstation/iceboxstation_hydro_pig.dmm
@@ -1,0 +1,55 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/mob/living/basic/pig/named/Yanas,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
+"f" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
+"w" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/mob/living/basic/cow/black/pipa,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
+"x" = (
+/obj/machinery/hydroponics/constructable,
+/mob/living/basic/chicken/cock/clucky,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
+"B" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/mob/living/basic/pig/named/Sanya,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
+"I" = (
+/obj/machinery/hydroponics/constructable,
+/mob/living/basic/chicken/wife,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
+"R" = (
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/mob/living/basic/pig/named/Marina,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
+
+(1,1,1) = {"
+B
+a
+"}
+(2,1,1) = {"
+f
+x
+"}
+(3,1,1) = {"
+f
+I
+"}
+(4,1,1) = {"
+R
+w
+"}

--- a/_maps/bandastation/automapper/templates/metastation/metastation_hydro_pig.dmm
+++ b/_maps/bandastation/automapper/templates/metastation/metastation_hydro_pig.dmm
@@ -1,0 +1,52 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/mob/living/basic/pig/named/Sanya,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
+"s" = (
+/mob/living/basic/pig/named/Marina,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
+"u" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/bot,
+/mob/living/basic/chicken/cock/clucky,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
+"v" = (
+/mob/living/basic/pig/named/Yanas,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
+"y" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/mob/living/basic/cow/black/pipa,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
+"R" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/bot,
+/mob/living/basic/chicken/wife,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
+
+(1,1,1) = {"
+a
+v
+s
+"}
+(2,1,1) = {"
+y
+R
+u
+"}

--- a/_maps/bandastation/automapper/templates/tramstation/tramstation_hydro_pig.dmm
+++ b/_maps/bandastation/automapper/templates/tramstation/tramstation_hydro_pig.dmm
@@ -1,0 +1,55 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/door/window/left/directional/south,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
+"d" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
+"i" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/mob/living/basic/pig/named/Sanya,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
+"o" = (
+/mob/living/basic/cow/black/pipa,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
+"C" = (
+/obj/machinery/light/warm/directional/north,
+/mob/living/basic/pig/named/Yanas,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
+"U" = (
+/mob/living/basic/pig/named/Marina,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
+"V" = (
+/mob/living/basic/chicken/cock/clucky,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
+"Y" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
+"Z" = (
+/mob/living/basic/chicken/wife,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
+
+(1,1,1) = {"
+U
+V
+i
+"}
+(2,1,1) = {"
+C
+Y
+a
+"}
+(3,1,1) = {"
+o
+Z
+d
+"}


### PR DESCRIPTION
## Что этот PR делает
Добавляет 6 мобов в ботанику на траме, мете, дельте и айс боксе через автомапер
## Почему это хорошо для игры
Зоопарк?
## Изображения изменений

<img width="303" height="169" alt="image" src="https://github.com/user-attachments/assets/d63a1f16-eee5-4fd7-8edc-a54dcd525409" />

## Тестирование
ну вроде работает на локалке 
## Changelog

:cl:
add: Добавлены растущие свиньи на Deltastation, IceBoxStation, Tramstation, MetaStation
/:cl:
