### PR TITLE
Support digitigrade chameleon shoes

### DIFF
--- a/code/modules/clothing/chameleon/_chameleon_action.dm
+++ b/code/modules/clothing/chameleon/_chameleon_action.dm
@@ -136,6 +136,13 @@
 
 	if(ismob(chameleon_item.loc))
 		var/mob/wearer = chameleon_item.loc
+		// BANDASTATION EDIT START - support digi clothing
+		if(ishuman(wearer))
+			var/mob/living/carbon/human/human = wearer
+			var/slot = human.get_slot_by_item(chameleon_item)
+			if(!chameleon_item.mob_can_equip(human, slot, bypass_equip_delay_self = TRUE, ignore_equipped = TRUE))
+				human.put_in_hands(chameleon_item)
+		// BANDASTATION EDIT END
 		wearer.update_clothing(chameleon_item.slot_flags | ITEM_SLOT_HANDS)
 		wearer.refresh_obscured()
 
@@ -156,6 +163,7 @@
 
 		item_target.worn_icon_state = picked_item::worn_icon_state
 		item_target.inhand_icon_state = picked_item::inhand_icon_state
+		item_target.supports_variations_flags = picked_item::supports_variations_flags // BANDASTATION EDIT - support digi clothing
 
 		if(picked_item::greyscale_colors)
 			if(picked_item.greyscale_config_worn)
@@ -181,6 +189,7 @@
 			var/obj/item/clothing/clothing_target = item_target
 			var/obj/item/clothing/picked_clothing = picked_item
 			clothing_target.flags_cover = picked_clothing::flags_cover
+			clothing_target.digitigrade_worn_icon_state = picked_clothing::digitigrade_worn_icon_state // BANDASTATION EDIT - support digi clothing
 
 
 	if((picked_item::greyscale_config) && picked_item::greyscale_colors)

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -113,7 +113,7 @@
 		M.update_worn_shoes()
 
 /obj/item/clothing/shoes/generate_digitigrade_icons(icon/base_icon, greyscale_colors)
-	return icon(SSgreyscale.GetColoredIconByType(/datum/greyscale_config/digitigrade, greyscale_colors), "boots_worn")
+	return icon(SSgreyscale.GetColoredIconByType(/datum/greyscale_config/digitigrade, greyscale_colors), digitigrade_worn_icon_state) // BANDASTATION EDIT - icon state is var
 
 /**
  * adjust_laces adjusts whether our shoes (assuming they can be tied) and tied, untied, or knotted

--- a/code/modules/clothing/shoes/sneakers.dm
+++ b/code/modules/clothing/shoes/sneakers.dm
@@ -19,8 +19,10 @@
 	var/colors = SSgreyscale.ParseColorString(greyscale_colors)
 	return colors ? colors[1] : ..()
 
+/* BANDASTATION EDIT - icon state is var
 /obj/item/clothing/shoes/sneakers/generate_digitigrade_icons(icon/base_icon, greyscale_colors)
 	return icon(SSgreyscale.GetColoredIconByType(/datum/greyscale_config/digitigrade, greyscale_colors), "sneakers_worn")
+*/
 
 /obj/item/clothing/shoes/sneakers/random
 	flags_1 = parent_type::flags_1 | NO_NEW_GAGS_PREVIEW_1 // same icon/color as base type

--- a/modular_bandastation/_defines220/_defines220.dme
+++ b/modular_bandastation/_defines220/_defines220.dme
@@ -25,3 +25,4 @@
 #include "code/defines/calibers.dm"
 #include "code/defines/colors.dm"
 #include "code/defines/custom_emote_panel.dm"
+#include "code/defines/clothing_defines.dm"

--- a/modular_bandastation/_defines220/code/defines/clothing_defines.dm
+++ b/modular_bandastation/_defines220/code/defines/clothing_defines.dm
@@ -1,0 +1,3 @@
+// Defines for possible digi shoes worn icon state variants
+#define DIGI_BOOTS_WORN "boots_worn"
+#define DIGI_SNEAKERS_WORN "sneakers_worn"

--- a/modular_bandastation/objects/_objects.dme
+++ b/modular_bandastation/objects/_objects.dme
@@ -24,6 +24,7 @@
 #include "code/items/wallets.dm"
 #include "code/items/mech_core.dm"
 #include "code/items/sabre.dm"
+#include "code/items/clothing/clothing.dm"
 #include "code/items/clothing/belt.dm"
 #include "code/items/clothing/accessories/accessories.dm"
 #include "code/items/clothing/glasses/glasses.dm"

--- a/modular_bandastation/objects/code/items/clothing/clothing.dm
+++ b/modular_bandastation/objects/code/items/clothing/clothing.dm
@@ -1,0 +1,3 @@
+/obj/item/clothing
+	/// Icon state to generate worn sprite on digi bodyshape
+	var/digitigrade_worn_icon_state

--- a/modular_bandastation/objects/code/items/clothing/shoes/shoes.dm
+++ b/modular_bandastation/objects/code/items/clothing/shoes/shoes.dm
@@ -1,4 +1,25 @@
 // MARK: Shoes //
+/obj/item/clothing/shoes
+	digitigrade_worn_icon_state = DIGI_BOOTS_WORN
+
+/obj/item/clothing/shoes/sneakers
+	digitigrade_worn_icon_state = DIGI_SNEAKERS_WORN
+
+/obj/item/clothing/shoes/chameleon
+	supports_variations_flags = /obj/item/clothing/shoes/sneakers/black::supports_variations_flags
+	digitigrade_worn_icon_state = /obj/item/clothing/shoes/sneakers/black::digitigrade_worn_icon_state
+
+/obj/item/clothing/shoes/chameleon/get_general_color(icon/base_icon)
+	var/datum/action/item_action/chameleon/change/action = locate() in actions
+	var/target_type = action?.active_type
+	if(!target_type)
+		return ..()
+	var/obj/item/target_item = SSwardrobe.provide_type(target_type)
+	if(target_item)
+		var/result = target_item.get_general_color(base_icon)
+		qdel(target_item)
+		return result
+	return ..()
 
 // MARK: Misc shoes
 /obj/item/clothing/shoes/shark


### PR DESCRIPTION

## Что этот PR делает

Позволяет носить хамелеон бутсы с диги ногами
## Почему это хорошо для игры

Хамелеон бутсы принимают облик обуви, которую и так можно носить с диги ногами, однако на лайве их нельзя надеть
## Тестирование

На локалке. Обувь с поддержкой диги ног надевается. Обувь без поддержки - снимается и суётся в руки/на пол
## Changelog

:cl:
qol: Обладатели диги ног теперь могут носить хамелеон обувь.
/:cl:
