### PR TITLE
Cyberiad: paramedic room

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -3312,6 +3312,9 @@
 /turf/open/floor/wood/parquet/amaranth,
 /area/station/maintenance/ghetto/fore/starboard)
 "aQK" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "aQL" = (
@@ -6125,6 +6128,7 @@
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
 	},
+/obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "byf" = (
@@ -10285,8 +10289,10 @@
 /turf/open/space/openspace,
 /area/space/nearstation)
 "cye" = (
-/obj/item/storage/medkit/emergency,
-/obj/structure/table/glass,
+/obj/machinery/suit_storage_unit/medical,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "cyl" = (
@@ -11630,6 +11636,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "cOo" = (
@@ -52485,8 +52492,21 @@
 /turf/open/floor/iron/stairs/right,
 /area/station/engineering/hallway)
 "mNe" = (
-/obj/structure/closet/wardrobe/white/medical,
-/obj/item/clothing/head/soft/paramedic,
+/obj/structure/table/glass,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/item/paper_bin,
+/obj/item/flashlight/pen/paramedic,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_y = 10;
+	pixel_x = -7
+	},
+/obj/item/toy/figure/paramedic{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/surgicaldrill,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "mNh" = (
@@ -52543,11 +52563,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry/ghetto)
 "mOh" = (
-/obj/effect/landmark/start/paramedic,
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "mOm" = (
@@ -55690,7 +55712,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "nCS" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /obj/machinery/computer/crew,
+/obj/structure/fireaxecabinet/jawsofrecovery/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "nCX" = (
@@ -63671,10 +63697,10 @@
 "pyz" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/airalarm/directional/north,
-/obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/item/flashlight/pen/paramedic,
-/obj/item/toy/figure/paramedic,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/computer/records/medical,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "pyM" = (
@@ -69942,6 +69968,9 @@
 "ren" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
@@ -76434,10 +76463,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "sHx" = (
+/obj/machinery/light_switch/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/light_switch/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "sHy" = (
@@ -90961,18 +90993,18 @@
 /area/station/engineering/supermatter/room)
 "wro" = (
 /obj/structure/cable,
-/obj/structure/table/glass,
-/obj/item/clothing/glasses/hud/health{
-	pixel_y = -2
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/firealarm/directional/west,
+/obj/structure/closet/secure_closet/paramedic,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
 /obj/item/storage/belt/medical{
 	pixel_y = 6
 	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_y = 10
+/obj/item/clothing/glasses/hud/health{
+	pixel_y = -2
 	},
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/paramedic)
 "wrs" = (


### PR DESCRIPTION
## Что этот PR делает

Небольшой ремап комнаты перемедиков на Кибериаде, под оффовские реалии.

## Почему это хорошо для игры

Я вспомнил как управлять свои кораблем, мы причалим к вам через несколько минут

## Изображения изменений

<img width="160" height="192" alt="StrongDMM-2025-11-24 20 03 25" src="https://github.com/user-attachments/assets/0ebd1b8a-8976-4e07-bb82-7a1dffba5789" />

## Тестирование

Локалочка

## Changelog

:cl:
map: Кибериада: комната парамедиков теперь имеет свой персональный шкафчик, мод и челюсти жизни парамедов.
/:cl:
