### PR TITLE
Del: remove lead pipes

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_syndidome.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_syndidome.dmm
@@ -652,7 +652,6 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/syndibiodome)
 "io" = (
-/obj/item/lead_pipe,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/ruin/syndibiodome)

--- a/_maps/RandomRuins/SpaceRuins/garbagetruck3.dmm
+++ b/_maps/RandomRuins/SpaceRuins/garbagetruck3.dmm
@@ -299,7 +299,6 @@
 /turf/open/floor/plating/dumpsterair,
 /area/ruin/space/has_grav/garbagetruck/squat)
 "pM" = (
-/obj/item/lead_pipe,
 /obj/structure/door_assembly/door_assembly_mhatch,
 /obj/effect/decal/cleanable/glass,
 /obj/item/restraints/handcuffs/cable/zipties/used,

--- a/_maps/RandomRuins/SpaceRuins/garbagetruck4.dmm
+++ b/_maps/RandomRuins/SpaceRuins/garbagetruck4.dmm
@@ -55,10 +55,6 @@
 /obj/item/trash/candy{
 	pixel_x = 7
 	},
-/obj/item/lead_pipe{
-	pixel_x = -2;
-	pixel_y = -4
-	},
 /obj/item/plate_shard{
 	pixel_x = 6;
 	pixel_y = 0

--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -4247,7 +4247,7 @@
 /area/station/cargo/storage)
 "beF" = (
 /obj/structure/table/wood/fancy,
-/obj/item/lead_pipe{
+/obj/item/banhammer{
 	desc = "Revolutionary! Really makes your head hurt thinking about it.";
 	name = "Dadaist Art Exposition"
 	},

--- a/_maps/minigame/basketball/soviet_bear.dmm
+++ b/_maps/minigame/basketball/soviet_bear.dmm
@@ -30,7 +30,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/oil,
-/obj/item/lead_pipe,
 /turf/open/floor/plating,
 /area/centcom/basketball)
 "cz" = (

--- a/_maps/shuttles/pirate_irs.dmm
+++ b/_maps/shuttles/pirate_irs.dmm
@@ -1153,7 +1153,6 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 10
 	},
-/obj/item/lead_pipe,
 /obj/item/flamethrower{
 	name = "Fallujah firehose";
 	desc = "Someone's got a friend in Syria!"


### PR DESCRIPTION
## Что этот PR делает
Удаляет lead_pipe со всех локаций. 

## Почему это хорошо для игры
Больше не слышно *звук_падающей_трубы*. 
<img width="220" height="234" alt="image" src="https://github.com/user-attachments/assets/e54f3149-a1df-458e-ba3d-470320de8c27" />


## Changelog

:cl:
del: Громкие трубы удалены со всех карт
/:cl: