### PR TITLE
[CONFIG] Cyberiad minplayer limit

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -41,7 +41,7 @@ map tramstation
 endmap
 
 map cyberiad
-	maxplayers 100
+	minplayers 50
 	votable
 endmap
 


### PR DESCRIPTION

## Что этот PR делает
Добавляет нижний порог выбора Кибериады из пула карт - 50 игроков
## Почему это хорошо для игры
Кибериада плохо подходит для лоупопов
## Тестирование
Не требуется
## Changelog

:cl:
config: Для Кибериады был добавлен нижний порог в 50 человек для выбора карты
/:cl:
