### PR TITLE
Balance: Запрет разбора буйных автоматов

### DIFF
--- a/modular_bandastation/balance/_balance.dme
+++ b/modular_bandastation/balance/_balance.dme
@@ -23,6 +23,7 @@
 #include "code/station_traits.dm"
 #include "code/supply_packs.dm"
 #include "code/vehicle/paddy.dm"
+#include "code/vending.dm"
 #include "code/weapons/baton.dm"
 #include "code/weapons/dragnet.dm"
 #include "code/weapons/rifle.dm"

--- a/modular_bandastation/balance/code/vending.dm
+++ b/modular_bandastation/balance/code/vending.dm
@@ -1,0 +1,5 @@
+/obj/machinery/vending/tool_act(mob/living/user, obj/item/tool, list/modifiers)
+	if(src.ai_controller)
+		src.balloon_alert(user, "не поддаётся!")
+		return ITEM_INTERACT_BLOCKING
+	. = ..()


### PR DESCRIPTION
## Что этот PR делает
Запрещает разбирать в два клика вендоматы с ИИ. Ивент с заражением вендоматов теперь не шутка.

## Почему это хорошо для игры
Ивент теперь не побеждается в два клика по цели.

## Изображения изменений
<img width="370" height="243" alt="image" src="https://github.com/user-attachments/assets/b5809822-0426-4615-b13b-0bd92d9c3618" />


## Тестирование
Автомат на меня прыгал, разобрать не дало

## Changelog

:cl:
balance: Бешеные вендоматы теперь нельзя разобрать инструментами.
/:cl:
