### PR TITLE
Fix clown ops shuttle, remap small Syndie CC base

### DIFF
--- a/_maps/shuttles/ss220/infiltrator_clown.dmm
+++ b/_maps/shuttles/ss220/infiltrator_clown.dmm
@@ -1,0 +1,1386 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ap" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo13"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"aO" = (
+/obj/item/storage/toolbox/syndicate,
+/obj/item/screwdriver{
+	pixel_y = 9
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/engineering)
+"bd" = (
+/obj/structure/chair/comfy/shuttle/tactical{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"bi" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/light/floor,
+/mob/living/basic/bot/medbot/nukie,
+/turf/open/floor/iron/white,
+/area/shuttle/syndicate/medical)
+"bP" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/machinery/door/poddoor/shutters{
+	id = "infiltrator_window_shutters";
+	name = "Blast Shutters";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/syndicate/hallway)
+"cn" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/syndicate/hallway)
+"cD" = (
+/turf/closed/wall/r_wall/plastitanium/syndicate,
+/area/shuttle/syndicate/hallway)
+"cK" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/machinery/door/poddoor/shutters{
+	id = "infiltrator_window_shutters";
+	name = "Blast Shutters";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/syndicate/hallway)
+"do" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/hallway)
+"dG" = (
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "infiltrator_entrance"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/turf/open/floor/plating,
+/area/shuttle/syndicate/airlock)
+"dP" = (
+/obj/structure/chair/comfy/shuttle/tactical{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"eO" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo11"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"ff" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo10"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"fs" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/airlock)
+"fO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/airlock)
+"gm" = (
+/obj/item/weldingtool/largetank{
+	pixel_y = 3
+	},
+/obj/item/multitool,
+/obj/item/wrench,
+/obj/item/crowbar/red,
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/engineering)
+"go" = (
+/obj/machinery/porta_turret/syndicate/shuttle{
+	dir = 5
+	},
+/turf/closed/wall/r_wall/plastitanium/syndicate,
+/area/shuttle/syndicate/bridge)
+"gw" = (
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/engineering)
+"gx" = (
+/obj/machinery/power/shuttle_engine/huge,
+/turf/template_noop,
+/area/shuttle/syndicate/medical)
+"hq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/airlock)
+"hs" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo9"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"hy" = (
+/obj/machinery/door/window/survival_pod/left/directional/south,
+/obj/effect/turf_decal/box,
+/obj/machinery/nuclearbomb/syndicate/bananium{
+	anchored = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/hallway)
+"hA" = (
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/syndicate/hallway)
+"hG" = (
+/turf/closed/wall/r_wall/plastitanium/syndicate,
+/area/shuttle/syndicate/bridge)
+"iq" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo12"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"iw" = (
+/obj/machinery/suit_storage_unit/syndicate,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/hallway)
+"iH" = (
+/obj/machinery/porta_turret/syndicate/shuttle{
+	dir = 5
+	},
+/turf/closed/wall/r_wall/plastitanium/syndicate,
+/area/shuttle/syndicate/engineering)
+"iK" = (
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/power_store/cell/high{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/stock_parts/power_store/cell/high,
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/engineering)
+"jz" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/engineering)
+"jF" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/hallway)
+"jP" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo16"
+	},
+/obj/item/banner/syndicate,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"jQ" = (
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"jX" = (
+/obj/item/sbeacondrop/bomb{
+	pixel_y = 5
+	},
+/obj/item/sbeacondrop/bomb,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/hallway)
+"ke" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/shuttle/syndicate/medical)
+"ko" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/syndicate/hallway)
+"kp" = (
+/obj/machinery/porta_turret/syndicate/shuttle{
+	dir = 9
+	},
+/turf/closed/wall/r_wall/plastitanium/syndicate,
+/area/shuttle/syndicate/hallway)
+"ks" = (
+/obj/machinery/computer/camera_advanced/syndie,
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo4"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"kB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/airlock)
+"kI" = (
+/obj/machinery/porta_turret/syndicate/shuttle{
+	dir = 5
+	},
+/turf/closed/wall/r_wall/plastitanium/syndicate,
+/area/shuttle/syndicate/hallway)
+"mR" = (
+/turf/template_noop,
+/area/template_noop)
+"nj" = (
+/obj/machinery/power/shuttle_engine/heater,
+/obj/structure/window/reinforced/tinted/spawner/directional/north,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate/medical)
+"nK" = (
+/obj/machinery/computer/shuttle/syndicate,
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo3"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"nL" = (
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/box,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/engineering)
+"oP" = (
+/turf/template_noop,
+/area/shuttle/syndicate/engineering)
+"oV" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution,
+/obj/machinery/light/directional/east,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/engineering)
+"pa" = (
+/obj/machinery/button/door/directional/east{
+	id = "infiltrator_shuttle_entrance";
+	req_access = list("syndicate");
+	name = "Shuttle Blast Door Control"
+	},
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external,
+/obj/machinery/door/poddoor{
+	id = "infiltrator_shuttle_entrance";
+	name = "Outer Blast Door"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "infiltrator_entrance"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/turf/open/floor/plating,
+/area/shuttle/syndicate/airlock)
+"pk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/sign/warning/vacuum/directional/south,
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/airlock)
+"qn" = (
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
+/area/shuttle/syndicate/bridge)
+"qD" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/shuttle/syndicate/engineering)
+"rO" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/button/door{
+	id = "infiltrator_window_shutters";
+	name = "Window Shutters Control"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/syndicate/bridge)
+"rU" = (
+/obj/structure/chair/comfy/shuttle/tactical{
+	dir = 1
+	},
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo6"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"sq" = (
+/obj/machinery/computer/crew/syndie,
+/obj/effect/decal/syndie_logo,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"st" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
+/turf/template_noop,
+/area/shuttle/syndicate/airlock)
+"sR" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/cup/beaker,
+/obj/item/reagent_containers/dropper{
+	pixel_x = -4;
+	pixel_y = -8
+	},
+/turf/open/floor/iron/white,
+/area/shuttle/syndicate/medical)
+"tb" = (
+/obj/structure/closet/syndicate/nuclear,
+/obj/item/crowbar/red,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/hallway)
+"tx" = (
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/syndicate/hallway)
+"uo" = (
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/shuttle/syndicate/engineering)
+"uM" = (
+/obj/machinery/computer/camera_advanced/shuttle_docker/syndicate,
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo2"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"vd" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating,
+/area/shuttle/syndicate/hallway)
+"vs" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/machinery/door/poddoor/shutters{
+	id = "infiltrator_window_shutters";
+	name = "Blast Shutters"
+	},
+/turf/open/floor/plating,
+/area/shuttle/syndicate/bridge)
+"wn" = (
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/assembly/voice{
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/engineering)
+"wt" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/hatch,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/bridge)
+"wG" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/hallway)
+"xb" = (
+/obj/machinery/door/window/survival_pod/left/directional/south,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/book/manual/nuclear,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/hallway)
+"xi" = (
+/turf/template_noop,
+/area/shuttle/syndicate/medical)
+"yI" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/hatch,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/hallway)
+"yO" = (
+/obj/machinery/computer/operating{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/shuttle/syndicate/medical)
+"yT" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/syndicate/hallway)
+"yU" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/shuttle/syndicate/engineering)
+"zg" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/structure/sign/departments/engineering/directional/east,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/syndicate/hallway)
+"zh" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo14"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"zU" = (
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/syndicate/hallway)
+"zV" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/hallway)
+"Ar" = (
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/hallway)
+"AY" = (
+/obj/machinery/porta_turret/syndicate/shuttle{
+	dir = 9
+	},
+/turf/closed/wall/r_wall/plastitanium/syndicate,
+/area/shuttle/syndicate/bridge)
+"Bs" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/airlock)
+"Dm" = (
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
+/area/shuttle/syndicate/hallway)
+"Do" = (
+/turf/closed/wall/r_wall/plastitanium/syndicate,
+/area/shuttle/syndicate/engineering)
+"DD" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/syndicate/bridge)
+"DF" = (
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate/medical)
+"DU" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
+/turf/template_noop,
+/area/shuttle/syndicate/hallway)
+"DV" = (
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
+/area/shuttle/syndicate/airlock)
+"Ex" = (
+/obj/structure/table/reinforced,
+/obj/item/bodypart/arm/left/robot{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/bodypart/arm/right/robot{
+	pixel_x = -10;
+	pixel_y = 9
+	},
+/obj/item/stack/medical/ointment,
+/obj/item/stack/medical/wrap/gauze,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/healthanalyzer,
+/turf/open/floor/iron/white,
+/area/shuttle/syndicate/medical)
+"EO" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/airlock)
+"EZ" = (
+/obj/structure/chair/comfy/shuttle/tactical{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"Fc" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/syndicate/bridge)
+"Ff" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/white,
+/area/shuttle/syndicate/medical)
+"Fl" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/shuttle/syndicate/engineering)
+"FJ" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo15"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"He" = (
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate/engineering)
+"Hm" = (
+/obj/structure/bed/medical/emergency,
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white,
+/area/shuttle/syndicate/medical)
+"HA" = (
+/obj/machinery/suit_storage_unit/syndicate,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/hallway)
+"HC" = (
+/turf/closed/wall/r_wall/plastitanium/syndicate,
+/area/shuttle/syndicate/medical)
+"HD" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/shuttle/syndicate/engineering)
+"Ir" = (
+/obj/item/storage/box/handcuffs{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/zipties,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/hallway)
+"Iv" = (
+/obj/machinery/porta_turret/syndicate/shuttle{
+	dir = 9
+	},
+/turf/closed/wall/r_wall/plastitanium/syndicate,
+/area/shuttle/syndicate/medical)
+"IV" = (
+/obj/item/assembly/signaler{
+	pixel_x = 8
+	},
+/obj/item/assembly/infra,
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/engineering)
+"Jz" = (
+/obj/structure/railing/corner/end/flip{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/shuttle/syndicate/engineering)
+"JZ" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark/corner,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/syndicate/hallway)
+"Kg" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/syndie/surgery,
+/obj/machinery/light/directional/west,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/white,
+/area/shuttle/syndicate/medical)
+"Kh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/airlock)
+"KD" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
+/obj/structure/sign/warning/vacuum/directional/south,
+/obj/machinery/light/directional/south,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/syndicate/hallway)
+"KX" = (
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/engineering)
+"Lq" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/structure/sign/departments/medbay/alt/directional/west,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/syndicate/hallway)
+"Lr" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo17"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"LB" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/sign/poster/contraband/syndicate_recruitment/directional/north,
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/airlock)
+"Mt" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/shuttle/syndicate/hallway)
+"Mv" = (
+/turf/open/floor/iron/white,
+/area/shuttle/syndicate/medical)
+"Nm" = (
+/obj/machinery/porta_turret/syndicate/shuttle{
+	dir = 6
+	},
+/turf/closed/wall/r_wall/plastitanium/syndicate,
+/area/shuttle/syndicate/airlock)
+"Nr" = (
+/turf/closed/wall/r_wall/plastitanium/syndicate,
+/area/shuttle/syndicate/airlock)
+"Oc" = (
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/syndicate/bridge)
+"Pt" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo19"
+	},
+/obj/item/banner/syndicate,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"PN" = (
+/obj/structure/table/reinforced,
+/obj/item/healthanalyzer,
+/obj/item/healthanalyzer{
+	pixel_y = 10
+	},
+/turf/open/floor/iron/white,
+/area/shuttle/syndicate/medical)
+"PY" = (
+/obj/machinery/computer/records/security/laptop/syndie,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/hallway)
+"QK" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo8"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"QY" = (
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/syndicate/hallway)
+"Rl" = (
+/obj/machinery/sleeper/syndie{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/shuttle/syndicate/medical)
+"RJ" = (
+/obj/item/grenade/syndieminibomb{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/grenade/syndieminibomb{
+	pixel_x = -1
+	},
+/obj/item/grenade/c4{
+	pixel_x = -6
+	},
+/obj/item/grenade/c4{
+	pixel_x = -6
+	},
+/obj/item/grenade/c4{
+	pixel_x = -6
+	},
+/obj/item/grenade/c4{
+	pixel_x = -6
+	},
+/obj/item/grenade/c4{
+	pixel_x = -6
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/hallway)
+"Sa" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo18"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"Sr" = (
+/obj/machinery/light/floor,
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/engineering)
+"Sy" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/cup/bottle/epinephrine{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/cup/bottle/multiver{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/cup/bottle/multiver{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/cup/bottle/epinephrine{
+	pixel_x = 6
+	},
+/turf/open/floor/iron/white,
+/area/shuttle/syndicate/medical)
+"Ts" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external,
+/obj/machinery/door/poddoor{
+	id = "infiltrator_shuttle_entrance";
+	name = "Outer Blast Door"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "infiltrator_entrance"
+	},
+/obj/docking_port/mobile/infiltrator{
+	dir = 1;
+	port_direction = 2
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/turf/open/floor/plating,
+/area/shuttle/syndicate/airlock)
+"Ub" = (
+/obj/structure/closet,
+/obj/item/clothing/under/syndicate/scrubs,
+/obj/item/clothing/gloves/latex/nitrile,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/tank/internals/anesthetic,
+/turf/open/floor/iron/white,
+/area/shuttle/syndicate/medical)
+"UF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/airlock)
+"UJ" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/regular{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/storage/medkit/regular{
+	pixel_y = 8
+	},
+/obj/item/storage/medkit/regular{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/storage/medkit/fire{
+	pixel_x = -6
+	},
+/obj/item/storage/medkit/brute{
+	pixel_x = 6
+	},
+/turf/open/floor/iron/white,
+/area/shuttle/syndicate/medical)
+"Vi" = (
+/obj/machinery/porta_turret/syndicate/shuttle{
+	dir = 10
+	},
+/turf/closed/wall/r_wall/plastitanium/syndicate,
+/area/shuttle/syndicate/airlock)
+"Vo" = (
+/obj/structure/table/optable,
+/turf/open/floor/iron/white,
+/area/shuttle/syndicate/medical)
+"Vv" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/airlock)
+"VJ" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo5"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"VQ" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/airlock)
+"WN" = (
+/obj/machinery/suit_storage_unit/syndicate,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/hallway)
+"WR" = (
+/obj/machinery/power/shuttle_engine/heater,
+/obj/structure/window/reinforced/tinted/spawner/directional/north,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/shuttle/syndicate/engineering)
+"Xf" = (
+/obj/machinery/power/shuttle_engine/huge,
+/turf/template_noop,
+/area/shuttle/syndicate/engineering)
+"Yc" = (
+/obj/structure/chair/comfy/shuttle/tactical{
+	dir = 1
+	},
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo7"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+"Yt" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark/corner{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/syndicate/hallway)
+"YK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/syndicate/engineering)
+"Zl" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/dark,
+/area/shuttle/syndicate/airlock)
+"Zx" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
+/area/shuttle/syndicate/medical)
+"ZB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/recharge_floor,
+/area/shuttle/syndicate/hallway)
+"ZP" = (
+/obj/structure/chair/comfy/shuttle/tactical{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/syndicate/bridge)
+
+(1,1,1) = {"
+mR
+mR
+mR
+mR
+mR
+mR
+mR
+mR
+mR
+mR
+mR
+mR
+mR
+ke
+ke
+ke
+ke
+ke
+ke
+mR
+mR
+mR
+"}
+(2,1,1) = {"
+mR
+mR
+mR
+mR
+mR
+mR
+mR
+mR
+Mt
+Mt
+Mt
+Mt
+Iv
+HC
+HC
+HC
+HC
+HC
+HC
+HC
+mR
+mR
+"}
+(3,1,1) = {"
+mR
+mR
+mR
+mR
+mR
+kp
+cK
+cK
+cD
+cD
+cD
+cD
+HC
+sR
+Sy
+Ub
+Kg
+yO
+nj
+DF
+xi
+gx
+"}
+(4,1,1) = {"
+mR
+mR
+Mt
+Mt
+DU
+cD
+iw
+hA
+PY
+Ir
+RJ
+jX
+HC
+PN
+Mv
+Zx
+Mv
+Vo
+nj
+DF
+xi
+xi
+"}
+(5,1,1) = {"
+mR
+hG
+hG
+hG
+hG
+hG
+HA
+hA
+hA
+hA
+hA
+hA
+HC
+UJ
+Zx
+bi
+Zx
+Ex
+nj
+DF
+xi
+xi
+"}
+(6,1,1) = {"
+AY
+qn
+ZP
+dP
+dP
+hG
+WN
+hA
+hA
+QY
+hA
+hA
+Lq
+Mv
+Mv
+Zx
+Ff
+DV
+Nr
+Nr
+st
+mR
+"}
+(7,1,1) = {"
+hG
+Fc
+Oc
+Oc
+DD
+qn
+hG
+yI
+yI
+Dm
+zV
+hA
+cn
+Mv
+Hm
+Rl
+Rl
+Nr
+Nr
+Nr
+Nr
+Vi
+"}
+(8,1,1) = {"
+vs
+sq
+VJ
+hs
+ap
+jP
+hG
+tx
+ko
+Dm
+cD
+cD
+Yt
+yT
+DV
+Nr
+Nr
+DV
+LB
+fO
+DV
+Nr
+"}
+(9,1,1) = {"
+vs
+uM
+rU
+ff
+jQ
+Lr
+wt
+hA
+hA
+tb
+vd
+hy
+hA
+hA
+dG
+UF
+fs
+fs
+Bs
+EO
+fO
+Ts
+"}
+(10,1,1) = {"
+vs
+nK
+Yc
+eO
+zh
+Sa
+wt
+hA
+hA
+tb
+vd
+xb
+hA
+hA
+dG
+kB
+hq
+hq
+Vv
+Zl
+Kh
+pa
+"}
+(11,1,1) = {"
+vs
+ks
+QK
+iq
+FJ
+Pt
+hG
+tx
+ko
+Dm
+cD
+cD
+JZ
+KD
+DV
+Nr
+Nr
+DV
+VQ
+pk
+DV
+Nr
+"}
+(12,1,1) = {"
+hG
+rO
+Oc
+Oc
+DD
+qn
+hG
+yI
+yI
+Dm
+jF
+hA
+cn
+KX
+gm
+IV
+wn
+Nr
+Nr
+Nr
+Nr
+Nm
+"}
+(13,1,1) = {"
+go
+qn
+bd
+EZ
+EZ
+hG
+iw
+hA
+hA
+zU
+hA
+hA
+zg
+KX
+uo
+uo
+qD
+DV
+Nr
+Nr
+st
+mR
+"}
+(14,1,1) = {"
+mR
+hG
+hG
+hG
+hG
+hG
+HA
+hA
+hA
+hA
+hA
+hA
+Do
+gw
+KX
+Sr
+KX
+iK
+WR
+He
+oP
+Xf
+"}
+(15,1,1) = {"
+mR
+mR
+Mt
+Mt
+DU
+cD
+WN
+hA
+do
+Ar
+ZB
+wG
+Do
+nL
+uo
+uo
+Jz
+aO
+WR
+He
+oP
+oP
+"}
+(16,1,1) = {"
+mR
+mR
+mR
+mR
+mR
+kI
+bP
+bP
+cD
+cD
+cD
+cD
+Do
+HD
+YK
+yU
+oV
+jz
+WR
+He
+oP
+oP
+"}
+(17,1,1) = {"
+mR
+mR
+mR
+mR
+mR
+mR
+mR
+mR
+Mt
+Mt
+Mt
+Mt
+iH
+Do
+Do
+Do
+Do
+Do
+Do
+Do
+mR
+mR
+"}
+(18,1,1) = {"
+mR
+mR
+mR
+mR
+mR
+mR
+mR
+mR
+mR
+mR
+mR
+mR
+mR
+Fl
+Fl
+Fl
+Fl
+Fl
+Fl
+mR
+mR
+mR
+"}

--- a/_maps/templates/lazy_templates/ss220/syndie_cc_small.dmm
+++ b/_maps/templates/lazy_templates/ss220/syndie_cc_small.dmm
@@ -1,81 +1,31 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"acA" = (
-/obj/structure/sign/poster/contraband/random/directional/south,
-/obj/structure/railing/corner/end/flip{
-	dir = 4
-	},
+"aj" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"at" = (
 /turf/open/floor/wood,
 /area/centcom/syndicate_base)
-"app" = (
-/obj/structure/sign/poster/contraband/random/directional/west,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/centcom/syndicate_base)
-"aqq" = (
-/obj/structure/fans/tiny/invisible,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/red/line,
+"aB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"aAs" = (
-/obj/effect/turf_decal/siding/thinplating_new/dark,
-/obj/structure/table/wood{
-	color = "#996633"
-	},
-/obj/item/pizzabox/margherita,
-/obj/item/pizzabox/margherita,
-/obj/item/knife/kitchen,
-/turf/open/floor/wood/parquet,
-/area/centcom/syndicate_base/control)
-"aDf" = (
-/obj/item/target,
-/obj/effect/decal/cleanable/confetti,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"aDp" = (
-/turf/open/floor/iron/stairs/medium{
-	color = "#adadad";
+"aJ" = (
+/obj/structure/fans/tiny/invisible,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/area/centcom/syndicate_base)
-"aHv" = (
-/obj/machinery/light/directional/north,
-/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"aLl" = (
-/obj/structure/chair/sofa/middle/brown,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"aSV" = (
-/obj/structure/curtain/bounty/start_closed{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/iron,
-/area/centcom/syndicate_base)
-"aTN" = (
-/obj/structure/ore_box,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/delivery/white,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"aXh" = (
-/obj/structure/table/wood/poker,
-/obj/item/reagent_containers/cup/glass/bottle/vodka{
-	pixel_x = -5;
-	pixel_y = 9
-	},
-/obj/item/toy/cards/deck/syndicate,
-/turf/open/floor/iron/white,
-/area/centcom/syndicate_base)
-"bbA" = (
+"aK" = (
 /obj/structure/chair/comfy/purp{
 	dir = 8
 	},
@@ -88,103 +38,161 @@
 /obj/effect/landmark/start/nukeop_overwatch,
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_base/control)
-"bcl" = (
-/obj/effect/turf_decal/delivery/red,
-/turf/open/floor/iron/dark,
+"aT" = (
+/obj/docking_port/stationary{
+	area_type = /area/centcom/syndicate_base;
+	dir = 2;
+	dwidth = 3;
+	height = 7;
+	name = "Syndicate Assault Pod Dock";
+	roundstart_template = /datum/map_template/shuttle/assault_pod/default;
+	width = 7
+	},
+/turf/open/floor/plating,
 /area/centcom/syndicate_base)
-"bgj" = (
-/turf/open/floor/iron/stairs/right{
+"aU" = (
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"aV" = (
+/turf/open/floor/iron/stairs/left{
 	dir = 1
 	},
 /area/centcom/syndicate_base)
-"bjf" = (
-/obj/item/banner/syndicate,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"bjU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+"be" = (
+/obj/machinery/door/poddoor/ert{
+	id = "nukeop_ready";
+	name = "Shuttle Dock Door"
 	},
-/turf/closed/indestructible/syndicate,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"blJ" = (
+"bq" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/directional/north,
+/obj/structure/chair/sofa/left/brown,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"bnr" = (
-/turf/open/floor/iron/grimy,
-/area/centcom/syndicate_base)
-"bpw" = (
-/obj/machinery/computer/shuttle/syndicate{
-	name = "Nuclear Operatives Shuttle Console"
+"cc" = (
+/obj/machinery/light/directional/north,
+/obj/structure/fans/tiny/invisible,
+/obj/structure/marker_beacon/burgundy,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/turf/open/floor/carpet/black,
-/area/centcom/syndicate_base/control)
-"bxW" = (
-/obj/structure/railing/corner/end{
-	dir = 8
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 10
 	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"bJW" = (
-/obj/machinery/photocopier/syndicate,
-/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
-/turf/open/floor/carpet/black,
-/area/centcom/syndicate_base/control)
-"bLA" = (
-/obj/structure/table,
-/obj/item/gun/energy/ionrifle,
+"ci" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Syndicate Base"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"bMd" = (
-/obj/machinery/computer/shuttle/syndicate{
-	name = "Nuclear Operatives Shuttle Console";
-	dir = 4
+"cu" = (
+/obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"cH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fans/tiny/invisible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/carpet/black,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"cK" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"cN" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/delivery/white,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"cQ" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo18"
+	},
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_base/control)
-"bNg" = (
+"cS" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/table/reinforced/plastitaniumglass,
-/obj/machinery/fax/admin/syndicate,
-/turf/open/floor/carpet/black,
+/obj/item/toy/plush/carpplushie,
+/obj/item/toy/sword,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"cV" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood/parquet,
 /area/centcom/syndicate_base/control)
-"bRD" = (
-/obj/effect/turf_decal/siding/wood/corner{
+"di" = (
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"do" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
+/area/centcom/syndicate_base)
+"dy" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo4"
+	},
+/obj/effect/turf_decal/siding/dark/inner_corner{
 	dir = 4
 	},
-/turf/open/floor/iron/grimy,
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/syndicate_base/control)
+"dK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/syndicate_base)
-"bRF" = (
-/obj/machinery/computer/message_monitor{
+"dU" = (
+/obj/structure/fans/tiny/invisible,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"dY" = (
+/obj/machinery/computer/camera_advanced{
 	pixel_x = -6;
 	dir = 8
 	},
-/obj/item/paper/monitorkey,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/east,
-/obj/machinery/light/directional/north,
 /turf/open/floor/carpet/black,
 /area/centcom/syndicate_base/control)
-"bUd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/delivery/white,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"bUU" = (
-/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
-/turf/open/floor/carpet/red,
+"ec" = (
+/turf/open/floor/wood/parquet,
 /area/centcom/syndicate_base/control)
-"bVX" = (
-/obj/effect/decal/cleanable/dirt,
+"ei" = (
+/obj/item/banner/syndicate,
+/turf/open/floor/carpet/black,
+/area/centcom/syndicate_base/control)
+"ep" = (
+/obj/item/banner/syndicate,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"ew" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/small/directional/east,
+/obj/structure/chair/sofa/left/brown,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"chA" = (
+"eK" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/fans/tiny/invisible,
 /obj/structure/marker_beacon/burgundy,
 /obj/effect/turf_decal/stripes/line{
@@ -196,12 +204,142 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"ciG" = (
-/turf/open/floor/iron/stairs/left{
+"eR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fans/tiny/invisible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"eV" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/fax/admin/syndicate,
+/turf/open/floor/carpet/black,
+/area/centcom/syndicate_base/control)
+"fb" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo16"
+	},
+/obj/effect/turf_decal/siding/dark/inner_corner{
+	dir = 8
+	},
+/obj/structure/chair/comfy/red{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/syndicate_base/control)
+"fl" = (
+/turf/open/floor/iron/smooth,
+/area/centcom/syndicate_base)
+"fn" = (
+/obj/structure/mop_bucket,
+/obj/item/mop,
+/obj/item/soap/syndie,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/white,
+/area/centcom/syndicate_base)
+"fu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"fw" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"gc" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/iron/smooth,
+/area/centcom/syndicate_base)
+"gd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/vehicle/ridden/scooter{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"gl" = (
+/obj/structure/chair/sofa/middle/brown,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"gn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"gq" = (
+/obj/machinery/computer/mech_bay_power_console,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"gE" = (
+/turf/open/floor/iron/stairs/medium{
+	color = "#adadad";
 	dir = 1
 	},
 /area/centcom/syndicate_base)
-"cji" = (
+"gR" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo6"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/syndicate_base/control)
+"hz" = (
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/obj/structure/table/wood/fancy/black,
+/obj/item/paper/fluff/overwatch{
+	pixel_y = 8;
+	pixel_x = -2
+	},
+/obj/item/circuitboard/computer/overwatch{
+	pixel_x = -2
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/syndicate_base/control)
+"hA" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"hZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/south,
+/obj/structure/bed/dogbed/cayenne,
+/mob/living/basic/carp/pet/cayenne,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"id" = (
+/obj/structure/ore_box,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/delivery/white,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"ih" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo10"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/syndicate_base/control)
+"iw" = (
+/obj/structure/sign/poster/contraband/random/directional/north,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"iG" = (
 /obj/machinery/door/poddoor/ert{
 	id = "nukeop_ready";
 	name = "Shuttle Dock Door"
@@ -212,33 +350,177 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"crr" = (
-/obj/effect/decal/syndie_logo{
-	icon_state = "logo9"
+"iP" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/cardboard,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"iX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"ja" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/ore_box,
+/obj/effect/turf_decal/delivery/white,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"jt" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/structure/table/wood{
+	color = "#996633"
 	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium/red,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/wood/parquet,
 /area/centcom/syndicate_base/control)
-"cyn" = (
+"jC" = (
+/turf/open/floor/carpet/black,
+/area/centcom/syndicate_base/control)
+"jG" = (
+/obj/machinery/washing_machine,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"jO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fans/tiny/invisible,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"jZ" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/centcom/syndicate_base)
+"ke" = (
+/turf/open/floor/iron/stairs/left{
+	dir = 1;
+	color = "gray"
+	},
+/area/centcom/syndicate_base)
+"kl" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/nukeop,
+/turf/open/floor/carpet/black,
+/area/centcom/syndicate_base)
+"ko" = (
+/obj/effect/turf_decal/delivery/red,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"kr" = (
+/obj/structure/weightmachine/weightlifter,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"kw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/corner/end{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"kI" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/red,
+/obj/item/pen/red,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"kK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"kL" = (
+/obj/machinery/light/small/directional/east,
+/obj/structure/chair/stool/directional/south,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"kM" = (
+/obj/structure/fans/tiny/invisible,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"cDl" = (
-/obj/structure/sign/poster/contraband/random/directional/north,
-/obj/machinery/light/small/directional/north,
+"li" = (
+/obj/structure/railing/corner/end/flip{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"lp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"lw" = (
+/obj/structure/ore_box,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/delivery/white,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"lD" = (
+/obj/structure/fluff/shower_drain,
+/obj/machinery/shower/directional/south,
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/iron/freezer,
+/area/centcom/syndicate_base)
+"lL" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Syndicate Base"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/wood,
 /area/centcom/syndicate_base)
-"cHl" = (
+"lR" = (
+/obj/machinery/shieldwall{
+	icon_state = "wave2";
+	max_integrity = 9999
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"lT" = (
+/turf/open/floor/iron/stairs/right{
+	dir = 4
+	},
+/area/centcom/syndicate_base)
+"mh" = (
+/obj/machinery/door/poddoor/ert{
+	id = "nukeop_outside"
+	},
+/turf/open/floor/iron/grimy,
+/area/centcom/syndicate_base)
+"mk" = (
+/obj/structure/fans/tiny/invisible,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"mp" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/centcom/syndicate_base)
+"mw" = (
 /obj/item/reagent_containers/cup/glass/bottle/rum{
 	pixel_x = -16;
 	pixel_y = 11
@@ -249,441 +531,140 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/syndicate_base)
-"cNm" = (
-/turf/open/floor/wood/parquet,
-/area/centcom/syndicate_base/control)
-"cSv" = (
-/obj/structure/chair/sofa/right/brown,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+"mC" = (
+/turf/open/floor/iron/white,
 /area/centcom/syndicate_base)
-"cWW" = (
-/obj/effect/turf_decal/arrows{
+"mR" = (
+/obj/structure/railing{
 	dir = 1
 	},
-/obj/structure/fans/tiny/invisible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"cZG" = (
-/obj/structure/ore_box,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"cZH" = (
-/obj/effect/decal/syndie_logo{
-	icon_state = "logo6"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/syndicate_base/control)
-"deV" = (
-/obj/structure/fans/tiny/invisible,
-/obj/structure/marker_beacon/burgundy,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"dfR" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Syndicate Base"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/turf/open/floor/iron/grimy,
-/area/centcom/syndicate_base)
-"dlo" = (
-/obj/structure/closet/syndicate/personal,
-/obj/machinery/light/small/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/dark_red/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"dlt" = (
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/obj/machinery/door/airlock/external{
-	id_tag = "syndicate_away"
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"dlQ" = (
-/obj/structure/chair/stool/bar{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"don" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/ert{
-	id = "nukeop_storage"
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"dts" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"dCq" = (
-/turf/open/floor/iron/stairs/right{
-	dir = 8
-	},
-/area/centcom/syndicate_base)
-"dCB" = (
-/obj/structure/chair/comfy/red{
-	dir = 8
-	},
-/obj/effect/landmark/start/nukeop_leader,
-/turf/open/floor/carpet/black,
-/area/centcom/syndicate_base)
-"dNj" = (
-/obj/effect/turf_decal/siding/thinplating_new/dark,
-/obj/machinery/jukebox,
-/turf/open/floor/wood/parquet,
-/area/centcom/syndicate_base/control)
-"dPy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/iron/grimy,
-/area/centcom/syndicate_base)
-"dUG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/cardboard,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"eim" = (
-/obj/machinery/light/small/directional/west,
-/obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/random,
-/obj/structure/railing,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/syndicate_base)
-"emh" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/machinery/door/window/survival_pod/left/directional/south{
-	req_access = list("syndicate")
-	},
-/obj/item/assembly/flash/handheld{
-	pixel_y = 4
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"epF" = (
-/obj/structure/ore_box,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"evm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"eEu" = (
-/obj/machinery/computer/camera_advanced{
-	pixel_x = -6;
-	dir = 8
-	},
-/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+"mV" = (
+/obj/item/storage/fancy/donut_box,
+/obj/structure/table/wood/fancy/black,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/machinery/light/directional/north,
 /turf/open/floor/carpet/black,
 /area/centcom/syndicate_base/control)
-"eFN" = (
-/obj/effect/decal/syndie_logo{
-	icon_state = "logo4"
-	},
-/obj/effect/turf_decal/siding/dark/inner_corner{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/syndicate_base/control)
-"ePf" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/centcom/syndicate_base)
-"eSY" = (
-/obj/structure/mop_bucket,
-/obj/item/mop,
-/obj/item/soap/syndie,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/centcom/syndicate_base)
-"eXO" = (
-/obj/effect/decal/cleanable/vomit,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
-/area/centcom/syndicate_base)
-"fbq" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/centcom/syndicate_base)
-"ffq" = (
-/obj/machinery/light/small/directional/east,
-/obj/structure/toilet,
-/turf/open/floor/iron/white,
-/area/centcom/syndicate_base)
-"flo" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Syndicate Base"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/command,
-/turf/open/floor/iron/grimy,
-/area/centcom/syndicate_base)
-"fmQ" = (
-/obj/machinery/light/small/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny/invisible,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/red/corner,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"fnU" = (
-/turf/closed/indestructible/syndicate,
-/area/centcom/syndicate_base)
-"ful" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny/invisible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
+"nd" = (
+/obj/machinery/shieldwall{
+	icon_state = "wave2";
+	max_integrity = 9999
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/poddoor/ert{
+	id = "nukeop_ready"
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"fxM" = (
-/turf/closed/indestructible/syndicate,
-/area/centcom/syndicate_base/control)
-"fAH" = (
-/obj/structure/ore_box,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"fHu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/iron/recharge_floor,
-/area/centcom/syndicate_base)
-"fQZ" = (
-/turf/open/floor/iron/stairs/medium{
-	dir = 1
-	},
-/area/centcom/syndicate_base)
-"fTe" = (
-/obj/effect/turf_decal/delivery/red,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"fZK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/railing/corner/end{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"gbc" = (
-/obj/effect/turf_decal/arrows{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"gqH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"gty" = (
+"ni" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/structure/table/wood{
 	color = "#996633"
 	},
-/obj/item/storage/box/drinkingglasses,
+/obj/item/pizzabox/margherita,
+/obj/item/pizzabox/margherita,
+/obj/item/knife/kitchen,
 /turf/open/floor/wood/parquet,
 /area/centcom/syndicate_base/control)
-"gyK" = (
-/obj/machinery/button/door/indestructible{
-	wires = 1;
-	id = "nukeop_ready";
-	name = "Shuttle Dock Door";
-	specialfunctions = 4;
-	req_access = list("syndicate")
+"nq" = (
+/turf/open/floor/iron/stairs/right{
+	dir = 1;
+	color = "gray"
 	},
-/turf/closed/indestructible/syndicate,
 /area/centcom/syndicate_base)
-"gOQ" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"gVh" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/ore_box,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"gVQ" = (
-/obj/effect/baseturf_helper{
-	baseturf = /turf/open/misc/asteroid
+"nt" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo15"
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_base/control)
-"gXs" = (
-/obj/structure/fans/tiny/invisible,
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/iron/dark,
+"on" = (
+/obj/structure/table/reinforced,
+/obj/item/taperecorder,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/syndicate_base)
-"gXS" = (
-/obj/structure/fans/tiny/invisible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"gZt" = (
-/obj/structure/chair/stool{
-	dir = 1
-	},
-/obj/effect/landmark/start/nukeop,
-/turf/open/floor/carpet/black,
-/area/centcom/syndicate_base)
-"hii" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/wood/parquet,
-/area/centcom/syndicate_base/control)
-"hiV" = (
-/obj/effect/turf_decal/siding/wood/corner,
-/turf/open/floor/iron/grimy,
-/area/centcom/syndicate_base)
-"hse" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/machinery/door/window/survival_pod/left/directional/south{
-	req_access = list("syndicate")
-	},
-/obj/machinery/recharger{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"hxf" = (
+"ov" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"hxU" = (
-/obj/structure/ore_box,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery/white,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"hAD" = (
-/obj/machinery/light/small/directional/east,
+"ow" = (
+/obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/toilet{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/centcom/syndicate_base)
-"hDK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny/invisible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"hEn" = (
-/obj/item/kirbyplants/random,
-/obj/structure/railing,
+/obj/structure/sign/poster/contraband/random/directional/south,
+/obj/machinery/recharge_station,
 /turf/open/floor/wood,
 /area/centcom/syndicate_base)
-"hLd" = (
+"oH" = (
+/obj/effect/turf_decal/delivery/red,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny/invisible,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/red/line,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/closet/cardboard,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"hMQ" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/curtain/bounty/start_closed{
-	pixel_y = -32
+"oK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery/red,
+/obj/structure/ore_box,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"oR" = (
+/obj/structure/table/wood{
+	color = "#996633"
 	},
+/obj/item/pizzabox/margherita,
+/obj/item/knife/kitchen,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/centcom/syndicate_base)
-"hOo" = (
-/turf/open/floor/iron/white,
-/area/centcom/syndicate_base)
-"hSN" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
+"oX" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/iron/grimy,
-/area/centcom/syndicate_base)
-"hXC" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/mineral/sandbags,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"icT" = (
-/obj/structure/sink/directional/east,
-/obj/structure/mirror/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
+"pb" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"iiw" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/wood,
+"pc" = (
+/obj/machinery/light/directional/north,
+/obj/structure/fans/tiny/invisible,
+/obj/structure/marker_beacon/burgundy,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"inv" = (
+"pf" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo14"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/syndicate_base/control)
+"pn" = (
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/iron/recharge_floor,
+/area/centcom/syndicate_base)
+"ps" = (
+/obj/machinery/vending/clothing,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"pK" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
 	},
@@ -695,69 +676,229 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_base/control)
-"ios" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Syndicate Base"
+"pM" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"ipn" = (
-/obj/machinery/button/door/indestructible{
-	pixel_x = -24;
-	wires = 1;
-	id = "nukeop_ready";
-	name = "Shuttle Dock Door";
-	specialfunctions = 4;
-	req_access = list("syndicate")
+"pT" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/centcom/syndicate_base)
+"qb" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"qp" = (
+/obj/docking_port/stationary{
+	area_type = /area/centcom/syndicate_mothership;
+	height = 22;
+	name = "Syndicate Mothership Dock";
+	shuttle_id = "syndicate_away";
+	width = 18;
+	dwidth = 8
+	},
+/turf/open/floor/plating,
+/area/centcom/syndicate_base)
+"qt" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo11"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/syndicate_base/control)
+"qX" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"rr" = (
+/obj/effect/turf_decal/siding/wideplating/dark,
+/turf/open/floor/plating,
+/area/centcom/syndicate_base)
+"rt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"iwO" = (
-/turf/open/floor/iron/stairs/left{
-	dir = 1;
-	color = "gray"
-	},
+"rw" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/syndicate_base)
-"iAT" = (
-/obj/structure/chair/stool{
+"rz" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"rE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"sf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fans/tiny/invisible,
+/obj/structure/marker_beacon/burgundy,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"sm" = (
+/turf/closed/indestructible/syndicate,
+/area/centcom/syndicate_base)
+"sq" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/centcom/syndicate_base)
+"sw" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/ore_box,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"sB" = (
+/obj/structure/chair/sofa/corp/left{
 	dir = 1
 	},
-/obj/structure/sign/poster/contraband/random/directional/west,
-/obj/effect/landmark/start/nukeop,
-/turf/open/floor/carpet/black,
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo2"
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/syndicate_base/control)
+"sC" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/iron/smooth,
 /area/centcom/syndicate_base)
-"iBV" = (
+"sW" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"tb" = (
+/obj/docking_port/stationary{
+	dwidth = 25;
+	height = 50;
+	name = "Syndicate Auxiliary Shuttle Dock";
+	shuttle_id = "emergency_syndicate";
+	width = 50;
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/centcom/syndicate_base)
+"tc" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/directional/north,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"tq" = (
+/obj/structure/chair/stool/directional/south,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"tu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"tx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"tF" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"tH" = (
+/obj/machinery/fax/admin/syndicate,
+/obj/structure/table/wood/fancy/black,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/turf/open/floor/carpet/black,
+/area/centcom/syndicate_base/control)
+"tL" = (
+/turf/open/floor/carpet/red,
+/area/centcom/syndicate_base/control)
+"tM" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/machinery/jukebox,
+/turf/open/floor/wood/parquet,
+/area/centcom/syndicate_base/control)
+"tP" = (
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"ub" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/delivery/white,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/mineral/sandbags,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"un" = (
+/obj/item/storage/box/drinkingglasses,
+/obj/structure/table/wood{
+	color = "#996633"
+	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/item/rag{
+	pixel_y = -6
+	},
+/turf/open/floor/iron,
+/area/centcom/syndicate_base)
+"us" = (
+/obj/item/kirbyplants/random,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"uw" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/sofa/middle/brown,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"uD" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+/obj/machinery/chem_dispenser/drinks/fullupgrade{
 	dir = 1
 	},
 /turf/open/floor/wood/parquet,
 /area/centcom/syndicate_base/control)
-"iDh" = (
-/obj/structure/closet/syndicate/personal,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/dark_red/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"iVu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/ore_box,
-/obj/effect/turf_decal/delivery/white,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"jdM" = (
-/obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/iron/grimy,
-/area/centcom/syndicate_base)
-"jfm" = (
+"uV" = (
 /obj/effect/turf_decal/arrows{
 	dir = 1
 	},
@@ -771,7 +912,52 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"jfZ" = (
+"uW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fans/tiny/invisible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"vc" = (
+/obj/machinery/computer/shuttle/syndicate{
+	name = "Nuclear Operatives Shuttle Console";
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/syndicate_base/control)
+"vh" = (
+/turf/open/space/basic,
+/area/space)
+"vA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fans/tiny/invisible,
+/obj/structure/marker_beacon/burgundy,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"vR" = (
+/obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"wf" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"wV" = (
 /obj/item/storage/box/donkpockets{
 	pixel_x = 4;
 	pixel_y = 4
@@ -790,120 +976,204 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/syndicate_base)
-"jkN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood,
+"xd" = (
+/turf/open/floor/plating,
 /area/centcom/syndicate_base)
-"jmk" = (
-/obj/structure/sign/poster/contraband/random/directional/south,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/iron/grimy,
-/area/centcom/syndicate_base)
-"jpY" = (
-/obj/machinery/light/small/directional/north,
-/obj/machinery/vending/cigarette/syndicate,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"jrf" = (
-/obj/machinery/light/directional/west,
-/obj/structure/fans/tiny/invisible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"jsR" = (
-/obj/machinery/computer/mech_bay_power_console,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"jtX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"jud" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/closet/crate/cardboard/mothic,
-/obj/effect/turf_decal/delivery/white,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"jAn" = (
-/obj/machinery/oven/range,
-/obj/item/food/cookie{
-	pixel_y = 5
-	},
-/obj/item/food/cookie{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/food/cookie{
-	pixel_x = -6;
-	pixel_y = 11
-	},
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"jIP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/delivery/white,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"jLf" = (
-/obj/effect/decal/cleanable/dirt,
+"xs" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"jLT" = (
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/iron/grimy,
-/area/centcom/syndicate_base)
-"jVL" = (
-/obj/machinery/light/small/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"jYa" = (
 /obj/structure/fans/tiny/invisible,
-/obj/effect/turf_decal/caution/stand_clear{
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/corner{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"kcQ" = (
-/obj/structure/ore_box,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+"xH" = (
+/obj/structure/fans/tiny/invisible,
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"xJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/mirror/directional/west,
+/obj/structure/sink/directional/east,
+/turf/open/floor/iron/white,
+/area/centcom/syndicate_base)
+"xO" = (
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+	dir = 8
 	},
-/obj/effect/turf_decal/delivery/white,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/structure/table/wood{
+	color = "#996633"
+	},
+/turf/open/floor/iron,
+/area/centcom/syndicate_base)
+"xR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"keH" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/ore_box,
-/obj/effect/turf_decal/delivery/white,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"khe" = (
-/obj/effect/decal/cleanable/dirt,
+"yf" = (
+/obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fans/tiny/invisible,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/red/corner,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"yk" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"ym" = (
+/obj/structure/closet/syndicate/personal,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"yy" = (
+/obj/effect/spawner/random/vending/snackvend,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"yF" = (
+/obj/effect/baseturf_helper{
+	baseturf = /turf/open/misc/asteroid
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"yL" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/banner/syndicate,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"zj" = (
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"zN" = (
+/obj/structure/table/reinforced,
+/obj/item/food/syndicake{
+	pixel_y = 3
+	},
+/obj/item/flashlight/lamp{
+	pixel_y = 14
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"zU" = (
+/obj/machinery/light/small/directional/west,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"zW" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/katana{
+	pixel_x = -3;
+	pixel_y = 2;
+	force = 20;
+	desc = "A gift from your benefactors."
+	},
+/obj/item/storage/belt/sheath/katana/empty{
+	pixel_y = 3;
+	pixel_x = 7
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"Ac" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"Ai" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo17"
+	},
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/syndicate_base/control)
+"AJ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/centcom/syndicate_base)
+"AN" = (
+/turf/open/floor/iron/stairs/left{
+	dir = 8
+	},
+/area/centcom/syndicate_base)
+"AT" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo7"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/syndicate_base/control)
+"Bd" = (
+/obj/structure/fans/tiny/invisible,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"Be" = (
+/obj/structure/chair/sofa/left/brown,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"Bh" = (
+/obj/effect/baseturf_helper{
+	baseturf = /turf/open/misc/asteroid
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/syndicate_base/control)
+"Bp" = (
+/obj/structure/closet/syndicate/personal,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"BC" = (
+/turf/open/floor/iron/stairs/right{
+	dir = 1;
+	color = "#adadad"
+	},
+/area/centcom/syndicate_base)
+"BG" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/fans/tiny/invisible,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"BM" = (
+/turf/open/floor/iron/stairs/right{
+	dir = 1
+	},
+/area/centcom/syndicate_base)
+"Ce" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo13"
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/syndicate_base/control)
+"Cp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -913,105 +1183,296 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"klm" = (
+"Cx" = (
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"Cy" = (
+/obj/machinery/button/door/indestructible{
+	wires = 1;
+	id = "nukeop_ready";
+	name = "Shuttle Dock Door";
+	specialfunctions = 4;
+	req_access = list("syndicate");
+	pixel_y = -8
+	},
+/turf/closed/indestructible/syndicate,
+/area/centcom/syndicate_base)
+"CG" = (
+/obj/machinery/light/small/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/random,
+/obj/structure/railing,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"CL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/ore_box,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"CO" = (
+/obj/structure/chair/sofa/right/brown,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"CR" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"Dc" = (
+/turf/open/floor/iron/stairs/left{
+	dir = 4
+	},
+/area/centcom/syndicate_base)
+"Dk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/ert{
+	id = "nukeop_storage"
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"Dq" = (
+/obj/machinery/photocopier/syndicate,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/turf/open/floor/carpet/black,
+/area/centcom/syndicate_base/control)
+"DM" = (
+/obj/machinery/door/window/survival_pod/left/directional/south{
+	req_access = list("syndicate")
+	},
+/turf/open/floor/carpet/red,
+/area/centcom/syndicate_base/control)
+"DO" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/centcom/syndicate_base)
+"Ek" = (
+/obj/effect/decal/syndie_logo,
+/obj/effect/turf_decal/siding/dark/inner_corner{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/syndicate_base/control)
+"Eu" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/centcom/syndicate_base)
+"EE" = (
+/obj/structure/noticeboard/directional/west,
+/obj/item/paper/fluff/stations/centcom/disk_memo{
+	default_raw_text = "ПОЛУЧИТЕ ЭТОТ ЕБУЧИЙ ДИСК!"
+	},
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"EO" = (
+/turf/open/floor/iron/stairs/medium{
+	color = "gray";
+	dir = 1
+	},
+/area/centcom/syndicate_base)
+"EW" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"Ff" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/ore_box,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"Fo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"Fr" = (
 /obj/machinery/computer/shuttle/syndicate/recall,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"kni" = (
+"Fs" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/smooth,
+/area/centcom/syndicate_base)
+"Fu" = (
+/obj/structure/noticeboard/directional/west,
+/obj/item/banner/syndicate,
+/turf/open/floor/carpet/black,
+/area/centcom/syndicate_base/control)
+"Fx" = (
+/turf/open/floor/iron/stairs/left{
+	dir = 1;
+	color = "#adadad"
+	},
+/area/centcom/syndicate_base)
+"Fz" = (
+/obj/structure/sign/poster/contraband/random/directional/south,
+/obj/structure/railing/corner/end/flip{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"FH" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
+/area/centcom/syndicate_base/control)
+"FK" = (
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/door/airlock/external{
+	id_tag = "syndicate_away"
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"FM" = (
+/obj/machinery/light/small/directional/north,
+/obj/structure/sign/poster/contraband/random/directional/north,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"FY" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/centcom/syndicate_base)
+"Ge" = (
 /obj/machinery/light/small/directional/east,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"Gn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/random/directional/north,
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_y = 5
+	},
+/obj/item/pen/edagger{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"Gu" = (
+/obj/machinery/mech_bay_recharge_port,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"Gz" = (
+/obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"koA" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/centcom/syndicate_base)
-"kqr" = (
-/obj/item/storage/fancy/donut_box,
-/obj/structure/table/wood/fancy/black,
-/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
-/obj/machinery/light/directional/north,
-/turf/open/floor/carpet/black,
-/area/centcom/syndicate_base/control)
-"kEs" = (
-/obj/effect/decal/cleanable/blood,
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"kEw" = (
-/obj/structure/railing/corner/end/flip{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"kFg" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/grimy,
-/area/centcom/syndicate_base)
-"kVN" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"ldu" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Syndicate Base"
-	},
-/turf/open/floor/plating,
-/area/centcom/syndicate_base)
-"lkx" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Syndicate Base"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/turf/open/floor/iron/white,
-/area/centcom/syndicate_base)
-"lnr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/ore_box,
+"GL" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"lrc" = (
-/obj/docking_port/stationary{
-	area_type = /area/centcom/syndicate_base;
-	height = 22;
-	name = "Syndicate Mothership Dock";
-	shuttle_id = "syndicate_away";
-	width = 18;
-	dwidth = 8
+"GT" = (
+/obj/machinery/computer/camera_advanced,
+/turf/open/floor/carpet/black,
+/area/centcom/syndicate_base/control)
+"Hk" = (
+/obj/structure/table/wood/poker,
+/obj/item/reagent_containers/cup/glass/bottle/vodka{
+	pixel_x = -5;
+	pixel_y = 9
 	},
-/turf/open/floor/plating,
+/obj/item/toy/cards/deck/syndicate,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/white,
 /area/centcom/syndicate_base)
-"ltU" = (
-/obj/item/storage/box/drinkingglasses,
-/obj/structure/sign/poster/contraband/random/directional/north,
+"Hx" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"HC" = (
+/obj/structure/fans/tiny/invisible,
+/obj/structure/marker_beacon/burgundy,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"HG" = (
+/obj/machinery/computer/security/overwatch{
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/centcom/syndicate_base/control)
+"HX" = (
+/obj/machinery/computer/crew{
+	pixel_x = -6;
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/turf/open/floor/carpet/black,
+/area/centcom/syndicate_base/control)
+"Ia" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/centcom/syndicate_base)
+"Id" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/recharger{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_y = 6;
+	pixel_x = 6
+	},
+/obj/item/gun/energy/ionrifle,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"Ik" = (
+/obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/iron/white,
+/area/centcom/syndicate_base)
+"Ip" = (
+/obj/machinery/chem_dispenser/drinks/fullupgrade{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/east,
 /obj/structure/table/wood{
 	color = "#996633"
 	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 9
-	},
-/obj/item/rag{
-	pixel_y = -6
-	},
 /turf/open/floor/iron,
 /area/centcom/syndicate_base)
-"lGp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"lHj" = (
+"Iz" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/paper_bin{
 	pixel_x = -2;
@@ -1022,15 +1483,66 @@
 	},
 /turf/open/floor/carpet/red,
 /area/centcom/syndicate_base/control)
-"lKs" = (
-/obj/machinery/door/poddoor/ert{
-	id = "nukeop_ready";
-	name = "Shuttle Dock Door"
+"IM" = (
+/obj/structure/sign/poster/contraband/random/directional/south,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/centcom/syndicate_base)
+"Jg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/vehicle/ridden/scooter{
+	dir = 1
 	},
-/obj/effect/turf_decal/bot,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"Jo" = (
+/obj/machinery/light/small/directional/north,
+/obj/structure/table/rolling,
+/obj/item/reagent_containers/condiment/soymilk,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"Js" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/item/stack/spacecash/c1{
+	pixel_y = 12
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"Ju" = (
+/obj/machinery/button/door/indestructible{
+	wires = 1;
+	id = "nukeop_ready";
+	name = "Shuttle Dock Door";
+	specialfunctions = 4;
+	req_access = list("syndicate")
+	},
+/turf/closed/indestructible/syndicate,
+/area/centcom/syndicate_base)
+"JQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/closet/crate/cardboard/mothic,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"lPt" = (
+"JW" = (
+/obj/vehicle/ridden/scooter{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"JX" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/centcom/syndicate_base)
+"JZ" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/syndicatedetonator{
 	pixel_x = -6;
@@ -1050,161 +1562,41 @@
 	},
 /turf/open/floor/carpet/red,
 /area/centcom/syndicate_base/control)
-"lRu" = (
-/obj/structure/table,
-/obj/item/paper/fluff{
-	name = "записка";
-	default_raw_text = "Пришлось срочно вылететь на задание. Печенье доделаете сами. - Джордж";
-	pixel_x = 3
+"Kd" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
-/obj/item/pai_card{
-	pixel_x = -4
-	},
-/turf/open/floor/wood,
+/turf/open/floor/iron/smooth,
 /area/centcom/syndicate_base)
-"lWm" = (
-/turf/open/floor/iron/stairs/right{
-	dir = 1;
-	color = "gray"
-	},
-/area/centcom/syndicate_base)
-"lZQ" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"maY" = (
-/obj/effect/decal/cleanable/blood,
-/obj/machinery/light/small/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/random/directional/south,
-/obj/machinery/recharge_station,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"mcR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"miA" = (
-/obj/effect/decal/syndie_logo,
-/obj/effect/turf_decal/siding/dark/inner_corner{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/syndicate_base/control)
-"mjL" = (
-/obj/structure/fans/tiny/invisible,
-/obj/structure/marker_beacon/burgundy,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"mjQ" = (
-/obj/structure/noticeboard/directional/west,
-/obj/item/banner/syndicate,
+"Kj" = (
 /turf/open/floor/carpet/black,
-/area/centcom/syndicate_base/control)
-"mkU" = (
-/obj/item/target,
-/turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"mmT" = (
-/obj/machinery/light/small/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/random,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"mpO" = (
-/obj/effect/decal/syndie_logo{
-	icon_state = "logo13"
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/syndicate_base/control)
-"mtm" = (
-/obj/item/banner/syndicate,
-/turf/open/floor/carpet/black,
-/area/centcom/syndicate_base/control)
-"muB" = (
-/obj/item/kirbyplants/random,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"mvf" = (
-/obj/effect/decal/syndie_logo{
-	icon_state = "logo19"
-	},
-/obj/effect/turf_decal/siding/dark/inner_corner,
+"Kt" = (
 /obj/structure/chair/comfy/red{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/syndicate_base/control)
-"mvw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/obj/effect/landmark/start/nukeop_leader,
+/turf/open/floor/carpet/black,
 /area/centcom/syndicate_base)
-"mwf" = (
-/obj/machinery/light/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"mxA" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
-/area/centcom/syndicate_base)
-"mBE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/random/directional/west,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/centcom/syndicate_base)
-"mEk" = (
-/obj/effect/turf_decal/siding/wood{
+"Kz" = (
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/turf/open/floor/iron/grimy,
-/area/centcom/syndicate_base)
-"mNS" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/smooth,
 /area/centcom/syndicate_base)
-"mRk" = (
-/obj/machinery/shieldwall{
-	icon_state = "wave2";
-	max_integrity = 9999
+"Lc" = (
+/obj/item/paper_bin{
+	pixel_y = 7
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/door/poddoor/ert{
-	id = "nukeop_ready"
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"mRM" = (
+/obj/item/pen/fourcolor,
+/obj/structure/table/wood/fancy/black,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/turf/open/floor/carpet/black,
+/area/centcom/syndicate_base/control)
+"Lh" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/syndicatedetonator{
 	pixel_x = -6;
@@ -1217,107 +1609,217 @@
 	},
 /turf/open/floor/carpet/red,
 /area/centcom/syndicate_base/control)
-"nbn" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/iron/grimy,
-/area/centcom/syndicate_base)
-"ngQ" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"niK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/katana/cursed{
-	desc = "A gift from your benefactors.";
-	force = 20
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"niY" = (
-/obj/structure/ore_box,
+"Li" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"njR" = (
-/obj/structure/fans/tiny/invisible,
-/obj/structure/marker_beacon/burgundy,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+"Lp" = (
+/obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/iron/smooth,
 /area/centcom/syndicate_base)
-"npT" = (
-/obj/item/paper_bin{
-	pixel_y = 7
+"Lr" = (
+/obj/machinery/computer/message_monitor{
+	pixel_x = -6;
+	dir = 8
 	},
-/obj/item/pen/fourcolor,
-/obj/structure/table/wood/fancy/black,
-/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/item/paper/monitorkey,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/obj/machinery/light/directional/north,
 /turf/open/floor/carpet/black,
 /area/centcom/syndicate_base/control)
-"nwV" = (
-/obj/machinery/light/small/directional/east,
-/obj/structure/fans/tiny/invisible,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/red/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"nCv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"nCM" = (
-/obj/machinery/light/directional/north,
-/obj/structure/fans/tiny/invisible,
-/obj/structure/marker_beacon/burgundy,
+"LH" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"nFd" = (
-/obj/structure/closet/syndicate/personal,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/thinplating_new/dark,
-/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"nFN" = (
-/obj/structure/mirror/directional/west,
-/obj/structure/sink/directional/east,
+"LN" = (
+/obj/structure/sign/poster/contraband/c20r/directional/north,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"LP" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/machinery/vending/boozeomat/syndicate,
+/turf/open/floor/wood/parquet,
+/area/centcom/syndicate_base/control)
+"LW" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"Mh" = (
+/obj/machinery/computer/shuttle/syndicate/recall,
+/obj/machinery/button/door/indestructible{
+	id = "nukeop_ready";
+	name = "Mission Launch Control";
+	pixel_y = 24;
+	specialfunctions = 4;
+	wires = 1;
+	req_access = list("syndicate")
+	},
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"Mj" = (
+/obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/centcom/syndicate_base)
-"nHO" = (
-/obj/effect/decal/cleanable/blood,
+"Mk" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/centcom/syndicate_base)
+"Mm" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/centcom/syndicate_base)
+"MD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/delivery/white,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"nNU" = (
+"ME" = (
+/obj/item/reagent_containers/cup/glass/bottle/beer{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/syndicatedetonator{
+	pixel_x = 4
+	},
+/obj/structure/table/wood/poker,
+/obj/structure/sign/poster/contraband/random/directional/west,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/carpet/black,
+/area/centcom/syndicate_base)
+"MV" = (
+/turf/closed/indestructible/opsglass,
+/area/centcom/syndicate_base)
+"MZ" = (
+/obj/machinery/microwave{
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/structure/table/wood{
+	color = "#996633"
+	},
+/turf/open/floor/iron,
+/area/centcom/syndicate_base)
+"Nf" = (
+/obj/structure/ore_box,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"Nu" = (
+/obj/machinery/light/small/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"NA" = (
+/obj/structure/closet/syndicate/personal,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"ND" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/iron/smooth,
+/area/centcom/syndicate_base)
+"NK" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/syndicate_base)
+"Oe" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/centcom/syndicate_base)
+"On" = (
+/obj/machinery/vending/tool,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"Or" = (
+/turf/open/floor/iron/stairs/medium{
+	dir = 1
+	},
+/area/centcom/syndicate_base)
+"OB" = (
+/obj/item/toy/nuke,
+/obj/structure/table/wood/poker,
+/turf/open/floor/carpet/black,
+/area/centcom/syndicate_base)
+"OS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/fans/tiny/invisible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"OU" = (
+/obj/machinery/vending/cigarette/syndicate,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"Pb" = (
+/obj/item/kirbyplants/random,
+/obj/structure/railing,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"Pq" = (
+/obj/structure/chair/stool/directional/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"Px" = (
+/obj/item/paper/fluff{
+	name = "записка";
+	default_raw_text = "Пришлось срочно вылететь на задание. Печенье доделаете сами. - Джордж";
+	pixel_x = 3
+	},
+/obj/item/pai_card{
+	pixel_x = -4
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"PA" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/turf/open/floor/iron,
+/area/centcom/syndicate_base)
+"PP" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/centcom/syndicate_base)
+"PY" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/paper_bin{
 	pixel_y = 7
@@ -1325,19 +1827,149 @@
 /obj/item/pen/fountain,
 /turf/open/floor/carpet/red,
 /area/centcom/syndicate_base/control)
-"nOK" = (
-/obj/effect/turf_decal/stripes/line{
+"Qa" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
 	},
-/turf/closed/indestructible/syndicate,
+/turf/open/floor/plating,
 /area/centcom/syndicate_base)
-"nQs" = (
-/obj/machinery/door/poddoor/ert{
-	id = "nukeop_outside"
+"Qi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/boozeomat/syndicate,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
 	},
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron,
 /area/centcom/syndicate_base)
-"nSk" = (
+"Qt" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"Qu" = (
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/structure/closet/syndicate/personal,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"Ra" = (
+/obj/item/kirbyplants/random,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"Rc" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/wood/parquet,
+/area/centcom/syndicate_base/control)
+"Rg" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/waterbottle/large{
+	pixel_x = -15;
+	pixel_y = 9
+	},
+/obj/item/stack/spacecash/c100,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"Ri" = (
+/obj/structure/table/wood{
+	color = "#996633"
+	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/item/food/cookie{
+	pixel_x = -6;
+	pixel_y = 11
+	},
+/obj/item/food/cookie{
+	pixel_y = 5
+	},
+/obj/item/food/cookie{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/stack/spacecash/c20,
+/turf/open/floor/iron,
+/area/centcom/syndicate_base)
+"RA" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Syndicate Base"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/turf/open/floor/iron/white,
+/area/centcom/syndicate_base)
+"RN" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/white,
+/area/centcom/syndicate_base)
+"RS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"RX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"Sb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"Sd" = (
+/obj/machinery/door/poddoor/ert{
+	id = "nukeop_ready";
+	name = "Shuttle Dock Door"
+	},
+/turf/open/floor/iron/stairs/medium{
+	color = "#adadad";
+	dir = 1
+	},
+/area/centcom/syndicate_base)
+"Sj" = (
+/obj/structure/fans/tiny/invisible,
+/obj/structure/marker_beacon/burgundy,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"Sm" = (
+/obj/machinery/door/poddoor/ert{
+	id = "SST_to_ATOM"
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"Sp" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"Su" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"Sw" = (
 /obj/structure/chair/comfy/purp{
 	dir = 4
 	},
@@ -1350,143 +1982,78 @@
 /obj/effect/landmark/start/nukeop_overwatch,
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_base/control)
-"nSN" = (
-/obj/structure/chair/sofa/left/brown,
+"SA" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"SM" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/centcom/syndicate_base)
+"Tf" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/item/stack/spacecash/c10{
+	pixel_x = -19;
+	pixel_y = 10
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"Tg" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/sofa/right/brown,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"Tk" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"Tz" = (
+/obj/effect/turf_decal/arrows{
+	dir = 1
+	},
+/obj/structure/fans/tiny/invisible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"nUA" = (
-/obj/structure/table/wood,
-/obj/machinery/microwave{
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 5
-	},
-/turf/open/floor/iron,
+"TC" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"odA" = (
-/obj/effect/decal/syndie_logo{
-	icon_state = "logo17"
-	},
-/obj/effect/turf_decal/siding/dark,
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/syndicate_base/control)
-"oea" = (
-/obj/effect/decal/syndie_logo{
-	icon_state = "logo11"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/syndicate_base/control)
-"ogO" = (
-/obj/machinery/fax/admin/syndicate,
-/obj/structure/table/wood/fancy/black,
-/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
-/turf/open/floor/carpet/black,
-/area/centcom/syndicate_base/control)
-"oiT" = (
-/obj/item/reagent_containers/cup/glass/bottle/beer{
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/obj/item/syndicatedetonator{
-	pixel_x = 4
-	},
-/obj/structure/table/wood/poker,
-/turf/open/floor/carpet/black,
-/area/centcom/syndicate_base)
-"oju" = (
+"TZ" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/delivery/white,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"omf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny/invisible,
+"Ub" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/closed/indestructible/syndicate,
 /area/centcom/syndicate_base)
-"onL" = (
+"Ur" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Syndicate Base"
+	},
+/turf/open/floor/iron/smooth,
+/area/centcom/syndicate_base)
+"Uv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/boozeomat/syndicate,
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/centcom/syndicate_base)
-"orc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"ovu" = (
-/obj/structure/fans/tiny/invisible,
-/obj/machinery/door/poddoor/ert{
-	id = "SST_pod_ready";
-	name = "Shuttle Dock Door"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"ovP" = (
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"oxa" = (
-/obj/item/banner/syndicate,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"oyT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/ore_box,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"oKL" = (
-/obj/machinery/computer/crew{
-	pixel_x = -6;
-	dir = 8
-	},
-/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
-/turf/open/floor/carpet/black,
-/area/centcom/syndicate_base/control)
-"oOS" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/wood/parquet,
-/area/centcom/syndicate_base/control)
-"oPQ" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/white,
-/area/centcom/syndicate_base)
-"oRl" = (
-/obj/structure/curtain/bounty/start_closed{
-	pixel_y = -32
-	},
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"oTz" = (
-/turf/open/floor/carpet/black,
-/area/centcom/syndicate_base/control)
-"oTB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/recharge_station,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"oUP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fans/tiny/invisible,
-/obj/structure/marker_beacon/burgundy,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -1496,100 +2063,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"paG" = (
-/obj/effect/decal/syndie_logo{
-	icon_state = "logo16"
-	},
-/obj/effect/turf_decal/siding/dark/inner_corner{
-	dir = 8
-	},
-/obj/structure/chair/comfy/red{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/syndicate_base/control)
-"piT" = (
-/obj/item/kirbyplants/random,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"plv" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/nukeop,
-/turf/open/floor/carpet/black,
-/area/centcom/syndicate_base)
-"psX" = (
+"Ux" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"pwf" = (
-/turf/open/floor/carpet/red,
-/area/centcom/syndicate_base/control)
-"pxu" = (
-/obj/effect/turf_decal/siding/thinplating_new/dark,
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/fullupgrade{
-	dir = 1
-	},
-/turf/open/floor/wood/parquet,
-/area/centcom/syndicate_base/control)
-"pxW" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/fullupgrade{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/centcom/syndicate_base)
-"pCf" = (
-/turf/open/floor/iron/stairs/medium{
-	color = "gray";
-	dir = 1
-	},
-/area/centcom/syndicate_base)
-"pOV" = (
-/obj/structure/table/wood{
-	color = "#996633"
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/random/directional/south,
-/obj/item/pizzabox/margherita,
-/obj/item/knife/kitchen,
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 10
-	},
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/centcom/syndicate_base)
-"pSB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/vehicle/ridden/scooter{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"pSO" = (
-/obj/effect/decal/syndie_logo{
-	icon_state = "logo10"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/syndicate_base/control)
-"pUk" = (
-/turf/closed/indestructible/opsglass,
-/area/centcom/syndicate_base)
-"pUQ" = (
-/turf/open/floor/carpet/black,
-/area/centcom/syndicate_base)
-"qbl" = (
+"Uy" = (
 /obj/effect/decal/syndie_logo{
 	icon_state = "logo12"
 	},
@@ -1598,449 +2078,169 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_base/control)
-"qkt" = (
-/obj/machinery/light/directional/north,
-/obj/structure/fans/tiny/invisible,
-/obj/structure/marker_beacon/burgundy,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+"Uz" = (
+/turf/closed/indestructible/syndicate,
+/area/centcom/syndicate_base/control)
+"UE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
 /area/centcom/syndicate_base)
-"qqR" = (
-/obj/structure/closet/crate/cardboard,
-/obj/effect/turf_decal/delivery/red,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"qwD" = (
-/turf/open/floor/iron/stairs/left{
+"UJ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
+/turf/open/floor/iron/smooth,
 /area/centcom/syndicate_base)
-"qAX" = (
-/obj/effect/decal/cleanable/blood,
+"UO" = (
 /obj/machinery/light/small/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"qEz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/mech_bay_recharge_port,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"qIZ" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_y = 5
-	},
-/obj/item/pen/edagger{
-	pixel_x = 4;
-	pixel_y = 5
-	},
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"qNs" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/dogbed,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"qPk" = (
-/obj/docking_port/stationary{
-	dwidth = 25;
-	height = 50;
-	name = "Syndicate Auxiliary Shuttle Dock";
-	shuttle_id = "emergency_syndicate";
-	width = 50;
-	dir = 2
-	},
+/obj/effect/turf_decal/box,
+/obj/structure/punching_bag,
 /turf/open/floor/plating,
 /area/centcom/syndicate_base)
-"reD" = (
-/obj/effect/baseturf_helper{
-	baseturf = /turf/open/misc/asteroid
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"rlk" = (
-/obj/effect/decal/syndie_logo{
-	icon_state = "logo7"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/syndicate_base/control)
-"rnW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"rqQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny/invisible,
-/obj/structure/marker_beacon/burgundy,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"rrb" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"ryx" = (
-/obj/item/toy/nuke,
-/obj/structure/table/wood/poker,
-/turf/open/floor/carpet/black,
-/area/centcom/syndicate_base)
-"rzF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch{
-	name = "Syndicate Base"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/turf/open/floor/iron/white,
-/area/centcom/syndicate_base)
-"rJo" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/iron/grimy,
-/area/centcom/syndicate_base)
-"rMi" = (
-/obj/machinery/washing_machine,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"rQg" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"rVx" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/tool,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"rVI" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Syndicate Base"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"saI" = (
-/turf/open/floor/iron/stairs/right{
-	dir = 4
-	},
-/area/centcom/syndicate_base)
-"sfM" = (
-/obj/structure/table,
-/obj/item/storage/crayons,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"sgp" = (
-/obj/structure/urinal/directional/north,
-/turf/open/floor/iron/white,
-/area/centcom/syndicate_base)
-"siL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"slA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny/invisible,
-/obj/structure/marker_beacon/burgundy,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"soz" = (
-/obj/item/storage/crayons,
-/obj/structure/table/wood{
-	color = "#996633"
-	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/centcom/syndicate_base)
-"srn" = (
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"suT" = (
-/obj/machinery/light/small/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/iron/grimy,
-/area/centcom/syndicate_base)
-"szK" = (
-/obj/machinery/computer/camera_advanced,
-/turf/open/floor/carpet/black,
-/area/centcom/syndicate_base/control)
-"sFl" = (
-/turf/open/floor/iron/stairs/left{
-	dir = 8
-	},
-/area/centcom/syndicate_base)
-"sFZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery/white,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"sLM" = (
-/turf/open/space/basic,
-/area/space)
-"sNe" = (
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/centcom/syndicate_base)
-"sUc" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/centcom/syndicate_base)
-"sUZ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"sZm" = (
-/obj/structure/closet/syndicate/personal,
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/siding/thinplating_new/dark,
-/obj/effect/turf_decal/tile/dark_red/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"tdd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/iron/grimy,
-/area/centcom/syndicate_base)
-"tls" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/bar{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"tnT" = (
+"US" = (
 /obj/structure/fans/tiny/invisible,
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"tou" = (
-/obj/structure/fans/tiny/invisible,
+"Vk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"tsc" = (
-/obj/structure/ore_box,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"tCJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"tDh" = (
-/obj/machinery/shieldwall{
-	icon_state = "wave2";
-	max_integrity = 9999
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"tEM" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/delivery/white,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/mineral/sandbags,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"tJr" = (
-/obj/effect/decal/syndie_logo{
-	icon_state = "logo15"
+"Vo" = (
+/obj/machinery/computer/shuttle/syndicate{
+	name = "Nuclear Operatives Shuttle Console"
 	},
-/obj/effect/turf_decal/siding/dark{
+/turf/open/floor/carpet/black,
+/area/centcom/syndicate_base/control)
+"Vt" = (
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/centcom/syndicate_base)
+"Vx" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo19"
+	},
+/obj/effect/turf_decal/siding/dark/inner_corner,
+/obj/structure/chair/comfy/red{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_base/control)
-"tJz" = (
-/obj/machinery/computer/security/overwatch{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/centcom/syndicate_base/control)
-"tLQ" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"tLW" = (
-/obj/machinery/light/directional/south,
-/obj/effect/decal/cleanable/dirt,
+"VB" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/toy/plush/nukeplushie,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"tOi" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/grimy,
-/area/centcom/syndicate_base)
-"tWa" = (
-/obj/machinery/light/small/directional/south,
-/obj/effect/mapping_helpers/broken_floor,
+"VN" = (
+/obj/machinery/recharge_station,
 /turf/open/floor/wood,
 /area/centcom/syndicate_base)
-"tYt" = (
-/obj/effect/spawner/random/vending/snackvend,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"uln" = (
+"VP" = (
+/obj/structure/ore_box,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/random/directional/south,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"umq" = (
-/obj/structure/closet/syndicate/personal,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/spacecash/c20,
-/obj/effect/turf_decal/siding/thinplating_new/dark,
-/obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"uns" = (
-/obj/effect/turf_decal/siding/thinplating_new/dark,
-/obj/machinery/vending/boozeomat/syndicate,
-/turf/open/floor/wood/parquet,
-/area/centcom/syndicate_base/control)
-"uwa" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"uze" = (
-/obj/vehicle/ridden/scooter{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"uCR" = (
-/obj/machinery/light/small/directional/west,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"uKg" = (
+"VX" = (
 /obj/structure/fans/tiny/invisible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"uRN" = (
-/obj/docking_port/stationary{
-	area_type = /area/centcom/syndicate_base;
-	dir = 2;
-	dwidth = 3;
-	height = 7;
-	name = "Syndicate Assault Pod Dock";
-	roundstart_template = /datum/map_template/shuttle/assault_pod/default;
-	width = 7
-	},
-/turf/open/floor/plating,
-/area/centcom/syndicate_base)
-"vef" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"veZ" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"vfA" = (
-/turf/open/floor/iron/stairs/left{
-	dir = 1;
-	color = "#adadad"
-	},
-/area/centcom/syndicate_base)
-"viA" = (
-/turf/open/floor/plating,
-/area/centcom/syndicate_base)
-"vpZ" = (
+/obj/structure/marker_beacon/burgundy,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/effect/turf_decal/delivery/white,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"vru" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"vuE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
-/area/centcom/syndicate_base)
-"vwR" = (
+"Wa" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"vDJ" = (
+"Wg" = (
+/turf/open/floor/iron/stairs/right{
+	dir = 8
+	},
+/area/centcom/syndicate_base)
+"Wj" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/toy/nuke,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"Wo" = (
+/obj/structure/fans/tiny/invisible,
+/obj/structure/marker_beacon/burgundy,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"WM" = (
+/obj/machinery/light/small/directional/south,
+/obj/structure/sign/poster/contraband/random/directional/south,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"WO" = (
+/obj/structure/table/reinforced,
+/obj/item/toy/nuke{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"WS" = (
+/obj/structure/chair/stool{
+	dir = 1
+	},
+/obj/effect/landmark/start/nukeop,
+/turf/open/floor/carpet/black,
+/area/centcom/syndicate_base)
+"Xc" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/red/line,
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"Xf" = (
+/obj/structure/closet/syndicate/personal,
+/obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"Xm" = (
+/obj/machinery/light/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"Xx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/closet/crate/cardboard,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"XD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -2049,2531 +2249,2855 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"vIe" = (
-/obj/machinery/door/window/survival_pod/left/directional/south{
-	req_access = list("syndicate")
-	},
-/turf/open/floor/carpet/red,
-/area/centcom/syndicate_base/control)
-"vPu" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/iron/grimy,
-/area/centcom/syndicate_base)
-"vQE" = (
-/obj/machinery/door/poddoor/ert{
-	id = "SST_to_ATOM"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"vRN" = (
-/obj/machinery/light/small/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"vUB" = (
-/obj/effect/turf_decal/delivery/red,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"vVI" = (
+"XH" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 4
+	},
+/turf/closed/indestructible/syndicate,
+/area/centcom/syndicate_base)
+"XI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/ore_box,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"Yu" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/iron/smooth,
+/area/centcom/syndicate_base)
+"YA" = (
+/obj/structure/fans/tiny/invisible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/syndicate_base)
-"vVY" = (
-/turf/open/floor/iron/stairs/right{
-	dir = 1;
-	color = "#adadad"
-	},
-/area/centcom/syndicate_base)
-"vYw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/iron/grimy,
-/area/centcom/syndicate_base)
-"wgp" = (
-/obj/machinery/computer/shuttle/syndicate/recall,
-/obj/machinery/button/door/indestructible{
-	id = "nukeop_ready";
-	name = "Mission Launch Control";
-	pixel_y = 24;
-	specialfunctions = 4;
-	wires = 1;
-	req_access = list("syndicate")
-	},
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"wkC" = (
-/obj/machinery/door/poddoor/ert{
-	id = "nukeop_ready";
-	name = "Shuttle Dock Door"
-	},
-/turf/open/floor/iron/stairs/medium{
-	color = "#adadad";
-	dir = 1
-	},
-/area/centcom/syndicate_base)
-"wrP" = (
-/obj/effect/decal/syndie_logo{
-	icon_state = "logo18"
-	},
-/obj/effect/turf_decal/siding/dark,
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/syndicate_base/control)
-"wBp" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"wMN" = (
-/obj/structure/noticeboard/directional/west,
-/obj/item/paper/fluff/stations/centcom/disk_memo{
-	default_raw_text = "ПОЛУЧИТЕ ЭТОТ ЕБУЧИЙ ДИСК!"
-	},
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"wOm" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 1
-	},
-/obj/effect/decal/syndie_logo{
-	icon_state = "logo2"
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/syndicate_base/control)
-"wXs" = (
-/obj/structure/sign/poster/contraband/c20r/directional/north,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"wXx" = (
-/obj/structure/table/wood,
-/obj/structure/curtain/bounty/start_closed{
-	pixel_y = -32
-	},
-/obj/item/reagent_containers/cup/glass/waterbottle/large{
-	pixel_x = -15;
-	pixel_y = 9
-	},
-/obj/item/stack/spacecash/c100,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"wZM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/bar{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"xfp" = (
-/obj/structure/bed/dogbed,
-/obj/structure/sign/poster/contraband/random/directional/north,
-/turf/open/floor/wood,
-/area/centcom/syndicate_base)
-"xyp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/delivery/white,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"xND" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/grimy,
-/area/centcom/syndicate_base)
-"xSx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery/white,
-/turf/open/floor/iron/dark,
-/area/centcom/syndicate_base)
-"yaB" = (
-/obj/effect/decal/syndie_logo{
-	icon_state = "logo14"
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/syndicate_base/control)
-"yaO" = (
-/obj/machinery/shower/directional/south,
-/obj/machinery/light/small/directional/south,
-/obj/structure/fluff/shower_drain,
-/obj/structure/curtain/cloth/fancy,
+"YE" = (
+/obj/structure/sink/directional/west,
+/obj/structure/mirror/directional/east,
 /turf/open/floor/iron/white,
 /area/centcom/syndicate_base)
-"ycx" = (
-/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
-/obj/structure/table/wood/fancy/black,
-/obj/item/paper/fluff/overwatch{
-	pixel_y = 8;
-	pixel_x = -2
+"YN" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/ore_box,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"YS" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Syndicate Base"
 	},
-/obj/item/circuitboard/computer/overwatch{
-	pixel_x = -2
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/turf/open/floor/iron/grimy,
+/area/centcom/syndicate_base)
+"Zh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/directional/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_base)
+"Zm" = (
+/obj/structure/fans/tiny/invisible,
+/obj/machinery/door/poddoor/ert{
+	id = "SST_pod_ready";
+	name = "Shuttle Dock Door"
 	},
-/turf/open/floor/carpet/black,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"Zo" = (
+/obj/structure/table,
+/obj/item/storage/crayons,
+/turf/open/floor/wood,
+/area/centcom/syndicate_base)
+"Zp" = (
+/obj/effect/turf_decal/arrows{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/syndicate_base)
+"ZF" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/iron/smooth,
+/area/centcom/syndicate_base)
+"ZN" = (
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/turf/open/floor/carpet/red,
+/area/centcom/syndicate_base/control)
+"ZQ" = (
+/obj/effect/decal/syndie_logo{
+	icon_state = "logo9"
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_base/control)
 
 (1,1,1) = {"
-sLM
-fnU
-fnU
-bjU
-fnU
-don
-don
-don
-fnU
-don
-don
-don
-fnU
-don
-don
-don
-fnU
-don
-don
-don
-fnU
-don
-don
-don
-don
-fnU
-don
-don
-don
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-sLM
-sLM
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
+vh
+sm
+sm
+XH
+sm
+Dk
+Dk
+Dk
+sm
+Dk
+Dk
+Dk
+sm
+Dk
+Dk
+Dk
+sm
+Dk
+Dk
+Dk
+sm
+Dk
+Dk
+Dk
+Dk
+sm
+Dk
+Dk
+Dk
+sm
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
 "}
 (2,1,1) = {"
-fnU
-fnU
-hxf
-hxf
-uCR
-gOQ
-gOQ
-hxf
-uCR
-gOQ
-gOQ
-hxf
-uCR
-gOQ
-gOQ
-hxf
-uCR
-gOQ
-gOQ
-hxf
-nCv
-gbc
-dts
-hxf
-gOQ
-jVL
-hxf
-gOQ
-gOQ
-fnU
-eSY
-icT
-oPQ
-nFN
-eXO
-fnU
-srn
-srn
-srn
-mcR
-fnU
-sLM
-sLM
-fnU
-gOQ
-njR
-gXS
-jrf
-gXS
-gXS
-gXS
-gXS
-gXS
-jrf
-gXS
-gXS
-jrf
-gXS
-gXS
-gXS
-gXS
-gXS
-jrf
-gXS
-chA
-gOQ
-fnU
+sm
+sm
+lp
+lp
+zU
+TC
+TC
+lp
+zU
+TC
+TC
+lp
+zU
+TC
+TC
+lp
+zU
+TC
+TC
+lp
+iX
+Zp
+fu
+lp
+TC
+Nu
+lp
+TC
+TC
+sm
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+sm
+TC
+TC
+TC
+wf
+TC
+TC
+TC
+TC
+wf
+TC
+TC
+TC
+TC
+wf
+TC
+TC
+TC
+TC
+wf
+TC
+TC
+TC
+sm
 "}
 (3,1,1) = {"
-fnU
-qkt
-gXS
-gXS
-gXS
-gXS
-gXS
-omf
-ful
-omf
-omf
-omf
-gXS
-slA
-omf
-omf
-omf
-omf
-omf
-omf
-omf
-jfm
-gXS
-gXS
-rqQ
-jIP
-gqH
-vDJ
-rrb
-fnU
-sgp
-ePf
-ePf
-hOo
-hOo
-fnU
-srn
-orc
-orc
-uln
-fnU
-sLM
-sLM
-fnU
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+sm
+pc
+kM
+kM
+kM
+kM
+kM
+OS
+eR
+OS
+OS
+OS
+kM
+vA
+OS
+OS
+OS
+OS
+OS
+OS
+OS
+uV
+kM
+kM
+eK
+MD
+LH
+XD
+Qt
+sm
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+sm
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+sm
 "}
 (4,1,1) = {"
-mRk
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-oyT
-qqR
-sUZ
-gOQ
-fnU
-hOo
-hOo
-ePf
-ePf
-ePf
-ios
-vru
-vru
-orc
-mwf
-fnU
-sLM
-sLM
-fnU
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-rrb
-fnU
+nd
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+XI
+ko
+tF
+TC
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+vh
+vh
+sm
+pb
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+Hx
+sm
 "}
 (5,1,1) = {"
-mRk
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-iVu
-ovP
-keH
-gOQ
-fnU
-lkx
-fnU
-lkx
-fnU
-rzF
-fnU
-fZK
-vru
-vru
-acA
-fnU
-sLM
-sLM
-fnU
-blJ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+nd
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+RS
+di
+ja
+TC
+sm
+PP
+RA
+RN
+xJ
+fn
+sm
+jG
+hA
+Zo
+tx
+sm
+vh
+vh
+sm
+TC
+HC
+kM
+kM
+kM
+kM
+kM
+kM
+kM
+kM
+kM
+kM
+kM
+kM
+kM
+kM
+kM
+kM
+kM
+kM
+Sj
+TC
+sm
 "}
 (6,1,1) = {"
-mRk
-cyn
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-tCJ
-bcl
-sUZ
-gOQ
-fnU
-yaO
-fnU
-ffq
-aXh
-hAD
-fnU
-hEn
-qwD
-saI
-muB
-fnU
-fnU
-fnU
-fnU
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+nd
+cH
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+rt
+ko
+iP
+TC
+sm
+Hk
+sm
+UE
+mC
+UE
+sm
+at
+Su
+Su
+Ux
+sm
+vh
+vh
+sm
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+TC
+sm
 "}
 (7,1,1) = {"
-mRk
-cyn
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-xSx
-tsc
-oju
-gOQ
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-flo
-flo
-fnU
-fnU
-cSv
-gOQ
-gOQ
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+nd
+cH
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+RS
+VP
+Li
+TC
+sm
+Ia
+RA
+mC
+UE
+mC
+lL
+Su
+Su
+Su
+vR
+sm
+vh
+vh
+sm
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+TC
+sm
 "}
 (8,1,1) = {"
-mRk
-cyn
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-tCJ
-vUB
-gVh
-gOQ
-fnU
-wMN
-plv
-oiT
-iAT
-kVN
-fnU
-bjf
-mEk
-jLT
-bjf
-fnU
-aLl
-gOQ
-gOQ
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+nd
+cH
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+rt
+tP
+GL
+qX
+sm
+sm
+sm
+UE
+UE
+mC
+sm
+kK
+Su
+Su
+Fz
+sm
+vh
+vh
+sm
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+TC
+sm
 "}
 (9,1,1) = {"
-mRk
-cyn
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-jud
-lnr
-bUd
-rrb
-fnU
-cDl
-plv
-ryx
-gZt
-tWa
-fnU
-qNs
-mEk
-dPy
-maY
-fnU
-nSN
-gOQ
-gOQ
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+nd
+cH
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+oX
+di
+sw
+Qt
+sm
+lD
+RA
+Ik
+YE
+Mj
+sm
+Pb
+Dc
+lT
+us
+sm
+sm
+sm
+sm
+pb
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+Hx
+sm
 "}
 (10,1,1) = {"
-mRk
-cyn
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-nwV
-vVI
-mvw
-mvw
-vVI
-fnU
-wXs
-plv
-cHl
-gZt
-srn
-fnU
-xfp
-mEk
-jLT
-oTB
-fnU
-blJ
-gOQ
-gOQ
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-rrb
-fnU
+nd
+cH
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+dU
+rt
+di
+TZ
+qX
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+YS
+YS
+sm
+sm
+yL
+TC
+TC
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+TC
+sm
 "}
 (11,1,1) = {"
-mRk
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-fnU
-pUk
-pUk
-pUk
-pUk
-fnU
-srn
-pUQ
-dCB
-pUQ
-srn
-fnU
-kEs
-mEk
-jLT
-qIZ
-fnU
-cSv
-gOQ
-gOQ
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+nd
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+BG
+JQ
+ko
+TZ
+TC
+sm
+EE
+kl
+ME
+WS
+at
+sm
+ep
+pT
+gc
+ep
+sm
+Tg
+TC
+TC
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+TC
+sm
 "}
 (12,1,1) = {"
-mRk
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-lrc
-dlt
-ovP
-ovP
-ovP
-ovP
-cji
-rJo
-rJo
-rJo
-rJo
-rJo
-rJo
-rJo
-kFg
-vPu
-wXx
-pUk
-aLl
-gOQ
-gOQ
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+nd
+cH
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+BG
+Sb
+rE
+CL
+TC
+sm
+iw
+kl
+OB
+WS
+at
+sm
+Gn
+pT
+ND
+ow
+sm
+uw
+TC
+TC
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+TC
+sm
 "}
 (13,1,1) = {"
-mRk
-cyn
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-dlt
-ovP
-ovP
-ovP
-ovP
-cji
-nbn
-nbn
-nbn
-bRD
-hiV
-xND
-vYw
-nbn
-hSN
-oRl
-pUk
-nSN
-gOQ
-gOQ
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+nd
+cH
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xs
+SA
+SA
+SA
+SA
+sm
+LN
+kl
+mw
+WS
+yk
+sm
+Rg
+pT
+gc
+hZ
+sm
+bq
+TC
+TC
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+Qt
+sm
 "}
 (14,1,1) = {"
-mRk
-cyn
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-fnU
-pUk
-pUk
-pUk
-pUk
-fnU
-wgp
-kVN
-srn
-tdd
-jLT
-fnU
-dlQ
-wZM
-tls
-dlQ
-fnU
-aHv
-gOQ
-gOQ
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+nd
+cH
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+sm
+MV
+MV
+MV
+MV
+sm
+at
+Kj
+Kt
+Kj
+CR
+sm
+sW
+pT
+gc
+VN
+sm
+Sp
+TC
+TC
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+TC
+sm
 "}
 (15,1,1) = {"
-mRk
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-fmQ
-psX
-rnW
-rnW
-rnW
-fnU
-tYt
-kVN
-srn
-mEk
-suT
-fnU
-ltU
-soz
-jfZ
-pOV
-fnU
-cSv
-gOQ
-gOQ
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+nd
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+qp
+FK
+di
+di
+di
+di
+iG
+sq
+sq
+mp
+sq
+sq
+sq
+sq
+DO
+gc
+at
+sm
+Tg
+TC
+TC
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+TC
+sm
 "}
 (16,1,1) = {"
-mRk
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-hLd
-kcQ
-gqH
-xyp
-tLW
-fnU
-jpY
-uwa
-jkN
-mEk
-jLT
-fnU
-koA
-mxA
-mxA
-hMQ
-pUk
-nSN
-gOQ
-gOQ
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-rrb
-fnU
+nd
+cH
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+FK
+di
+di
+di
+di
+iG
+Kd
+Kd
+Kd
+SM
+Yu
+AJ
+Kd
+Kd
+sC
+at
+sm
+ew
+TC
+TC
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+TC
+sm
 "}
 (17,1,1) = {"
-mRk
-cyn
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-fAH
-fTe
-epF
-hxf
-fnU
-lRu
-vru
-iiw
-mEk
-bnr
-ldu
-mxA
-vuE
-vuE
-aSV
-pUk
-oxa
-reD
-gOQ
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+nd
+cH
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+sm
+MV
+MV
+MV
+MV
+sm
+Mh
+at
+cK
+pT
+gc
+sm
+FM
+Su
+Su
+WM
+sm
+rz
+TC
+TC
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+Hx
+sm
 "}
 (18,1,1) = {"
-mRk
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-sFZ
-dUG
-tEM
-hxf
-fnU
-jAn
-srn
-vru
-mEk
-jLT
-fnU
-nUA
-pxW
-fbq
-onL
-fnU
-oxa
-gOQ
-gOQ
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+nd
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+yf
+RX
+Cp
+Cp
+Cp
+sm
+yy
+at
+at
+pT
+Lp
+sm
+aU
+aU
+aU
+aU
+sm
+cS
+TC
+TC
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+TC
+sm
 "}
 (19,1,1) = {"
-mRk
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-siL
-fTe
-sUZ
-dts
-wkC
-mNS
-mNS
-mNS
-tOi
-jdM
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-cSv
-gOQ
-gOQ
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-rrb
-fnU
+nd
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+jO
+id
+LH
+ub
+Xm
+sm
+OU
+LW
+Su
+pT
+gc
+sm
+un
+Ri
+wV
+oR
+sm
+Wj
+TC
+TC
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+TC
+sm
 "}
 (20,1,1) = {"
-mRk
-cyn
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-hxU
-ovP
-niY
-hxf
-fnU
-piT
-srn
-kVN
-mEk
-jmk
-fnU
-umq
-app
-mBE
-iDh
-fnU
-nSN
-gOQ
-gOQ
-gOQ
-tou
-qPk
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+nd
+cH
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+Nf
+zj
+tF
+lp
+sm
+Px
+Su
+at
+pT
+FY
+sm
+NK
+jZ
+do
+PA
+sm
+VB
+yF
+TC
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+TC
+sm
 "}
 (21,1,1) = {"
-mRk
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-tCJ
-bcl
-sUZ
-gOQ
-fnU
-sfM
-kVN
-srn
-mEk
-jLT
-fnU
-nFd
-sNe
-sUc
-iDh
-fnU
-aHv
-gOQ
-gOQ
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+nd
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+Vk
+ov
+cN
+lp
+Sd
+UJ
+UJ
+UJ
+Kz
+fl
+Ur
+do
+do
+jZ
+PA
+sm
+tc
+TC
+TC
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+Hx
+sm
 "}
 (22,1,1) = {"
-fnU
-nCM
-uKg
-khe
-hDK
-hDK
-uKg
-uKg
-uKg
-hDK
-hDK
-khe
-hDK
-oUP
-khe
-hDK
-khe
-hDK
-hDK
-uKg
-uKg
-cWW
-hDK
-hDK
-mjL
-vpZ
-cZG
-aTN
-rrb
-fnU
-lZQ
-iiw
-kVN
-mEk
-jLT
-fnU
-sZm
-sUc
-sNe
-dlo
-fnU
-cSv
-gOQ
-gOQ
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+nd
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+gn
+ko
+tF
+lp
+sm
+On
+at
+at
+pT
+gc
+sm
+MZ
+Ip
+xO
+Qi
+sm
+Tg
+TC
+TC
+TC
+aJ
+tb
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+TC
+sm
 "}
 (23,1,1) = {"
-fnU
-fnU
-klm
-hxf
-bVX
-hxf
-hxf
-evm
-hxf
-gOQ
-rQg
-gOQ
-gOQ
-rQg
-gOQ
-gOQ
-vRN
-hxf
-dts
-vRN
-hxf
-gbc
-gOQ
-jLf
-hxf
-kni
-hxf
-gOQ
-gOQ
-fnU
-rMi
-veZ
-srn
-mEk
-jLT
-fnU
-nFd
-sNe
-sUc
-iDh
-fnU
-aLl
-gOQ
-gOQ
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+nd
+cH
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+Ff
+ov
+Li
+qX
+sm
+zW
+at
+at
+Eu
+Fs
+sm
+sm
+sm
+sm
+sm
+sm
+ew
+TC
+TC
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+TC
+sm
 "}
 (24,1,1) = {"
-sLM
-fnU
-fnU
-nOK
-fnU
-fnU
-fnU
-fnU
-vQE
-vQE
-fnU
-vQE
-vQE
-fnU
-vQE
-vQE
-fnU
-vQE
-vQE
-fnU
-don
-don
-don
-gyK
-lKs
-fnU
-jtX
-jtX
-jtX
-fnU
-fnU
-fnU
-fnU
-dfR
-dfR
-fnU
-fnU
-rVI
-rVI
-fnU
-fnU
-nSN
-gOQ
-gOQ
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+nd
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+gn
+oH
+TZ
+TC
+sm
+Id
+cK
+at
+pT
+gc
+sm
+Qu
+ym
+Bp
+Qu
+sm
+Ac
+TC
+TC
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+TC
+sm
 "}
 (25,1,1) = {"
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-fxM
-fxM
-fxM
-fxM
-fxM
-fxM
-fxM
-fxM
-fxM
-fxM
-fxM
-fxM
-fxM
-fxM
-fnU
-fnU
-fnU
-fnU
-jYa
-fnU
-fnU
-fnU
-fnU
-fnU
-qEz
-bLA
-eim
-dCq
-sFl
-mmT
-hXC
-ovP
-ovP
-ovP
-fnU
-fnU
-pUk
-fnU
-vef
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-rrb
-fnU
+nd
+cH
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+Ff
+di
+TZ
+TC
+sm
+Gu
+at
+at
+pT
+gc
+ci
+Vt
+Vt
+Vt
+IM
+sm
+CO
+TC
+TC
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+Hx
+sm
 "}
 (26,1,1) = {"
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-fxM
-fxM
-kqr
-npT
-ogO
-bJW
-bMd
-bNg
-lHj
-mRM
-bUU
-hii
-aAs
-fxM
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-fnU
-fHu
-hXC
-kEw
-ovP
-ovP
-bxW
-hXC
-hXC
-ovP
-bgj
-nQs
-lWm
-vVY
-dlt
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+nd
+cH
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+rt
+oK
+YN
+TC
+sm
+pn
+at
+at
+pT
+ZF
+ci
+Vt
+Vt
+Oe
+IM
+sm
+gl
+TC
+TC
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+TC
+sm
 "}
 (27,1,1) = {"
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-fxM
-mjQ
-miA
-bbA
-crr
-mpO
-paG
-oTz
-pwf
-pwf
-vIe
-cNm
-gty
-fxM
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-fnU
-jsR
-hXC
-hXC
-hXC
-hXC
-lGp
-ovP
-ovP
-ovP
-fQZ
-nQs
-pCf
-aDp
-dlt
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+nd
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+rt
+di
+TZ
+TC
+sm
+gq
+at
+Ge
+pT
+gc
+sm
+Xf
+NA
+Xf
+Xf
+sm
+Be
+TC
+TC
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+TC
+sm
 "}
 (28,1,1) = {"
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-fxM
-szK
-wOm
-cZH
-pSO
-gVQ
-odA
-oTz
-pwf
-pwf
-bUU
-cNm
-dNj
-fxM
-fnU
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-fnU
-fnU
-fnU
-rVx
-hXC
-ovP
-ovP
-lGp
-hXC
-hXC
-ovP
-ciG
-nQs
-iwO
-vfA
-dlt
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+sm
+cc
+YA
+Uv
+uW
+uW
+YA
+YA
+YA
+uW
+uW
+Uv
+uW
+sf
+Uv
+uW
+Uv
+uW
+uW
+YA
+YA
+Tz
+uW
+uW
+Wo
+Xx
+rE
+lw
+Qt
+sm
+sm
+sm
+sm
+YS
+YS
+sm
+sm
+sm
+sm
+sm
+sm
+yL
+TC
+TC
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+TC
+sm
 "}
 (29,1,1) = {"
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-fxM
-bpw
-inv
-rlk
-oea
-yaB
-wrP
-oTz
-pwf
-pwf
-bUU
-cNm
-pxu
-fxM
-tnT
-uRN
-viA
-viA
-viA
-viA
-viA
-viA
-gXs
-lKs
-ipn
-hXC
-hXC
-hXC
-lGp
-hXC
-ovP
-ovP
-ovP
-ngQ
-fnU
-fnU
-fnU
-fnU
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+sm
+sm
+Fr
+lp
+Fo
+lp
+lp
+aB
+lp
+TC
+fw
+TC
+TC
+fw
+TC
+TC
+Gz
+lp
+fu
+Gz
+lp
+Zp
+TC
+tu
+lp
+cu
+lp
+TC
+TC
+sm
+ps
+Cx
+CG
+Wg
+AN
+mR
+dK
+qb
+Cx
+Ra
+sm
+sm
+MV
+sm
+pb
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+Hx
+sm
 "}
 (30,1,1) = {"
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-fxM
-mtm
-eFN
-nSk
-qbl
-tJr
-mvf
-oTz
-pwf
-pwf
-vIe
-cNm
-iBV
-fxM
-fnU
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-fnU
-fnU
-fnU
-pUk
-pUk
-pUk
-pUk
-niK
-ovP
-ovP
-hXC
-pSB
-fnU
-sLM
-sLM
-fnU
-gOQ
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-gOQ
-fnU
+vh
+sm
+sm
+Ub
+sm
+sm
+sm
+sm
+Sm
+Sm
+sm
+Sm
+Sm
+sm
+Sm
+Sm
+sm
+Sm
+Sm
+sm
+Dk
+Dk
+Dk
+Ju
+be
+sm
+xR
+xR
+xR
+sm
+kr
+Cx
+li
+Tk
+Cx
+kw
+Cx
+dK
+Cx
+BM
+mh
+nq
+BC
+FK
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+TC
+sm
 "}
 (31,1,1) = {"
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-fxM
-fxM
-bRF
-eEu
-oKL
-ycx
-tJz
-bNg
-nNU
-lPt
-bUU
-oOS
-uns
-fxM
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-fnU
-mkU
-nHO
-ovP
-wBp
-hse
-ovP
-hXC
-ovP
-ovP
-pSB
-fnU
-sLM
-sLM
-fnU
-vef
-tou
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-aqq
-rrb
-fnU
+vh
+vh
+vh
+vh
+vh
+vh
+Uz
+Uz
+Uz
+Uz
+Uz
+Uz
+Uz
+Uz
+Uz
+Uz
+Uz
+Uz
+Uz
+sm
+sm
+sm
+sm
+sm
+mk
+sm
+sm
+sm
+sm
+sm
+Jo
+Cx
+dK
+Cx
+Cx
+dK
+dK
+Cx
+Cx
+Or
+mh
+EO
+gE
+FK
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+TC
+sm
 "}
 (32,1,1) = {"
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-fxM
-fxM
-fxM
-fxM
-fxM
-fxM
-fxM
-fxM
-fxM
-fxM
-fxM
-fxM
-fxM
-fxM
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-viA
-fnU
-aDf
-qAX
-hXC
-ovP
-emh
-ovP
-tLQ
-hXC
-lGp
-uze
-fnU
-sLM
-sLM
-fnU
-gOQ
-deV
-uKg
-uKg
-uKg
-uKg
-uKg
-uKg
-uKg
-uKg
-uKg
-uKg
-uKg
-uKg
-uKg
-uKg
-uKg
-uKg
-uKg
-uKg
-mjL
-gOQ
-fnU
+vh
+vh
+vh
+vh
+vh
+vh
+Uz
+Uz
+mV
+Lc
+tH
+Dq
+vc
+eV
+Iz
+Lh
+ZN
+cV
+ni
+sm
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+sm
+kr
+dK
+Cx
+Cx
+dK
+Cx
+Cx
+Cx
+dK
+aV
+mh
+ke
+Fx
+FK
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+TC
+sm
 "}
 (33,1,1) = {"
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-fnU
-fnU
-fnU
-fnU
-fnU
-ovu
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-fnU
-sLM
-sLM
-fnU
-gOQ
-gOQ
-vwR
-gOQ
-vwR
-gOQ
-gOQ
-vwR
-gOQ
-gOQ
-vwR
-vwR
-gOQ
-gOQ
-vwR
-gOQ
-gOQ
-vwR
-gOQ
-vwR
-gOQ
-gOQ
-fnU
+vh
+vh
+vh
+vh
+vh
+vh
+Uz
+Fu
+Ek
+aK
+ZQ
+Ce
+fb
+jC
+tL
+tL
+DM
+ec
+jt
+sm
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+sm
+Cx
+Cx
+tq
+on
+Js
+Pq
+dK
+Cx
+Cx
+Jg
+sm
+sm
+MV
+sm
+pb
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+Hx
+sm
 "}
 (34,1,1) = {"
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-sLM
-fnU
-fnU
-tDh
-tDh
-tDh
-tDh
-tDh
-tDh
-tDh
-tDh
-tDh
-tDh
-tDh
-tDh
-tDh
-tDh
-tDh
-tDh
-tDh
-tDh
-tDh
-tDh
-fnU
-fnU
+vh
+vh
+vh
+vh
+vh
+vh
+Uz
+GT
+sB
+gR
+ih
+Bh
+Ai
+jC
+tL
+tL
+ZN
+ec
+tM
+sm
+sm
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+sm
+sm
+rw
+dK
+tq
+WO
+zN
+Pq
+Cx
+dK
+dK
+gd
+sm
+vh
+vh
+sm
+TC
+aJ
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Bd
+TC
+sm
+"}
+(35,1,1) = {"
+vh
+vh
+vh
+vh
+vh
+vh
+Uz
+Vo
+pK
+AT
+qt
+pf
+cQ
+jC
+tL
+tL
+ZN
+ec
+uD
+sm
+US
+aT
+xd
+xd
+xd
+xd
+xd
+xd
+xH
+be
+dK
+Cx
+tq
+Tf
+EW
+Pq
+JX
+Qa
+Mk
+JW
+sm
+vh
+vh
+sm
+TC
+pM
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+Xc
+TC
+sm
+"}
+(36,1,1) = {"
+vh
+vh
+vh
+vh
+vh
+vh
+Uz
+ei
+dy
+Sw
+Uy
+nt
+Vx
+jC
+tL
+tL
+DM
+ec
+FH
+sm
+sm
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+sm
+Cy
+Cx
+dK
+kL
+kI
+aj
+Zh
+Mm
+UO
+rr
+JW
+sm
+vh
+vh
+sm
+TC
+VX
+YA
+YA
+YA
+YA
+YA
+YA
+YA
+YA
+YA
+YA
+YA
+YA
+YA
+YA
+YA
+YA
+YA
+YA
+Wo
+TC
+sm
+"}
+(37,1,1) = {"
+vh
+vh
+vh
+vh
+vh
+vh
+Uz
+Uz
+Lr
+dY
+HX
+hz
+HG
+eV
+PY
+JZ
+ZN
+Rc
+LP
+sm
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+sm
+vh
+vh
+sm
+pb
+TC
+Wa
+TC
+Wa
+TC
+TC
+Wa
+TC
+TC
+Wa
+Wa
+TC
+TC
+Wa
+TC
+TC
+Wa
+TC
+Wa
+TC
+Hx
+sm
+"}
+(38,1,1) = {"
+vh
+vh
+vh
+vh
+vh
+vh
+Uz
+Uz
+Uz
+Uz
+Uz
+Uz
+Uz
+Uz
+Uz
+Uz
+Uz
+Uz
+Uz
+sm
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+xd
+sm
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+sm
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+sm
+"}
+(39,1,1) = {"
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+sm
+sm
+sm
+sm
+sm
+Zm
+sm
+sm
+sm
+sm
+sm
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+sm
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+TC
+sm
+"}
+(40,1,1) = {"
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+vh
+sm
+sm
+lR
+lR
+lR
+lR
+lR
+lR
+lR
+lR
+lR
+lR
+lR
+lR
+lR
+lR
+lR
+lR
+lR
+lR
+lR
+lR
+sm
+sm
 "}

--- a/modular_bandastation/mapping/code/templates.dm
+++ b/modular_bandastation/mapping/code/templates.dm
@@ -89,6 +89,9 @@
 /datum/map_template/shuttle/infiltrator/basic
 	prefix = "_maps/shuttles/ss220/"
 
+/datum/map_template/shuttle/infiltrator/clown
+	prefix = "_maps/shuttles/ss220/"
+
 // MARK: Deathmatch
 /datum/lazy_template/deathmatch/underground_thunderdome
 	name = "Underground Thunderdome"


### PR DESCRIPTION
## Что этот PR делает

Добавляет нашу версию инфильтратора для клоун опсов, что фиксит невозможность заспавнить инфильтратор на наше Синди ЦК. Небольшой ремап и расширение мини Синди ЦК базы.

## Почему это хорошо для игры

Теперь чтобы клоун опсы улетели не нужно устраивать танцы с бубнами, а просто отправить шаттл на базу.

## Изображения изменений

<img width="1280" height="2144" alt="StrongDMM-2026-05-22 22 10 22" src="https://github.com/user-attachments/assets/1c196e40-4226-477b-b1f7-d2bbcf451498" />
Клоун инфильтратор идентичен обычному, только поменяна бомба.

## Тестирование

Локал очка

## Changelog

<!-- Важно строго соблюдать ёмкость и стилистическую форму наполнения чейнджлога! -->

:cl:
fix: Теперь шаттл клоун-оперов может нормально прилететь на Синди ЦК.
map: Добавлен клоунский инфильтратор для клоун-оперов.
map: Расширена мини версия Синди ЦК, также изменены некоторые комнаты.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
<!-- Пример хороших чейнджлогов:
add: В аплинк повара добавлен мануал CQC за 20 ТК.
admin: Добавлено новое Smite действие - "Сломать колени".
balance: Разлёт дроби 12 калибра, скаттер лазер шеллов, драконьего дыхания и резиновой дроби был увеличен.
code_imp: Число дополнительных необходимых шкафов СБ теперь вычисляется точнее.
config: Добавлена/убрана настройка слотов СБ через конфиг.
del: Удалена возможность рыбалки в лотках гидропоники.
fix: Исправлена ошибка, из-за которой неудачный вызов ОБР мог резко ухудшить производительность игры.
image: Изменены спрайты для револьверов .357
map: Добавлена новая игровая карта - Nebula Station.
qol: Смерть в мини-играх больше не сбрасывает таймер возрождения.
refactor: Значительно улучшено качество кода модульной TTS сабсистемы.
server: Flaky тесты перенесены на ubuntu-20.04.
sound: Добавлен новый звук для Гамма кода на станции.
translation: Добавлен перевод приёмов и сообщений в чат для Спящего Карпа.
typo: Исправлена опечатка в предыстории расы КПБ.
-->
