### PR TITLE
Spatial TTS backport

### DIFF
--- a/code/__DEFINES/tts.dm
+++ b/code/__DEFINES/tts.dm
@@ -9,11 +9,11 @@
 ///TTS filter to activate a silicon effect on speech.
 #define TTS_FILTER_SILICON "silicon"
 //Hear all TTS over radio.
-#define TTS_SOUND_ALL_RADIO "Enabled"
+#define TTS_SOUND_ALL_RADIO "Включен"
 //Hear all TTS over departmental radio channels only.
-#define TTS_SOUND_DEPARTMENTAL_RADIO "Departmental Radio Only"
+#define TTS_SOUND_DEPARTMENTAL_RADIO "Только радио отделов"
 //Hear no TTS over radio.
-#define TTS_SOUND_NO_RADIO "Disabled"
+#define TTS_SOUND_NO_RADIO "Выключен"
 //Flag for TTS ghost radio
 #define TTS_GHOST_RADIO "GHOST RADIO"
 #define TTS_BLIPS_MASCULINE "Masculine"

--- a/code/controllers/subsystem/tts.dm
+++ b/code/controllers/subsystem/tts.dm
@@ -633,7 +633,7 @@ SUBSYSTEM_DEF(tts)
 		return request.is_complete() && request_blips.is_complete() && request_blips_radio.is_complete() && request_radio.is_complete() && request_radio_gibberish.is_complete()
 
 /proc/filter_tts_listeners(list/listeners, radio_frequency = null)
-	if(!SStts.tts_enabled || !listeners)
+	if((!SStts.tts_enabled && !SStts220.is_enabled) || !listeners) // BANDASTATION EDIT: TTS radio listener filter
 		return
 
 	if(isweakref(listeners))

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -228,7 +228,7 @@
 	to_chat(src, compose_message(speaker, message_language, raw_message, radio_freq, freq_name, freq_color, spans, message_mods))
 	// BANDASTATION ADD Start - TTS
 	var/message_to_tts = LAZYACCESS(message_mods, MODE_TTS_MESSAGE_OVERRIDE) || raw_message
-	speaker.cast_tts(src, message_to_tts, is_radio = !!radio_freq, tts_seed_override = LAZYACCESS(message_mods, MODE_TTS_SEED_OVERRIDE), channel_override = radio_freq ? CHANNEL_TTS_RADIO : null)
+	speaker.cast_tts(src, message_to_tts, is_radio = !!radio_freq, tts_seed_override = LAZYACCESS(message_mods, MODE_TTS_SEED_OVERRIDE), channel_override = radio_freq ? CHANNEL_TTS_RADIO : null, radio_freq = radio_freq)
 	// BANDASTATION ADD End - TTS
 
 /mob/eye/imaginary_friend/send_speech(message, range = IMAGINARY_FRIEND_SPEECH_RANGE, obj/source = src, bubble_type = bubble_icon, list/spans = list(), datum/language/message_language = null, list/message_mods = list(), forced = null)

--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -174,17 +174,46 @@
 		if(get_chat_toggles(ghost.client) & CHAT_GHOSTRADIO)
 			receive |= ghost
 			if(LAZYACCESS(message_mods, MODE_TTS_IDENTIFIER))
-				receive_radios[TTS_GHOST_RADIO] |= ghost
+				receive_radios[TTS_GHOST_RADIO] |= WEAKREF(ghost) // BANDASTATION EDIT: TTS listener lists store weakrefs
 
 	// Render the message and have everybody hear it.
 	// Always call this on the virtualspeaker to avoid issues.
 	var/spans = data["spans"]
 
-	if(LAZYACCESS(message_mods, MODE_TTS_IDENTIFIER))
-		receive_radios[TTS_GHOST_RADIO] = filter_tts_listeners(receive_radios[TTS_GHOST_RADIO], frequency)
-		for(var/radio in receive_radios)
-			LAZYSET(SStts.queued_radio_messages[message_mods[MODE_TTS_IDENTIFIER]], radio, receive_radios[radio])
-		LAZYSET(SStts.queued_radio_messages_compression, message_mods[MODE_TTS_IDENTIFIER], compression)
+	// BANDASTATION EDIT START: TTS radio playback
+
+	// if(LAZYACCESS(message_mods, MODE_TTS_IDENTIFIER))
+	// 	receive_radios[TTS_GHOST_RADIO] = filter_tts_listeners(receive_radios[TTS_GHOST_RADIO], frequency)
+	// 	for(var/radio in receive_radios)
+	// 		LAZYSET(SStts.queued_radio_messages[message_mods[MODE_TTS_IDENTIFIER]], radio, receive_radios[radio])
+	// 	LAZYSET(SStts.queued_radio_messages_compression, message_mods[MODE_TTS_IDENTIFIER], compression)
+
+	// Play radio TTS from the receiving radio, not from the speaker
+	if(SStts220.is_enabled && LAZYACCESS(message_mods, MODE_TTS_IDENTIFIER) && frequency != FREQ_ENTERTAINMENT)
+		for(var/radio_ref in receive_radios)
+			var/atom/radio_source
+			if(radio_ref != TTS_GHOST_RADIO)
+				var/datum/weakref/radio_weakref = radio_ref
+				radio_source = radio_weakref.resolve()
+				if(QDELETED(radio_source))
+					continue
+			for(var/hearer_ref in receive_radios[radio_ref])
+				var/datum/weakref/hearer_weakref = hearer_ref
+				var/mob/radio_listener = hearer_weakref.resolve()
+				if(!radio_listener)
+					continue
+				virt.cast_tts(
+					radio_listener,
+					message,
+					location = radio_source,
+					is_local = !isnull(radio_source),
+					is_radio = TRUE,
+					effects = LAZYACCESS(message_mods, MODE_TTS_FILTERS),
+					tts_seed_override = LAZYACCESS(message_mods, MODE_TTS_SEED_OVERRIDE),
+					channel_override = CHANNEL_TTS_RADIO,
+					radio_freq = frequency,
+				)
+	// BANDASTATION EDIT END: TTS radio playback
 
 	for(var/atom/movable/hearer as anything in receive)
 		if(!hearer)

--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -174,7 +174,11 @@
 		if(get_chat_toggles(ghost.client) & CHAT_GHOSTRADIO)
 			receive |= ghost
 			if(LAZYACCESS(message_mods, MODE_TTS_IDENTIFIER))
-				receive_radios[TTS_GHOST_RADIO] |= WEAKREF(ghost) // BANDASTATION EDIT: TTS listener lists store weakrefs
+	// BANDASTATION EDIT START: TTS listener lists store weakrefs
+				receive_radios[TTS_GHOST_RADIO] |= WEAKREF(ghost)
+	if(LAZYACCESS(message_mods, MODE_TTS_IDENTIFIER))
+		receive_radios[TTS_GHOST_RADIO] = filter_tts_listeners(receive_radios[TTS_GHOST_RADIO], frequency)
+	// BANDASTATION EDIT END: TTS listener lists store weakrefs
 
 	// Render the message and have everybody hear it.
 	// Always call this on the virtualspeaker to avoid issues.
@@ -197,14 +201,20 @@
 				radio_source = radio_weakref.resolve()
 				if(QDELETED(radio_source))
 					continue
+			var/list/radio_listeners = list()
 			for(var/hearer_ref in receive_radios[radio_ref])
 				var/datum/weakref/hearer_weakref = hearer_ref
 				var/mob/radio_listener = hearer_weakref.resolve()
 				if(!radio_listener)
 					continue
+				var/message_to_tts = isobserver(radio_listener) ? message : radio_listener.translate_language(virt, language, message, spans, message_mods)
+				if(message_to_tts == message)
+					message_to_tts = LAZYACCESS(message_mods, MODE_TTS_MESSAGE_OVERRIDE) || message_to_tts
+				LAZYADD(radio_listeners[message_to_tts], radio_listener)
+			for(var/message_to_tts in radio_listeners)
 				virt.cast_tts(
-					radio_listener,
-					message,
+					radio_listeners[message_to_tts],
+					message_to_tts,
 					location = radio_source,
 					is_local = !isnull(radio_source),
 					is_radio = TRUE,

--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -106,6 +106,15 @@
 	copy.levels = levels
 	return copy
 
+// BANDASTATION EDIT START: tts_component gate
+/datum/signal/subspace/vocal/proc/should_queue_radio()
+	if(!SStts220.is_enabled || frequency == FREQ_ENTERTAINMENT)
+		return FALSE
+
+	var/atom/movable/signal_source = virt?.GetSource()
+	return !isnull(signal_source?.get_tts_seed())
+// BANDASTATION EDIT END: tts_component gate
+
 /// Past this amount of compression, the resulting gibberish will actually
 /// replace characters, making it even harder to understand.
 #define COMPRESSION_REPLACE_CHARACTER_THRESHOLD 30
@@ -162,21 +171,22 @@
 	for(var/obj/item/radio/called_radio as anything in radios)
 		called_radio.on_receive_message(data)
 	var/list/message_mods = data["mods"]
+	var/should_do_modular_radio_tts = should_queue_radio() // BANDASTATION EDIT: Modular radio TTS does not rely on MODE_TTS_IDENTIFIER
 	// From the list of radios, find all mobs who can hear those.
 	var/list/receive = get_hearers_in_radio_ranges(radios)
 	var/list/receive_radios = null
 
-	if(LAZYACCESS(message_mods, MODE_TTS_IDENTIFIER)) // only do this if we have a TTS identifier to save on perf
+	if(LAZYACCESS(message_mods, MODE_TTS_IDENTIFIER) || should_do_modular_radio_tts) // BANDASTATION EDIT: Modular radio TTS keys off tts_component, not legacy voice identifiers
 		receive_radios = get_hearers_in_radio_ranges_track_radios(radios, frequency)
 
+	// BANDASTATION EDIT START: TTS listener lists store weakrefs
 	// Add observers who have ghost radio enabled.
 	for(var/mob/dead/observer/ghost in GLOB.player_list)
 		if(get_chat_toggles(ghost.client) & CHAT_GHOSTRADIO)
 			receive |= ghost
-			if(LAZYACCESS(message_mods, MODE_TTS_IDENTIFIER))
-	// BANDASTATION EDIT START: TTS listener lists store weakrefs
+			if(LAZYACCESS(message_mods, MODE_TTS_IDENTIFIER) || should_do_modular_radio_tts)
 				receive_radios[TTS_GHOST_RADIO] |= WEAKREF(ghost)
-	if(LAZYACCESS(message_mods, MODE_TTS_IDENTIFIER))
+	if(LAZYACCESS(message_mods, MODE_TTS_IDENTIFIER) || should_do_modular_radio_tts)
 		receive_radios[TTS_GHOST_RADIO] = filter_tts_listeners(receive_radios[TTS_GHOST_RADIO], frequency)
 	// BANDASTATION EDIT END: TTS listener lists store weakrefs
 
@@ -193,7 +203,7 @@
 	// 	LAZYSET(SStts.queued_radio_messages_compression, message_mods[MODE_TTS_IDENTIFIER], compression)
 
 	// Play radio TTS from the receiving radio, not from the speaker
-	if(SStts220.is_enabled && LAZYACCESS(message_mods, MODE_TTS_IDENTIFIER) && frequency != FREQ_ENTERTAINMENT)
+	if(should_do_modular_radio_tts)
 		for(var/radio_ref in receive_radios)
 			var/atom/radio_source
 			if(radio_ref != TTS_GHOST_RADIO)

--- a/code/modules/mob/dead/observer/observer_say.dm
+++ b/code/modules/mob/dead/observer/observer_say.dm
@@ -90,7 +90,7 @@
 		avoid_highlighting = speaker == src)
 
 	// BANDASTATION ADDITION START - TTS
-	if(isnull(message_mods[MODE_CUSTOM_SAY_EMOTE]) && isnull(message_mods[MODE_CUSTOM_SAY_ERASE_INPUT]) && radio_freq != FREQ_ENTERTAINMENT)
+	if(isnull(message_mods[MODE_CUSTOM_SAY_EMOTE]) && isnull(message_mods[MODE_CUSTOM_SAY_ERASE_INPUT]) && !radio_freq)
 		var/tts_message = message_mods[MODE_TTS_MESSAGE_OVERRIDE] || raw_message
 		speaker.cast_tts(
 			src,

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -231,7 +231,9 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	var/tts_message_to_use = tts_message || message
 
 
-	if(SStts.tts_enabled && voice && !message_mods[MODE_CUSTOM_SAY_ERASE_INPUT] && !HAS_TRAIT(src, TRAIT_SIGN_LANG) && !HAS_TRAIT(src, TRAIT_UNKNOWN_VOICE))
+	// BANDASTATION EDIT START: TTS radio identifiers
+	if((SStts.tts_enabled || SStts220.is_enabled) && voice && !message_mods[MODE_CUSTOM_SAY_ERASE_INPUT] && !HAS_TRAIT(src, TRAIT_SIGN_LANG) && !HAS_TRAIT(src, TRAIT_UNKNOWN_VOICE))
+	// BANDASTATION EDIT END
 		var/list/filter = list()
 		var/list/special_filter = list()
 		if(length(voice_filter) > 0)
@@ -396,7 +398,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	var/show_message_success = show_message(message, MSG_AUDIBLE, deaf_message, deaf_type, avoid_highlight)
 
 	// BANDASTATION ADDITION START - TTS
-	if(show_message_success && radio_freq != FREQ_ENTERTAINMENT)
+	if(show_message_success && !radio_freq)
 		var/message_to_tts = LAZYACCESS(message_mods, MODE_TTS_MESSAGE_OVERRIDE) || raw_message
 		speaker.cast_tts(
 			src,

--- a/modular_bandastation/_defines220/code/signals_atom.dm
+++ b/modular_bandastation/_defines220/code/signals_atom.dm
@@ -1,6 +1,6 @@
 ///from base of atom/change_tts_seed(): (mob/chooser, override, list/new_sound_effects)
 #define COMSIG_ATOM_TTS_SEED_CHANGE "atom_tts_seed_change"
-///from base of atom/cast_tts(): (mob/listener, message, atom/location, is_local, is_radio, list/effects, traits, preSFX, postSFX, channel_override)
+///from base of atom/cast_tts(): (mob/listener, message, atom/location, is_local, is_radio, list/effects, traits, preSFX, postSFX, channel_override, radio_freq)
 #define COMSIG_ATOM_TTS_CAST "atom_tts_cast"
 ///from base of atom/tts_effects_add(): (trait)
 #define COMSIG_ATOM_TTS_EFFECTS_ADD "atom_tts_trait_add"

--- a/modular_bandastation/_defines220/code/signals_atom.dm
+++ b/modular_bandastation/_defines220/code/signals_atom.dm
@@ -1,6 +1,6 @@
 ///from base of atom/change_tts_seed(): (mob/chooser, override, list/new_sound_effects)
 #define COMSIG_ATOM_TTS_SEED_CHANGE "atom_tts_seed_change"
-///from base of atom/cast_tts(): (mob/listener, message, atom/location, is_local, is_radio, list/effects, traits, preSFX, postSFX, channel_override, radio_freq)
+///from base of atom/cast_tts(): (listener, message, atom/location, is_local, is_radio, list/effects, traits, preSFX, postSFX, channel_override, radio_freq)
 #define COMSIG_ATOM_TTS_CAST "atom_tts_cast"
 ///from base of atom/tts_effects_add(): (trait)
 #define COMSIG_ATOM_TTS_EFFECTS_ADD "atom_tts_trait_add"

--- a/modular_bandastation/tts/code/preferences/tts_preferences.dm
+++ b/modular_bandastation/tts/code/preferences/tts_preferences.dm
@@ -25,20 +25,6 @@
 		return create_informed_default_value(preferences)
 	return input
 
-/datum/preference/numeric/volume/sound_tts_volume_radio
-	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
-	savefile_key = "sound_tts_volume_radio"
-	savefile_identifier = PREFERENCE_PLAYER
-
-	minimum = 0
-	maximum = 200
-
-/datum/preference/numeric/volume/sound_tts_volume_radio/apply_to_client_updated(client/client, value)
-	client.mob.set_sound_channel_volume(CHANNEL_TTS_RADIO, value)
-
-/datum/preference/numeric/volume/sound_tts_volume_radio/create_default_value()
-	return maximum / 2
-
 /datum/preference/numeric/volume/sound_tts_volume_announcement
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 	savefile_key = "sound_tts_volume_announcement"

--- a/modular_bandastation/tts/code/tts_component.dm
+++ b/modular_bandastation/tts/code/tts_component.dm
@@ -147,7 +147,8 @@
 	postSFX,
 	tts_seed_override,
 	tts_channel_override,
-	check_deafness = TRUE
+	check_deafness = TRUE,
+	radio_freq
 )
 
 	SIGNAL_HANDLER
@@ -155,19 +156,29 @@
 	if(!message)
 		return
 	var/datum/preferences/prefs = listener?.client?.prefs
-	if(prefs?.read_preference(/datum/preference/choiced/sound_tts) != TTS_SOUND_ENABLED || prefs?.read_preference(/datum/preference/numeric/volume/sound_tts_volume) == 0)
+	var/volume_preference = is_radio ? /datum/preference/numeric/volume/sound_tts_radio_volume : /datum/preference/numeric/volume/sound_tts_volume
+	if(prefs?.read_preference(/datum/preference/choiced/sound_tts) != TTS_SOUND_ENABLED || prefs?.read_preference(volume_preference) == 0)
 		return
 	if(check_deafness && HAS_TRAIT(listener, TRAIT_DEAF))
 		return
 	if(!speaker)
 		speaker = parent
+	if(isnull(additional_effects))
+		additional_effects = list()
+	if(is_radio)
+		var/radio_tts_pref = prefs?.read_preference(/datum/preference/choiced/sound_tts_radio)
+		if(radio_tts_pref == TTS_SOUND_NO_RADIO)
+			return
+		if(radio_tts_pref == TTS_SOUND_DEPARTMENTAL_RADIO && radio_freq == FREQ_COMMON)
+			return
+		additional_effects |= /datum/singleton/sound_effect/radio
+		// Global to listener, not positioned at the speaker
+		if(!location)
+			is_local = FALSE
+		if(listener == speaker && !prefs?.read_preference(/datum/preference/toggle/sound_tts_hear_self_radio))
+			return
 	if(!location)
 		location = parent
-	if(is_radio)
-		additional_effects |= /datum/singleton/sound_effect/radio
-		is_local = FALSE
-		if(listener == speaker) // don't hear both radio and whisper from yourself
-			return
 
 	var/list/tts_args = list()
 	tts_args[TTS_CAST_SPEAKER] = speaker

--- a/modular_bandastation/tts/code/tts_component.dm
+++ b/modular_bandastation/tts/code/tts_component.dm
@@ -165,6 +165,8 @@
 		speaker = parent
 	if(isnull(additional_effects))
 		additional_effects = list()
+	else
+		additional_effects = additional_effects.Copy()
 	if(is_radio)
 		var/radio_tts_pref = prefs?.read_preference(/datum/preference/choiced/sound_tts_radio)
 		if(radio_tts_pref == TTS_SOUND_NO_RADIO)

--- a/modular_bandastation/tts/code/tts_component.dm
+++ b/modular_bandastation/tts/code/tts_component.dm
@@ -136,7 +136,7 @@
 
 /datum/component/tts_component/proc/cast_tts(
 	atom/speaker,
-	mob/listener,
+	listener,
 	message,
 	atom/location,
 	is_local = TRUE,
@@ -155,36 +155,37 @@
 
 	if(!message)
 		return
-	var/datum/preferences/prefs = listener?.client?.prefs
 	var/volume_preference = is_radio ? /datum/preference/numeric/volume/sound_tts_radio_volume : /datum/preference/numeric/volume/sound_tts_volume
-	if(prefs?.read_preference(/datum/preference/choiced/sound_tts) != TTS_SOUND_ENABLED || prefs?.read_preference(volume_preference) == 0)
-		return
-	if(check_deafness && HAS_TRAIT(listener, TRAIT_DEAF))
-		return
 	if(!speaker)
 		speaker = parent
+	var/list/input_listeners = islist(listener) ? listener : list(listener)
+	var/tts_listeners = list()
+	for(var/mob/current_listener as anything in input_listeners)
+		var/datum/preferences/prefs = current_listener?.client?.prefs
+		if(prefs?.read_preference(/datum/preference/choiced/sound_tts) != TTS_SOUND_ENABLED || prefs?.read_preference(volume_preference) == 0)
+			continue
+		if(check_deafness && HAS_TRAIT(current_listener, TRAIT_DEAF))
+			continue
+		if(is_radio && current_listener == speaker && !prefs.read_preference(/datum/preference/toggle/sound_tts_hear_self_radio))
+			continue
+		tts_listeners += current_listener
+	if(!length(tts_listeners))
+		return
 	if(isnull(additional_effects))
 		additional_effects = list()
 	else
 		additional_effects = additional_effects.Copy()
 	if(is_radio)
-		var/radio_tts_pref = prefs?.read_preference(/datum/preference/choiced/sound_tts_radio)
-		if(radio_tts_pref == TTS_SOUND_NO_RADIO)
-			return
-		if(radio_tts_pref == TTS_SOUND_DEPARTMENTAL_RADIO && radio_freq == FREQ_COMMON)
-			return
 		additional_effects |= /datum/singleton/sound_effect/radio
 		// Global to listener, not positioned at the speaker
 		if(!location)
 			is_local = FALSE
-		if(listener == speaker && !prefs?.read_preference(/datum/preference/toggle/sound_tts_hear_self_radio))
-			return
 	if(!location)
 		location = parent
 
 	var/list/tts_args = list()
 	tts_args[TTS_CAST_SPEAKER] = speaker
-	tts_args[TTS_CAST_LISTENER] = listener
+	tts_args[TTS_CAST_LISTENER] = tts_listeners
 	tts_args[TTS_CAST_MESSAGE] = message
 	tts_args[TTS_CAST_LOCATION] = location
 	tts_args[TTS_CAST_LOCAL] = is_local

--- a/modular_bandastation/tts/code/tts_seed.dm
+++ b/modular_bandastation/tts/code/tts_seed.dm
@@ -14,11 +14,11 @@
 	. = ..()
 	add_tts_component()
 
-/atom/proc/cast_tts(mob/listener, message, atom/location, is_local = TRUE, is_radio = FALSE, list/effects, traits = TTS_TRAIT_RATE_FASTER, preSFX, postSFX, tts_seed_override, channel_override, check_deafness)
-	SEND_SIGNAL(src, COMSIG_ATOM_TTS_CAST, listener, message, location, is_local, is_radio, effects, traits, preSFX, postSFX, tts_seed_override, channel_override, check_deafness)
+/atom/proc/cast_tts(mob/listener, message, atom/location, is_local = TRUE, is_radio = FALSE, list/effects, traits = TTS_TRAIT_RATE_FASTER, preSFX, postSFX, tts_seed_override, channel_override, check_deafness, radio_freq)
+	SEND_SIGNAL(src, COMSIG_ATOM_TTS_CAST, listener, message, location, is_local, is_radio, effects, traits, preSFX, postSFX, tts_seed_override, channel_override, check_deafness, radio_freq)
 
-/atom/movable/virtualspeaker/cast_tts(mob/listener, message, atom/location, is_local, is_radio, list/effects, traits, preSFX, postSFX, tts_seed_override, channel_override, check_deafness)
-	SEND_SIGNAL(source, COMSIG_ATOM_TTS_CAST, listener, message, location, is_local, is_radio, effects, traits, preSFX, postSFX, tts_seed_override, channel_override, check_deafness)
+/atom/movable/virtualspeaker/cast_tts(mob/listener, message, atom/location, is_local, is_radio, list/effects, traits, preSFX, postSFX, tts_seed_override, channel_override, check_deafness, radio_freq)
+	SEND_SIGNAL(source, COMSIG_ATOM_TTS_CAST, listener, message, location || (is_radio ? radio : null), is_local, is_radio, effects, traits, preSFX, postSFX, tts_seed_override, channel_override, check_deafness, radio_freq)
 
 // TODO: Do it better?
 /atom/proc/get_tts_seed()

--- a/modular_bandastation/tts/code/tts_seed.dm
+++ b/modular_bandastation/tts/code/tts_seed.dm
@@ -14,10 +14,10 @@
 	. = ..()
 	add_tts_component()
 
-/atom/proc/cast_tts(mob/listener, message, atom/location, is_local = TRUE, is_radio = FALSE, list/effects, traits = TTS_TRAIT_RATE_FASTER, preSFX, postSFX, tts_seed_override, channel_override, check_deafness, radio_freq)
+/atom/proc/cast_tts(listener, message, atom/location, is_local = TRUE, is_radio = FALSE, list/effects, traits = TTS_TRAIT_RATE_FASTER, preSFX, postSFX, tts_seed_override, channel_override, check_deafness, radio_freq)
 	SEND_SIGNAL(src, COMSIG_ATOM_TTS_CAST, listener, message, location, is_local, is_radio, effects, traits, preSFX, postSFX, tts_seed_override, channel_override, check_deafness, radio_freq)
 
-/atom/movable/virtualspeaker/cast_tts(mob/listener, message, atom/location, is_local, is_radio, list/effects, traits, preSFX, postSFX, tts_seed_override, channel_override, check_deafness, radio_freq)
+/atom/movable/virtualspeaker/cast_tts(listener, message, atom/location, is_local, is_radio, list/effects, traits, preSFX, postSFX, tts_seed_override, channel_override, check_deafness, radio_freq)
 	SEND_SIGNAL(source, COMSIG_ATOM_TTS_CAST, listener, message, location || (is_radio ? radio : null), is_local, is_radio, effects, traits, preSFX, postSFX, tts_seed_override, channel_override, check_deafness, radio_freq)
 
 // TODO: Do it better?

--- a/modular_bandastation/tts/code/tts_subsystem.dm
+++ b/modular_bandastation/tts/code/tts_subsystem.dm
@@ -396,7 +396,7 @@ SUBSYSTEM_DEF(tts220)
 	channel_override = null,
 )
 	var/static/alist/channel_to_preference = alist(
-		CHANNEL_TTS_RADIO = /datum/preference/numeric/volume/sound_tts_volume_radio,
+		CHANNEL_TTS_RADIO = /datum/preference/numeric/volume/sound_tts_radio_volume,
 		CHANNEL_TTS_ANNOUNCEMENT = /datum/preference/numeric/volume/sound_tts_volume_announcement,
 		CHANNEL_TTS_TELEPATHY = /datum/preference/numeric/volume/sound_tts_volume_telepathy
 	)
@@ -422,6 +422,9 @@ SUBSYSTEM_DEF(tts220)
 
 		return
 
+	if(!turf_source) // 3D sounds need a turf source to calculate position
+		return
+
 	play_sfx_if_exists(listener, preSFX, output)
 
 	// Reserve channel only for players
@@ -430,18 +433,39 @@ SUBSYSTEM_DEF(tts220)
 		if(speaking_mob.client)
 			output.channel = get_local_channel_by_owner(speaker)
 			output.wait = TRUE
-	listener.playsound_local(
-		turf_source,
-		vol = output.volume,
-		falloff_exponent = SOUND_FALLOFF_EXPONENT,
+	output.channel ||= SSsounds.random_available_channel()
+
+	if(speaker == listener)
+		listener.playsound_local(
+			turf_source,
+			vol = 100,
+			falloff_exponent = SOUND_FALLOFF_EXPONENT,
+			channel = output.channel,
+			pressure_affected = TRUE,
+			sound_to_use = output,
+			max_distance = SOUND_RANGE,
+			falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE,
+			distance_multiplier = 1,
+			use_reverb = TRUE,
+			wait = output.wait,
+			volume_preference = channel_volume_preference_path
+		)
+		play_sfx_if_exists(listener, postSFX, output)
+		return
+
+	new /datum/threed_sound(
+		speaker,
+		output,
+		list(listener),
+		volume = 100,
+		sound_range = SOUND_RANGE,
+		sound_length = SSsounds.get_sound_length(filename2play) || FILE_CLEANUP_DELAY,
 		channel = output.channel,
-		pressure_affected = TRUE,
-		sound_to_use = output,
-		max_distance = SOUND_RANGE,
+		preference_volume = channel_volume_preference_path,
+		preference_signal = channel_override == CHANNEL_TTS_RADIO ? COMSIG_MOB_TTS_RADIO_VOLUME_PREFERENCE_APPLIED : COMSIG_MOB_TTS_VOLUME_PREFERENCE_APPLIED,
+		falloff_exponent = SOUND_FALLOFF_EXPONENT,
 		falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE,
-		distance_multiplier = 1,
-		use_reverb = TRUE,
-		wait = output.wait
+		pressure_affected = TRUE
 	)
 
 	play_sfx_if_exists(listener, postSFX, output)
@@ -470,6 +494,7 @@ SUBSYSTEM_DEF(tts220)
 /datum/controller/subsystem/tts220/proc/clear_channel(owner)
 	SIGNAL_HANDLER
 
+	SSsounds.free_sound_channel(tts_local_channels_by_owner[owner])
 	tts_local_channels_by_owner -= owner
 
 /datum/controller/subsystem/tts220/proc/cleanup_tts_file(filename)

--- a/modular_bandastation/tts/code/tts_subsystem.dm
+++ b/modular_bandastation/tts/code/tts_subsystem.dm
@@ -494,7 +494,9 @@ SUBSYSTEM_DEF(tts220)
 /datum/controller/subsystem/tts220/proc/clear_channel(owner)
 	SIGNAL_HANDLER
 
-	SSsounds.free_sound_channel(tts_local_channels_by_owner[owner])
+	var/channel = tts_local_channels_by_owner[owner]
+	if(channel)
+		SSsounds.free_sound_channel(tts_local_channels_by_owner[channel])
 	tts_local_channels_by_owner -= owner
 
 /datum/controller/subsystem/tts220/proc/cleanup_tts_file(filename)

--- a/modular_bandastation/tts/code/tts_subsystem.dm
+++ b/modular_bandastation/tts/code/tts_subsystem.dm
@@ -186,6 +186,8 @@ SUBSYSTEM_DEF(tts220)
 
 	if(!apply_sound_effects(request.effects, request.original_filename, request.output_filename))
 		return
+	if(!CONFIG_GET(flag/tts_cache_enabled))
+		addtimer(CALLBACK(src, PROC_REF(cleanup_tts_file), request.output_filename), FILE_CLEANUP_DELAY)
 
 	for(var/datum/sound_effects_request/adjacent_request as anything in filename_requests)
 		adjacent_request.cb.InvokeAsync()
@@ -380,7 +382,7 @@ SUBSYSTEM_DEF(tts220)
 
 		filename_suffixes |= effect.suffix
 
-	sortTim(filename_suffixes, GLOBAL_PROC_REF(cmp_text_asc))
+	//sortTim(filename_suffixes, GLOBAL_PROC_REF(cmp_text_asc))
 
 	var/filename2play = "[pure_filename][filename_suffixes.Join()].ogg"
 

--- a/modular_bandastation/tts/code/tts_subsystem.dm
+++ b/modular_bandastation/tts/code/tts_subsystem.dm
@@ -496,7 +496,7 @@ SUBSYSTEM_DEF(tts220)
 
 	var/channel = tts_local_channels_by_owner[owner]
 	if(channel)
-		SSsounds.free_sound_channel(tts_local_channels_by_owner[channel])
+		SSsounds.free_sound_channel(channel)
 	tts_local_channels_by_owner -= owner
 
 /datum/controller/subsystem/tts220/proc/cleanup_tts_file(filename)

--- a/modular_bandastation/tts/code/tts_subsystem.dm
+++ b/modular_bandastation/tts/code/tts_subsystem.dm
@@ -382,7 +382,7 @@ SUBSYSTEM_DEF(tts220)
 
 		filename_suffixes |= effect.suffix
 
-	//sortTim(filename_suffixes, GLOBAL_PROC_REF(cmp_text_asc))
+	sortTim(filename_suffixes, GLOBAL_PROC_REF(cmp_text_asc))
 
 	var/filename2play = "[pure_filename][filename_suffixes.Join()].ogg"
 

--- a/modular_bandastation/tts/code/tts_subsystem.dm
+++ b/modular_bandastation/tts/code/tts_subsystem.dm
@@ -3,6 +3,8 @@
 #define TTS_JOB_REPLACEMENTS "tts_job_replacements"
 
 #define FILE_CLEANUP_DELAY 30 SECONDS
+#define TTS_CLIENT_PLAYBACK_BASE_OFFSET 0.5 SECONDS
+#define TTS_CLIENT_PLAYBACK_MAX_PING_OFFSET 3 SECONDS
 
 SUBSYSTEM_DEF(tts220)
 	name = "Text-to-Speech 220"
@@ -408,9 +410,13 @@ SUBSYSTEM_DEF(tts220)
 )
 	var/channel_volume_preference_path = get_volume_preference_for_channel(channel_override)
 	var/list/valid_listeners = list()
+	var/highest_ping = 0
 	for(var/mob/listener as anything in listeners)
-		if(listener?.client?.prefs?.read_preference(channel_volume_preference_path))
-			valid_listeners += listener
+		var/client/listener_client = listener?.client
+		if(!listener_client?.prefs?.read_preference(channel_volume_preference_path))
+			continue
+		valid_listeners += listener
+		highest_ping = max(highest_ping, listener_client.avgping || listener_client.lastping)
 	if(!length(valid_listeners))
 		return
 
@@ -453,6 +459,8 @@ SUBSYSTEM_DEF(tts220)
 		reserved_channel = SSsounds.reserve_sound_channel()
 		output.channel = reserved_channel || SSsounds.random_available_channel()
 	var/sound_length = SSsounds.get_sound_length(filename2play) || FILE_CLEANUP_DELAY
+	// Calculate threed_sound cleanup delay based on listeners avg ping
+	var/client_playback_offset = TTS_CLIENT_PLAYBACK_BASE_OFFSET + min(ceil(highest_ping / 100), TTS_CLIENT_PLAYBACK_MAX_PING_OFFSET)
 
 	if(self_listener)
 		self_listener.playsound_local(
@@ -477,7 +485,7 @@ SUBSYSTEM_DEF(tts220)
 			threed_listeners,
 			volume = 100,
 			sound_range = SOUND_RANGE,
-			sound_length = sound_length,
+			sound_length = sound_length + client_playback_offset,
 			channel = output.channel,
 			preference_volume = channel_volume_preference_path,
 			preference_signal = channel_override == CHANNEL_TTS_RADIO ? COMSIG_MOB_TTS_RADIO_VOLUME_PREFERENCE_APPLIED : COMSIG_MOB_TTS_VOLUME_PREFERENCE_APPLIED,
@@ -486,7 +494,7 @@ SUBSYSTEM_DEF(tts220)
 			pressure_affected = TRUE
 		)
 	if(reserved_channel)
-		addtimer(CALLBACK(SSsounds, TYPE_PROC_REF(/datum/controller/subsystem/sounds, free_sound_channel), reserved_channel), sound_length + 1, TIMER_DELETE_ME) // FIXME: This is sucks and sound length shouldn't be modified, get_sound_length() is unreliable
+		addtimer(CALLBACK(SSsounds, TYPE_PROC_REF(/datum/controller/subsystem/sounds, free_sound_channel), reserved_channel), sound_length + client_playback_offset, TIMER_DELETE_ME)
 
 	if(postSFX)
 		for(var/mob/listener as anything in valid_listeners)
@@ -647,3 +655,5 @@ SUBSYSTEM_DEF(tts220)
 #undef TTS_JOB_REPLACEMENTS
 
 #undef FILE_CLEANUP_DELAY
+#undef TTS_CLIENT_PLAYBACK_BASE_OFFSET
+#undef TTS_CLIENT_PLAYBACK_MAX_PING_OFFSET

--- a/modular_bandastation/tts/code/tts_subsystem.dm
+++ b/modular_bandastation/tts/code/tts_subsystem.dm
@@ -228,7 +228,7 @@ SUBSYSTEM_DEF(tts220)
 
 /datum/controller/subsystem/tts220/proc/get_tts(
 	atom/speaker,
-	mob/listener,
+	listener,
 	message,
 	datum/tts_seed/tts_seed,
 	is_local = TRUE,
@@ -238,14 +238,18 @@ SUBSYSTEM_DEF(tts220)
 	postSFX = null,
 	channel_override,
 )
-
 	set waitfor = FALSE
 
 	if(!is_enabled)
 		return
 	if(!message)
 		return
-	if(isnull(listener) || !listener.client)
+	var/list/listeners = islist(listener) ? listener : list(listener)
+	var/list/valid_listeners = list()
+	for(var/mob/current_listener as anything in listeners)
+		if(current_listener?.client)
+			valid_listeners += current_listener
+	if(!length(valid_listeners))
 		return
 	if(ispath(tts_seed) && SStts220.tts_seeds[initial(tts_seed.name)])
 		tts_seed = SStts220.tts_seeds[initial(tts_seed.name)]
@@ -288,11 +292,11 @@ SUBSYSTEM_DEF(tts220)
 	if(fexists("[filename].ogg"))
 		tts_reused++
 		tts_rrps_counter++
-		play_tts(speaker, listener, filename, is_local, effect_singletons, preSFX, postSFX, channel_override)
+		play_tts(speaker, valid_listeners, filename, is_local, effect_singletons, preSFX, postSFX, channel_override)
 		return
 
 	var/datum/callback/play_tts_cb = CALLBACK(\
-		src, PROC_REF(play_tts), speaker, listener, filename, is_local, effect_singletons, preSFX, postSFX, channel_override
+		src, PROC_REF(play_tts), speaker, valid_listeners, filename, is_local, effect_singletons, preSFX, postSFX, channel_override
 	)
 
 	if(LAZYLEN(tts_queue[filename]))
@@ -355,7 +359,7 @@ SUBSYSTEM_DEF(tts220)
 
 /datum/controller/subsystem/tts220/proc/play_tts(
 	atom/speaker,
-	mob/listener,
+	list/listeners,
 	pure_filename,
 	is_local = TRUE,
 	list/effects,
@@ -363,8 +367,7 @@ SUBSYSTEM_DEF(tts220)
 	postSFX = null,
 	channel_override = null,
 )
-
-	if(!listener?.client)
+	if(!length(listeners))
 		return
 
 	var/list/filename_suffixes = list()
@@ -380,63 +383,79 @@ SUBSYSTEM_DEF(tts220)
 	var/filename2play = "[pure_filename][filename_suffixes.Join()].ogg"
 
 	if(!length(effects) || fexists(filename2play))
-		output_tts(speaker, listener, filename2play, is_local, preSFX, postSFX, channel_override)
+		output_tts(speaker, listeners, filename2play, is_local, preSFX, postSFX, channel_override)
 		return
 
-	var/datum/callback/output_tts_cb = CALLBACK(src, PROC_REF(output_tts), speaker, listener, filename2play, is_local, preSFX, postSFX, channel_override)
+	var/datum/callback/output_tts_cb = CALLBACK(src, PROC_REF(output_tts), speaker, listeners, filename2play, is_local, preSFX, postSFX, channel_override)
 	queue_sound_effect_processing(pure_filename, effects, filename2play, output_tts_cb)
+
+/datum/controller/subsystem/tts220/proc/get_volume_preference_for_channel(channel_override)
+	var/static/alist/channel_to_preference = alist(
+		CHANNEL_TTS_RADIO = /datum/preference/numeric/volume/sound_tts_radio_volume,
+		CHANNEL_TTS_ANNOUNCEMENT = /datum/preference/numeric/volume/sound_tts_volume_announcement,
+		CHANNEL_TTS_TELEPATHY = /datum/preference/numeric/volume/sound_tts_volume_telepathy
+	)
+	return channel_to_preference[channel_override] || /datum/preference/numeric/volume/sound_tts_volume
 
 /datum/controller/subsystem/tts220/proc/output_tts(
 	atom/speaker,
-	mob/listener,
+	list/listeners,
 	filename2play,
 	is_local = TRUE,
 	preSFX = null,
 	postSFX = null,
 	channel_override = null,
 )
-	var/static/alist/channel_to_preference = alist(
-		CHANNEL_TTS_RADIO = /datum/preference/numeric/volume/sound_tts_radio_volume,
-		CHANNEL_TTS_ANNOUNCEMENT = /datum/preference/numeric/volume/sound_tts_volume_announcement,
-		CHANNEL_TTS_TELEPATHY = /datum/preference/numeric/volume/sound_tts_volume_telepathy
-	)
-
-	var/channel_volume_preference_path = channel_to_preference[channel_override] || /datum/preference/numeric/volume/sound_tts_volume
-	var/volume = listener?.client?.prefs?.read_preference(channel_volume_preference_path)
-	if(!volume)
+	var/channel_volume_preference_path = get_volume_preference_for_channel(channel_override)
+	var/list/valid_listeners = list()
+	for(var/mob/listener as anything in listeners)
+		if(listener?.client?.prefs?.read_preference(channel_volume_preference_path))
+			valid_listeners += listener
+	if(!length(valid_listeners))
 		return
 
 	var/turf/turf_source = get_turf(speaker)
 
 	var/sound/output = sound(filename2play)
 	output.status = SOUND_STREAM
-	output.volume = volume
 	if(!is_local || isnull(speaker))
 		output.wait = TRUE
 		output.environment = SOUND_ENVIRONMENT_NONE
 		output.channel = channel_override
-
-		play_sfx_if_exists(listener, preSFX, output)
-		SEND_SOUND(listener, output)
-		play_sfx_if_exists(listener, postSFX, output)
-
+		for(var/mob/listener as anything in valid_listeners)
+			output.volume = listener.client.prefs.read_preference(channel_volume_preference_path)
+			play_sfx_if_exists(listener, preSFX, output)
+			SEND_SOUND(listener, output)
+			play_sfx_if_exists(listener, postSFX, output)
 		return
 
 	if(!turf_source) // 3D sounds need a turf source to calculate position
 		return
 
-	play_sfx_if_exists(listener, preSFX, output)
+	for(var/mob/listener as anything in valid_listeners)
+		output.volume = listener.client.prefs.read_preference(channel_volume_preference_path)
+		play_sfx_if_exists(listener, preSFX, output)
 
-	// Reserve channel only for players
+	output.volume = 100
+	var/list/threed_listeners = valid_listeners
+	var/mob/self_listener
 	if(ismob(speaker))
 		var/mob/speaking_mob = speaker
+		if(speaking_mob in valid_listeners)
+			self_listener = speaking_mob
+			threed_listeners = valid_listeners.Copy()
+			threed_listeners -= self_listener
 		if(speaking_mob.client)
 			output.channel = get_local_channel_by_owner(speaker)
 			output.wait = TRUE
-	output.channel ||= SSsounds.random_available_channel()
+	var/reserved_channel
+	if(!output.channel)
+		reserved_channel = SSsounds.reserve_sound_channel()
+		output.channel = reserved_channel || SSsounds.random_available_channel()
+	var/sound_length = SSsounds.get_sound_length(filename2play) || FILE_CLEANUP_DELAY
 
-	if(speaker == listener)
-		listener.playsound_local(
+	if(self_listener)
+		self_listener.playsound_local(
 			turf_source,
 			vol = 100,
 			falloff_exponent = SOUND_FALLOFF_EXPONENT,
@@ -450,25 +469,28 @@ SUBSYSTEM_DEF(tts220)
 			wait = output.wait,
 			volume_preference = channel_volume_preference_path
 		)
-		play_sfx_if_exists(listener, postSFX, output)
-		return
 
-	new /datum/threed_sound(
-		speaker,
-		output,
-		list(listener),
-		volume = 100,
-		sound_range = SOUND_RANGE,
-		sound_length = SSsounds.get_sound_length(filename2play) || FILE_CLEANUP_DELAY,
-		channel = output.channel,
-		preference_volume = channel_volume_preference_path,
-		preference_signal = channel_override == CHANNEL_TTS_RADIO ? COMSIG_MOB_TTS_RADIO_VOLUME_PREFERENCE_APPLIED : COMSIG_MOB_TTS_VOLUME_PREFERENCE_APPLIED,
-		falloff_exponent = SOUND_FALLOFF_EXPONENT,
-		falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE,
-		pressure_affected = TRUE
-	)
+	if(length(threed_listeners)) // Empty 3d sounds do not pick up listeners anyways
+		new /datum/threed_sound(
+			speaker,
+			output,
+			threed_listeners,
+			volume = 100,
+			sound_range = SOUND_RANGE,
+			sound_length = sound_length,
+			channel = output.channel,
+			preference_volume = channel_volume_preference_path,
+			preference_signal = channel_override == CHANNEL_TTS_RADIO ? COMSIG_MOB_TTS_RADIO_VOLUME_PREFERENCE_APPLIED : COMSIG_MOB_TTS_VOLUME_PREFERENCE_APPLIED,
+			falloff_exponent = SOUND_FALLOFF_EXPONENT,
+			falloff_distance = SOUND_DEFAULT_FALLOFF_DISTANCE,
+			pressure_affected = TRUE
+		)
+	if(reserved_channel)
+		addtimer(CALLBACK(SSsounds, TYPE_PROC_REF(/datum/controller/subsystem/sounds, free_sound_channel), reserved_channel), sound_length + 1, TIMER_DELETE_ME) // FIXME: This is sucks and sound length shouldn't be modified, get_sound_length() is unreliable
 
-	play_sfx_if_exists(listener, postSFX, output)
+	if(postSFX)
+		for(var/mob/listener as anything in valid_listeners)
+			play_sfx(listener, postSFX, listener.client.prefs.read_preference(channel_volume_preference_path), output.environment, output.channel)
 
 /datum/controller/subsystem/tts220/proc/play_sfx_if_exists(mob/listener, sfx, sound/output)
 	if(sfx)

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/sounds.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/sounds.tsx
@@ -74,20 +74,21 @@ export const sound_tts: FeatureChoiced = {
 };
 
 export const sound_tts_radio: FeatureChoiced = {
-  name: 'Enable TTS Over Radio',
-  category: 'SOUND',
+  name: 'TTS - Включить поверх радио',
+  category: 'Звук',
   description: `
-    When enabled, be able to hear text-to-speech sounds in game over radio channels.
-    When set to "Departmental Radio Only", text to speech over the radio will only play for departmental radio channels. Anything that isn't Common.
-    When disabled, text to speech will not play over radio sources.
+    Когда включено, вы будете слышать text-to-speech звуки в игре поверх радио каналов.
+    Когда режим выставлен в "Только радио отделов", text-to-speech звуки поверх радио будут слышны только для каналов отделов, и любых частот которые не являются Общей.
+    Когда выключено, text-to-speech не будет слышно поверх радио.
   `,
   component: FeatureDropdownInput,
 };
 
 export const sound_tts_hear_self_radio: FeatureToggle = {
-  name: 'Enable TTS Hear Self Over Radio',
-  category: 'SOUND',
-  description: 'When enabled, hear yourself over the radio when Text to Speech and TTS Over Radio is enabled.',
+  name: 'TTS - слышать себя в рации',
+  category: 'Звук',
+  description:
+    'Когда включено, вы будете слышать себя в рации когда говорите в неё.',
   component: CheckboxInput,
 };
 
@@ -95,13 +96,6 @@ export const sound_tts_volume: Feature<number> = {
   name: 'TTS - громкость',
   category: 'Звук',
   description: 'Громкость text-to-speech.',
-  component: FeatureSliderInput,
-};
-
-export const sound_tts_volume_radio: Feature<number> = {
-  name: 'TTS - громкость рации',
-  category: 'Звук',
-  description: 'Громкость text-to-speech для рации.',
   component: FeatureSliderInput,
 };
 
@@ -120,9 +114,10 @@ export const sound_tts_volume_telepathy: Feature<number> = {
 };
 
 export const sound_tts_radio_volume: Feature<number> = {
-  name: 'TTS Radio Volume',
-  category: 'SOUND',
-  description: 'The volume that radio text-to-speech sounds will play at. This is independent of regular TTS volume.',
+  name: 'TTS - громкость рации',
+  category: 'Звук',
+  description:
+    'Громкость text-to-speech для рации. Громкость независима от обычной громкости text-to-speech.',
   component: FeatureSliderInput,
 };
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Бэкпорт реворка TTS системы [95369](https://redirect.github.com/tgstation/tgstation/pull/95369) под модульную `SStts220`, который включает позиционирование звуков и проигрывание речи поверх радио при помощи `/datum/threed_sound`.

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, эти изменения следует добавить в игру. -->
TTS теперь работает с новым апстримным поведением звука: локальная речь позиционируется в мире, а свою речь по радио можно слышать в рации в зависимости от настроек.

Игроки получают ожидаемые настройки для радио TTS, доступна настройка слышимости себя по радио, ограничение проигрывания своей речи отделами каналов и громкость рации.

## Изображения изменений

<!-- Если изменения затрагивают визуал/спрайты/карты - прикрепите скриншоты, вставьте видео или иным образом визуализируйте изменения. -->
Не требуется, визуальных изменений нет.

## Тестирование

<!-- Опишите процесс тестирования - каким образом и что вы проверяли в своих изменениях. В этой секции недостаточно просто указать "Локально". -->

Длительный тест-мёрдж.

Проверено локально:
- Воспроизведение TTS звуков локально, в радио, в гостах, от принимающей рации,
- Кэш/очистка кэша,
- Позиционирование относительно говорящего в пространстве,
- Слышимость своей речи по радио, слышимость в режиме "Только радио отделов",
- Настройка громкости рации,
- Частично корнер кейсы, слышимость звуков при низкой атмосфере.

## Changelog

<!-- Важно строго соблюдать ёмкость и стилистическую форму наполнения чейнджлога! -->

:cl:
add: TTS теперь поддерживает позиционирование звука и отдельные настройки речи по радио. Доступны настройки слышимости своей речи для общего канала и каналов отделов.
translation: Переведены настройки в категории "Звук".
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
<!-- Пример хороших чейнджлогов:
add: В аплинк повара добавлен мануал CQC за 20 ТК.
admin: Добавлено новое Smite действие - "Сломать колени".
balance: Разлёт дроби 12 калибра, скаттер лазер шеллов, драконьего дыхания и резиновой дроби был увеличен.
code_imp: Число дополнительных необходимых шкафов СБ теперь вычисляется точнее.
config: Добавлена/убрана настройка слотов СБ через конфиг.
del: Удалена возможность рыбалки в лотках гидропоники.
fix: Исправлена ошибка, из-за которой неудачный вызов ОБР мог резко ухудшить производительность игры.
image: Изменены спрайты для револьверов .357
map: Добавлена новая игровая карта - Nebula Station.
qol: Смерть в мини-играх больше не сбрасывает таймер возрождения.
refactor: Значительно улучшено качество кода модульной TTS сабсистемы.
server: Flaky тесты перенесены на ubuntu-20.04.
sound: Добавлен новый звук для Гамма кода на станции.
translation: Добавлен перевод приёмов и сообщений в чат для Спящего Карпа.
typo: Исправлена опечатка в предыстории расы КПБ.
-->
