### PR TITLE
ERT request text correction

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -326,7 +326,7 @@
 			ert_request(reason, user)
 			to_chat(user, span_notice("ERT request sent."))
 			user.log_message("has requested an Emergency Response Team from CentCom with reason \"[reason]\"", LOG_SAY)
-			priority_announce("Отправлен запрос ОБР. Инициатор: [name]. Запрос принят к рассмотрению. Решение будет направлено в ближайшее время.", "[command_name()]: Служба быстрого реагирования", SSstation.announcer.get_rand_report_sound())
+			priority_announce("Отправлен запрос ОБР. Инициатор: [user]. Запрос принят к рассмотрению.", "[command_name()]: Служба быстрого реагирования", SSstation.announcer.get_rand_report_sound())
 			playsound(src, 'sound/machines/terminal/terminal_prompt.ogg', 50, FALSE)
 			COOLDOWN_START(src, important_action_cooldown, IMPORTANT_ACTION_COOLDOWN)
 		// BANDASTATION ADDITION - END

--- a/modular_bandastation/ert/code/ert_manager.dm
+++ b/modular_bandastation/ert/code/ert_manager.dm
@@ -128,7 +128,7 @@ ADMIN_VERB(ert_manager, R_ADMIN, "ERT Manager", "Manage ERT reqests.", ADMIN_CAT
 			message_admins("[key_name_admin(usr)] dispatched a [ert_type] ERT. Slots: [slot_text]")
 			log_admin("[key_name(usr)] dispatched a [ert_type] ERT. Slots: [slot_text]")
 			if(should_be_announced)
-				priority_announce("Внимание, [station_name()]. Мы рассматриваем возможность отправки ОБР, ожидайте.", "Активирован протокол ОБР")
+				priority_announce("Внимание, [station_name()]. Ваш запрос ОБР санкционирован. Идёт проверка доступности ресурсов. Результат будет объявлен в течении нескольких минут.", "Активирован протокол ОБР")
 			makeERTFromSlots(new_ert, admin_slots, commander_slots, security_slots, medical_slots, engineering_slots, janitor_slots, chaplain_slots, clown_slots)
 
 		if("view_player_panel")
@@ -136,10 +136,10 @@ ADMIN_VERB(ert_manager, R_ADMIN, "ERT Manager", "Manage ERT reqests.", ADMIN_CAT
 
 		if("denyErt")
 			GLOB.ert_request_answered = TRUE
-			var/message = "[station_name()], к сожалению, в данный момент мы не можем направить к вам ОБР."
+			var/message = "[station_name()], уведомляем вас, что развёртывание ОБР в данный момент невозможно."
 			if(params["reason"])
 				message += " Your ERT request has been denied for the following reasons:\n\n[params["reason"]]"
-			priority_announce(message, "ОБР недоступно")
+			priority_announce(message, "ОБР недоступен")
 		else
 			return FALSE
 
@@ -263,7 +263,7 @@ ADMIN_VERB(ert_manager, R_ADMIN, "ERT Manager", "Manage ERT reqests.", ADMIN_CAT
 
 	if(!length(candidates))
 		if(should_be_announced)
-			minor_announce("Внимание, [station_name()]. К сожалению, в настоящее время мы не можем направить к вам отряд быстрого реагирования.", "ОБР недоступен")
+			minor_announce("[station_name()], уведомляем вас, что развёртывание ОБР в данный момент невозможно.", "ОБР недоступен")
 		return FALSE
 
 	if(ertemplate.spawn_admin)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Переработка/корректировка текста запроса, отправки и рассмотрения ОБР.
При переводе я перепутал в инициаторе user с name, в итоге выдавало communications console.
Поправлена логика и последовательность выдаваемого текста - текст в целом переработан и теперь звучит более натурально и не кажется что там рассматривают запрос по два круга и просят дважды ожидать.

## Changelog

:cl:
fix: Исправлен запрос ОБР, который выдавал в тексте вместо инициатора саму консоль.
typo: Немного переработан текст запроса, отправки и отклонения ОБР. Выдаваемые анонсы теперь должны быть более логичны и последовательны.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
