### PR TITLE
BSA cooldown comeback

### DIFF
--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -298,7 +298,7 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 /obj/machinery/computer/bsa_control/ui_data()
 	var/obj/machinery/bsa/full/cannon = cannon_ref?.resolve()
 	var/list/data = list()
-	data["ready"] = cannon ? cannon.ready : FALSE
+	data["ready"] = cannon ? cannon.ready : FALSE // BANDASTATION ADDITION: BSA check
 	data["connected"] = cannon
 	data["notice"] = notice
 	data["unlocked"] = GLOB.bsa_unlock


### PR DESCRIPTION

## Что этот PR делает
Добавляет КД для бСА
Ну...КД добавляет для БСА. В одну минуту.
## Почему это хорошо для игры
Нельзя спамить из БСА
## Изображения изменений
Их съели воксы. Скрины кода кидать не буду
## Тестирование
На локалке потестил. КД минута, рантаймов нет, стрелять не даёт.
## Changelog

:cl:
balance: Добавлено КД для БСА в одну минуту
/:cl:
