### PR TITLE
Maps config update

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -36,12 +36,12 @@ map metastation
 endmap
 
 map tramstation
-	minplayers 35
+	minplayers 40
 	votable
 endmap
 
 map nebulastation
-	minplayers 35
+	minplayers 60
 	votable
 endmap
 
@@ -56,7 +56,7 @@ map kilostation
 endmap
 
 map wawastation
-    minplayers 50
+    minplayers 60
 	votable
 endmap
 


### PR DESCRIPTION
## Что этот PR делает

Изменяет минимальные количество людей, требуемое для появления карты в голосование, для карт Небула, Трам, Вава

## Почему это хорошо для игры

Эмпирический опыт говорит о том, что карты слишком большие на маленький онлайн

## Изображения изменений

Не требует

## Тестирование

Будет работать

## Changelog

<!-- Важно строго соблюдать ёмкость и стилистическую форму наполнения чейнджлога! -->

:cl:
config: Изменён конфиг min игроков для карт Небула (min 60), Вава (min 60), Трам (min 40).
/:cl:
