### PR TITLE
Any jetpack can be placed on space suit's storage

### DIFF
--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -64,7 +64,7 @@
 	allowed = list(
 		/obj/item/flashlight,
 		/obj/item/tank/internals,
-		/obj/item/tank/jetpack/captain,
+		/obj/item/tank/jetpack, // BANDASTATION EDIT - any jetpack is allowed
 		)
 	slowdown = 1
 	armor_type = /datum/armor/suit_space


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Позволяет цеплять любой джет на софтсьюты, а не только капитанский

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Летать лёжа с джетом в руках это, безусловно, очень круто, но можно занять им и пустующий слот костюма

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

Работает!!

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
qol: На космические скафандры теперь можно надевать любые джетпаки, а не только джетпак капитана.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
