### PR TITLE
[BALANCE] Gator and croc damage nerf

### DIFF
--- a/modular_bandastation/mobs/code/simple_animal/hostile/lizard.dm
+++ b/modular_bandastation/mobs/code/simple_animal/hostile/lizard.dm
@@ -80,8 +80,8 @@
 	maxHealth = 300
 	health = 300
 	obj_damage = 80
-	melee_damage_lower = 15
-	melee_damage_upper = 25
+	melee_damage_lower = 20
+	melee_damage_upper = 35
 
 /mob/living/basic/lizard/big/croco
 	name = "крокодил"
@@ -94,4 +94,4 @@
 	health = 200
 	obj_damage = 80
 	melee_damage_lower = 10
-	melee_damage_upper = 15
+	melee_damage_upper = 25


### PR DESCRIPTION
## Что этот PR делает

Меняет бредовый урон у аллигатора и крокодила на реалии ХП кукол ТГ

## Почему это хорошо для игры

Значение урона у джонов симплмобов уменьшено в РАЗЫ. Не будет такого, что аллигатор укусит раз и ты упадёшь в крит от кровотечения

## Изображения изменений

<img width="506" height="224" alt="image" src="https://github.com/user-attachments/assets/5a3aafde-1361-40a2-bf03-31ed07d4eaf8" />
Пять пропущенных от gator

## Тестирование

Забилдилась локалка, подрался с крокодилом и аллигатором

## Changelog

:cl:
balance: Аллигаторы и крокодилы получили значительный нёрф урона
/:cl: