### PR TITLE
Kilo: fix boulder dir

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -47983,7 +47983,9 @@
 	dir = 8;
 	id = "mining"
 	},
-/obj/machinery/bouldertech/refinery/smelter,
+/obj/machinery/bouldertech/refinery/smelter{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "pNZ" = (


### PR DESCRIPTION
## Что этот PR делает

Переворачивает машину, что обрабатывает булыжники в правильную сторону

## Почему это хорошо для игры

Руда будет нормально обрабатываться

## Изображения изменений

<img width="374" height="189" alt="image" src="https://github.com/user-attachments/assets/c0c24de2-29e9-47c6-8f54-f0fa6d5570ca" />

## Тестирование

Будет работать

## Changelog

<!-- Важно строго соблюдать ёмкость и стилистическую форму наполнения чейнджлога! -->

:cl:
map: Kilo: машина по обработке булыжников в карго теперь находится в правильном положении.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
<!-- Пример хороших чейнджлогов:
add: В аплинк повара добавлен мануал CQC за 20 ТК.
admin: Добавлено новое Smite действие - "Сломать колени".
balance: Разлёт дроби 12 калибра, скаттер лазер шеллов, драконьего дыхания и резиновой дроби был увеличен.
code_imp: Число дополнительных необходимых шкафов СБ теперь вычисляется точнее.
config: Добавлена/убрана настройка слотов СБ через конфиг.
del: Удалена возможность рыбалки в лотках гидропоники.
fix: Исправлена ошибка, из-за которой неудачный вызов ОБР мог резко ухудшить производительность игры.
image: Изменены спрайты для револьверов .357
map: Добавлена новая игровая карта - Nebula Station.
qol: Смерть в мини-играх больше не сбрасывает таймер возрождения.
refactor: Значительно улучшено качество кода модульной TTS сабсистемы.
server: Flaky тесты перенесены на ubuntu-20.04.
sound: Добавлен новый звук для Гамма кода на станции.
translation: Добавлен перевод приёмов и сообщений в чат для Спящего Карпа.
typo: Исправлена опечатка в предыстории расы КПБ.
-->
