### PR TITLE
FIX: Adjusting accessory rings

### DIFF
--- a/modular_bandastation/objects/code/items/clothing/accessories/gloves_accessories.dm
+++ b/modular_bandastation/objects/code/items/clothing/accessories/gloves_accessories.dm
@@ -47,7 +47,7 @@
 
 	attached_to.update_accessory_overlay()
 
-/obj/item/clothing/accessory/gloves_accessory/attach(obj/item/clothing/gloves/attach_to, mob/living/attacher)
+/obj/item/clothing/accessory/gloves_accessory/try_attach(obj/item/clothing/gloves/attach_to, mob/living/attacher)
 	. = ..()
 	if(!minimize_when_attached)
 		return

--- a/modular_bandastation/objects/code/items/clothing/gloves/gloves.dm
+++ b/modular_bandastation/objects/code/items/clothing/gloves/gloves.dm
@@ -54,11 +54,8 @@
 		return
 	if(user && !user.temporarilyRemoveItemFromInventory(accessory))
 		return
-	if(!accessory.attach(src, user))
+	if(!accessory.try_attach(src, user))
 		return
-
-	LAZYADD(attached_accessories, accessory)
-	accessory.forceMove(src)
 
 	accessory.attach(src)
 


### PR DESCRIPTION

## Что этот PR делает

Исправляет проблемы некорректного отображения и увеличения спрайтов у кольца-аксессуара после некоторых апстримов.

## Почему это хорошо для игры

Аквариум Рыбы попытались залить обновами, но теперь он спасён 

## Изображения изменений

Не требуется

## Тестирование

Локально, аксессуар до изменений терял иконку при надевании на перчатки и после снятия - увеличивался пропорционально в размерах по спрайту. Сейчас этого нет

## Changelog

:cl:
fix: Исправлена ошибка, при которой кольцо-аксессуар некорректно отображалось в слоте перчаток и пропорционально увеличивалось в размерах после каждого снятия.
/:cl:
