### PR TITLE
Tweak SSC whitelist check

### DIFF
--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -15,14 +15,13 @@
 		mind.set_current(src)
 
 	// Check if user should be added to interview queue
+	// BANDASTATION ADDITION - START
 	if (!client.holder && CONFIG_GET(flag/panic_bunker) && CONFIG_GET(flag/panic_bunker_interview) && !(client.ckey in GLOB.interviews.approved_ckeys))
 		var/required_living_minutes = CONFIG_GET(number/panic_bunker_living)
-		var/living_minutes = client.get_exp_living(TRUE)
-		if (required_living_minutes >= living_minutes)
-			client.interviewee = TRUE
+		if (required_living_minutes >= client.get_exp_living(TRUE))
+			if (!SScentral.can_run() || !SScentral.is_player_whitelisted(ckey))
+				client.interviewee = TRUE
 
-	// BANDASTATION ADDITION - START
-	check_whitelist_or_make_interviewee()
 	SStitle.show_title_screen_to(client)
 	// BANDASTATION ADDITION - END
 	. = ..()

--- a/config/bandastation/bandastation_config.txt
+++ b/config/bandastation/bandastation_config.txt
@@ -15,6 +15,8 @@ AI_SECRETARY_MODEL gpt-oss:20b-cloud
 ## SS Central
 #SS_CENTRAL_URL http://127.0.0.1:8000/v1
 #SS_CENTRAL_TOKEN 12345678
+## Uncomment to enable SS Central whitelist integration.
+## Empty value or "default" means no integration.
 #SERVER_TYPE default
 #FORCE_DISCORD_VERIFICATION
 ## Entry from the general config.txt

--- a/config/bandastation/bandastation_config.txt
+++ b/config/bandastation/bandastation_config.txt
@@ -15,14 +15,8 @@ AI_SECRETARY_MODEL gpt-oss:20b-cloud
 ## SS Central
 #SS_CENTRAL_URL http://127.0.0.1:8000/v1
 #SS_CENTRAL_TOKEN 12345678
-## Uncomment to enable SS Central whitelist integration.
-## Empty value or "default" means no integration.
-#SERVER_TYPE default
+
 #FORCE_DISCORD_VERIFICATION
-## Entry from the general config.txt
-## New behavior - enabled PANIC_BUNKER_INTERVIEW allows only whitelisted players to play, passing interview gives a year long whitelist
-#USEWHITELIST
-#PANIC_BUNKER_INTERVIEW
 
 ## A minimum amount of security required on roundstart
 ## If there is less security than this value, a percent of roundstart threat will be pushed to midround

--- a/config/config.txt
+++ b/config/config.txt
@@ -181,8 +181,12 @@ IPINTEL_REJECT_BAD
 ## byond membership starts at $10 for 3 months, so to use the webclient to evade, they would have sink 10 bucks in each evade.
 #WEBCLIENT_ONLY_BYOND_MEMBERS
 
-## Set to prevent anyone but those ckeys listed in config/whitelist.txt and config/admins.txt from joining your server
+## Set to prevent anyone but whitelisted ckeys from joining the server.
+## Requires SS Central whitelist integration (SERVER_TYPE configured).
 #USEWHITELIST
+## Uncomment to enable SS Central whitelist integration.
+## Empty value or "default" means no integration and will end with every player being not whitelisted.
+#SERVER_TYPE default
 
 ## The address shown for the game server in the TGS check command
 # PUBLIC_ADDRESS ss13.example.com:2506
@@ -334,6 +338,7 @@ NOTIFY_NEW_PLAYER_ACCOUNT_AGE 1
 
 ## Uncomment to enable the interview system for players who are below the living hour requirement instead of explicitly blocking them from the server
 ## Note this requires the PANIC_BUNKER to be enabled to do anything.
+## Bandastation: players bypass the interview if they have enough PANIC_BUNKER_LIVING playtime OR are whitelisted.
 #PANIC_BUNKER_INTERVIEW
 
 ## If a player connects during a bunker with less then or this amount of living time (Minutes), we deny the connection

--- a/config/config.txt
+++ b/config/config.txt
@@ -182,6 +182,7 @@ IPINTEL_REJECT_BAD
 #WEBCLIENT_ONLY_BYOND_MEMBERS
 
 ## Set to prevent anyone but whitelisted ckeys from joining the server.
+## Connection attempts from non-whitelisted ckeys will be rejected.
 ## Requires SS Central whitelist integration (SERVER_TYPE configured).
 #USEWHITELIST
 ## Uncomment to enable SS Central whitelist integration.
@@ -338,7 +339,7 @@ NOTIFY_NEW_PLAYER_ACCOUNT_AGE 1
 
 ## Uncomment to enable the interview system for players who are below the living hour requirement instead of explicitly blocking them from the server
 ## Note this requires the PANIC_BUNKER to be enabled to do anything.
-## Bandastation: players bypass the interview if they have enough PANIC_BUNKER_LIVING playtime OR are whitelisted.
+## Players bypass the interview if they have enough PANIC_BUNKER_LIVING playtime OR are whitelisted.
 #PANIC_BUNKER_INTERVIEW
 
 ## If a player connects during a bunker with less then or this amount of living time (Minutes), we deny the connection

--- a/modular_bandastation/metaserver/code/interview.dm
+++ b/modular_bandastation/metaserver/code/interview.dm
@@ -1,18 +1,3 @@
-/// Doesnt need the panic bunker to work
-/mob/dead/new_player/proc/check_whitelist_or_make_interviewee()
-	if(!CONFIG_GET(flag/panic_bunker_interview))
-		return
-
-	if(!SScentral.can_run())
-		stack_trace("Using whitelists and interviews without SS Central is not supported")
-		return
-
-	if(SScentral.is_player_whitelisted(ckey))
-		client.interviewee = FALSE
-		return
-
-	client.interviewee = TRUE
-
 /datum/config_entry/string/interview_webhook_url
 	protection = CONFIG_ENTRY_LOCKED | CONFIG_ENTRY_HIDDEN
 

--- a/modular_bandastation/metaserver/code/ss_central.dm
+++ b/modular_bandastation/metaserver/code/ss_central.dm
@@ -113,10 +113,14 @@ SUBSYSTEM_DEF(central)
 
 /// WARNING: only semi async - UNTIL based
 /datum/controller/subsystem/central/proc/is_player_whitelisted(ckey)
+	var/server_type = CONFIG_GET(string/server_type)
+	if(!server_type || server_type == /datum/config_entry/string/server_type::default)
+		return TRUE
+
 	if(ckey in GLOB.whitelist)
 		return TRUE
 
-	var/endpoint = "[CONFIG_GET(string/ss_central_url)]/whitelists?server_type=[CONFIG_GET(string/server_type)]&ckey=[ckey]&page=1&page_size=1"
+	var/endpoint = "[CONFIG_GET(string/ss_central_url)]/whitelists?server_type=[server_type]&ckey=[ckey]&page=1&page_size=1"
 	var/datum/http_response/response = SShttp.make_sync_request(RUSTG_HTTP_METHOD_GET, endpoint, "", list())
 	if(response.errored || response.status_code != 200 && response.status_code != 404)
 		stack_trace("Failed to check whitelist: HTTP error - [response.error]")

--- a/modular_bandastation/metaserver/code/ss_central.dm
+++ b/modular_bandastation/metaserver/code/ss_central.dm
@@ -115,7 +115,8 @@ SUBSYSTEM_DEF(central)
 /datum/controller/subsystem/central/proc/is_player_whitelisted(ckey)
 	var/server_type = CONFIG_GET(string/server_type)
 	if(!server_type || server_type == /datum/config_entry/string/server_type::default)
-		return TRUE
+		// Whitelist is not configured properly, assume player is not whitelisted
+		return FALSE
 
 	if(ckey in GLOB.whitelist)
 		return TRUE


### PR DESCRIPTION
## Что этот PR делает
Объединяет логику проверки вайтлиста с основным процессом бункера ТГ. От игроков теперь требуется анкета, только если у них нет необходимого плейтайма и они не добавлены в вайтлист. Изменяет поведение по умолчанию, когда SSC не настроен на обработку игроков как не внесенных в белый список.
Обновляет соответствующую конфигурацию.

## Почему это хорошо для игры
Более гибкая конфигурация бункера.

## Тестирование
Нет

## Changelog

:cl: Maxiemar
config: Улучшена конфигурация бункера, соответствующего анкетирования и вайтлиста.
/:cl:
