### PR TITLE
Случайные профессии у антагонистов

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -526,7 +526,7 @@ SUBSYSTEM_DEF(job)
 	job_debug("DO: Handle unrejectable unassigned")
 	//Mop up people who can't leave.
 	for(var/mob/dead/new_player/player in unassigned) //Players that wanted to back out but couldn't because they're antags (can you feel the edge case?)
-		if(!give_priority_job(player)) /// BANDASTATION EDIT - Job Priority Staffing
+		if(!give_random_job(player)) /// BANDASTATION EDIT - Job Priority Staffing
 			if(!assign_role(player, get_job_type(overflow_role))) //If everything is already filled, make them an assistant
 				job_debug("DO: Forced antagonist could not be assigned any random job or the overflow role. divide_occupations failed.")
 				job_debug("---------------------------------------------------")

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -526,7 +526,7 @@ SUBSYSTEM_DEF(job)
 	job_debug("DO: Handle unrejectable unassigned")
 	//Mop up people who can't leave.
 	for(var/mob/dead/new_player/player in unassigned) //Players that wanted to back out but couldn't because they're antags (can you feel the edge case?)
-		if(!give_random_job(player)) /// BANDASTATION EDIT - Job Priority Staffing
+		if(!give_random_job(player))
 			if(!assign_role(player, get_job_type(overflow_role))) //If everything is already filled, make them an assistant
 				job_debug("DO: Forced antagonist could not be assigned any random job or the overflow role. divide_occupations failed.")
 				job_debug("---------------------------------------------------")


### PR DESCRIPTION
## Что этот PR делает

Не получившие профессию антагонисты в начале мача, будут получать случайную профессию из всех доступных.

## Почему это хорошо для игры

Я заметил, что при выборе roundstart-трейтора мне почти всегда выдаётся химик, пока его слот свободен.
Для игрока, который не получил обычную профессию и не может быть возвращён в лобби, вызывается [give_priority_job()](https://github.com/ss220club/BandaStation/blob/master/modular_bandastation/jobs/code/controller/subsystem/job.dm#L9-L38)

Фактически пул выбранных профессий составляли только:

Инженер станции;
Врач;
Химик;
Ботаник;
Повар;
Учёный;
Шахтёр.

Система учитывает при сортировке количество человек на профессии на шахтере, враче, учёным, инженере - почти всегда будет хотя бы 1 человек. Поэтому выбор был только из Химик, Ботаник, Повар.

Старая система дарила мне боль и уныние заставляя играть 7 раз из 7 на химики. Я так больше не могу.


## Тестирование
Не было тестирования 

## Changelog

:cl:
fix: Исправлено детерминированное поведение выдачи ролей для антагонистов, теперь антагонист будет получать случайную роль вместо приоритетной.
/:cl: