### PR TITLE
Sync legacy tempo with BPM

### DIFF
--- a/code/modules/instruments/songs/_song.dm
+++ b/code/modules/instruments/songs/_song.dm
@@ -424,7 +424,7 @@
 		return
 	bpm = new_bpm
 
-	// legacy tempo = deciseconds per beat
+	// BANDASTATION ADD: legacy tempo = deciseconds per beat
 	tempo = sanitize_tempo((60 SECONDS) / bpm, TRUE)
 
 	SEND_SIGNAL(parent, COMSIG_INSTRUMENT_TEMPO_CHANGE, src)


### PR DESCRIPTION

## Что этот PR делает
Добавляет измение tempo при изменеии БПМ для совместимости с механиками оффов.
## Почему это хорошо для игры
Фиксим баги, и шью #2260 
## Изображения изменений
## Тестирование
Локальный сервер
## Changelog

:cl:
fix: Восстановление смены tempo
/:cl:
