### PR TITLE
Translate: Command items and miscellaneous

### DIFF
--- a/modular_bandastation/translations/code/translation_data/ru_names.toml
+++ b/modular_bandastation/translations/code/translation_data/ru_names.toml
@@ -12589,12 +12589,12 @@ prepositional = "реактивной маскирующей броне"
 gender = "female"
 
 ["reactive tesla armor"]
-nominable = "реактивная броня Теслы"
-genitive = "реактивной брони Теслы"
-dative = "реактивной броне Теслы"
-accusative = "реактивную броню Теслы"
-instrumental = "реактивной бронёй Теслы"
-prepositional = "реактивной броне Теслы"
+nominative = "реактивная Тесла броня"
+genitive = "реактивной Тесла брони"
+dative = "реактивной Тесла броне"
+accusative = "реактивную Тесла броню"
+instrumental = "реактивной Тесла бронёй"
+prepositional = "реактивной Тесла броне"
 gender = "female"
 
 ["reactive repulse armor"]


### PR DESCRIPTION
## Что этот PR делает

Перевод (без описаний) предметов глав и прочего в ru_names
Так же исправляет ошибку в переводе улучшения для быстрого раздатчика труб 
Теперь Поли будет срать с переведённым именем
Так же добавлены "# MARK:" где их не было

## Почему это хорошо для игры

Перевод

## Тестирование

Каждый шкафчик главы был выпотрошен

## Changelog

:cl:
typo: Исправлено улучшение на БРТ. Теперь там не написано для УБС
typo: Переведены некоторые предметы у глав, что были с английскими наименованиям (Перчатки Горилла и боуман ГСБ)
translation: Переведены предметы глав в их шкафчике и не только
translation: Перчатки Каза Рук (Крав мага) тоже переведён
translation: Переведена все виды реактивной брони
translation: Jaws of recovery переведён в Челюсти спасения
translation: Переведены все громкоговорители
translation: Переведены все резиновые печати, что используются в игре (сами предметы)
translation:  Переведено имя Поли и его призрака
/:cl: