### PR TITLE
FIX: Crew Monitor fix

### DIFF
--- a/tgui/packages/tgui/interfaces/CrewConsole220/constants.tsx
+++ b/tgui/packages/tgui/interfaces/CrewConsole220/constants.tsx
@@ -2,7 +2,7 @@ import { COLORS } from '../../constants';
 import type { CrewSensor } from './types';
 
 export const STAT_LIVING = 0;
-export const STAT_DEAD = 4;
+export const STAT_DEAD = 3;
 
 export const HEALTH_COLOR_BY_LEVEL = [
   '#17d568',


### PR DESCRIPTION

## Что этот PR делает

Исправляет циферку в определении константы ````STAT_DEAD```` в TGUI под актуальную в DM-коде

## Почему это хорошо для игры

До этого крю монитор не отображал статус "Мёртв" у погибших хуманов. Исправлено

## Изображения изменений

Не требуется

## Тестирование

Внёс новую циферку, зашёл на локалку, убил наглого ассистоса и посмотрел в крю монитор. Он отобразился как мёртвый, черепок на точке тоже на месте

## Changelog

:cl:
fix: Исправлена проблема с некорректным отображением жизненного статуса на мониторах экипажа.
/:cl:
