### PR TITLE
FIX: Janitor keys

### DIFF
--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -98,7 +98,7 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 				return TRUE
 			for(var/access_as_text in SSid_access.sub_department_managers_tgui)
 				var/list/info = SSid_access.sub_department_managers_tgui[access_as_text]
-				if(card.trim.assignment != info["head"])
+				if(card.trim.assignment != job_title_ru(info["head"])) // BANDASTATION FIX: janitor keycard
 					continue
 				COOLDOWN_START(src, access_grant_cooldown, ACCESS_GRANTING_COOLDOWN)
 				SEND_GLOBAL_SIGNAL(COMSIG_ON_DEPARTMENT_ACCESS, info["regions"])


### PR DESCRIPTION
## Что этот PR делает
(close: https://github.com/ss220club/BandaStation/issues/1447)
Теперь выдача доступов уборщику по кнопке вновь работает корректно.

## Почему это хорошо для игры

## Изображения изменений

## Тестирование

## Changelog

:cl: ReeZii
fix: Кнопка выдачи доступов уборщику для глав вновь снова работает
/:cl:
