### PR TITLE
Enhance ru_names translation workflow [ci skip]

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,5 +1,12 @@
 {
 	"version": "2.0.0",
+	"inputs": [
+		{
+			"id": "ruNameFragment",
+			"type": "promptString",
+			"description": "Enter original name of the object to translate"
+		}
+	],
 	"tasks": [
 		{
 			"type": "process",
@@ -229,9 +236,16 @@
 			"label": "tgui: rebuild tgfont"
 		},
 		{
-			"type": "shell",
-			"command": ".\\tools\\translations\\new_ru_name_fragment.cmd",
-			"args": ["${selectedText}"],
+			"type": "process",
+			"command": "powershell.exe",
+			"args": [
+				"-NoLogo",
+				"-ExecutionPolicy",
+				"Bypass",
+				"-File",
+				"${workspaceFolder}\\tools\\translations\\new_ru_name_fragment.ps1",
+				"${input:ruNameFragment}"
+			],
 			"presentation": {
 				"reveal": "always",
 				"panel": "dedicated",

--- a/tools/build/build.ts
+++ b/tools/build/build.ts
@@ -118,7 +118,11 @@ export const CutterTarget = new Juke.Target({
 
 // BANDASTATION EDIT START: merge split ru_names.toml fragments before compiling DM
 export const RuNamesMergeTarget = new Juke.Target({
-  inputs: ['tools/translations/ru_names_header.toml', `$modular_bandastation/translations/public/ru_names/**/*.toml`],
+  inputs: [
+    'tools/translations/ru_names_header.toml',
+    'modular_bandastation/translations/public/ru_names/**/*.toml',
+  ],
+  outputs: ['modular_bandastation/translations/public/ru_names.toml'],
   executes: async () => {
     const python = process.platform === 'win32' ? 'tools/bootstrap/python.bat' : 'python3';
     await Juke.exec(python, [

--- a/tools/build/build.ts
+++ b/tools/build/build.ts
@@ -120,6 +120,7 @@ export const CutterTarget = new Juke.Target({
 export const RuNamesMergeTarget = new Juke.Target({
   inputs: [
     'tools/translations/ru_names_header.toml',
+    'modular_bandastation/translations/public/ru_names',
     'modular_bandastation/translations/public/ru_names/**/*.toml',
   ],
   outputs: ['modular_bandastation/translations/public/ru_names.toml'],

--- a/tools/translations/new_ru_name_fragment.cmd
+++ b/tools/translations/new_ru_name_fragment.cmd
@@ -1,3 +1,0 @@
-@echo off
-call powershell.exe -NoLogo -ExecutionPolicy Bypass -File "%~dp0new_ru_name_fragment.ps1" %*
-exit /b %ERRORLEVEL%

--- a/tools/translations/new_ru_name_fragment.ps1
+++ b/tools/translations/new_ru_name_fragment.ps1
@@ -25,5 +25,6 @@ gender = "plural"
 "@
 
 [IO.File]::WriteAllText($path, $body + "`n", [Text.UTF8Encoding]::new($false))
-Write-Host "[ru_names] $path"
-$path
+
+Write-Host "New translation fragment created at:"
+[Uri]::new($path).AbsoluteUri


### PR DESCRIPTION
## Что делает этот PR?

Улучшает процесс добавления переводов имён через VS Code и позволяет не запускать мерж переводов без необходимости.

## Подробности

- Вместо передачи текста прямо через shell теперь используется отдельный диалог ввода и запуск PowerShell как процесса. Благодаря этому имена с апострофами и другими специальными символами больше не ломают команду.
- Путь к созданному файлу корректно выводится как ссылка, по которой можно перейти прямо из терминала.
- Исправлен путь поиска файлов переводов, поэтому Juke теперь замечает изменения в отдельных фрагментах, включая их удаление.
- Для объединённого файла явно указан выходной результат. Если исходные файлы не менялись, Juke пропускает повторный мерж.

## Тестирование

- Проверил работу таски для создания фрагментов переводов с разными именами, включающими апостроф (кавычку).
- Проверил мерж фрагментов при сборке - выполняется только при необходимости.

:cl: Maxiemar
fix: Исправлена ошибка, которая возникала при попытке автоматизированно создать файл перевода имени, содержащего специальные символы.
qol: Автоматизированное создание файла перевода имени больше не требует выделения текста в редакторе - теперь используется диалоговое окно.
fix: Исправлена ошибка, из-за которой сборка бандла переводов имен выполнялась всегда вне зависимости от наличия изменений в переводах имен.
fix: Исправлена ошибка, из-за которой сборка бандла переводов имен не выполнялась при удалении переводов отдельных имен.
/:cl: