### PR TITLE
Duct desync fix

### DIFF
--- a/code/modules/plumbing/ducts.dm
+++ b/code/modules/plumbing/ducts.dm
@@ -160,7 +160,11 @@
 	if(!net)
 		return ..()
 
-	var/list/atom/movable/visited = list(src = TRUE)
+	// BANDASTATION EDIT - TEMPORAL FIX - START
+	var/list/atom/movable/visited = list()
+	visited[src] = TRUE
+	// BANDASTATION EDIT - TEMPORAL FIX - END
+
 	while(neighbours.len)
 		var/atom/movable/neighbour = popleft(neighbours)
 


### PR DESCRIPTION
## Что этот PR делает

Исправляет ошибку связанную с дактами пламбинга.  По неизвестной мне причине (вероятно зависимость от версий) строка `var/list/atom/movable/visited = list(src = TRUE)` создаёт в списке visited не запись вида `{Ссылка на объект src} = 1`, а запись вида `"scr" = 1`. При этом на других версиях BYOND поведение меняется. Исправил на универсальный способ, который (я надеюсь) будет работать везде одинаково.

Запихнуть в модуль это не смог, т.к. нужно вызывать проки по линии наследования. К счастью, файл дактов последующие ПРы касающиеся пламбинга не трогают. Это временный фикс, пока оффы не сочтут эту проблему важной.

## Почему это хорошо для игры

Исправление багов.

## Тестирование

Локально с дебаггером.

## Changelog

:cl:
fix: Трубы пламбинга более не отсоединяются от машин сами по себе.
/:cl:
