### PR TITLE
Balance: DragNET damage increased

### DIFF
--- a/modular_bandastation/balance/code/weapons/dragnet.dm
+++ b/modular_bandastation/balance/code/weapons/dragnet.dm
@@ -2,4 +2,4 @@
 	damage = 15
 
 /obj/projectile/beam/disabler/scatter
-	damage = 2.6
+	damage = 5

--- a/modular_bandastation/balance/code/weapons/dragnet.dm
+++ b/modular_bandastation/balance/code/weapons/dragnet.dm
@@ -2,4 +2,4 @@
 	damage = 15
 
 /obj/projectile/beam/disabler/scatter
-	damage = 5
+	damage = 4.5


### PR DESCRIPTION
## Что этот PR делает

Увеличивает урон по стамине с 2.6 до 4.5, что позволяет достать его из того света оружейки. Сделано по трекеру: https://discord.com/channels/1097181193939730453/1516685352482635889

Драгнет на скаттере теперь сносит голого за два выстрела в упор, а на пяти тайлах за 4.
Риот шотган сносит куклу голую куклу на пяти тайлах за 2 выстрела с резиновой дроби.

## Почему это хорошо для игры

После нёрфа по БАУНТИ он стал неюзабельным абсолютно. Урона совсем не было и в обычной конфронтации наносил меньше 10 урона по стамине. Теперь он может быть хоть немного полезен.

## Тестирование

Поменял значение, запустил локалку, пострелял в голых и одетых в СБ броню кукол.
Урон наносится адекватно, сравнивая риот шотган и дизейблер на локалке

## Changelog

:cl:
balance: Транслокационный дробовик DragNET теперь наносит больше урона по выносливости. 
/:cl:
