### PR TITLE
Balance: Removed imbalanced ability from simple mob

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/netherworld/creature.dm
+++ b/code/modules/mob/living/basic/space_fauna/netherworld/creature.dm
@@ -42,7 +42,7 @@
 			min_health_slowdown = -1.5,\
 		)
 
-	GRANT_ACTION(/datum/action/cooldown/spell/jaunt/creature_teleport)
+	// GRANT_ACTION(/datum/action/cooldown/spell/jaunt/creature_teleport) // BANDASTATION REMOVAL
 
 /mob/living/basic/creature/proc/can_be_seen(turf/location)
 	// Check for darkness


### PR DESCRIPTION
## Что этот PR делает
Забирает абилку Uncanny Movement у /mob/living/basic/creature.

## Почему это хорошо для игры
Убирает одну из самых дизбалансных абилок из моба, в которого можно превратиться.

## Тестирование
Сбилдился, заспавнил мобов, проверил каждого на отсутствие абилки.

## Changelog

:cl:
balance: Симпл моб "Creature" больше не имеет способности Uncanny Movement.
/:cl: