### PR TITLE
Paddy rebalance

### DIFF
--- a/modular_bandastation/balance/code/vehicle/paddy.dm
+++ b/modular_bandastation/balance/code/vehicle/paddy.dm
@@ -1,4 +1,4 @@
 /obj/vehicle/sealed/mecha/ripley/paddy
-	movedelay = 1.5
-	slow_pressure_step_in = 2
-	fast_pressure_step_in = 1.5
+	movedelay = 4
+	slow_pressure_step_in = 4
+	fast_pressure_step_in = 2.5

--- a/modular_bandastation/balance/code/vehicle/paddy.dm
+++ b/modular_bandastation/balance/code/vehicle/paddy.dm
@@ -1,4 +1,4 @@
 /obj/vehicle/sealed/mecha/ripley/paddy
-	movedelay = 4
-	slow_pressure_step_in = 4
-	fast_pressure_step_in = 2.5
+	movedelay = 2.5
+	slow_pressure_step_in = 3
+	fast_pressure_step_in = 2


### PR DESCRIPTION
## Что этот PR делает

Меняет модульные значения скорости сб-меха Падди к +- таким же, как на оффах, только чуточку быстрее

## Почему это хорошо для игры

Наш модуль делал из Падди машину для убийств, что бегает быстрее человека, т.е. от меха в узком коридоре никак не сбежать

## Изображения изменений

Не требуется

## Тестирование

Походила в мехе, скорость близка к боевым мехам, стал медленнее

## Changelog

<!-- Важно строго соблюдать ёмкость и стилистическую форму наполнения чейнджлога! -->

:cl:
balance: Скорость передвижения меха Падди была снижена.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
<!-- Пример хороших чейнджлогов:
add: В аплинк повара добавлен мануал CQC за 20 ТК.
admin: Добавлено новое Smite действие - "Сломать колени".
balance: Разлёт дроби 12 калибра, скаттер лазер шеллов, драконьего дыхания и резиновой дроби был увеличен.
code_imp: Число дополнительных необходимых шкафов СБ теперь вычисляется точнее.
config: Добавлена/убрана настройка слотов СБ через конфиг.
del: Удалена возможность рыбалки в лотках гидропоники.
fix: Исправлена ошибка, из-за которой неудачный вызов ОБР мог резко ухудшить производительность игры.
image: Изменены спрайты для револьверов .357
map: Добавлена новая игровая карта - Nebula Station.
qol: Смерть в мини-играх больше не сбрасывает таймер возрождения.
refactor: Значительно улучшено качество кода модульной TTS сабсистемы.
server: Flaky тесты перенесены на ubuntu-20.04.
sound: Добавлен новый звук для Гамма кода на станции.
translation: Добавлен перевод приёмов и сообщений в чат для Спящего Карпа.
typo: Исправлена опечатка в предыстории расы КПБ.
-->
