### PR TITLE
FIX: NT Frontier UI fix

### DIFF
--- a/code/modules/modular_computers/file_system/programs/frontier.dm
+++ b/code/modules/modular_computers/file_system/programs/frontier.dm
@@ -217,7 +217,7 @@
 			return TRUE
 		if("purchase_boost")
 			var/datum/scientific_partner/partner = locate(text2path(params["boost_seller"])) in SSresearch.scientific_partners
-			var/datum/techweb_node/node = SSresearch.techweb_nodes[params["purchased_boost"]]
+			var/datum/techweb_node/node = SSresearch.techweb_nodes[text2path(params["purchased_boost"])]
 			if(partner && node)
 				var/possible_boost = partner.purchase_boost(linked_techweb, node)
 				if(possible_boost)


### PR DESCRIPTION

## Что этот PR делает

Исправляет проблему с некорректной работой кнопки приобретения скидки на исследования в NT Frontier - ````purchase_boost```` при нажатии кнопки передавал значение ````node```` не по ````DM type````, в результате чего ````node```` оказывался ````null```` и срабатывал звук ошибки при нажатии, вместо приобретения скидки

## Почему это хорошо для игры

РнД может выдохнуть с облегчением, скидки возвращены

## Изображения изменений

Не требуется

## Тестирование

Запустил локально с надлежащими дебаг-логами проверки конкретного UI-фрагмента. Отследил по нему, что ````node: NULL````. Решил произвести преобразование в ````DM path```` аналогично тому, как это было сделано в других кнопках приложения. Как результат - всё работает, всё красиво

## Changelog

:cl:
fix: Исправлена ошибка некорректного срабатывания кнопки приобретения скидки на исследования в приложении "NT Frontier"
/:cl: