### PR TITLE
Add skrell mutation toxin

### DIFF
--- a/modular_bandastation/species/code/reagents/mutation.dm
+++ b/modular_bandastation/species/code/reagents/mutation.dm
@@ -27,7 +27,7 @@
 /datum/reagent/mutationtoxin/skrell
 	name = "Skrell Mutation Toxin"
 	description = "Мутационный токсин для превращения в скрелла."
-	color = "#949494"
+	color = "#00bfff"
 	race = /datum/species/skrell
 	taste_description = "соли"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED

--- a/modular_bandastation/species/code/reagents/mutation.dm
+++ b/modular_bandastation/species/code/reagents/mutation.dm
@@ -23,3 +23,16 @@
 	results = list(/datum/reagent/mutationtoxin/tajaran = 1)
 	required_reagents = list(/datum/reagent/consumable/cream = 1)
 	required_container = /obj/item/slime_extract/green
+
+/datum/reagent/mutationtoxin/skrell
+	name = "Skrell Mutation Toxin"
+	description = "Мутационный токсин для превращения в скрелла."
+	color = "#949494"
+	race = /datum/species/skrell
+	taste_description = "соли"
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+
+/datum/chemical_reaction/slime/slimeskrell
+	results = list(/datum/reagent/mutationtoxin/skrell = 1)
+	required_reagents = list(/datum/reagent/water/salt = 1)
+	required_container = /obj/item/slime_extract/green


### PR DESCRIPTION
## Что этот PR делает

Добавляет в рецепты с зеленым экстрактом токсин мутации в скрелла.

## Почему это хорошо для игры

Большинство рас имеет токсин мутации, кроме скреллов и https://discord.com/channels/1097181193939730453/1530238837647740938

## Изображения изменений

<img width="607" height="271" alt="Screenshot_59" src="https://github.com/user-attachments/assets/3cec4d59-fdcc-4fc3-8035-b703ae8c0978" />
<img width="125" height="121" alt="Screenshot_60" src="https://github.com/user-attachments/assets/ab8e6a36-2fcf-4c26-a17f-cc7af58f265d" />

## Тестирование

Соленая водичка -> зеленый экстракт -> скрелл токсин -> кольнуть человечка -> скрелл

## Changelog

<!-- Важно строго соблюдать ёмкость и стилистическую форму наполнения чейнджлога! -->

:cl:
add: Добавлен токсин мутации в скрелла, который можно получить путем добавления солёной воды в зелёный слаймовый экстракт.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
<!-- Пример хороших чейнджлогов:
add: В аплинк повара добавлен мануал CQC за 20 ТК.
admin: Добавлено новое Smite действие - "Сломать колени".
balance: Разлёт дроби 12 калибра, скаттер лазер шеллов, драконьего дыхания и резиновой дроби был увеличен.
code_imp: Число дополнительных необходимых шкафов СБ теперь вычисляется точнее.
config: Добавлена/убрана настройка слотов СБ через конфиг.
del: Удалена возможность рыбалки в лотках гидропоники.
fix: Исправлена ошибка, из-за которой неудачный вызов ОБР мог резко ухудшить производительность игры.
image: Изменены спрайты для револьверов .357
map: Добавлена новая игровая карта - Nebula Station.
qol: Смерть в мини-играх больше не сбрасывает таймер возрождения.
refactor: Значительно улучшено качество кода модульной TTS сабсистемы.
server: Flaky тесты перенесены на ubuntu-20.04.
sound: Добавлен новый звук для Гамма кода на станции.
translation: Добавлен перевод приёмов и сообщений в чат для Спящего Карпа.
typo: Исправлена опечатка в предыстории расы КПБ.
-->
