### PR TITLE
Фикс перепутаных местами списков лево-право в интерфейсе фильтра для плампа

### DIFF
--- a/tgui/packages/tgui/interfaces/ChemFilter.tsx
+++ b/tgui/packages/tgui/interfaces/ChemFilter.tsx
@@ -68,10 +68,10 @@ export const ChemFilter = (props) => {
       <Window.Content scrollable>
         <Stack>
           <Stack.Item grow>
-            <ChemFilterPane title="Right" list={right} buttonColor="red" />
+            <ChemFilterPane title="Left" list={left} buttonColor="yellow" />
           </Stack.Item>
           <Stack.Item grow>
-            <ChemFilterPane title="Left" list={left} buttonColor="yellow" />
+            <ChemFilterPane title="Right" list={right} buttonColor="red" />
           </Stack.Item>
         </Stack>
       </Window.Content>


### PR DESCRIPTION
## Что этот PR делает
Фикс перепутаных местами списков лево-право в интерфейсе фильтра для плампа

## Почему это хорошо для игры
Ну они перепутаны, это немного бросается в глаза

## Изображения изменений
ДО
<img width="1080" height="659" alt="img-2026-04-30-23-41-16" src="https://github.com/user-attachments/assets/b1642ef8-0f6b-4395-931f-952a08514a46" />

ПОСЛЕ
<img width="1065" height="689" alt="NVIDIA_Overlay_qcuJhwOKDk" src="https://github.com/user-attachments/assets/d5899945-a49d-4bcb-8abd-f68ebe6b6a19" />


## Тестирование
Локально

## Changelog
Фикс перепутаных местами списков лево-право в интерфейсе фильтра для плампа

:cl:
fix: Исправлены перепутаные местами списки фильтра плампинга. Теперь списки идут слева направо.
/:cl:
