### PR TITLE
BALANCE: stunprod w_class from huge to normal

### DIFF
--- a/modular_bandastation/balance/code/weapons/baton.dm
+++ b/modular_bandastation/balance/code/weapons/baton.dm
@@ -1,2 +1,5 @@
 /obj/item/melee/baton/telescopic
 	stamina_damage = 35
+
+/obj/item/melee/baton/security/cattleprod
+	w_class = WEIGHT_CLASS_NORMAL


### PR DESCRIPTION
## Что этот PR делает

Станпроды теперь можно класть в сумки, ура!

## Почему это хорошо для игры

То что нельзя класть станпроды в сумки это бред, я никогда не видел чтобы их нормально использовали.


## Тестирование

Проверял как лезет станпрод в сумочку

## Changelog


:cl:
balance: Размер самодельных станпродов был уменьшен с HUGE до NORMAL.
/:cl:

