### PR TITLE
Fix: Removed mutation toxins from remains

### DIFF
--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -5,7 +5,8 @@ GLOBAL_LIST_INIT(remains_blocked_reagents, list(
 		subtypesof(/datum/reagent/mutationtoxin),
 		/datum/reagent/aslimetoxin,
 		/datum/reagent/gluttonytoxin,
-		/datum/reagent/gondola_mutation_toxin))
+		/datum/reagent/gondola_mutation_toxin,
+		/datum/reagent/magillitis))
 // BANDASTATION ADD END
 
 /obj/effect/decal/remains


### PR DESCRIPTION
## Что этот PR делает
Удаляет токсины из спавна останков, принудительно превращающих куклу в другую расу/гандо~~на~~лу/морфа и т.п.
Так же инициализирует список запрещённых реагентов один раз, а не при инициализации каждых останков.

## Почему это хорошо для игры
Игроки не превращаются в симплов/другие расы по чистой случайности.

## Тестирование
Проверил наличие реагентов в блэклисте и задебажил сам список

## Changelog

:cl:
fix: Останки в техах больше не превращают игроков в слаймов, морфов и т.п.
/:cl: