### PR TITLE
Cyberiad and Kilo update

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -47801,6 +47801,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"lDn" = (
+/obj/effect/turf_decal/tile/purple/half{
+	dir = 1
+	},
+/obj/machinery/gizmo/toggle/tucker_tubes,
+/turf/open/floor/iron/white,
+/area/station/science/lower)
 "lDx" = (
 /obj/effect/landmark/start/ai,
 /obj/item/radio/intercom/directional/west{
@@ -213065,7 +213072,7 @@ uHZ
 bkE
 nMx
 uzL
-pxu
+lDn
 byv
 qMU
 byv

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -637,24 +637,27 @@
 /area/station/construction/mining/aux_base)
 "ajt" = (
 /obj/structure/rack,
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 1
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 5
+	},
 /obj/item/controller{
 	pixel_x = -7
 	},
-/obj/item/compact_remote{
-	pixel_x = -7
-	},
-/obj/item/compact_remote{
-	pixel_x = -7
-	},
-/obj/machinery/airalarm/directional/north,
 /obj/item/integrated_circuit/loaded/speech_relay{
 	pixel_x = 7
 	},
 /obj/item/integrated_circuit/loaded/hello_world{
 	pixel_x = 7
 	},
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 1
+/obj/item/compact_remote{
+	pixel_x = -7
+	},
+/obj/item/compact_remote{
+	pixel_x = -7
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/ordnance/office)
@@ -23079,23 +23082,7 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/fore)
 "hCY" = (
-/obj/item/disk/computer{
-	pixel_x = -5;
-	pixel_y = 8
-	},
-/obj/item/disk/computer{
-	pixel_x = 7;
-	pixel_y = 2
-	},
-/obj/item/disk/computer{
-	pixel_x = -8;
-	pixel_y = -3
-	},
-/obj/structure/table,
-/obj/item/disk/computer/ordnance{
-	pixel_x = 2;
-	pixel_y = 1
-	},
+/obj/machinery/gizmo/toggle/tucker_tubes,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
 "hDa" = (
@@ -31411,8 +31398,21 @@
 /area/space/nearstation)
 "kkg" = (
 /obj/structure/table,
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 5
+/obj/item/disk/computer{
+	pixel_x = -8;
+	pixel_y = -3
+	},
+/obj/item/disk/computer{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/disk/computer{
+	pixel_x = 7;
+	pixel_y = 2
+	},
+/obj/item/disk/computer/ordnance{
+	pixel_x = 2;
+	pixel_y = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)


### PR DESCRIPTION
## Что этот PR делает

Оффы добавили некую машину gizmo, а именно ее подтип tucke tubes на все свои карты в комнаты с экспериментором, так что и на наши карты тоже надо добавить. На Кило нет экспериментора, так что будет машина жить в циркуитной

## Почему это хорошо для игры

Не отстаем от нововведений оффов

## Изображения изменений

<img width="549" height="388" alt="image" src="https://github.com/user-attachments/assets/58f3f997-411f-45f2-bc2e-20a4f50db4d0" />
<img width="352" height="319" alt="image" src="https://github.com/user-attachments/assets/1693aeff-4090-4eb9-afcc-968823224af1" />

## Тестирование

Одна машинка, которой ничего не требуется, значит будет работать

## Changelog

<!-- Важно строго соблюдать ёмкость и стилистическую форму наполнения чейнджлога! -->

:cl:
map: Cyberiad: в комнату для экспериментов в РНД добавлена машина - gizmo.
map: Kilo: в комнату циркуитов в РНД добавлена машина - gizmo.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
<!-- Пример хороших чейнджлогов:
add: В аплинк повара добавлен мануал CQC за 20 ТК.
admin: Добавлено новое Smite действие - "Сломать колени".
balance: Разлёт дроби 12 калибра, скаттер лазер шеллов, драконьего дыхания и резиновой дроби был увеличен.
code_imp: Число дополнительных необходимых шкафов СБ теперь вычисляется точнее.
config: Добавлена/убрана настройка слотов СБ через конфиг.
del: Удалена возможность рыбалки в лотках гидропоники.
fix: Исправлена ошибка, из-за которой неудачный вызов ОБР мог резко ухудшить производительность игры.
image: Изменены спрайты для револьверов .357
map: Добавлена новая игровая карта - Nebula Station.
qol: Смерть в мини-играх больше не сбрасывает таймер возрождения.
refactor: Значительно улучшено качество кода модульной TTS сабсистемы.
server: Flaky тесты перенесены на ubuntu-20.04.
sound: Добавлен новый звук для Гамма кода на станции.
translation: Добавлен перевод приёмов и сообщений в чат для Спящего Карпа.
typo: Исправлена опечатка в предыстории расы КПБ.
-->
