### PR TITLE
Move whirlpool chasm to its turf

### DIFF
--- a/_maps/virtual_domains/water_grot.dmm
+++ b/_maps/virtual_domains/water_grot.dmm
@@ -131,7 +131,7 @@
 /obj/structure/flora/rock/pile/style_random,
 /obj/effect/abstract/whirlpool,
 /obj/effect/abstract/mist,
-/turf/open/water/groundwater,
+/turf/open/water/groundwater/whirlpool,
 /area/virtual_domain)
 "tp" = (
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -277,7 +277,7 @@
 "Qz" = (
 /obj/effect/abstract/whirlpool,
 /obj/effect/abstract/mist,
-/turf/open/water/groundwater,
+/turf/open/water/groundwater/whirlpool,
 /area/virtual_domain)
 "Uj" = (
 /obj/structure/table/wood,

--- a/modular_bandastation/domains/code/domains.dm
+++ b/modular_bandastation/domains/code/domains.dm
@@ -72,6 +72,8 @@
 	icon_state = "whirlpool"
 	layer = ABOVE_OPEN_TURF_LAYER
 
+/turf/open/water/groundwater/whirlpool
+
 /turf/open/water/groundwater/whirlpool/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/chasm, null, mapload)

--- a/modular_bandastation/domains/code/domains.dm
+++ b/modular_bandastation/domains/code/domains.dm
@@ -72,11 +72,9 @@
 	icon_state = "whirlpool"
 	layer = ABOVE_OPEN_TURF_LAYER
 
-/obj/effect/abstract/whirlpool/Initialize(mapload)
+/turf/open/water/groundwater/whirlpool/Initialize(mapload)
 	. = ..()
-	var/turf/T = get_turf(src)
-	if(T && !T.GetComponent(/datum/component/chasm))
-		T.AddComponent(/datum/component/chasm, null, mapload)
+	AddComponent(/datum/component/chasm, null, mapload)
 
 /obj/effect/abstract/mist
 	name = "туман"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->
Переносит создание чазма водоворота с визуального объекта на отдельный тип водного турфа исправляя некорректное удаление компонентов при удалении турфа.

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, эти изменения следует добавить в игру. -->
Не влияет на игровой процесс.

## Изображения изменений

<!-- Если изменения затрагивают визуал/спрайты/карты - прикрепите скриншоты, вставьте видео или иным образом визуализируйте изменения. -->
<img width="345" height="66" alt="image" src="https://github.com/user-attachments/assets/a3382602-cf04-4b73-96e2-16c0a0f23765" />

## Тестирование

<!-- Опишите процесс тестирования - каким образом и что вы проверяли в своих изменениях. В этой секции недостаточно просто указать "Локально". -->
Проверен CI Suite в форке https://github.com/PetyaFX/BandaStation/actions/runs/3404397155

## Changelog

<!-- Важно строго соблюдать ёмкость и стилистическую форму наполнения чейнджлога! -->

:cl:
fix: Исправлена некорректная очистка компонетов эффекта водоворота, приводившая к нестабильному выполнению CI теста.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
<!-- Пример хороших чейнджлогов:
add: В аплинк повара добавлен мануал CQC за 20 ТК.
admin: Добавлено новое Smite действие - "Сломать колени".
balance: Разлёт дроби 12 калибра, скаттер лазер шеллов, драконьего дыхания и резиновой дроби был увеличен.
code_imp: Число дополнительных необходимых шкафов СБ теперь вычисляется точнее.
config: Добавлена/убрана настройка слотов СБ через конфиг.
del: Удалена возможность рыбалки в лотках гидропоники.
fix: Исправлена ошибка, из-за которой неудачный вызов ОБР мог резко ухудшить производительность игры.
image: Изменены спрайты для револьверов .357
map: Добавлена новая игровая карта - Nebula Station.
qol: Смерть в мини-играх больше не сбрасывает таймер возрождения.
refactor: Значительно улучшено качество кода модульной TTS сабсистемы.
server: Flaky тесты перенесены на ubuntu-20.04.
sound: Добавлен новый звук для Гамма кода на станции.
translation: Добавлен перевод приёмов и сообщений в чат для Спящего Карпа.
typo: Исправлена опечатка в предыстории расы КПБ.
-->
