### PR TITLE
FIX: Roundstart heavy rulesets

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -280,7 +280,11 @@ SUBSYSTEM_DEF(dynamic)
 			log_dynamic("Roundstart: Ruleset is a solo ruleset. Cancelling other picks.")
 			QDEL_LIST(picked_rulesets)
 			rulesets_weighted -= picked_ruleset
-			picked_rulesets += picked_ruleset
+			// BANDASTATION EDIT: Repeatable rulesets fix
+			//picked_rulesets += picked_ruleset
+			picked_rulesets += picked_ruleset.type
+			qdel(picked_ruleset)
+			// BANDASTATION EDIT: END
 			break
 		if(current_tier.tier != DYNAMIC_TIER_HIGH && (picked_ruleset.ruleset_flags & RULESET_HIGH_IMPACT))
 			for(var/datum/dynamic_ruleset/roundstart/high_impact_ruleset as anything in rulesets_weighted)
@@ -290,7 +294,11 @@ SUBSYSTEM_DEF(dynamic)
 				rulesets_weighted -= high_impact_ruleset
 		if(!picked_ruleset.repeatable)
 			rulesets_weighted -= picked_ruleset
-			picked_rulesets += picked_ruleset
+			// BANDASTATION EDIT: Repeatable rulesets fix
+			//picked_rulesets += picked_ruleset
+			picked_rulesets += picked_ruleset.type
+			qdel(picked_ruleset)
+			// BANDASTATION EDIT: END
 			continue
 
 		rulesets_weighted[picked_ruleset] -= picked_ruleset.repeatable_weight_decrease

--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -279,12 +279,9 @@ SUBSYSTEM_DEF(dynamic)
 		if(picked_ruleset.solo)
 			log_dynamic("Roundstart: Ruleset is a solo ruleset. Cancelling other picks.")
 			QDEL_LIST(picked_rulesets)
+			total_weight -= rulesets_weighted[picked_ruleset] // BANDASTATION ADDITION: Repeatable rulesets fix
 			rulesets_weighted -= picked_ruleset
-			// BANDASTATION EDIT: Repeatable rulesets fix
-			//picked_rulesets += picked_ruleset
 			picked_rulesets += picked_ruleset.type
-			qdel(picked_ruleset)
-			// BANDASTATION EDIT: END
 			break
 		if(current_tier.tier != DYNAMIC_TIER_HIGH && (picked_ruleset.ruleset_flags & RULESET_HIGH_IMPACT))
 			for(var/datum/dynamic_ruleset/roundstart/high_impact_ruleset as anything in rulesets_weighted)
@@ -293,12 +290,9 @@ SUBSYSTEM_DEF(dynamic)
 				total_weight -= rulesets_weighted[high_impact_ruleset]
 				rulesets_weighted -= high_impact_ruleset
 		if(!picked_ruleset.repeatable)
+			total_weight -= rulesets_weighted[picked_ruleset] // BANDASTATION ADDITION: Repeatable rulesets fix
 			rulesets_weighted -= picked_ruleset
-			// BANDASTATION EDIT: Repeatable rulesets fix
-			//picked_rulesets += picked_ruleset
 			picked_rulesets += picked_ruleset.type
-			qdel(picked_ruleset)
-			// BANDASTATION EDIT: END
 			continue
 
 		rulesets_weighted[picked_ruleset] -= picked_ruleset.repeatable_weight_decrease


### PR DESCRIPTION

## Что этот PR делает
Попытка исправить невозможность выпадения хэви раунстарт рулсетов, а точнее добавление non repeatable рулсетов в picked_rulesets
## Почему это хорошо для игры
Фикс ошибки

## Тестирование
главное верить в успех (смотрел под дебаггером)

## Changelog

:cl:
fix: Исправлена проблема выпадения heavy roundstart рулсетов.
/:cl:
