### PR TITLE
фикс визибл мессаге при броске

### DIFF
--- a/code/modules/mob/living/living_item_handling.dm
+++ b/code/modules/mob/living/living_item_handling.dm
@@ -51,7 +51,7 @@
 	var/list/base_verbs = list("throw", "toss", "hurl", "chuck", "fling")
 	var/chosen_verb = prob(0.5) ? "yeet" : pick(base_verbs)
 	var/self_throw_verb = ru_attack_verb(chosen_verb)
-	var/visible_throw_verb = ru_attack_verb(plural_s(chosen_verb))
+	var/visible_throw_verb = ru_attack_verb(chosen_verb + plural_s(chosen_verb))
 	// BANDAСТATION EDIT END
 	var/neckgrab_throw = FALSE // we can't check for if it's a neckgrab throw when totaling up power_throw since we've already stopped pulling them by then, so get it early
 	var/frequency_number = 1 //We assign a default frequency number for the sound of the throw.


### PR DESCRIPTION

## Что этот PR делает

чинит видимое сообщение когда кто-то бросает предмет

## Почему это хорошо для игры

не будет писаться "[имя] s [предмет]"


## Тестирование

проставил брейкпоинты, почекал переменные

## Changelog

:cl:
fix: Починил отображение бросков
/:cl: