### PR TITLE
Remove sloth ruins

### DIFF
--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -124,7 +124,7 @@
 	suffix = "lavaland_surface_sloth.dmm"
 	// Generates nothing but atmos runtimes and salt
 	cost = 0
-	unpickable = TRUE
+	unpickable = TRUE //BANDASTATION EDIT
 
 /datum/map_template/ruin/lavaland/ratvar
 	name = "Lava-Ruin Dead God"


### PR DESCRIPTION
## Что этот PR делает

Убирает из спавна рандомных руин на лаве бесполезные и вечно недоделанные руины лени

## Почему это хорошо для игры

Бессмысленные руины, которые спавняться всегда гарантированно, и в целом не имеют никакой ценности в игре

## Изображения изменений

Не надо

## Тестирование

Запустилось

## Changelog

:cl:
del: На Лаваленде больше не будут спавниться руины лени
/:cl:
