### PR TITLE
Fix: integral circuit duplicator not working

### DIFF
--- a/code/modules/wiremod/core/component_printer.dm
+++ b/code/modules/wiremod/core/component_printer.dm
@@ -543,6 +543,7 @@
 			"id" = "[index]",
 			"icon" = "integrated_circuit",
 			"categories" = list("/Saved Circuits"),
+			"path" = index,
 		)
 		index++
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Там кто-то рефакторил машинки интегралок и отломал дубликатор, этот ПР чинит это

## Почему это хорошо для игры

Интегралки это и так больно из раунда в раунд плести эту паутину, а со сломаным дубликатором прям ужас

## Изображения изменений

-

## Тестирование

Добавил фикс, дубликатор стал работать как должен, схемы создает корректно, не путая их (ну и в целом создаёт). Тестил локально соот-в

## Changelog

:cl:
fix: Исправлена ошибка из-за которой дубликатор модулей не печатал интегральные схемы.
/:cl:
