### PR TITLE
hotfix: changing the pirate's holster

### DIFF
--- a/code/modules/antagonists/pirate/pirate_outfits.dm
+++ b/code/modules/antagonists/pirate/pirate_outfits.dm
@@ -146,7 +146,7 @@
 	suit = null
 	ears = /obj/item/radio/headset/syndicate/alt/leader
 	head = null
-	accessory = /obj/item/clothing/accessory/holster/detective/full //BANDASTATION EDIT: Accessory holsters
+	accessory = /obj/item/clothing/accessory/holster/detective/veteran_advisor //BANDASTATION EDIT: Accessory holsters
 
 /datum/outfit/pirate/lustrous
 	name = "Lustrous Scintillant"


### PR DESCRIPTION

## Что этот PR делает

По ошибке выдал пирату IRS кобуру детектива вместо 1911-ой при мерже аксессуарных кобур, исправляюсь

## Почему это хорошо для игры

Фиксит недоработку

## Изображения изменений

-

## Тестирование

-

## Changelog

:cl:
fix: Аудитору IRS возвращена кобура с Colt 1911.
/:cl: