### PR TITLE
[BALANCE] Debug and centcom items removed from Christmas gifts

### DIFF
--- a/code/game/objects/items/gift.dm
+++ b/code/game/objects/items/gift.dm
@@ -110,13 +110,21 @@
 	var/datum/weakref/recipient_ref = null
 
 /obj/item/gift/anything/get_gift_type()
-	var/static/list/obj/item/possible_gifts = null
+	var/static/list/possible_gifts = null
 
 	if(isnull(possible_gifts))
-		possible_gifts = get_sane_item_types(/obj/item)
+		var/list/all_items = get_sane_item_types(/obj/item)
+		// BANDASTATION EDIT START: No debug and centcom items
+		possible_gifts = list()
 
-	var/gift_type = pick(possible_gifts)
-	return gift_type
+		for(var/typepath in all_items)
+			var/type_str = "[typepath]"
+			if(findtext(type_str, "debug") || findtext(type_str, "centcom"))
+				continue
+			possible_gifts += typepath
+		// BANDASTATION EDIT END: No debug and centcom items
+
+	return pick(possible_gifts)
 
 /obj/item/gift/anything/attack_self(mob/user)
 	if (isnull(recipient_ref))


### PR DESCRIPTION
## Что этот PR делает
Убирает предметы с "debug" и "centcom" названиями из возможного пула предметов из подарка.
Гринчи похитили новый год :(
## Почему это хорошо для игры
Не знаю, меня попросили
## Изображения изменений
<img width="500" height="281" alt="image" src="https://github.com/user-attachments/assets/73465593-f6c4-4d29-b226-1c8bec69fa4a" />

## Тестирование
Локальный сервер
## Changelog

:cl:
del: Дебаговые и часть ЦК предметов убраны из праздничных подарков
/:cl:
