### PR TITLE
Tweak benefit tier selection from Central

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1029,6 +1029,11 @@ GLOBAL_LIST_INIT(unrecommended_builds, list(
 		if(NAMEOF(src, view))
 			view_size.setDefault(var_value)
 			return TRUE
+		// BANDASTATION EDIT START: Restricted donator level editing
+		if(NAMEOF(src, donator_level))
+			if(!usr?.client?.holder || (get_player_admin_flags(usr.client) & R_EVERYTHING) != R_EVERYTHING)
+				return FALSE
+		// BANDASTATION EDIT END: Restricted donator level editing
 	. = ..()
 
 /client/proc/rescale_view(change, min, max)

--- a/modular_bandastation/loadout/code/client.dm
+++ b/modular_bandastation/loadout/code/client.dm
@@ -12,14 +12,12 @@
 /client/proc/get_donator_level()
 	if(CONFIG_GET(flag/enable_localhost_rank) && is_localhost())
 		return CONFIG_GET(number/localhost_donate_tier)
-	return max(donator_level, get_donator_level_from_admin())
+	return max(donator_level, get_donator_level_from_host())
 
-/client/proc/get_donator_level_from_admin()
+/client/proc/get_donator_level_from_host()
 	var/rank_flags = get_player_admin_flags(src)
 	if(!rank_flags)
 		return BASIC_DONATOR_LEVEL
-	if(rank_flags & R_EVERYTHING)
+	if(rank_flags == R_EVERYTHING)
 		return MAX_DONATOR_LEVEL
-	if(rank_flags & R_ADMIN)
-		return ADMIN_DONATOR_LEVEL
 	return BASIC_DONATOR_LEVEL

--- a/modular_bandastation/metaserver/code/ss_central.dm
+++ b/modular_bandastation/metaserver/code/ss_central.dm
@@ -202,7 +202,7 @@ SUBSYSTEM_DEF(central)
 	GLOB.whitelist -= ckey
 
 /datum/controller/subsystem/central/proc/update_player_donate_tier_async(client/player)
-	var/endpoint = "[CONFIG_GET(string/ss_central_url)]/donates?ckey=[player.ckey]&active_only=true&page=1&page_size=1"
+	var/endpoint = "[CONFIG_GET(string/ss_central_url)]/donates?ckey=[player.ckey]&active_only=true&page=1&page_size=50"
 	SShttp.create_async_request(RUSTG_HTTP_METHOD_GET, endpoint, "", list(), CALLBACK(src, PROC_REF(update_player_donate_tier_callback), player))
 
 /datum/controller/subsystem/central/proc/update_player_donate_tier_callback(client/player, datum/http_response/response)
@@ -211,17 +211,17 @@ SUBSYSTEM_DEF(central)
 		return
 
 	var/list/data = json_decode(response.body)
-	player.donator_level = max(player.donator_level, get_max_donation_tier_from_response_data(data))
+	player.donator_level = get_max_donation_tier_from_response_data(data)
 
 /datum/controller/subsystem/central/proc/update_player_donate_tier_blocking(client/player)
-	var/endpoint = "[CONFIG_GET(string/ss_central_url)]/donates?ckey=[player.ckey]&active_only=true&page=1&page_size=1"
+	var/endpoint = "[CONFIG_GET(string/ss_central_url)]/donates?ckey=[player.ckey]&active_only=true&page=1&page_size=50"
 	var/datum/http_response/response = SShttp.make_sync_request(RUSTG_HTTP_METHOD_GET, endpoint, "", list())
 	if(response.errored || response.status_code != 200)
 		stack_trace("Failed to get player donate tier: HTTP status code [response.status_code] - [response.error] - [response.body]")
 		return
 
 	var/list/data = json_decode(response.body)
-	player.donator_level = max(player.donator_level, get_max_donation_tier_from_response_data(data))
+	player.donator_level = get_max_donation_tier_from_response_data(data)
 
 /datum/controller/subsystem/central/proc/get_max_donation_tier_from_response_data(list/data)
 	if(!length(data["items"]))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->
Увеличивает размер ответа Central с 1 до 50 льгот для выбора максимального тира.
Заменяет сохранённый тир актуальным, позволяя понижать его после отзыва льгот.
Убирает фиксированный тир для администраторов. Фоллбэк на хостовый т5 сохраняется только при полном наборе прав.
Отключает возможность редактирования `donation_level` в vv без наличия прав хоста.

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, эти изменения следует добавить в игру. -->
Игровые льготы соответствуют данным Central. Наличие отдельных админских прав больше не даёт т5.

## Изображения изменений
<img width="1281" height="877" alt="image" src="https://github.com/user-attachments/assets/7f614eb9-1517-42a5-8353-ea8526a87520" />

<!-- Если изменения затрагивают визуал/спрайты/карты - прикрепите скриншоты, вставьте видео или иным образом визуализируйте изменения. -->

## Тестирование

<!-- Опишите процесс тестирования - каким образом и что вы проверяли в своих изменениях. В этой секции недостаточно просто указать "Локально". -->
Изолировано проверены запросы с ответами тестового централа, максимум среди страницы льгот, понижение тира, пустой ответ.

## Changelog

<!-- Важно строго соблюдать ёмкость и стилистическую форму наполнения чейнджлога! -->

:cl:
fix: Исправлено определение донат тира при наличии нескольких льгот и после их отзыва.
admin: Уровень донат тира администраторов теперь определяется на основе тира от роли в дискорде.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
<!-- Пример хороших чейнджлогов:
add: В аплинк повара добавлен мануал CQC за 20 ТК.
admin: Добавлено новое Smite действие - "Сломать колени".
balance: Разлёт дроби 12 калибра, скаттер лазер шеллов, драконьего дыхания и резиновой дроби был увеличен.
code_imp: Число дополнительных необходимых шкафов СБ теперь вычисляется точнее.
config: Добавлена/убрана настройка слотов СБ через конфиг.
del: Удалена возможность рыбалки в лотках гидропоники.
fix: Исправлена ошибка, из-за которой неудачный вызов ОБР мог резко ухудшить производительность игры.
image: Изменены спрайты для револьверов .357
map: Добавлена новая игровая карта - Nebula Station.
qol: Смерть в мини-играх больше не сбрасывает таймер возрождения.
refactor: Значительно улучшено качество кода модульной TTS сабсистемы.
server: Flaky тесты перенесены на ubuntu-20.04.
sound: Добавлен новый звук для Гамма кода на станции.
translation: Добавлен перевод приёмов и сообщений в чат для Спящего Карпа.
typo: Исправлена опечатка в предыстории расы КПБ.
-->
