### PR TITLE
Support for Asian symbols

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -41,7 +41,7 @@
 /proc/sanitize(text, apply_ic_filter = FALSE)
 	text = rustutils_regex_replace(text, "\[\n\t\]", "i", "#")
 	if(apply_ic_filter)
-		text = rustutils_regex_replace(text, "\[^a-zA-Za-åa-ö-w-я 0-9/@%\"!#?¨'.,:;*+\]", "i", "")
+		text = rustutils_regex_replace(text, "\[^a-zA-Za-åa-ö-w-я 0-9/@%\"!#?¨'.,:;*+\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF\uAC00-\uD7AF\u1100-\u11FF]", "i", "")
 
 	return html_encode(text)
 // BANDASTATION EDIT END - Sanitize emotes


### PR DESCRIPTION
## Что этот PR делает

Данный PR расширяет стандартный диапазон разрешённых символов для IC фильтра текста. Это нужно в некоторых эстетических местах, вроде космических ниндзя и некоторых ивентах.

ПР за авторством теневой администрации прайма.

## Почему это хорошо для игры

Больше свободы в реализации приколов при минимальных рисках.

## Изображения изменений

<img width="83" height="126" alt="image" src="https://github.com/user-attachments/assets/c34e2d81-00f3-4123-bc2d-3e1858d97136" />

## Тестирование

Локалочка показала, что всё работает.

## Changelog

:cl:
add: Добавлена поддержка катаканы, хириганы и китайских/корейских иероглифов
/:cl:
