### PR TITLE
[Balance] Slip Change: Remove 2 seconds Immobilize_time, add paralyze_time 0.5

### DIFF
--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -76,7 +76,7 @@
 	force_drop = FALSE,
 	slot_whitelist,
 	datum/callback/can_slip_callback,
-	immobilize = 0 SECONDS, /// BANDASTATION ADDITION - Immobilizing slippery
+	immobilize = immobilize_time /// BANDASTATION ADDITION - Immobilizing slippery
 )
 	src.knockdown_time = max(knockdown, 0)
 	src.paralyze_time = max(paralyze, 0)


### PR DESCRIPTION
## Что этот PR делает
Заменяет полную 2х секундную остановку при поскальзывании на 0.5 секунд паралича
## Почему это хорошо для игры
2 секунды не возможности двигаться это слишком много, это изменение позволяет сократить это время в 4 раза, но борется с мгновенным поднятием упавших во время драки вещей
## Тестирование
Проверил на локалке работает

https://github.com/user-attachments/assets/cf56a4e5-c9f1-464a-9d95-44cfd0246095


## Changelog

:cl:

balance: Slip Change: Removed 2 seconds of immobilize time, replaced with 0.5 seconds of paralysis
/:cl:
