### PR TITLE
Fix Phazon mech construction

### DIFF
--- a/code/modules/vehicles/mecha/mecha_construction_paths.dm
+++ b/code/modules/vehicles/mecha/mecha_construction_paths.dm
@@ -842,6 +842,7 @@
 			"action" = ITEM_DELETE,
 			"back_key" = TOOL_WELDER,
 			"desc" = "The external armor is welded, and the <b>mech power core</b> socket is open.",
+			"icon_state" = "phazon25",
 			"forward_message" = "inserted mech power core",
 			"backward_message" = "cut off external armor"
 		),


### PR DESCRIPTION
## Что этот PR делает

Теперь фазон не прозрачный на предпоследнем этапе постройки

## Почему это хорошо для игры

Кто-то.. даже не знаю кто... забыл добавить строчку про спрайт при строительстве

## Изображения изменений

Не требуется, просто фазон не пропадает

## Тестирование

Локалка

## Changelog

:cl:
fix: Фазон теперь при строительстве на предпоследнем этапе не становится прозрачным
/:cl:
