### PR TITLE
FIX: Double runechat

### DIFF
--- a/code/__DEFINES/lag_switch.dm
+++ b/code/__DEFINES/lag_switch.dm
@@ -16,9 +16,5 @@
 #define DISABLE_PARALLAX 7
 /// Disables footsteps, TRAIT_BYPASS_MEASURES exempted
 #define DISABLE_FOOTSTEPS 8
-// BANDASTATION EDIT START - ghost runechat
-/// Disables ghost_runechat, no exemptions
-#define DISABLE_GHOST_RUNECHAT 9
 
-#define MEASURES_AMOUNT 9 // The total number of switches defined above
-// BANDASTATION EDIT START - ghost runechat
+#define MEASURES_AMOUNT 8 // The total number of switches defined above

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -365,10 +365,7 @@ GLOBAL_LIST_INIT(skin_tone_names, list(
 
 // Displays a message in deadchat, sent by source. source is not linkified, message is, to avoid stuff like character names to be linkified.
 // Automatically gives the class deadsay to the whole message (message + source)
-// BANDASTATION EDIT START - ghost runechat
-/proc/deadchat_broadcast(message, source=null, mob/follow_target=null, turf/turf_target=null, speaker_key=null, message_type=DEADCHAT_REGULAR, admin_only=FALSE, raw_message)
-	var/should_show_runechat = !SSlag_switch.measures[DISABLE_GHOST_RUNECHAT] && raw_message && follow_target && !follow_target.orbiting
-// BANDASTATION EDIT END - ghost runechat
+/proc/deadchat_broadcast(message, source=null, mob/follow_target=null, turf/turf_target=null, speaker_key=null, message_type=DEADCHAT_REGULAR, admin_only=FALSE)
 	message = span_deadsay("[source][span_linkify(message)]")
 
 	if(admin_only)
@@ -428,13 +425,10 @@ GLOBAL_LIST_INIT(skin_tone_names, list(
 				var/turf_link = TURF_LINK(M, turf_target)
 				rendered_message = "[turf_link] [message]"
 
-			// BANDASTATION EDIT START - ghost runechat
-			if(should_show_runechat && M.client?.prefs.read_preference(/datum/preference/toggle/enable_runechat) && M.see_invisible >= follow_target.invisibility)
-				M.create_chat_message(follow_target, raw_message = raw_message, spans = list("deadsay"))
-			// BANDASTATION EDIT END - ghost runechat
 			to_chat(M, rendered_message, avoid_highlighting = speaker_key == M.key)
 		else
 			to_chat(M, message, avoid_highlighting = speaker_key == M.key)
+
 
 //Used in chemical_mob_spawn. Generates a random mob based on a given gold_core_spawnable value.
 /proc/create_random_mob(spawn_location, mob_class = HOSTILE_SPAWN)

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -160,11 +160,6 @@
 	// Bandastation Edit Start
 	else if (extra_classes.Find("looc"))
 		LAZYADD(prefixes, "<span style='font-size: 6px; color: #6699cc;'><b>\[LOOC\]</b></span> ")
-	else if (extra_classes.Find("deadsay"))
-		target.chat_color = "#b826b3"
-		// We need to force these vars to avoid color override
-		target.chat_color_name = "ghost"
-		chat_color_name_to_use = "ghost"
 	// Bandastation Edit End
 
 	if(isnull(chat_color_name_to_use))

--- a/code/modules/admin/verbs/admingame.dm
+++ b/code/modules/admin/verbs/admingame.dm
@@ -480,9 +480,6 @@ ADMIN_VERB(lag_switch_panel, R_ADMIN, "Show Lag Switches", "Display the controls
 	dat += "Disable late joining: <a href='byond://?_src_=holder;[HrefToken()];change_lag_switch=[DISABLE_NON_OBSJOBS]'><b>[SSlag_switch.measures[DISABLE_NON_OBSJOBS] ? "On" : "Off"]</b></a><br/>"
 	dat += "<br/>============! MAD GHOSTS ZONE !============<br/>"
 	dat += "Disable deadmob keyLoop (except staff, informs dchat): <a href='byond://?_src_=holder;[HrefToken()];change_lag_switch=[DISABLE_DEAD_KEYLOOP]'><b>[SSlag_switch.measures[DISABLE_DEAD_KEYLOOP] ? "On" : "Off"]</b></a><br/>"
-	// BANDASTATION EDIT START - ghost runechat
-	dat += "Disable ghosts runechat: <a href='byond://?_src_=holder;[HrefToken()];change_lag_switch=[DISABLE_GHOST_RUNECHAT]'><b>[SSlag_switch.measures[DISABLE_GHOST_RUNECHAT] ? "On" : "Off"]</b></a><br/>"
-	// BANDASTATION EDIT END - ghost runechat
 	dat += "==========================================<br/>"
 	dat += "<br/><b>Measures below can be bypassed with a <abbr title='TRAIT_BYPASS_MEASURES'><u>special trait</u></abbr></b><br/>"
 	dat += "Slowmode say verb (informs world): <a href='byond://?_src_=holder;[HrefToken()];change_lag_switch=[SLOWMODE_SAY]'><b>[SSlag_switch.measures[SLOWMODE_SAY] ? "On" : "Off"]</b></a><br/>"

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -169,7 +169,7 @@
 	var/displayed_key = key
 	if(client?.holder?.fakekey)
 		displayed_key = null
-	deadchat_broadcast(rendered, source, follow_target = src, speaker_key = displayed_key, raw_message = message) // BANDASTATION EDIT - ghost runechat
+	deadchat_broadcast(rendered, source, follow_target = src, speaker_key = displayed_key)
 	for(var/mob/mobs_hearing as anything in GLOB.player_list)
 		if(SSticker.current_state != GAME_STATE_FINISHED && (mobs_hearing.see_invisible < invisibility || !isdead(mobs_hearing)))
 			continue


### PR DESCRIPTION

## Что этот PR делает
Исправляет дублирование рунчата.
## Почему это хорошо для игры
Багфикс
## Тестирование
Локально
## Changelog

:cl:
fix: Исправлено дублирование рунчата у призраков.
/:cl:
