### PR TITLE
Bugfix_kniht_flexh(flesh_surgery)

### DIFF
--- a/code/genesis_call.dme
+++ b/code/genesis_call.dme
@@ -50,12 +50,3 @@
  */
 /world/proc/_()
 	var/static/_ = world.Genesis()
-// BEGIN_INTERNALS
-// END_INTERNALS
-// BEGIN_FILE_DIR
-#define FILE_DIR .
-// END_FILE_DIR
-// BEGIN_PREFERENCES
-// END_PREFERENCES
-// BEGIN_INCLUDE
-// END_INCLUDE


### PR DESCRIPTION
## Что этот PR делает

Исправляет баг из-за которого спелл не работал, а так-же переводит ту часть, что была не на русском. 
По сути весь фикс это замена 217 стоки, ОДНАКО, теперь органы в выборе на извлечение будут на английском. Я попытался разные варианты, но так и не смог придумать способа вывода списка органов на русском

## Почему это хорошо для игры

Спелл работает, и переведен 

## Изображения изменений
## Тестирование

Проверил работу и часть фраз от взаимодействия на локалке, но требуются доп тесты со сторонними наблюдателями от 2 и 3 лица

## Changelog

:cl: kostya.vat
fix: Починил работу спела

translation: Попытался перевести этот хтонический ужас, но лучше б глаза мои его не видели
/:cl:
