### PR TITLE
FIX: Two Syndicate Infiltrator shuttles spawn

### DIFF
--- a/_maps/templates/lazy_templates/ss220/syndie_cc.dmm
+++ b/_maps/templates/lazy_templates/ss220/syndie_cc.dmm
@@ -4751,7 +4751,6 @@
 	area_type = /area/centcom/syndicate_base;
 	height = 22;
 	name = "Syndicate Mothership Dock";
-	roundstart_template = /datum/map_template/shuttle/infiltrator/basic;
 	shuttle_id = "syndicate_away";
 	width = 18;
 	dwidth = 8

--- a/_maps/templates/lazy_templates/ss220/syndie_cc_small.dmm
+++ b/_maps/templates/lazy_templates/ss220/syndie_cc_small.dmm
@@ -985,7 +985,6 @@
 	area_type = /area/centcom/syndicate_base;
 	height = 22;
 	name = "Syndicate Mothership Dock";
-	roundstart_template = /datum/map_template/shuttle/infiltrator/basic;
 	shuttle_id = "syndicate_away";
 	width = 18;
 	dwidth = 8


### PR DESCRIPTION

## Что этот PR делает

Исправляет появление сразу двух шаттлов нюки (один на СЦК, второй в космосе в режиме mobile) в режиме войны.

Вероятно не самое правильное решение, однако быстрое и рабочее.

## Почему это хорошо для игры

Код от боеголовки выдается один, админам меньше работы

## Тестирование

Проверял на разных картах (один из симптомов(вроде)), полноценно работает

## Changelog

:cl:
map: Убрал раундстарт спавн шаттла Syndicate Infiltrator на СЦК. Теперь не будет проблем с неправильным кодом от боеголовки.
/:cl:
