### PR TITLE
add: change in the distribution of unloading occupancy

### DIFF
--- a/modular_bandastation/objects/code/items/clothing/accessories/accessories.dm
+++ b/modular_bandastation/objects/code/items/clothing/accessories/accessories.dm
@@ -16,7 +16,7 @@
 
 /datum/storage/pockets/ammo_webbing
 	max_slots = 4
-	max_total_storage = 12
+	max_total_storage = 9
 	max_specific_storage = WEIGHT_CLASS_NORMAL
 
 /datum/storage/pockets/ammo_webbing/New()

--- a/modular_bandastation/objects/code/items/clothing/accessories/accessories.dm
+++ b/modular_bandastation/objects/code/items/clothing/accessories/accessories.dm
@@ -15,7 +15,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 
 /datum/storage/pockets/ammo_webbing
-	max_slots = 6
+	max_slots = 4
 	max_total_storage = 12
 	max_specific_storage = WEIGHT_CLASS_NORMAL
 

--- a/modular_bandastation/objects/code/items/clothing/accessories/accessories.dm
+++ b/modular_bandastation/objects/code/items/clothing/accessories/accessories.dm
@@ -16,6 +16,7 @@
 
 /datum/storage/pockets/ammo_webbing
 	max_slots = 6
+	max_total_storage = 12
 	max_specific_storage = WEIGHT_CLASS_NORMAL
 
 /datum/storage/pockets/ammo_webbing/New()


### PR DESCRIPTION

## Что этот PR делает

Добавление дополнительной переменной для учитывания наполняемости разгрузки магазинами разного веса и меняет количество слотов с 6 --> 4
Сейчас должно быть так:
3 магазина обычного веса, ИЛИ 4 магазина маленького веса (пистолетные), ИЛИ 3 обычного и 1 маленького.

## Почему это хорошо для игры

Устраняет проблему, при которой во все 6 слотов можно было запихнуть магазины обычного размера, что не устраивало по фидбеку.

## Изображения изменений

Не нужно

## Тестирование

Локалка

## Changelog

:cl:
add: Изменено количество слотов в разгрузке с 6 до 4.
add: Изменено распределение предметов в аксессуарной разгрузке с разной атомарностью. Теперь она вмещает только 3 магазина обычного размера, маленького размера - до 4.
/:cl: