### PR TITLE
Fix: Duplicated syndie radio

### DIFF
--- a/_maps/RandomZLevels/TheBeach.dmm
+++ b/_maps/RandomZLevels/TheBeach.dmm
@@ -1298,11 +1298,11 @@
 /turf/open/floor/wood/large,
 /area/awaymission/beach)
 "qk" = (
-/obj/machinery/telecomms/allinone,
 /obj/item/wirecutters{
 	pixel_y = 9
 	},
 /obj/machinery/light/directional/south,
+/obj/structure/table/glass,
 /turf/open/floor/iron/dark/diagonal,
 /area/awaymission/beach)
 "ql" = (


### PR DESCRIPTION
## Что этот PR делает
Убирает с пляжа телекомы, которые дублируют синди-канал. Аналогичное решение с содержимым #1644 

## Почему это хорошо для игры
Больше нет дубликатов ТТСа/сообщений в чате.

## Изображения изменений
<img width="1199" height="677" alt="image" src="https://github.com/user-attachments/assets/25678ebd-6461-43ef-aa7e-9ed0a8f90578" />

## Тестирование
Лклка

## Changelog

:cl:
fix: Синди канал больше не дублируется при существовании TheBeach гейта.
/:cl:
