### PR TITLE
FIX: Cyborg items in cryo console

### DIFF
--- a/modular_bandastation/cryosleep/code/cryopod/cryopod.dm
+++ b/modular_bandastation/cryosleep/code/cryopod/cryopod.dm
@@ -273,7 +273,7 @@ GLOBAL_LIST_EMPTY(objectives)
 	var/obj/machinery/computer/cryopod/control_computer = get_linked_control_computer()
 	var/mob/mob_occupant = occupant
 
-	if(issilicon(mob_occupant))
+	if(!mob_occupant || issilicon(mob_occupant))
 		return
 
 	var/atom/drop_location = drop_location()


### PR DESCRIPTION

## Что этот PR делает

(close: https://github.com/ss220club/BandaStation/issues/2009)
Теперь вещи силиконов не будут отображаться в окне Выдачи вещей из криокапсул

## Почему это хорошо для игры

## Изображения изменений

## Тестирование

## Changelog

:cl: ReeZii
fix: Теперь вещи силиконов не будут появляться в консоли криокапсул
/:cl:
