### PR TITLE
Del: Odd vendors in maint spawner

### DIFF
--- a/code/game/objects/effects/spawners/random/engineering.dm
+++ b/code/game/objects/effects/spawners/random/engineering.dm
@@ -121,7 +121,7 @@
 	loot = list(
 		/obj/effect/spawner/random/engineering/vending_restock/common = 935,
 		/obj/effect/spawner/random/engineering/vending_restock/rare = 60,
-		// /obj/effect/spawner/random/engineering/vending_restock/oddity = 5, // BANDASTATION REMOVAL: removed trash vendors on station
+		// /obj/effect/spawner/random/engineering/vending_restock/oddity = 5, // BANDASTATION EDIT: Remove bad vendors on the station
 	)
 
 /obj/effect/spawner/random/engineering/vending_restock/wardrobe

--- a/code/game/objects/effects/spawners/random/engineering.dm
+++ b/code/game/objects/effects/spawners/random/engineering.dm
@@ -121,7 +121,7 @@
 	loot = list(
 		/obj/effect/spawner/random/engineering/vending_restock/common = 935,
 		/obj/effect/spawner/random/engineering/vending_restock/rare = 60,
-		/obj/effect/spawner/random/engineering/vending_restock/oddity = 5,
+		// /obj/effect/spawner/random/engineering/vending_restock/oddity = 5, // BANDASTATION REMOVAL: removed trash vendors on station
 	)
 
 /obj/effect/spawner/random/engineering/vending_restock/wardrobe


### PR DESCRIPTION
## Что этот PR делает
Удаляет из возможного спавна в техах неадекватные вендор-рестоки.

## Почему это хорошо для игры
В техах не должно лежать вендора с ЦКшными вещами (костюмы и плащи с высокими дефами, рапиры с 95% блока, пенетрой и 50 брута) и кучей оружия (включая админский ARG и диглы).
<img width="545" height="63" alt="image" src="https://github.com/user-attachments/assets/b588dabc-74f3-4d70-9b55-1053bbe120d5" />


## Тестирование
Сбилдил, зашёл на локалку, в спавнере не было удалённого лута.

## Changelog

:cl:
del: В техах больше нельзя найти ресток для ЦКшного, магического и "либерального" вендора.
/:cl: