### PR TITLE
FIX: BandaStation posters error during holidays

### DIFF
--- a/modular_bandastation/objects/code/structures/posters.dm
+++ b/modular_bandastation/objects/code/structures/posters.dm
@@ -1,9 +1,9 @@
 /obj/structure/sign/poster/apply_holiday()
-    var/old_state = icon_state
-    . = ..()
+	var/old_state = icon_state
+	. = ..()
 
-    if(icon_state != old_state && icon == 'modular_bandastation/objects/icons/obj/structures/posters.dmi')
-        icon = 'icons/obj/poster.dmi'
+	if(icon_state != old_state && icon == 'modular_bandastation/objects/icons/obj/structures/posters.dmi')
+		icon = 'icons/obj/poster.dmi'
 
 // Contraband
 /obj/structure/sign/poster/contraband/lady


### PR DESCRIPTION

## Что этот PR делает

Добавил модульным плакатам проверку на праздник, дабы они тоже меняли иконку а не выдавали ERROR

fix #2274

## Почему это хорошо для игры

Нету ERROR, классно же

## Тестирование

Работает на локалке

## Changelog

:cl:
fix: Модульные плакаты больше не выдают ERROR в праздничные дни
/:cl:
