### PR TITLE
Fix: Госты больше не залазят в машины

### DIFF
--- a/code/modules/vehicles/sealed.dm
+++ b/code/modules/vehicles/sealed.dm
@@ -56,7 +56,7 @@
 
 
 /obj/vehicle/sealed/proc/mob_try_enter(mob/rider)
-	if(!istype(rider) || !isliving(M))
+	if(!istype(rider) || !isliving(rider))
 		return FALSE
 	var/enter_delay = get_enter_delay(rider)
 	if (enter_delay == 0)


### PR DESCRIPTION

## Что этот PR делает
Чинит баг, при котором госты могли перетянуть себя в машину и сесть в неё, занимая слот.
## Почему это хорошо для игры
Госты больше не в гонке
## Тестирование
Локалочка
## Changelog

:cl:
fix: Госты больше не в гонке (не могут залезать в машины).
/:cl:
