### PR TITLE
FIX: Jelly for jelly

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1437,7 +1437,7 @@
 	var/heal = -0.75 * metabolization_ratio * seconds_per_tick
 	// BANDASTATION EDIT: START - jelly for jelly
 	if(!isjellyperson(affected_mob))
-		heal *= -1
+		heal *= -0.5
 	// BANDASTATION EDIT: END
 	var/need_mob_update
 	need_mob_update = affected_mob.adjust_brute_loss(heal, updating_health = FALSE, required_bodytype = affected_bodytype)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1435,6 +1435,10 @@
 /datum/reagent/medicine/regen_jelly/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, metabolization_ratio)
 	. = ..()
 	var/heal = -0.75 * metabolization_ratio * seconds_per_tick
+	// BANDASTATION EDIT: START - jelly for jelly
+	if(!isjellyperson(affected_mob))
+		heal *= -1
+	// BANDASTATION EDIT: END
 	var/need_mob_update
 	need_mob_update = affected_mob.adjust_brute_loss(heal, updating_health = FALSE, required_bodytype = affected_bodytype)
 	need_mob_update += affected_mob.adjust_fire_loss(heal, updating_health = FALSE, required_bodytype = affected_bodytype)


### PR DESCRIPTION
## Что этот PR делает
Делает regenerative jelly эксклюзивным удовольствием для jellyperson, согласно описанию реагента.
<img width="2098" height="801" alt="image" src="https://github.com/user-attachments/assets/6025e3c1-1e73-48df-adcb-252c2f73d200" />

## Почему это хорошо для игры
Реагент, доступный всем, без передозировок и негативных эффектов - плохо.

## Тестирование
Залил реагент хуману, тот начал погибать. Залил реагент слаймперсоне, тот начал регенить.

## Changelog
:cl:
fix: Regenerative Jelly лечит слаймперсон и наносит вред всем остальным.
/:cl: