### PR TITLE
Changing GP-9 cargo crate content

### DIFF
--- a/modular_bandastation/weapon/code/ranged/supply_packs.dm
+++ b/modular_bandastation/weapon/code/ranged/supply_packs.dm
@@ -1,13 +1,11 @@
 /datum/supply_pack/security/gp9_pistols
 	name = "GP-9 Pistols Crate"
-	desc = "В этом ящике находятся два пистолета GP-9 калибра 9x25мм НТ с двумя магазинами заряженными резиной, а также по одной коробке соответствующих летальных и нелетальных боеприпасов."
+	desc = "В этом ящике находятся два пистолета GP-9 калибра 9x25мм, а также четыре нелетальных магазина калибра 9x25мм НТ."
 	cost = CARGO_CRATE_VALUE * 10
 	access_view = ACCESS_SECURITY
 	contains = list(
-		/obj/item/gun/ballistic/automatic/pistol/gp9 = 2,
-		/obj/item/ammo_box/magazine/c9x25mm_pistol/rubber = 2,
-		/obj/item/ammo_box/c9x25mm = 1,
-		/obj/item/ammo_box/c9x25mm/rubber = 1,
+		/obj/item/gun/ballistic/automatic/pistol/gp9/no_mag = 2,
+		/obj/item/ammo_box/magazine/c9x25mm_pistol/rubber = 4,
 	)
 	crate_name = "GP-9 handguns crate"
 


### PR DESCRIPTION
## Что этот PR делает

Меняет наполнение ящика с пистолетами ГП-9

## Почему это хорошо для игры

Из-за скилл ищуе, я вспомнила, что могу менять код

## Изображения изменений

<img width="290" height="233" alt="Screenshot_573" src="https://github.com/user-attachments/assets/c718521a-18ac-418b-9c94-4856a2f94e15" />
<img width="377" height="192" alt="Screenshot_574" src="https://github.com/user-attachments/assets/471f78de-0ff0-4405-8be9-981d5499877b" />

## Тестирование

Локалка

## Changelog

:cl:
balance: В карго ящике с пистолетами ГП-9 теперь лежит только 2 пистолета без магазинов, и 4 магазина с резиной
/:cl:
