### PR TITLE
FIX: Fixed issue with using the RCD to repair bots and drones

### DIFF
--- a/code/modules/mob/living/basic/bots/repairbot/repairbot.dm
+++ b/code/modules/mob/living/basic/bots/repairbot/repairbot.dm
@@ -86,7 +86,7 @@
 		/datum/action/repairbot_resources = null,
 	)
 	grant_actions_by_list(abilities)
-	add_traits(list(TRAIT_SPACEWALK, TRAIT_NEGATES_GRAVITY, TRAIT_MOB_MERGE_STACKS, TRAIT_FIREDOOR_OPENER), INNATE_TRAIT)
+	add_traits(list(TRAIT_SPACEWALK, TRAIT_NEGATES_GRAVITY, TRAIT_MOB_MERGE_STACKS, TRAIT_FIREDOOR_OPENER, TRAIT_ADVANCED_RCD_KNOWLEDGE), INNATE_TRAIT)
 	our_welder = new(src)
 	our_welder.switched_on(src)
 	our_crowbar = new(src)

--- a/code/modules/mob/living/basic/bots/repairbot/repairbot.dm
+++ b/code/modules/mob/living/basic/bots/repairbot/repairbot.dm
@@ -86,7 +86,7 @@
 		/datum/action/repairbot_resources = null,
 	)
 	grant_actions_by_list(abilities)
-	add_traits(list(TRAIT_SPACEWALK, TRAIT_NEGATES_GRAVITY, TRAIT_MOB_MERGE_STACKS, TRAIT_FIREDOOR_OPENER, TRAIT_ADVANCED_RCD_KNOWLEDGE), INNATE_TRAIT)
+	add_traits(list(TRAIT_SPACEWALK, TRAIT_NEGATES_GRAVITY, TRAIT_MOB_MERGE_STACKS, TRAIT_FIREDOOR_OPENER), INNATE_TRAIT)
 	our_welder = new(src)
 	our_welder.switched_on(src)
 	our_crowbar = new(src)

--- a/modular_bandastation/skillchip_rcd/code/skillchip_rcd.dm
+++ b/modular_bandastation/skillchip_rcd/code/skillchip_rcd.dm
@@ -1,3 +1,7 @@
+/// Whitelist of mobs that can use the tool without a chip
+/proc/can_inherently_use_rcd(mob/user)
+	return issilicon(user) || isdrone(user) || istype(user, /mob/living/basic/bot/repairbot)
+
 /datum/design/rcd_loaded
 	name = "Rapid Construction Device (RCD)"
 
@@ -13,7 +17,7 @@
 	var/list/modes_requiring_advanced_rcd_knowledge = list(RCD_DECONSTRUCT)
 
 /obj/item/construction/rcd/proc/check_engineer_skillchip(mob/user, alert = TRUE)
-	if(!HAS_TRAIT(user, TRAIT_ADVANCED_RCD_KNOWLEDGE) && !issilicon(user))
+	if(!HAS_TRAIT(user, TRAIT_ADVANCED_RCD_KNOWLEDGE) && !can_inherently_use_rcd(user))
 		if(alert)
 			balloon_alert(user, "нет скиллчипа!")
 		return FALSE


### PR DESCRIPTION

## Что этот PR делает

Исправление зависимости ремонтного бота и дронов от наличия скиллчипа инженера для использования РЦД.

## Почему это хорошо для игры

Фиксим багулину

## Изображения изменений

Не особо нужно

## Тестирование

Локалка

## Changelog

<!-- Важно строго соблюдать ёмкость и стилистическую форму наполнения чейнджлога! -->

:cl:
fix: Исправлена ошибка, при которой ремонтный бот и дроны не могли использовать РЦД.
/:cl: