### PR TITLE
Revert "Fix: Flatpack can no longer be inserted into the Bag of Holding"

### DIFF
--- a/code/datums/storage/subtypes/others/bag_of_holding.dm
+++ b/code/datums/storage/subtypes/others/bag_of_holding.dm
@@ -20,12 +20,6 @@
 
 	return ..()
 
-	/// BANDASTATION ADDITION START - Flatpack fix
-/datum/storage/bag_of_holding/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
-	. = ..()
-	set_holdable(cant_hold_list = /obj/item/flatpack)
-	/// BANDASTATION ADDITION END - Flatpack fix
-
 /datum/storage/bag_of_holding/proc/recursive_insertion(obj/item/to_insert, mob/living/user)
 	if(confirm_recursive_insertion(to_insert, user))
 		create_rift(to_insert, user)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Ревёрт https://github.com/ss220club/BandaStation/pull/1434.

## Почему это хорошо для игры

Оффы нормально пофиксили, кусок ненужного кода

## Changelog

:cl:
fix: Флатпаки снова можно засовывать в БоХ (но развертывать нельзя!)
/:cl: