### PR TITLE
Cyberiad: toxins update

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -403,9 +403,12 @@
 	},
 /area/station/hallway/secondary/entry)
 "agm" = (
-/obj/machinery/air_sensor/ordnance_burn_chamber,
+/obj/machinery/door/airlock/research/glass/incinerator/ordmix_exterior,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/engine/vacuum,
-/area/station/science/ordnance)
+/area/station/science/ordnance/burnchamber)
 "agq" = (
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
@@ -1704,12 +1707,8 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "awY" = (
-/obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
-/turf/open/floor/engine,
-/area/station/science/ordnance)
+/turf/closed/wall/r_wall,
+/area/station/science/ordnance/freezerchamber)
 "axd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2666,9 +2665,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "aHL" = (
-/obj/machinery/igniter/incinerator_ordmix,
+/obj/machinery/air_sensor/ordnance_burn_chamber,
 /turf/open/floor/engine/vacuum,
-/area/station/science/ordnance)
+/area/station/science/ordnance/burnchamber)
 "aHN" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Secure Tech Storage";
@@ -3015,7 +3014,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "aMR" = (
@@ -3269,7 +3267,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/dark/airless,
-/area/station/science/ordnance)
+/area/station/science/ordnance/freezerchamber)
 "aQk" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
@@ -4596,11 +4594,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/heavy{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "bgG" = (
@@ -7864,7 +7861,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/airless,
-/area/station/science/ordnance)
+/area/station/science/ordnance/freezerchamber)
 "bVk" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -9574,10 +9571,10 @@
 "cpi" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/item/aicard,
-/obj/item/circuitboard/aicore,
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/purple/anticorner,
+/obj/item/circuitboard/aicore,
+/obj/item/aicard,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "cpk" = (
@@ -13074,6 +13071,14 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/security/courtroom)
+"dfi" = (
+/obj/machinery/light_switch/directional/west,
+/obj/structure/closet/secure_closet/research_director,
+/obj/effect/turf_decal/tile/purple/anticorner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/rd)
 "dfo" = (
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
@@ -13530,13 +13535,11 @@
 /turf/open/floor/grass,
 /area/station/commons/dorms)
 "dkl" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/station/science/ordnance)
 "dkn" = (
 /obj/machinery/holopad,
@@ -15934,7 +15937,7 @@
 	},
 /obj/machinery/air_sensor/ordnance_freezer_chamber,
 /turf/open/floor/iron/dark/airless,
-/area/station/science/ordnance)
+/area/station/science/ordnance/freezerchamber)
 "dOJ" = (
 /obj/machinery/telecomms/server/presets/science,
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
@@ -17782,7 +17785,7 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/iron/dark/airless,
-/area/station/science/ordnance)
+/area/station/science/ordnance/freezerchamber)
 "enN" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
@@ -18634,6 +18637,17 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/kitchen/abandoned)
+"eBu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/heavy{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "eBv" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21978,7 +21992,7 @@
 "fsD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
-/area/station/science/ordnance)
+/area/station/science/ordnance/burnchamber)
 "fsE" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -27121,10 +27135,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
 "gGg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "gGi" = (
@@ -28423,6 +28436,12 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"gUJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "gUK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -29059,7 +29078,7 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/area/station/science/ordnance/freezerchamber)
 "hcY" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -29813,9 +29832,15 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "hmw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/closed/wall/r_wall,
-/area/station/science/ordnance)
+/obj/machinery/atmospherics/components/binary/pump/off,
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/airlock_sensor/incinerator_ordmix{
+	pixel_y = 32
+	},
+/turf/open/floor/engine,
+/area/station/science/ordnance/burnchamber)
 "hmy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/corner{
@@ -30565,9 +30590,6 @@
 "hvQ" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/science/ordnance)
@@ -30808,6 +30830,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "hyp" = (
@@ -32243,10 +32266,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "hOt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/area/station/command/heads_quarters/rd)
 "hOB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37407,19 +37433,14 @@
 	},
 /area/station/service/bar)
 "jdO" = (
+/obj/machinery/airalarm/directional/east,
+/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
+/obj/effect/mapping_helpers/airalarm/link{
+	chamber_id = "ordnanceburn"
+	},
+/obj/effect/mapping_helpers/airalarm/mixingchamber_access,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/button/ignition/incinerator/ordmix{
-	pixel_x = -6;
-	pixel_y = 7
-	},
-/obj/machinery/button/door/incinerator_vent_ordmix{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/machinery/airlock_controller/incinerator_ordmix{
-	pixel_y = -6
-	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "jdP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -40923,10 +40944,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "jYn" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
-	},
 /obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "jYo" = (
@@ -42611,6 +42630,10 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/station/engineering/hallway/west)
+"ktk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall,
+/area/station/science/ordnance/burnchamber)
 "ktn" = (
 /obj/machinery/air_sensor/plasma_tank,
 /turf/open/floor/engine/plasma,
@@ -44749,8 +44772,9 @@
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "kRY" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_burn_chamber_input,
 /turf/open/floor/engine/vacuum,
-/area/station/science/ordnance)
+/area/station/science/ordnance/burnchamber)
 "kSa" = (
 /obj/machinery/door/airlock/security/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -46906,6 +46930,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"lsI" = (
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/burnchamber)
 "lsJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /obj/effect/decal/cleanable/dirt,
@@ -47367,10 +47394,14 @@
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
 "lzb" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/upper)
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/station/science/ordnance/burnchamber)
 "lzf" = (
 /obj/structure/table,
 /obj/item/lightreplacer,
@@ -50608,11 +50639,8 @@
 	},
 /area/station/service/kitchen/kitchen_backroom/ghetto)
 "mpY" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance)
+/turf/closed/wall/r_wall,
+/area/station/science/ordnance/burnchamber)
 "mqb" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/plate/small{
@@ -52035,6 +52063,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
+"mHF" = (
+/obj/effect/turf_decal/box/red,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1;
+	name = "Exfiltrate Port"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "mHG" = (
 /obj/machinery/duct,
 /turf/open/floor/plating,
@@ -52960,11 +52996,10 @@
 /turf/open/floor/wood/large,
 /area/station/service/theater)
 "mTi" = (
-/obj/structure/closet/secure_closet/research_director,
-/obj/machinery/light_switch/directional/west,
 /obj/machinery/keycard_auth/wall_mounted/directional/south,
-/obj/effect/turf_decal/tile/purple/anticorner{
-	dir = 8
+/obj/effect/turf_decal/tile/purple/half,
+/obj/machinery/computer/robotics{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
@@ -53912,9 +53947,9 @@
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "ngu" = (
-/obj/machinery/door/poddoor/incinerator_ordmix,
+/obj/machinery/igniter/incinerator_ordmix,
 /turf/open/floor/engine/vacuum,
-/area/station/science/ordnance)
+/area/station/science/ordnance/burnchamber)
 "ngz" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/open/floor/iron/dark,
@@ -54898,7 +54933,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/airless,
-/area/station/science/ordnance)
+/area/station/science/ordnance/freezerchamber)
 "nrp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash,
@@ -56443,15 +56478,20 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "nNg" = (
-/obj/machinery/atmospherics/components/binary/pump/off,
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/button/ignition/incinerator/ordmix{
+	pixel_x = -6;
+	pixel_y = 7
 	},
-/obj/machinery/airlock_sensor/incinerator_ordmix{
-	pixel_y = 32
+/obj/machinery/button/door/incinerator_vent_ordmix{
+	pixel_x = 5;
+	pixel_y = 7
 	},
-/turf/open/floor/engine,
-/area/station/science/ordnance)
+/obj/machinery/airlock_controller/incinerator_ordmix{
+	pixel_y = -6
+	},
+/turf/closed/wall/r_wall,
+/area/station/science/ordnance/burnchamber)
 "nNk" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -57582,6 +57622,12 @@
 /obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"oaz" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "oaQ" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/two,
@@ -59133,7 +59179,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/airless,
-/area/station/science/ordnance)
+/area/station/science/ordnance/freezerchamber)
 "ote" = (
 /obj/structure/rack,
 /obj/item/stack/ducts/fifty,
@@ -60590,9 +60636,6 @@
 /turf/open/floor/plating,
 /area/station/security/courtroom)
 "oLe" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -65789,7 +65832,7 @@
 /area/station/service/chapel/office)
 "pXP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
-/turf/closed/wall/r_wall,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "pXR" = (
 /obj/effect/mapping_helpers/burnt_floor,
@@ -67586,6 +67629,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/pod,
 /area/station/maintenance/ghetto/storage)
+"qyl" = (
+/obj/machinery/photocopier/prebuilt,
+/turf/open/floor/carpet,
+/area/station/command/heads_quarters/qm)
 "qyp" = (
 /obj/effect/turf_decal/tile/dark_green{
 	dir = 1
@@ -68694,6 +68741,13 @@
 	dir = 4
 	},
 /area/station/engineering/atmos)
+"qNu" = (
+/obj/machinery/door/firedoor/heavy{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/science/ordnance)
 "qNy" = (
 /obj/machinery/light/directional/north,
 /obj/structure/noticeboard/directional/north{
@@ -69108,6 +69162,7 @@
 /area/station/maintenance/ghetto/auxiliary)
 "qTt" = (
 /obj/machinery/light/small/directional/east,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/upper)
 "qTw" = (
@@ -72047,9 +72102,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "rEK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/engine/vacuum,
-/area/station/science/ordnance)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/station/science/ordnance/burnchamber)
 "rEL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
@@ -72959,7 +73014,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/purple/anticorner{
+/obj/effect/turf_decal/tile/purple/half{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -73274,16 +73329,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "rUG" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 4
 	},
-/obj/effect/turf_decal/box/red,
-/obj/machinery/airalarm/directional/east,
-/obj/effect/mapping_helpers/airalarm/mixingchamber_access,
-/obj/effect/mapping_helpers/airalarm/link{
-	chamber_id = "ordnanceburn"
-	},
-/obj/effect/mapping_helpers/airalarm/tlv_no_checks,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "rUO" = (
@@ -74068,12 +74116,10 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/ghetto)
 "sdy" = (
-/obj/machinery/computer/rdconsole{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/purple/half{
 	dir = 4
 	},
+/obj/machinery/photocopier/prebuilt,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "sdA" = (
@@ -75127,13 +75173,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "sqp" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple/half{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/rd)
+/obj/machinery/door/poddoor/incinerator_ordmix,
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/burnchamber)
 "sqq" = (
 /obj/structure/table,
 /obj/effect/spawner/random/contraband/prison,
@@ -76353,9 +76395,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "sFU" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/monitored/ordnance_burn_chamber_input,
-/turf/open/floor/engine/vacuum,
-/area/station/science/ordnance)
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/turf/closed/wall/r_wall,
+/area/station/science/ordnance/burnchamber)
 "sFY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -79202,6 +79244,13 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/science/server)
+"tsN" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/science/ordnance)
 "tsU" = (
 /obj/structure/table/glass,
 /turf/open/floor/iron,
@@ -83197,10 +83246,10 @@
 /obj/effect/mapping_helpers/requests_console/assistance,
 /obj/effect/mapping_helpers/requests_console/ore_update,
 /obj/effect/mapping_helpers/requests_console/announcement,
-/obj/machinery/computer/robotics{
+/obj/effect/turf_decal/tile/purple/half,
+/obj/machinery/computer/rdconsole{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple/half,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "usk" = (
@@ -85926,7 +85975,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark/airless,
-/area/station/science/ordnance)
+/area/station/science/ordnance/freezerchamber)
 "vdY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /obj/machinery/light/small/directional/south,
@@ -86124,13 +86173,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "vgI" = (
-/obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/purple/anticorner{
 	dir = 1
 	},
 /obj/item/toy/figure/rd{
 	pixel_y = 8
 	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "vgJ" = (
@@ -87486,6 +87535,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
+"vuH" = (
+/obj/effect/decal/remains/mouse/pinkie,
+/turf/open/floor/engine/vacuum,
+/area/station/science/ordnance/burnchamber)
 "vuN" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
@@ -88482,12 +88535,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "vIA" = (
-/obj/machinery/door/airlock/research/glass/incinerator/ordmix_exterior,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
-/turf/open/floor/engine/vacuum,
-/area/station/science/ordnance)
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/station/science/ordnance/burnchamber)
 "vIE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -93819,8 +93871,10 @@
 /turf/open/floor/wood/parquet,
 /area/station/maintenance/department/security/ghetto)
 "xba" = (
-/obj/item/radio/intercom/directional/west,
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "xbb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -94735,9 +94789,9 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "xkn" = (
-/obj/effect/decal/remains/mouse/pinkie,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/engine/vacuum,
-/area/station/science/ordnance)
+/area/station/science/ordnance/burnchamber)
 "xkx" = (
 /obj/structure/flora/tree/jungle/small/style_random,
 /turf/open/floor/grass,
@@ -96002,11 +96056,12 @@
 /turf/open/floor/iron/dark/small,
 /area/station/security/interrogation/ghetto)
 "xBZ" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix{
-	dir = 8
-	},
+/obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /turf/open/floor/engine,
-/area/station/science/ordnance)
+/area/station/science/ordnance/burnchamber)
 "xCk" = (
 /obj/structure/cable,
 /obj/machinery/power/solar_control{
@@ -150848,7 +150903,7 @@ doz
 doz
 doz
 doz
-xba
+nFU
 naG
 xOK
 gKE
@@ -151112,8 +151167,8 @@ oVm
 iUJ
 qcE
 mLI
-oGf
-xLW
+dkl
+tsN
 aWU
 pGj
 nFU
@@ -151623,7 +151678,7 @@ nFU
 nFU
 nFU
 jpd
-uck
+iUJ
 uck
 uck
 oGf
@@ -151872,22 +151927,22 @@ ceC
 ceC
 ceC
 ceC
-ceC
-nFU
-nFU
-nFU
-nFU
+mpY
+mpY
+mpY
+mpY
 fsD
 fsD
+qNu
 aYf
 bgF
-ghn
+eBu
 ghn
 gKh
-nFU
+awY
 enM
-nFU
-nFU
+awY
+awY
 doz
 doz
 doz
@@ -152129,22 +152184,22 @@ doz
 doz
 doz
 doz
-doz
-ngu
+sqp
+lsI
 kRY
 sFU
-pXP
-dkl
+lzb
+sFU
 pXP
 aCZ
-hOt
-gGg
 oxp
+gGg
+gUJ
 gkO
 hcK
 bVa
 vdp
-nFU
+awY
 doz
 doz
 doz
@@ -152386,22 +152441,22 @@ doz
 doz
 doz
 doz
-doz
+sqp
 ngu
 aHL
 agm
 vIA
 xBZ
-awY
 oxp
+oaz
+mHF
 sci
-mpY
 oxp
 avu
-nFU
+awY
 dOI
 osX
-nFU
+awY
 doz
 doz
 doz
@@ -152643,22 +152698,22 @@ doz
 doz
 doz
 doz
-doz
-ngu
+sqp
+vuH
 xkn
 rEK
 hmw
 nNg
 jdO
 rUG
-sci
+xba
 jYn
 wFO
 gcQ
 hcK
 nro
 aQj
-nFU
+awY
 doz
 doz
 doz
@@ -152900,22 +152955,22 @@ doz
 doz
 doz
 doz
-doz
-nFU
+mpY
+mpY
+mpY
+mpY
+ktk
+mpY
 nFU
 nFU
 nFU
 nbt
 nFU
 nFU
-nbt
-nFU
-nFU
-nFU
-nFU
-nFU
-nFU
-nFU
+awY
+awY
+awY
+awY
 doz
 doz
 doz
@@ -153160,13 +153215,13 @@ doz
 doz
 doz
 doz
-doz
 job
 ieX
 qDJ
 ieX
 ieX
-job
+ieX
+ieX
 job
 doz
 doz
@@ -186299,7 +186354,7 @@ eTJ
 luq
 fXG
 tiH
-eNf
+qyl
 qWd
 sPI
 msp
@@ -209449,7 +209504,7 @@ htm
 htm
 htm
 htm
-lzb
+htm
 htm
 htm
 htm
@@ -209705,9 +209760,9 @@ ugh
 hZk
 uiY
 rQM
-htm
-htm
-htm
+hOt
+dfi
+gNu
 gqq
 ylO
 dve
@@ -209962,7 +210017,7 @@ qjN
 nqn
 eIh
 oLe
-sqp
+xMU
 mTi
 gNu
 nWt
@@ -215614,7 +215669,7 @@ rMZ
 rMZ
 rMZ
 tLv
-bTH
+jqC
 jqC
 cjj
 yfh
@@ -215871,7 +215926,7 @@ bTH
 bTH
 bTH
 bTH
-bTH
+jqC
 aly
 oLt
 yfh


### PR DESCRIPTION
## Что этот PR делает

Фикс зон токсинов в рнд Коробки, теперь аиралярмы будут работать нормально, привязаны к определенной зоне. Добавлена термомашина в трубопровод Burn Chamber. РД и КМу добавлены принтеры в офисы.

## Почему это хорошо для игры

QoL апдейт

## Изображения изменений

<img width="480" height="512" alt="StrongDMM-2025-11-30 21 44 38" src="https://github.com/user-attachments/assets/4ee6c7a9-24ce-4966-9635-084c92b69543" />

## Тестирование

Локалка

## Changelog

:cl:
map: Кибериада: токсинная чуток изменена, изменены зоны и добавлена термомашина. У РД и КМа в кабинетах теперь есть собственные принтеры.
/:cl:
