### PR TITLE
Cyberiad: table fix

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -98618,11 +98618,6 @@
 /obj/item/watertank,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
-"ygZ" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard/west)
 "yha" = (
 /obj/structure/railing,
 /turf/open/floor/glass/reinforced,
@@ -209183,7 +209178,7 @@ gwo
 wfV
 qpn
 kkl
-ygZ
+niF
 xov
 lbS
 sHs


### PR DESCRIPTION
## Что этот PR делает

 Быстрый фикс стола в коридоре у робо на Кибериаде для селфмержа :xdd:

## Почему это хорошо для игры

А стол посередине коридора может быть хорош?

## Изображения изменений

Там просто убран стол

## Тестирование

Будет работать без стола

## Changelog

<!-- Важно строго соблюдать ёмкость и стилистическую форму наполнения чейнджлога! -->

:cl:
map: Cyberiad: в коридоре между библиотекой и робо теперь не будет стоять одинокий стол.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
<!-- Пример хороших чейнджлогов:
add: В аплинк повара добавлен мануал CQC за 20 ТК.
admin: Добавлено новое Smite действие - "Сломать колени".
balance: Разлёт дроби 12 калибра, скаттер лазер шеллов, драконьего дыхания и резиновой дроби был увеличен.
code_imp: Число дополнительных необходимых шкафов СБ теперь вычисляется точнее.
config: Добавлена/убрана настройка слотов СБ через конфиг.
del: Удалена возможность рыбалки в лотках гидропоники.
fix: Исправлена ошибка, из-за которой неудачный вызов ОБР мог резко ухудшить производительность игры.
image: Изменены спрайты для револьверов .357
map: Добавлена новая игровая карта - Nebula Station.
qol: Смерть в мини-играх больше не сбрасывает таймер возрождения.
refactor: Значительно улучшено качество кода модульной TTS сабсистемы.
server: Flaky тесты перенесены на ubuntu-20.04.
sound: Добавлен новый звук для Гамма кода на станции.
translation: Добавлен перевод приёмов и сообщений в чат для Спящего Карпа.
typo: Исправлена опечатка в предыстории расы КПБ.
-->
