### PR TITLE
Rainbow extract "update"

### DIFF
--- a/code/modules/mining/lavaland/mining_loot/consumables.dm
+++ b/code/modules/mining/lavaland/mining_loot/consumables.dm
@@ -179,7 +179,7 @@
 /obj/item/reagent_containers/cup/bottle/potion/flight
 	name = "strange elixir"
 	desc = "A flask with an almost-holy aura emitting from it. The label on the bottle says: 'erqo'hyy tvi'rf lbh jv'atf'."
-	list_reagents = list(/datum/reagent/flightpotion = 5)
+	list_reagents = list(/datum/reagent/mutationtoxin/fly = 5) ///BANDASTATION EDIT ORIGINAL datum/reagent/flightpotion = 5
 
 /datum/reagent/flightpotion
 	name = "Flight Potion"

--- a/code/modules/mining/lavaland/mining_loot/consumables.dm
+++ b/code/modules/mining/lavaland/mining_loot/consumables.dm
@@ -179,7 +179,7 @@
 /obj/item/reagent_containers/cup/bottle/potion/flight
 	name = "strange elixir"
 	desc = "A flask with an almost-holy aura emitting from it. The label on the bottle says: 'erqo'hyy tvi'rf lbh jv'atf'."
-	list_reagents = list(/datum/reagent/mutationtoxin/fly = 5) ///BANDASTATION EDIT ORIGINAL datum/reagent/flightpotion = 5
+	list_reagents = list(/datum/reagent/flightpotion = 5)
 
 /datum/reagent/flightpotion
 	name = "Flight Potion"

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -576,9 +576,12 @@
 	..()
 
 /datum/chemical_reaction/slime/flight_potion
+	results = list(/datum/reagent/mutationtoxin/fly = 1) ///BANDASTATION EDIT
 	required_reagents = list(/datum/reagent/water/holywater = 5, /datum/reagent/uranium = 5)
 	required_container = /obj/item/slime_extract/rainbow
 
+/*
 /datum/chemical_reaction/slime/flight_potion/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	new /obj/item/reagent_containers/cup/bottle/potion/flight(get_turf(holder.my_atom))
 	..()
+*/

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -576,12 +576,10 @@
 	..()
 
 /datum/chemical_reaction/slime/flight_potion
-	results = list(/datum/reagent/mutationtoxin/fly = 1) ///BANDASTATION EDIT
+	results = list(/datum/reagent/mutationtoxin/fly = 1) //BANDASTATION MOD START: Flight potion removal
 	required_reagents = list(/datum/reagent/water/holywater = 5, /datum/reagent/uranium = 5)
 	required_container = /obj/item/slime_extract/rainbow
 
-/*
 /datum/chemical_reaction/slime/flight_potion/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
-	new /obj/item/reagent_containers/cup/bottle/potion/flight(get_turf(holder.my_atom))
+	// new /obj/item/reagent_containers/cup/bottle/potion/flight(get_turf(holder.my_atom)) //BANDASTATION MOD END: Flight potion removal
 	..()
-*/


### PR DESCRIPTION
## Что этот PR делает

Теперь в радужных экстрактах вместо странного эликсира токсин мутации в муху 

## Почему это хорошо для игры

Никаких больше крыльев каждый раунд

## Изображения изменений

<img width="231" height="223" alt="Screenshot_578" src="https://github.com/user-attachments/assets/f85b4445-7bff-434b-bf44-ba20c5f652c2" />
<img width="619" height="202" alt="Screenshot_586" src="https://github.com/user-attachments/assets/3ad2c258-a122-45a9-ba1d-ea4dadc22392" />

## Тестирование

Локалка

## Changelog

:cl:
add: Теперь при добавлении в радужный экстракт урана+святой воды не создается зелье крыльев, а токсин мутации в муху
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
