### PR TITLE
Revert tajaran mutation toxin

### DIFF
--- a/modular_bandastation/species/code/reagents/mutation.dm
+++ b/modular_bandastation/species/code/reagents/mutation.dm
@@ -19,9 +19,7 @@
 	taste_description = "шерсти"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/* TODO220: Replace with something. Currently copied felinid
 /datum/chemical_reaction/slime/slimetajaran
 	results = list(/datum/reagent/mutationtoxin/tajaran = 1)
-	required_reagents = list(/datum/reagent/consumable/milk = 1)
+	required_reagents = list(/datum/reagent/consumable/cream = 1)
 	required_container = /obj/item/slime_extract/green
-*/


### PR DESCRIPTION
## Что этот PR делает

Возвращает рецепт токсина мутации в таяр, который пострадал из-за фелинидов с апстрима

## Почему это хорошо для игры

Вернуть то, что было, но никто не пофиксил

## Изображения изменений

<img width="638" height="205" alt="image" src="https://github.com/user-attachments/assets/cff307e1-b176-44e3-9f91-3e511bd629bd" />

## Тестирование

Локалка

## Changelog

:cl:
fix: Токсин мутации в таяр можно снова получить через зеленые экстракты в ксено, добавив cream в них
/:cl:
