### PR TITLE
Icebox: fix modular gamma port

### DIFF
--- a/_maps/bandastation/automapper/automapper_config.toml
+++ b/_maps/bandastation/automapper/automapper_config.toml
@@ -353,7 +353,7 @@ trait_name = "Station"
 map_files = ["iceboxstation_gamma_port.dmm"]
 directory = "_maps/bandastation/automapper/templates/iceboxstation/"
 required_map = "IceBoxStation.dmm"
-coordinates = [91, 181, 3]
+coordinates = [90, 180, 3]
 trait_name = "Station"
 
 [templates.iceboxstation_library_galactic_map]
@@ -451,7 +451,7 @@ trait_name = "Station"
 map_files = ["iceboxstation_sec_closet.dmm"]
 directory = "_maps/bandastation/automapper/templates/iceboxstation/"
 required_map = "IceBoxStation.dmm"
-coordinates = [102, 188, 3]
+coordinates = [110, 183, 3]
 trait_name = "Station"
 
 [templates.iceboxstation_wrynroach]

--- a/_maps/bandastation/automapper/templates/iceboxstation/iceboxstation_gamma_port.dmm
+++ b/_maps/bandastation/automapper/templates/iceboxstation/iceboxstation_gamma_port.dmm
@@ -1,145 +1,40 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 10
+	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "b" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"d" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 5
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"g" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"i" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/obj/machinery/light/directional/south,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/smooth_edge{
-	dir = 1
-	},
-/area/station/security/lockers)
-"j" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 9
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"k" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"o" = (
-/obj/structure/sign/warning/secure_area,
-/turf/closed/wall/ice,
-/area/icemoon/surface/outdoors/nospawn)
-"p" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 4
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"r" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"s" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"t" = (
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"x" = (
-/obj/effect/turf_decal/weather/snow/corner,
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"y" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/obj/structure/sign/nanotrasen,
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 10
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"A" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/snow/corner{
-	dir = 6
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"C" = (
-/obj/structure/fence{
-	dir = 1
-	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"E" = (
+"c" = (
+/turf/open/floor/iron/smooth,
+/area/station/security/lockers)
+"d" = (
 /obj/structure/fence{
 	dir = 1
 	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
-"F" = (
-/turf/open/floor/glass,
-/area/station/security/lockers)
-"J" = (
 /obj/effect/turf_decal/weather/snow/corner{
-	dir = 8
+	dir = 10
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"K" = (
+"e" = (
+/turf/closed/wall/r_wall,
+/area/station/security/lockers)
+"h" = (
+/obj/structure/fence/door,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"l" = (
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/smooth,
+/area/station/security/lockers)
+"m" = (
 /turf/template_noop,
 /area/template_noop)
-"S" = (
-/obj/machinery/door/poddoor/shuttledock{
-	checkdir = 8
-	},
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/atmos_shield_gen/active,
-/obj/machinery/atmos_shield_gen/active{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/security/lockers)
-"X" = (
+"n" = (
 /obj/docking_port/stationary{
 	dir = 8;
 	dwidth = 4;
@@ -153,134 +48,290 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"o" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/sign/nanotrasen,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"p" = (
+/obj/structure/sign/warning/secure_area/directional/south,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"r" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"x" = (
+/obj/structure/fence/door{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"z" = (
+/turf/open/floor/glass,
+/area/station/security/lockers)
+"A" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"C" = (
+/turf/closed/wall/ice,
+/area/icemoon/surface/outdoors/nospawn)
+"D" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Security - Equipment Room"
+	},
+/obj/structure/closet/bombcloset/security,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/smooth,
+/area/station/security/lockers)
+"E" = (
+/mob/living/simple_animal/hostile/asteroid/polarbear{
+	move_force = 999;
+	name = "Louie"
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"G" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/obj/structure/sign/warning/directional/east,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"H" = (
+/mob/living/simple_animal/hostile/asteroid/polarbear{
+	move_force = 999;
+	name = "Dewey"
+	},
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"I" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 6
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"J" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/l3closet/security,
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
+	},
+/area/station/security/lockers)
+"K" = (
+/obj/effect/turf_decal/bot/right,
+/obj/machinery/recharge_station,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/smooth,
+/area/station/security/lockers)
+"M" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 9
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"N" = (
+/obj/structure/sign/warning/secure_area/directional/north,
+/obj/structure/flora/grass/green/style_random,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"O" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"P" = (
+/obj/effect/turf_decal/weather/snow/corner,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"Q" = (
+/obj/machinery/door/poddoor/shuttledock{
+	checkdir = 8
+	},
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/atmos_shield_gen/active,
+/obj/machinery/atmos_shield_gen/active{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/security/lockers)
+"S" = (
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"T" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 9
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"V" = (
+/obj/structure/flora/rock/pile/icy/style_random,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"W" = (
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"X" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"Y" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
+"Z" = (
+/obj/effect/turf_decal/weather/snow/corner{
+	dir = 5
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 
 (1,1,1) = {"
-K
-C
-b
-s
-g
-E
-C
-b
-g
-C
-K
+m
+r
+M
+Y
+d
+x
+r
+M
+d
+r
+m
+m
 "}
 (2,1,1) = {"
-K
-j
+m
+T
+S
+S
+S
+O
+O
+S
+S
 a
-a
-a
-J
-J
-a
-a
-t
-K
+m
+m
 "}
 (3,1,1) = {"
-K
-k
-a
-a
-a
-a
-a
-a
-a
-x
-o
+m
+A
+S
+S
+S
+S
+S
+S
+S
+P
+m
+m
 "}
 (4,1,1) = {"
-K
-k
-a
-a
-a
-a
-a
-a
-a
-a
-y
+m
+A
+S
+S
+S
+S
+S
+S
+S
+p
+C
+W
 "}
 (5,1,1) = {"
-K
-k
-a
-a
-a
-a
-a
-a
-a
-a
+m
 A
+S
+S
+S
+S
+S
+S
+S
+S
+o
+V
 "}
 (6,1,1) = {"
-K
-d
-p
-p
-p
+m
+Z
+G
 X
-p
-p
-p
-r
-o
+X
+n
+X
+X
+G
+I
+h
+b
 "}
 (7,1,1) = {"
-K
-K
-K
-K
-K
-S
-K
-K
-K
-K
-K
+m
+V
+e
+e
+e
+Q
+e
+e
+e
+E
+C
+N
 "}
 (8,1,1) = {"
+m
+H
+e
 K
-K
-K
-K
-K
-F
-K
-i
-K
-K
-K
+c
+c
+l
+D
+e
+m
+m
+m
 "}
 (9,1,1) = {"
-K
-K
-K
-K
-K
-K
-K
-K
-K
-K
-K
-"}
-(10,1,1) = {"
-K
-K
-K
-K
-K
-K
-K
-K
-K
-K
-K
+m
+m
+m
+m
+m
+z
+m
+J
+e
+m
+m
+m
 "}

--- a/_maps/bandastation/automapper/templates/iceboxstation/iceboxstation_sec_closet.dmm
+++ b/_maps/bandastation/automapper/templates/iceboxstation/iceboxstation_sec_closet.dmm
@@ -1,13 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/north,
+/obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/secequipment,
-/turf/open/floor/iron/smooth_edge,
-/area/station/security/lockers)
+/turf/open/floor/iron/dark/textured,
+/area/station/security/office)
 
 (1,1,1) = {"
 a


### PR DESCRIPTION
## Что этот PR делает

Фиксит модульный кусок в раздевалке брига Айсбокса (доп ящик сб), потому что оффы заремаппили бриг 

## Почему это хорошо для игры

Не круто, когда в бриге дыра

## Изображения изменений

Представьте, что лампочки и фаералярма висящий в воздухе не существует, это пофикшено
<img width="627" height="726" alt="image" src="https://github.com/user-attachments/assets/0669322f-7691-42f7-9993-1dd54286d0c0" />

## Тестирование

Локалка

## Changelog

<!-- Важно строго соблюдать ёмкость и стилистическую форму наполнения чейнджлога! -->

:cl:
map: Icebox: исправлен модульный порт гамма-шаттла в бриге.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
<!-- Пример хороших чейнджлогов:
add: В аплинк повара добавлен мануал CQC за 20 ТК.
admin: Добавлено новое Smite действие - "Сломать колени".
balance: Разлёт дроби 12 калибра, скаттер лазер шеллов, драконьего дыхания и резиновой дроби был увеличен.
code_imp: Число дополнительных необходимых шкафов СБ теперь вычисляется точнее.
config: Добавлена/убрана настройка слотов СБ через конфиг.
del: Удалена возможность рыбалки в лотках гидропоники.
fix: Исправлена ошибка, из-за которой неудачный вызов ОБР мог резко ухудшить производительность игры.
image: Изменены спрайты для револьверов .357
map: Добавлена новая игровая карта - Nebula Station.
qol: Смерть в мини-играх больше не сбрасывает таймер возрождения.
refactor: Значительно улучшено качество кода модульной TTS сабсистемы.
server: Flaky тесты перенесены на ubuntu-20.04.
sound: Добавлен новый звук для Гамма кода на станции.
translation: Добавлен перевод приёмов и сообщений в чат для Спящего Карпа.
typo: Исправлена опечатка в предыстории расы КПБ.
-->
