### PR TITLE
ADMIN: Possessed objects NOW SPEAKS

### DIFF
--- a/code/modules/mob/dead/observer/observer_say.dm
+++ b/code/modules/mob/dead/observer/observer_say.dm
@@ -57,7 +57,7 @@
 		return
 
 	// BANDASTATION EDIT START: Possessed objects can speak
-	var/possessed_atom = usr.GetComponent(/datum/component/object_possession)?.possessed
+	var/obj/possessed_atom = usr.GetComponent(/datum/component/object_possession)?.possessed
 	if(!possessed_atom)
 		. = say_dead(message)
 	else


### PR DESCRIPTION
## Что этот PR делает
Теперь всё, во что администратор сможет вселиться через Possess Object (atom/movable) говорят не только через OSay или say прок.

## Почему это хорошо для игры
ГОВОРЯЩИЕ ЖУЖУКИ, ВЕНДОРЫ И ДАЖЕ ВАШИ КОШЕЛЬКИ!

## Изображения изменений
<img width="494" height="167" alt="image" src="https://github.com/user-attachments/assets/a3e1256d-8a59-400d-9f50-8687cf714a80" />
<img width="344" height="171" alt="image" src="https://github.com/user-attachments/assets/e63fa8ea-170b-45dd-8e44-f506ec32e296" />
<img width="712" height="47" alt="image" src="https://github.com/user-attachments/assets/b1e9ce3b-3bae-4805-bc71-1e0ca07fda53" />

## Тестирование
Говорил за объекты, в которые смог вселиться.

## Changelog

:cl:
admin: Во время Possess Object сообщения отправляются от лица объекта, в который вселился администратор, а не в дедчат.
/:cl:
