### PR TITLE
FIX: Спавны кастомных работ

### DIFF
--- a/modular_bandastation/jobs/code/job_types/blueshield/job.dm
+++ b/modular_bandastation/jobs/code/job_types/blueshield/job.dm
@@ -4,7 +4,7 @@
 	auto_deadmin_role_flags = DEADMIN_POSITION_SECURITY
 	faction = FACTION_STATION
 	total_positions = 1
-	spawn_positions = 0
+	spawn_positions = 1
 	supervisors = "Представитель Нанотрейзен и Центральное Командование"
 	minimal_player_age = 7
 	exp_requirements = 1800

--- a/modular_bandastation/jobs/code/job_types/explorer/job.dm
+++ b/modular_bandastation/jobs/code/job_types/explorer/job.dm
@@ -9,7 +9,7 @@
 	outfit = /datum/outfit/job/explorer
 	faction = FACTION_STATION
 	total_positions = 4
-	spawn_positions = 0
+	spawn_positions = 3
 	minimal_player_age = 18
 	exp_requirements = 180
 	exp_required_type = EXP_TYPE_CREW

--- a/modular_bandastation/jobs/code/job_types/magistrate/job.dm
+++ b/modular_bandastation/jobs/code/job_types/magistrate/job.dm
@@ -5,7 +5,7 @@
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD|DEADMIN_POSITION_SECURITY
 	faction = FACTION_STATION
 	total_positions = 1
-	spawn_positions = 0
+	spawn_positions = 1
 	supervisors = "Центральное командование"
 	minimal_player_age = 14
 	exp_requirements = 1500

--- a/modular_bandastation/jobs/code/job_types/nanotrasen_representative/job.dm
+++ b/modular_bandastation/jobs/code/job_types/nanotrasen_representative/job.dm
@@ -4,7 +4,7 @@
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
 	faction = FACTION_STATION
 	total_positions = 1
-	spawn_positions = 0
+	spawn_positions = 1
 	supervisors = "Центральное Командование"
 	minimal_player_age = 14
 	exp_requirements = 1500


### PR DESCRIPTION
## Что этот PR делает
Исправляет невозможность раундстарт спавна за профессии НТРа, Синего Щита, исследователей и магистрата.
## Почему это хорошо для игры
Багфикс
## Тестирование
Дебаггер, локально

## Changelog

:cl:
fix: Исправлена невозможность раундстарт спавна за профессии НТРа, Синего Щита, исследователя и магистрата.
/:cl:
