### PR TITLE
Cyberiad: brig again

### DIFF
--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -8123,6 +8123,13 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"bYf" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/security/prison/visit)
 "bYm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 6
@@ -64418,6 +64425,7 @@
 /obj/structure/displaycase{
 	start_showpiece_type = /obj/item/melee/chainofcommand
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "pEG" = (
@@ -79695,6 +79703,7 @@
 /area/station/maintenance/port/fore)
 "tuM" = (
 /obj/machinery/suit_storage_unit/hos,
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "tuO" = (
@@ -98428,7 +98437,6 @@
 	name = "spider bed"
 	},
 /mob/living/basic/spider/giant/sgt_araneus,
-/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "ycY" = (
@@ -186594,7 +186602,7 @@ mvm
 lUF
 kXa
 kSa
-kkU
+bYf
 kkU
 dWf
 pKp

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -1358,6 +1358,7 @@
 /obj/machinery/door/airlock/security,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/security/mechbay)
 "arT" = (
@@ -1411,6 +1412,7 @@
 /obj/machinery/door/airlock/command/hos,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/security/hos,
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "asE" = (
@@ -10218,6 +10220,7 @@
 /obj/machinery/door/airlock/security/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/security/processing)
 "cxd" = (
@@ -13222,6 +13225,7 @@
 	name = "Prison Lockdown Blast Doors"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "dhb" = (
@@ -16531,6 +16535,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
 /obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
 /obj/effect/mapping_helpers/airlock/access/any/security/hos,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "dXD" = (
@@ -18291,6 +18296,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "ewc" = (
@@ -28207,6 +28213,7 @@
 /obj/machinery/door/airlock/security/glass,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom/holding)
 "gPw" = (
@@ -29180,6 +29187,7 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/detective,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/security/detectives_office)
 "hcs" = (
@@ -31373,6 +31381,7 @@
 /obj/machinery/door/airlock/security/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/security/processing)
 "hDa" = (
@@ -39595,6 +39604,7 @@
 	name = "Security Blast Door";
 	id = "Secure Gate"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "jGr" = (
@@ -44881,6 +44891,7 @@
 "kSa" = (
 /obj/machinery/door/airlock/security/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/security/prison/visit)
 "kSb" = (
@@ -50669,6 +50680,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "mnZ" = (
@@ -55935,6 +55947,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/security/processing)
 "nDf" = (
@@ -57870,6 +57883,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/duct,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs)
 "obz" = (
@@ -63380,6 +63394,7 @@
 /obj/machinery/door/airlock/security/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "psw" = (
@@ -64839,6 +64854,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/security/processing)
 "pJK" = (
@@ -66955,6 +66971,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/nanotrasen_representative,
 /obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
 /obj/effect/mapping_helpers/airlock/access/any/security/hos,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "qlM" = (
@@ -67987,6 +68004,7 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/security/range)
 "qAA" = (
@@ -68564,6 +68582,7 @@
 /obj/machinery/door/airlock/security,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "qJm" = (
@@ -82680,6 +82699,7 @@
 /obj/machinery/door/airlock/highsecurity,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "ugf" = (
@@ -83857,6 +83877,7 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/door/airlock/security/glass,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/security/mechbay)
 "uyH" = (
@@ -86585,6 +86606,7 @@
 /obj/machinery/door/airlock/security,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/security/evidence)
 "vjQ" = (

--- a/_maps/map_files/Cyberiad/Cyberiad.dmm
+++ b/_maps/map_files/Cyberiad/Cyberiad.dmm
@@ -2092,7 +2092,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/table,
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
 "aAw" = (
@@ -3789,10 +3788,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "aVD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/south,
+/obj/structure/bed{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "aVF" = (
@@ -4296,13 +4296,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bcb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor/border_only,
 /obj/structure/cable,
-/obj/machinery/door/window/brigdoor/security/cell/left/directional/north{
-	id = "Cell 1";
-	name = "Cell 1"
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
@@ -5782,10 +5781,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "buc" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "bui" = (
@@ -6711,10 +6708,20 @@
 /turf/open/floor/iron,
 /area/station/maintenance/ghetto/starboard)
 "bFn" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/machinery/door/poddoor/preopen{
+	name = "Security Blast Door";
+	id = "Secure Gate"
+	},
+/obj/machinery/door/window/brigdoor/security/cell/left/directional/south{
+	id = "Cell 4";
+	name = "Cell 4"
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "bFo" = (
 /obj/structure/table,
@@ -7018,7 +7025,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/ghetto/morgue)
 "bJQ" = (
-/obj/structure/bed/maint,
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "bJW" = (
@@ -8497,17 +8506,12 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "cck" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/machinery/camera/directional/east{
-	c_tag = "Brig - Lobby - East"
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/station/security/brig/entrance)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/security/holding_cell)
 "ccn" = (
 /obj/effect/spawner/random/structure/girder,
 /obj/effect/decal/cleanable/dirt,
@@ -9281,7 +9285,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "clv" = (
-/obj/structure/table,
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
 "clK" = (
@@ -9695,11 +9702,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "cqV" = (
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 8
-	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/security/brig)
+/area/station/security/courtroom/holding)
 "crd" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
@@ -9966,14 +9971,15 @@
 /turf/open/openspace,
 /area/station/science/xenobiology)
 "cuu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 4";
+	name = "Cell 4 locker"
 	},
-/obj/effect/landmark/firealarm_sanity,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "cuA" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
@@ -10500,6 +10506,10 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/camera/directional/west{
+	c_tag = "Security - Interrogation Room 2";
+	network = list("ss13","Security")
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "cBo" = (
@@ -10689,7 +10699,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/firealarm/directional/south,
+/obj/machinery/button/door/directional/south{
+	id = "interrogation_room";
+	req_access = list("security")
+	},
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
 "cDZ" = (
@@ -10730,10 +10743,21 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "cEv" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	name = "Security Blast Door";
+	id = "Secure Gate"
+	},
+/obj/machinery/door/window/brigdoor/security/cell/right/directional/south{
+	id = "Cell 3";
+	name = "Cell 3"
+	},
+/turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "cEy" = (
 /obj/machinery/light/directional/west,
@@ -12713,18 +12737,7 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "daN" = (
-/obj/machinery/door/airlock/security/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	name = "Security Blast Door";
-	id = "Secure Gate"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "daP" = (
@@ -19170,6 +19183,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood/large,
 /area/station/service/bar/atrium/ghetto)
+"eHO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/holding_cell)
 "eHP" = (
 /obj/structure/table,
 /obj/machinery/light/small/directional/north,
@@ -21402,6 +21423,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"fkt" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "interrogation_room";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/security/courtroom/holding)
 "fkv" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 8
@@ -23646,9 +23676,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "fKC" = (
@@ -24011,11 +24040,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/central)
 "fOT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/turf/open/floor/iron,
-/area/station/security/brig)
+/obj/machinery/door/airlock/security/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/turf/open/floor/iron/dark,
+/area/station/security/holding_cell)
 "fOU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -26933,16 +26963,14 @@
 /turf/open/floor/plating,
 /area/station/medical/medbay)
 "gCq" = (
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/status_display/door_timer{
+	id = "Cell 1";
+	name = "Cell 1";
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/camera/directional/north{
-	c_tag = "Brig - Cell 1";
-	network = list("ss13","Security")
+/turf/open/floor/iron/stairs/left{
+	dir = 8
 	},
-/turf/open/floor/iron,
 /area/station/security/holding_cell)
 "gCt" = (
 /obj/structure/bookcase/random,
@@ -27102,9 +27130,6 @@
 /area/station/maintenance/ghetto/starboard)
 "gEo" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/camera/directional/north{
-	c_tag = "Brig - Hallway Main - Center"
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -28178,6 +28203,12 @@
 	},
 /turf/open/floor/wood/guaiacum,
 /area/station/maintenance/ghetto/fore/starboard)
+"gPt" = (
+/obj/machinery/door/airlock/security/glass,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/open/floor/iron/dark,
+/area/station/security/courtroom/holding)
 "gPw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -29473,18 +29504,13 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "hgE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
-	name = "Cell 2 locker"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/landmark/firealarm_sanity,
+/turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "hgF" = (
 /obj/item/radio/intercom/directional/west,
@@ -29967,15 +29993,10 @@
 	},
 /area/station/hallway/secondary/entry)
 "hmB" = (
-/obj/machinery/flasher/directional/north{
-	id = "Cell 2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/light/small/dim/directional/north,
-/obj/structure/bed,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "hmF" = (
 /obj/machinery/atmospherics/components/binary/valve/digital/on{
@@ -32708,6 +32729,9 @@
 "hSS" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/chair{
+	pixel_y = -2
+	},
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
 "hSW" = (
@@ -34204,8 +34228,8 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters{
-	name = "Vacant Store Shutters";
-	id = "interrogation_smalltwo"
+	name = "Interrogation Room Shutters";
+	id = "interrogation_room1"
 	},
 /turf/open/floor/plating,
 /area/station/security/interrogation)
@@ -34847,6 +34871,8 @@
 /area/station/service/hydroponics)
 "iuP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "iuR" = (
@@ -35289,12 +35315,13 @@
 /area/space/nearstation)
 "iBH" = (
 /obj/effect/turf_decal/tile/red{
-	dir = 1
+	dir = 8
 	},
-/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/security/holding_cell)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "iBQ" = (
 /turf/open/floor/iron/recharge_floor,
 /area/station/maintenance/department/electrical)
@@ -36105,15 +36132,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "iMy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/status_display/door_timer{
-	id = "Cell 1";
-	name = "Cell 1";
-	pixel_y = 32
+/obj/machinery/light/small/dim/directional/east,
+/obj/machinery/camera/directional/east{
+	c_tag = "Brig - Cell 1"
 	},
+/obj/machinery/flasher/directional/south{
+	id = "Cell 1"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/table/wood,
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "iMA" = (
@@ -36524,12 +36551,13 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "iRT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/small/directional/south,
-/obj/machinery/firealarm/directional/south,
+/obj/structure/table/reinforced,
+/obj/item/restraints/handcuffs{
+	pixel_y = 3
+	},
+/obj/item/restraints/handcuffs,
 /turf/open/floor/iron,
-/area/station/security/brig)
+/area/station/security/courtroom/holding)
 "iRW" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood,
@@ -37086,7 +37114,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
@@ -37202,6 +37229,9 @@
 "iZO" = (
 /obj/effect/turf_decal/tile/red,
 /obj/structure/sign/departments/security/directional/east,
+/obj/machinery/camera/directional/east{
+	c_tag = "Brig - Lobby - East"
+	},
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "iZP" = (
@@ -40377,10 +40407,10 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/item/storage/fancy/cigarettes/cigpack_robust,
 /obj/item/inspector{
 	pixel_y = 8
 	},
+/obj/item/storage/fancy/cigarettes/cigpack_robust,
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
 "jPV" = (
@@ -40509,9 +40539,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "jRH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/structure/bed,
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "jRN" = (
@@ -41667,13 +41699,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "kgG" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red/anticorner/contrasted{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/structure/bed/maint,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "kgT" = (
@@ -44108,6 +44135,9 @@
 "kJB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "interrogation_room"
+	},
 /turf/open/floor/plating,
 /area/station/security/courtroom/holding)
 "kJC" = (
@@ -44240,13 +44270,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/ghetto/aft)
 "kKv" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/security/brig)
+/area/station/security/holding_cell)
 "kKA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46450,12 +46475,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "lnn" = (
-/obj/structure/table,
-/obj/item/folder/red{
-	pixel_y = 3
-	},
-/turf/open/floor/iron,
-/area/station/security/courtroom/holding)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/dark,
+/area/station/security/holding_cell)
 "lnp" = (
 /obj/structure/railing{
 	dir = 8
@@ -47346,12 +47371,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/fore/starboard)
 "lwQ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "lwX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -50642,11 +50665,10 @@
 "mnS" = (
 /obj/machinery/door/airlock/security/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "mnZ" = (
@@ -50885,7 +50907,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/red/fourcorners,
+/obj/structure/table,
+/obj/item/taperecorder{
+	pixel_y = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
 "mrl" = (
@@ -51128,8 +51153,8 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/ghetto/storage)
 "muQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/table/reinforced,
+/obj/item/storage/box/evidence,
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
 "muS" = (
@@ -52332,7 +52357,6 @@
 	pixel_x = 6;
 	pixel_y = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
 "mJq" = (
@@ -52456,8 +52480,8 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "mKN" = (
-/obj/structure/sign/departments/security/directional/east,
-/turf/closed/wall/r_wall,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "mKW" = (
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
@@ -55062,14 +55086,17 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/ghetto/central)
 "nrl" = (
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 3";
+	name = "Cell 3 locker"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/landmark/firealarm_sanity,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "nro" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
@@ -55104,14 +55131,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "nrR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/status_display/door_timer{
-	id = "Cell 2";
-	name = "Cell 2";
-	pixel_y = 32
+/obj/machinery/light/small/dim/directional/west,
+/obj/machinery/camera/directional/west{
+	c_tag = "Brig - Cell 2"
 	},
+/obj/machinery/flasher/directional/south{
+	id = "Cell 2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/table/wood,
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "nrT" = (
@@ -59858,17 +59888,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "ozC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/window/brigdoor/security/cell/right/directional/north{
-	id = "Cell 2";
-	name = "Cell 2"
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "ozY" = (
@@ -61622,7 +61645,8 @@
 "oVU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/button/door/directional/west{
-	id = "interrogation_smalltwo"
+	id = "interrogation_room1";
+	req_access = list("security")
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
@@ -61696,6 +61720,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"oWL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Security - Interrogation Room 1";
+	network = list("ss13","Security")
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/interrogation)
 "oWM" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/chair/comfy/brown{
@@ -62028,7 +62062,7 @@
 /turf/open/floor/iron,
 /area/station/science/lab)
 "pbC" = (
-/obj/machinery/holopad/secure,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "pbK" = (
@@ -62090,16 +62124,15 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
 "pcx" = (
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/status_display/door_timer{
+	id = "Cell 2";
+	name = "Cell 2";
+	pixel_y = -32
 	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Brig - Cell 2";
-	network = list("ss13","Security")
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "pcC" = (
 /obj/machinery/light/small/directional/east,
@@ -62735,6 +62768,15 @@
 /obj/item/radio/intercom/directional/east,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/folder/red{
+	pixel_y = 3;
+	pixel_x = -3
+	},
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_y = 7;
+	pixel_x = 5
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
@@ -63428,6 +63470,9 @@
 	c_tag = "Security - Interrogation Room";
 	network = list("ss13","Security")
 	},
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
 "pty" = (
@@ -64023,11 +64068,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/port)
 "pBm" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "pBn" = (
@@ -64569,6 +64610,11 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"pGR" = (
+/obj/effect/turf_decal/tile/red,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "pHh" = (
 /turf/closed/wall,
 /area/station/service/kitchen)
@@ -67123,7 +67169,8 @@
 "qoZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/button/door/directional/east{
-	id = "interrogation_small"
+	id = "interrogation_room2";
+	req_access = list("security")
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
@@ -68195,6 +68242,7 @@
 	},
 /obj/effect/mapping_helpers/mail_sorting/security/detectives_office,
 /obj/structure/cable,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/stairs/right,
 /area/station/security/brig)
 "qEI" = (
@@ -68737,16 +68785,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "qMx" = (
-/obj/machinery/flasher/directional/north{
-	id = "Cell 1"
-	},
 /obj/effect/turf_decal/tile/red{
-	dir = 4
+	dir = 8
 	},
-/obj/structure/bed,
-/obj/machinery/light/small/dim/directional/north,
-/turf/open/floor/iron,
-/area/station/security/holding_cell)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/security/brig)
 "qMz" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -69413,13 +69459,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "qVg" = (
-/obj/structure/cable,
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_y = 2
+/turf/open/floor/iron/stairs/right{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/station/security/courtroom/holding)
+/area/station/security/holding_cell)
 "qVj" = (
 /turf/closed/wall,
 /area/station/maintenance/department/medical/ghetto/central)
@@ -72216,13 +72259,14 @@
 /turf/open/space/openspace,
 /area/space/nearstation)
 "rED" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/security/holding_cell)
+/turf/open/floor/iron,
+/area/station/security/brig/entrance)
 "rEF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -72572,8 +72616,8 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters{
-	name = "Vacant Store Shutters";
-	id = "interrogation_small"
+	name = "Interrogation Room Shutters";
+	id = "interrogation_room2"
 	},
 /turf/open/floor/plating,
 /area/station/security/interrogation)
@@ -76735,6 +76779,8 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/camera,
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
 "sHS" = (
@@ -82706,7 +82752,6 @@
 /area/station/engineering/hallway)
 "uhc" = (
 /obj/machinery/light/floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
 "uhf" = (
@@ -83014,18 +83059,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/ghetto/aft)
 "ulu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 1";
-	name = "Cell 1 locker"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/landmark/firealarm_sanity,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "ulv" = (
 /obj/structure/table,
@@ -86099,6 +86138,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "vdk" = (
@@ -86539,10 +86579,6 @@
 /area/station/hallway/primary/central/aft)
 "vjL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
 "vjP" = (
@@ -87664,6 +87700,9 @@
 /obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Brig - Hallway Main - Center"
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
@@ -90326,7 +90365,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "wfQ" = (
-/obj/effect/turf_decal/tile/red/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
 "wfV" = (
@@ -91984,7 +92025,7 @@
 /area/station/ai/satellite/maintenance)
 "wAV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/security/courtroom/holding)
 "wAY" = (
@@ -96559,10 +96600,19 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "xFP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/station/security/brig/entrance)
+/obj/machinery/door/airlock/security/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/poddoor/preopen{
+	name = "Security Blast Door";
+	id = "Secure Gate"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/holding_cell)
 "xFS" = (
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/iron/dark/textured_large,
@@ -193206,9 +193256,9 @@ rqm
 bEH
 bEH
 bEH
+rED
 bEH
-cck
-xFP
+gkK
 iZO
 gkK
 gkK
@@ -193463,13 +193513,13 @@ ajE
 wLg
 wLg
 wLg
-wLg
+ajE
+xFP
+xFP
 bjv
 cVH
 cVH
 cVH
-bjv
-daN
 oEz
 tef
 hRz
@@ -193718,12 +193768,12 @@ uJq
 wyw
 iji
 buc
-sPk
-sPk
-cqV
-bjv
+pBm
+pBm
+ajE
+qVg
 gCq
-iBH
+bjv
 nrl
 bcb
 jRH
@@ -193977,12 +194027,12 @@ iji
 ale
 bXH
 vdf
-pBm
+ajE
 mKN
-qMx
+hmB
 cEv
 ulu
-bjv
+lnn
 iMy
 fSq
 xwx
@@ -194233,14 +194283,14 @@ uej
 iji
 sWy
 pbC
-sPk
 wIq
+ajE
+lwQ
+cck
 bjv
-fBY
-fBY
-fBY
+cVH
+cVH
 bjv
-rED
 fSq
 aka
 yiG
@@ -194491,12 +194541,12 @@ iji
 ils
 pBJ
 iuP
-iRT
-bjv
+ajE
+daN
 hmB
 bFn
 hgE
-bjv
+eHO
 nrR
 fSq
 gkx
@@ -194748,10 +194798,10 @@ iji
 kgG
 sPk
 bJQ
-fOT
-bjv
+ajE
+kKv
 pcx
-lwQ
+bjv
 cuu
 ozC
 aVD
@@ -195004,14 +195054,14 @@ vis
 ajE
 iji
 iji
-iji
 uxJ
-bjv
-fBY
-fBY
-fBY
-bjv
+ajE
+fOT
 mnS
+bjv
+fBY
+fBY
+fBY
 fSq
 xwx
 xwx
@@ -195261,14 +195311,14 @@ wyw
 eQc
 xqz
 hjs
-xqz
+qMx
 fKx
-kKv
 xqz
-xqz
+iBH
+hjs
 iYC
 xqz
-fKx
+xqz
 cds
 jIe
 jGq
@@ -195773,12 +195823,12 @@ wBV
 otu
 mgl
 gCw
-kJB
-kJB
+fkt
+fkt
 tnB
 sbn
-kJB
-kJB
+fkt
+fkt
 myX
 myX
 myX
@@ -196285,12 +196335,12 @@ dcW
 cdB
 wBV
 aVF
-wyw
+pGR
 kJB
 muQ
 uhc
 vjL
-gnN
+aAs
 rSN
 fyk
 imA
@@ -196547,13 +196597,13 @@ kJB
 iiu
 wAV
 clv
-aAs
-clv
+gnN
+fyk
 jvo
 hWJ
 cbo
 qAA
-vUi
+oWL
 fgy
 fqI
 fgy
@@ -196800,10 +196850,10 @@ ewd
 wBV
 aVF
 wyw
-kJB
+gPt
+fyk
 hOl
-lnn
-wfQ
+pCt
 mri
 aAs
 cDV
@@ -197059,11 +197109,11 @@ aVF
 wyw
 kJB
 dLz
-clv
-pCt
-qVg
-clv
-jvo
+fyk
+egn
+ipU
+wBt
+wfQ
 qcA
 cla
 dAM
@@ -197313,14 +197363,14 @@ jdw
 cOi
 wBV
 aVF
-wyw
+pGR
 kJB
+iRT
+rSN
 fyk
+cqV
 rSN
-egn
-ipU
-rSN
-wBt
+fyk
 rJx
 vtz
 aVl


### PR DESCRIPTION
## Что этот PR делает

Вновь изменяет бриг, где камеры и допроску

## Почему это хорошо для игры

Проклятье брига

## Изображения изменений

<img width="1026" height="696" alt="Screenshot_54" src="https://github.com/user-attachments/assets/f6f8a383-2879-4bfb-b798-975ac42d29f8" />

## Тестирование

Локалка

## Changelog

<!-- Важно строго соблюдать ёмкость и стилистическую форму наполнения чейнджлога! -->

:cl:
map: Cyberiad: допросная поменялась в планировке столов, появились шаттеры на кнопку, изменно расположение камер временного содержания, добавлены фаерлоки в бриге там, где их не было.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
<!-- Пример хороших чейнджлогов:
add: В аплинк повара добавлен мануал CQC за 20 ТК.
admin: Добавлено новое Smite действие - "Сломать колени".
balance: Разлёт дроби 12 калибра, скаттер лазер шеллов, драконьего дыхания и резиновой дроби был увеличен.
code_imp: Число дополнительных необходимых шкафов СБ теперь вычисляется точнее.
config: Добавлена/убрана настройка слотов СБ через конфиг.
del: Удалена возможность рыбалки в лотках гидропоники.
fix: Исправлена ошибка, из-за которой неудачный вызов ОБР мог резко ухудшить производительность игры.
image: Изменены спрайты для револьверов .357
map: Добавлена новая игровая карта - Nebula Station.
qol: Смерть в мини-играх больше не сбрасывает таймер возрождения.
refactor: Значительно улучшено качество кода модульной TTS сабсистемы.
server: Flaky тесты перенесены на ubuntu-20.04.
sound: Добавлен новый звук для Гамма кода на станции.
translation: Добавлен перевод приёмов и сообщений в чат для Спящего Карпа.
typo: Исправлена опечатка в предыстории расы КПБ.
-->
