### PR TITLE
Fix timestamp issues

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -1,6 +1,6 @@
 /// Returns UTC timestamp with the specifified format, with optionally deciseconds or optional IC time (year offset), AKA Nanotrasen Standard Time (NST)
-/proc/server_timestamp(format = "hh:mm:ss", show_ds, ic_time, twelve_hour_clock)
-	var/time_string = twelve_hour_clock ? time_to_twelve_hour(format, world.timeofday, world.timezone) : time2text(world.timeofday, format, world.timezone)
+/proc/server_timestamp(format = "hh:mm:ss", show_ds, ic_time, twelve_hour_clock, timezone = TIMEZONE_UTC)
+	var/time_string = twelve_hour_clock ? time_to_twelve_hour(format, world.timeofday, timezone) : time2text(world.timeofday, format, timezone)
 	if(ic_time && findtext(format, "YYYY")) //if we have a year, replace the year
 		time_string = replacetext_char(time_string, "[GLOB.year_integer]", CURRENT_STATION_YEAR)
 	return show_ds ? "[time_string]:[world.timeofday % 10]" : time_string

--- a/modular_bandastation/ticket_manager/code/__DEFINES/_defines.dm
+++ b/modular_bandastation/ticket_manager/code/__DEFINES/_defines.dm
@@ -2,3 +2,5 @@
 
 #define TICKET_REPLY_COOLDOWN 5 SECONDS
 #define TICKET_AUTOCLOSE_TIMER 20 MINUTES
+
+#define TIMESTAMP(...) (time2text(world.timeofday, "DDD MMM DD hh:mm:ss YYYY", TIMEZONE_UTC))

--- a/modular_bandastation/ticket_manager/code/help_ticket/help_ticket.dm
+++ b/modular_bandastation/ticket_manager/code/help_ticket/help_ticket.dm
@@ -46,7 +46,7 @@
 		stat_name += "..."
 
 	id = ++ticket_counter
-	opened_at = round_timestamp()
+	opened_at = TIMESTAMP()
 	initiator_client = creator.persistent_client
 	initiator = key_name(creator)
 	initiator_key = creator.key
@@ -159,7 +159,7 @@
 	messages += list(list(
 		"sender" = TICKET_LOG_SENDER_ADMIN_TICKET_LOG,
 		"message" = "[converter.ckey] конвертировал тикет в [ticket_type_id]",
-		"time" = round_timestamp(),
+		"time" = TIMESTAMP(),
 	))
 
 	return TRUE
@@ -218,7 +218,7 @@
 	messages += list(list(
 		"sender" = TICKET_LOG_SENDER_ADMIN_TICKET_LOG,
 		"message" = "[linked_admin.key] отказался от тикета",
-		"time" = round_timestamp(),
+		"time" = TIMESTAMP(),
 	))
 
 	linked_admin = null

--- a/modular_bandastation/ticket_manager/code/ticket_manager/manager_helpers.dm
+++ b/modular_bandastation/ticket_manager/code/ticket_manager/manager_helpers.dm
@@ -138,7 +138,7 @@
 	needed_ticket.messages += list(list(
 		"sender" = sender.key,
 		"message" = emoji_parse(message),
-		"time" = round_timestamp(),
+		"time" = TIMESTAMP(),
 	))
 	SStgui.update_uis(src)
 
@@ -157,7 +157,7 @@
 		if(initiator.current_help_ticket != needed_ticket)
 			CRASH("Ticket with id [ticket_id] is not the current help ticket for [initiator.ckey]!")
 
-		needed_ticket.closed_at = round_timestamp()
+		needed_ticket.closed_at = TIMESTAMP()
 		initiator.current_help_ticket = null
 
 		var/blackbox_action = ticket_closed ? "Closed" : "Resolved"
@@ -221,7 +221,7 @@
 	needed_ticket.messages += list(list(
 		"sender" = TICKET_LOG_SENDER_CLIENT_DISCONNECTED,
 		"message" = "[user.key] отключился",
-		"time" = round_timestamp(),
+		"time" = TIMESTAMP(),
 	))
 	SStgui.update_uis(src)
 	// Gotta async this cause clients only logout on destroy, and sleeping in destroy is disgusting
@@ -240,7 +240,7 @@
 	needed_ticket.messages += list(list(
 		"sender" = TICKET_LOG_SENDER_CLIENT_CONNECTED,
 		"message" = "[user.key] подключился",
-		"time" = round_timestamp(),
+		"time" = TIMESTAMP(),
 	))
 	SStgui.update_uis(src)
 	SSblackbox.LogAhelp(needed_ticket.id, "Reconnected", "Client reconnected", user.key)
@@ -348,7 +348,7 @@
 	user_ticket.messages += list(list(
 		"sender" = TICKET_LOG_SENDER_ADMIN_TICKET_LOG,
 		"message" = strip_html_full(message),
-		"time" = round_timestamp(),
+		"time" = TIMESTAMP(),
 	))
 
 	SStgui.update_uis(GLOB.ticket_manager)
@@ -361,7 +361,7 @@
 	ticket.messages += list(list(
 		"sender" = TICKET_LOG_SENDER_ADMIN_TICKET_LOG,
 		"message" = strip_html_full(message),
-		"time" = round_timestamp(),
+		"time" = TIMESTAMP(),
 	))
 
 	SStgui.update_uis(GLOB.ticket_manager)


### PR DESCRIPTION
## Что этот PR делает
Исправляет временные метки в тикетах после #2444. Все метки снова отображаются в часовом поясе клиента.
Исправляет хелпер `server_timestamp()`, чтобы он действительно использовал UTC согласно комментарию, а не часовой пояс сервера.

## Почему это хорошо для игры
Админы снова могут отслеживать время отправки сообщений в тикетах.

## Тестирование
<img width="136" height="49" alt="image" src="https://github.com/user-attachments/assets/d31192e9-6a54-488a-b397-cc8149ff60bd" />
<img width="310" height="56" alt="image" src="https://github.com/user-attachments/assets/3ad67be3-1812-4faa-a129-9fc8be3f7d6a" />

## Changelog

<!-- Важно строго соблюдать ёмкость и стилистическую форму наполнения чейнджлога! -->

:cl: Maxiemar
fix: Время снова отображается корректно в админ и ментор-тикетах.
fix: Server Time/NST теперь использует UTC, как и задумывалось.
/:cl:
