### PR TITLE
Public Bans

### DIFF
--- a/code/modules/admin/sql_ban_system.dm
+++ b/code/modules/admin/sql_ban_system.dm
@@ -636,6 +636,8 @@
 
 	notify_all_banned_players(player_ckey, player_ip, player_cid, player_ban_notification, other_ban_notification, is_server_ban, applies_to_admins)
 
+	SScentral.create_ban_request(player_ckey, admin_ckey, is_server_ban, roles_to_ban, reason, duration, interval, severity, player_ip, player_cid) // BANDASTATION ADDITION: Ban logging
+
 	var/datum/admin_help/linked_ahelp_ticket = admin_ticket_log(player_ckey, "[kna] [msg]")
 
 	if(is_server_ban && linked_ahelp_ticket)

--- a/modular_bandastation/metaserver/code/ss_central.dm
+++ b/modular_bandastation/metaserver/code/ss_central.dm
@@ -215,3 +215,103 @@ SUBSYSTEM_DEF(central)
 		tiers += item["tier"]
 
 	return max(tiers)
+
+/datum/controller/subsystem/central/proc/create_ban_request(
+	ckey,
+	admin_ckey,
+	list/roles_to_ban,
+	is_server_ban,
+	reason,
+	duration,
+	interval,
+	severity,
+	player_ip = null,
+	player_cid = null
+)
+	var/endpoint = "[CONFIG_GET(string/ss_central_url)]/bans"
+	var/list/headers = list()
+	headers["Authorization"] = "Bearer [CONFIG_GET(string/ss_central_token)]"
+
+	duration = text2num(duration)
+
+	// convert duration to hours
+	var/duration_hours
+	if(!interval || interval == "MINUTE")
+		duration_hours = duration / 60.0
+	else if(interval == "HOUR")
+		duration_hours = duration
+	else if(interval == "DAY")
+		duration_hours = duration * 24
+	else if(interval == "WEEK")
+		duration_hours = duration * 24 * 7
+	else
+		duration_hours = duration
+
+	// determine job
+	var/job = (!is_server_ban && roles_to_ban && roles_to_ban.len == 1) ? roles_to_ban[1] : null
+
+	var/is_permaban = (duration_hours <= 0)
+
+	// backend expects null duration for permabans
+	if(is_permaban)
+		duration_hours = null
+
+	var/bantype
+
+	if(job)
+		if(is_permaban)
+			bantype = "JOB_PERMABAN"
+		else
+			bantype = "JOB_TEMPBAN"
+	else
+		if(is_permaban)
+			bantype = "PERMABAN"
+		else
+			bantype = "TEMPBAN"
+
+	var/list/body = list()
+	body["player_ckey"] = ckey
+	body["admin_ckey"] = admin_ckey
+	body["reason"] = reason
+	body["server_type"] = "BandaStation" // should be called from config actually
+	body["duration_hours"] = duration_hours
+	body["bantype"] = bantype
+	body["job"] = job
+
+	if(player_ip)
+		body["player_ip"] = player_ip
+	if(player_cid)
+		body["player_cid"] = player_cid
+
+	body["round_id"] = GLOB.round_id
+
+	SShttp.create_async_request(
+		RUSTG_HTTP_METHOD_POST,
+		endpoint,
+		json_encode(body),
+		headers,
+		CALLBACK(src, PROC_REF(create_ban_request_callback), ckey)
+	)
+
+
+/datum/controller/subsystem/central/proc/create_ban_request_callback(ckey, datum/http_response/response)
+	if(response.errored)
+		stack_trace("Failed to log ban: HTTP error - [response.error]")
+		return
+
+	switch(response.status_code)
+		if(201)
+			// successful
+			. = .
+
+		if(404)
+			message_admins("Не удалось залогировать бан: игрок не найден)")
+			return
+
+		if(409)
+			message_admins("Не удалось залогировать бан: бан уже существует)")
+			return
+
+		else
+			stack_trace("Could not log ban: HTTP [response.status_code] - [response.body]")
+			return


### PR DESCRIPTION

## Что этот PR делает
Наивная имплементация публичных банов через дискорд вебхук

В `SScentral.create_ban_request` формируется запрос в эндпоинт бана -> передаются данные о бане по формату -> через вебхук отправляется сообщение

## Почему это хорошо для игры
Игроки увидят баны в дискорде

## Тестирование
<img width="463" height="227" alt="image" src="https://github.com/user-attachments/assets/2a8592a3-a6f2-45b2-8d8e-ab8c6410c646" />
Игровой код к сожалению не удалось полноценно отдебажить, так как нет возможности полноценно поднять бэкенд сервера докером.

## Changelog

:cl:
add: добавлен прок запроса к бэкенду для создания публичного сообщения о бане
/:cl:
