### PR TITLE
Fix blueshield suit storage on tram

### DIFF
--- a/_maps/bandastation/automapper/templates/tramstation/tramstation_ntr_blueshield_office.dmm
+++ b/_maps/bandastation/automapper/templates/tramstation/tramstation_ntr_blueshield_office.dmm
@@ -652,7 +652,7 @@
 /area/station/command/heads_quarters/nanotrasen_representative)
 "vg" = (
 /obj/structure/reagent_dispensers/wall/peppertank/directional/north,
-/obj/machinery/suit_storage_unit/security,
+/obj/machinery/suit_storage_unit/blueshield,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/blueshield)
 "vp" = (


### PR DESCRIPTION
## Что этот PR делает

Заменяет в модульной части трама, в офисе БЩ сек мод за бщ мод

## Почему это хорошо для игры

Эээ, ну.. у бщ есть мод бщ, зачем ему сековский

## Изображения изменений

Не нужно

## Тестирование

Зачем

## Changelog

:cl:
fix: На Траме в офисе БЩ теперь лежит его МОД, а не сбшный.
/:cl:
