### PR TITLE
Cyberiad: pacman fix

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -436,7 +436,7 @@
 /area/station/engineering/supermatter/room)
 "agz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/fore/starboard)
 "agB" = (
@@ -15697,7 +15697,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "dLf" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/fore)
 "dLg" = (
@@ -16261,7 +16261,7 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "dUR" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "dUT" = (
@@ -34939,7 +34939,7 @@
 /area/station/command/heads_quarters/qm)
 "ivT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "ivV" = (
@@ -37354,10 +37354,10 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
 "jbE" = (
-/obj/machinery/power/port_gen/pacman,
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/tcommsat/server)
 "jbG" = (
@@ -42911,7 +42911,7 @@
 /turf/open/floor/plating,
 /area/station/ai/satellite/hallway)
 "kvG" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/greater)
 "kvH" = (
@@ -47560,11 +47560,11 @@
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/port/aft)
 "lzZ" = (
-/obj/machinery/power/port_gen/pacman,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/iron,
 /area/station/maintenance/aft)
 "lAb" = (
@@ -47985,7 +47985,7 @@
 /turf/open/openspace,
 /area/station/security/prison)
 "lFQ" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "lFT" = (
@@ -48216,9 +48216,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "lIV" = (
-/obj/machinery/power/port_gen/pacman,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/maintenance/department/security/ghetto)
 "lJc" = (
@@ -51127,7 +51127,7 @@
 /area/station/security/courtroom/holding)
 "muS" = (
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "muX" = (
@@ -51748,7 +51748,6 @@
 /area/station/maintenance/starboard/upper)
 "mCX" = (
 /obj/structure/cable,
-/obj/machinery/power/port_gen/pacman,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
@@ -51757,7 +51756,7 @@
 	c_tag = "Engineering - Equipment Storage Hardsuits";
 	network = list("ss13","engineering")
 	},
-/obj/item/stack/sheet/mineral/plasma/five,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "mDd" = (
@@ -54846,11 +54845,11 @@
 /turf/open/floor/engine,
 /area/station/science/lower)
 "npi" = (
-/obj/structure/reagent_dispensers/plumbed{
-	dir = 8
-	},
 /obj/effect/turf_decal/delivery/white{
 	color = "#52B4E9"
+	},
+/obj/structure/reagent_dispensers/plumbed{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
@@ -56490,12 +56489,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nLU" = (
-/obj/machinery/power/port_gen/pacman,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/ai/satellite/service)
 "nLY" = (
@@ -58946,7 +58945,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage/ghetto)
 "opb" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/central)
 "oph" = (
@@ -64575,7 +64574,7 @@
 /area/station/maintenance/ghetto/aft)
 "pHl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/port)
 "pHq" = (
@@ -66181,7 +66180,7 @@
 "qbg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/east,
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "qbn" = (
@@ -66729,7 +66728,7 @@
 /area/station/maintenance/department/electrical/ghetto)
 "qjL" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/engineering/storage)
 "qjN" = (
@@ -67815,7 +67814,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/prison/ghetto)
 "qzA" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/gravity_generator)
 "qzE" = (
@@ -74852,7 +74851,7 @@
 "skW" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/storage)
 "sla" = (
@@ -75361,7 +75360,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "sqI" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "sqO" = (
@@ -78716,7 +78715,7 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "tlD" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "tlF" = (
@@ -79466,7 +79465,7 @@
 /area/station/engineering/main)
 "ttw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/iron,
 /area/station/engineering/storage_shared)
 "ttx" = (
@@ -80017,7 +80016,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
 "tAF" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "tAH" = (
@@ -82710,7 +82709,7 @@
 /area/station/maintenance/aft)
 "uhj" = (
 /obj/machinery/firealarm/directional/north,
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/starboard)
 "uhw" = (
@@ -84900,7 +84899,7 @@
 "uMv" = (
 /obj/effect/turf_decal/bot,
 /obj/item/radio/intercom/directional/east,
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/engineering/storage)
 "uMw" = (
@@ -85148,7 +85147,7 @@
 /turf/closed/wall,
 /area/station/hallway/primary/central/aft)
 "uPa" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port/aft)
 "uPy" = (
@@ -87321,8 +87320,8 @@
 /area/station/medical/medbay/lobby)
 "vrO" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/power/port_gen/pacman,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "vrQ" = (
@@ -90915,7 +90914,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix/ghetto)
 "wmG" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "wmI" = (
@@ -94997,7 +94996,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/ghetto/fore/starboard)
 "xlx" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "xlH" = (
@@ -97042,7 +97041,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "xMi" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "xMu" = (


### PR DESCRIPTION
## Что этот PR делает

Меняет пустые пакманы на Кибериаде на заполненные

## Почему это хорошо для игры

Расставляя пакманы в прошлый раз кто-то (не будем показывать пальцем) забыл, что у пакмана есть подтип с предзагруженной плазмой

## Изображения изменений

В мапдифе

## Тестирование

Поменялся только подтип, будет работать

## Changelog

<!-- Важно строго соблюдать ёмкость и стилистическую форму наполнения чейнджлога! -->

:cl:
map: Cyberiad: PACMAN генераторы на станции теперь содержат предзагруженную плазму внутри.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
<!-- Пример хороших чейнджлогов:
add: В аплинк повара добавлен мануал CQC за 20 ТК.
admin: Добавлено новое Smite действие - "Сломать колени".
balance: Разлёт дроби 12 калибра, скаттер лазер шеллов, драконьего дыхания и резиновой дроби был увеличен.
code_imp: Число дополнительных необходимых шкафов СБ теперь вычисляется точнее.
config: Добавлена/убрана настройка слотов СБ через конфиг.
del: Удалена возможность рыбалки в лотках гидропоники.
fix: Исправлена ошибка, из-за которой неудачный вызов ОБР мог резко ухудшить производительность игры.
image: Изменены спрайты для револьверов .357
map: Добавлена новая игровая карта - Nebula Station.
qol: Смерть в мини-играх больше не сбрасывает таймер возрождения.
refactor: Значительно улучшено качество кода модульной TTS сабсистемы.
server: Flaky тесты перенесены на ubuntu-20.04.
sound: Добавлен новый звук для Гамма кода на станции.
translation: Добавлен перевод приёмов и сообщений в чат для Спящего Карпа.
typo: Исправлена опечатка в предыстории расы КПБ.
-->
