### PR TITLE
FIX: Tgui-dev build error

### DIFF
--- a/tgui/packages/tgui-panel/index.tsx
+++ b/tgui/packages/tgui-panel/index.tsx
@@ -57,7 +57,7 @@ function setupApp() {
   if (import.meta.webpackHot) {
     setupHotReloading();
 
-    import.meta.webpackHot.accept(['./app', './emotes'], () => {
+    import.meta.webpackHot.accept(['./app'], () => {
       render(<App />);
     });
   }


### PR DESCRIPTION

## Что этот PR делает

Убрал отсутствующую папку из HMR т.к она крашила tgui-dev. 

Файлы с эмоутами обрабатываются в panel.tsx, который в своё время импортируется в ./app и уже находится в HMR.

## Почему это хорошо для игры

Можно дебагать тгуи

## Тестирование

Всё работает

## Changelog

:cl:
fix: tgui-dev снова работает без ошибки
/:cl:
