### PR TITLE
Balance: CentCom cloak's

### DIFF
--- a/modular_bandastation/objects/code/items/clothing/suits/cloaks.dm
+++ b/modular_bandastation/objects/code/items/clothing/suits/cloaks.dm
@@ -27,7 +27,7 @@
 	icon = 'modular_bandastation/aesthetics/clothing/centcom/icons/obj/clothing/cloaks/cloaks.dmi'
 	worn_icon = 'modular_bandastation/aesthetics/clothing/centcom/icons/mob/clothing/cloaks/cloaks.dmi'
 	icon_state = "centcom"
-	armor_type = /datum/armor/armor_centcom_cloak
+	armor_type = /datum/armor/centcom_cloak
 	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | FREEZE_PROOF | UNACIDABLE | ACID_PROOF
 
 /datum/armor/armor_centcom_cloak
@@ -36,6 +36,13 @@
 	laser = 50
 	energy = 60
 	wound = 30
+
+/datum/armor/centcom_cloak
+	melee = 10
+	bullet = 10
+	laser = 10
+	energy = 10
+	wound = 10
 
 /obj/item/clothing/neck/cloak/centcom/officer
 	name = "fleet officer's official cloak"
@@ -60,6 +67,8 @@
 	desc = "Свободная накидка из дюраткани, укрепленной пластитановой нитью, выполненная на заказ. Сочетает в себе два основных качества \
 	офицерского убранства - пафос и защиту. Линейка этих дорогих плащей встречается у крайне состоятельных членов старшего офицерского состава."
 	icon_state = "gr_cape"
+	armor_type = /datum/armor/armor_centcom_cloak
+
 
 // Blueshield
 /obj/item/clothing/neck/cloak/blueshield

--- a/modular_bandastation/objects/code/items/clothing/suits/cloaks.dm
+++ b/modular_bandastation/objects/code/items/clothing/suits/cloaks.dm
@@ -69,7 +69,6 @@
 	icon_state = "gr_cape"
 	armor_type = /datum/armor/armor_centcom_cloak
 
-
 // Blueshield
 /obj/item/clothing/neck/cloak/blueshield
 	name = "blueshield's cloak"


### PR DESCRIPTION
## Что этот PR делает
Снижает броню у ЦКшных плащей, за исключением одного, который относится к APEX-у.

## Почему это хорошо для игры
Как выяснилось, броня плащей стакалась с верхней одеждой, превращая и так неубиваемых ЦКшников в что-то страшнее самого заманченного деда. Теперь этого не будет.

## Тестирование
Проверил в игре датумы на плащах, убедился в том, что плащ теперь не более, чем приятный бонус, а не целый слой защиты.

## Changelog

:cl:
balance: Большинство плащей офицеров ЦК теперь имеют пониженный армор, не позволяя настакивать много защиты.
/:cl:
